### PR TITLE
Fix pypa/gh-action-pypi-publish version

### DIFF
--- a/.github/workflows/grapl-release.yml
+++ b/.github/workflows/grapl-release.yml
@@ -241,7 +241,7 @@ jobs:
 
       - name: Upload graph-descriptions to Test PyPI
         if: env.CHANNEL == 'beta'
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@v1.1.0
         with:
           user: __token__
           password: ${{ secrets.GRAPL_ANALYZERLIB_TEST_PYPI_TOKEN }}
@@ -249,7 +249,7 @@ jobs:
 
       - name: Upload graph-descriptions to PyPI
         if: env.CHANNEL == 'latest'
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@v1.1.0
         with:
           user: __token__
           password: ${{ secrets.GRAPL_ANALYZERLIB_PYPI_TOKEN }}
@@ -266,7 +266,7 @@ jobs:
 
       - name: Upload grapl_analyzerlib to Test PyPI
         if: env.CHANNEL == 'beta'
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@v1.1.0
         with:
           user: __token__
           password: ${{ secrets.GRAPL_ANALYZERLIB_TEST_PYPI_TOKEN }}
@@ -274,7 +274,7 @@ jobs:
 
       - name: Upload grapl_analzyerlib to PyPI
         if: env.CHANNEL == 'latest'
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@v1.1.0
         with:
           user: __token__
           password: ${{ secrets.GRAPL_ANALYZERLIB_PYPI_TOKEN }}

--- a/.github/workflows/grapl-release.yml
+++ b/.github/workflows/grapl-release.yml
@@ -265,7 +265,7 @@ jobs:
           docker rm -f grapl-analyzerlib
 
       - name: Upload grapl_analyzerlib to Test PyPI
-        if: $CHANNEL == "beta"
+        if: $CHANNEL == 'beta'
         uses: pypa/gh-action-pypi-publish@v1
         with:
           user: __token__
@@ -273,7 +273,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
 
       - name: Upload grapl_analzyerlib to PyPI
-        if: $CHANNEL == "latest"
+        if: $CHANNEL == 'latest'
         uses: pypa/gh-action-pypi-publish@v1
         with:
           user: __token__

--- a/.github/workflows/grapl-release.yml
+++ b/.github/workflows/grapl-release.yml
@@ -265,7 +265,7 @@ jobs:
           docker rm -f grapl-analyzerlib
 
       - name: Upload grapl_analyzerlib to Test PyPI
-        if: $CHANNEL == 'beta'
+        if: env.CHANNEL == 'beta'
         uses: pypa/gh-action-pypi-publish@v1
         with:
           user: __token__
@@ -273,7 +273,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
 
       - name: Upload grapl_analzyerlib to PyPI
-        if: $CHANNEL == 'latest'
+        if: env.CHANNEL == 'latest'
         uses: pypa/gh-action-pypi-publish@v1
         with:
           user: __token__


### PR DESCRIPTION
We were pointing at `@v1` instead of `@v1.1.0` which appears to not work.