### PR TITLE
Fix Cors Error

### DIFF
--- a/src/js/graphql_endpoint/server.js
+++ b/src/js/graphql_endpoint/server.js
@@ -9,13 +9,20 @@ const { validateJwt } = require('./modules/jwt.js');
 const PORT = process.env.PORT || 5000;
 const IS_LOCAL = (process.env.IS_LOCAL == 'True') || null;  // get this from environment
 
+let origin = true;
+
+if (!IS_LOCAL) {
+    origin = process.env.UX_BUCKET;
+}
 
 // TODO: Move cors to its own module
 const corsOptions = {
-    origin: true,
+    origin,
     allowedHeaders: "Content-Type, Cookie, Access-Control-Allow-Headers, Authorization, X-Requested-With",
     credentials: true
 };
+
+
 
 const middleware = [cors(corsOptions)];
 

--- a/src/js/grapl-cdk/index.ts
+++ b/src/js/grapl-cdk/index.ts
@@ -164,7 +164,7 @@ class GraphQLEndpoint extends cdk.Stack {
                 environment: {
                     "EG_ALPHAS": engagement_graph.alphaNames.join(","),
                     "JWT_SECRET": jwt_secret,
-                    "BUCKET_PREFIX": process.env.BUCKET_PREFIX
+                    "UX_BUCKET": "https://" +  process.env.BUCKET_PREFIX + "engagement-ux-bucket.s3.amazonaws.com"
                 },
                 timeout: Duration.seconds(25),
                 memorySize: 128,


### PR DESCRIPTION
Quick fix to add a dynamic origin check for the bucket we pass into the graphql endpoint stack.

In the future we should pull that bucket name out of a passed property from the bucket itself.