### PR TITLE
Internal 9 fix workflow

### DIFF
--- a/.github/workflows/grapl-release.yml
+++ b/.github/workflows/grapl-release.yml
@@ -2,7 +2,7 @@ name: Grapl Release
 
 on:
   release:
-    types: [released]
+    types: [released, prereleased]
 
 jobs:
   release:


### PR DESCRIPTION
Trigger the release workflow on `prerelease` releases as well as `release` releases.