### PR TITLE
Check whether versions need to be bumped before building

### DIFF
--- a/.github/workflows/grapl-release.yml
+++ b/.github/workflows/grapl-release.yml
@@ -43,11 +43,11 @@ jobs:
           if [[ "$CHANNEL" == "latest" ]]; then
               python etc/build_scripts/check_pypi_version.py \
                 grapl_graph_descriptions \
-                $(cat src/rust/grapl_graph_descriptions/VERSION)
+                $(cat src/rust/graph-descriptions/VERSION)
           else
               python etc/build_scripts/check_pypi_version.py \
                 grapl_graph_descriptions \
-                $(cat src/python/grapl_graph_descriptions/VERSION) \
+                $(cat src/rust/graph-descriptions/VERSION) \
                 true
           fi
           deactivate

--- a/.github/workflows/grapl-release.yml
+++ b/.github/workflows/grapl-release.yml
@@ -8,8 +8,18 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    strategy:
+        matrix:
+          python-version: [3.7]
+
     steps:
+
       - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Configure git
         run: |

--- a/.github/workflows/grapl-release.yml
+++ b/.github/workflows/grapl-release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Install bump2version CLI
         run: |
-          python -mvenv venv && . venv/bin/activate
+          python3 -mvenv venv && . venv/bin/activate
           pip install bump2version
           deactivate
 

--- a/.github/workflows/grapl-release.yml
+++ b/.github/workflows/grapl-release.yml
@@ -21,37 +21,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Configure git
-        run: |
-          git config --global user.name 'Grapl CI'
-          git config --global user.email 'grapl.code@graplsecurity.com'
-
-      - name: Install bump2version CLI
-        run: |
-          python3 -mvenv venv && . venv/bin/activate
-          pip install bump2version
-          deactivate
-
-      - name: Bump grapl_graph_descriptions version
-        run: |
-          . venv/bin/activate
-          cd src/rust/graph-descriptions
-          bump2version --no-tag patch
-          cd ../../..
-          deactivate
-
-      - name: Bump grapl_analyzerlib version
-        run: |
-          . venv/bin/activate
-          cd src/python/grapl_analyzerlib
-          bump2version --no-tag patch
-          cd ../../..
-          deactivate
-
-      - name: Push version bumps
-        run: |
-          git push
-
       - name: Determine release channel
         run: |
           BRANCH=${{ github.event.release.target_commitish }}
@@ -61,6 +30,42 @@ jobs:
               CHANNEL="beta"
           fi
           echo "::set-env name=CHANNEL::$CHANNEL"
+
+      - name: Install pypi-simple
+        run: |
+          python3 -mvenv venv && . venv/bin/activate
+          pip install pypi-simple
+          deactivate
+
+      - name: Check whether grapl_graph_descriptions version has been bumped
+        run: |
+          . venv/bin/activate
+          if [[ "$CHANNEL" == "latest" ]]; then
+              python etc/build_scripts/check_pypi_version.py \
+                grapl_graph_descriptions \
+                $(cat src/rust/grapl_graph_descriptions/VERSION)
+          else
+              python etc/build_scripts/check_pypi_version.py \
+                grapl_graph_descriptions \
+                $(cat src/python/grapl_graph_descriptions/VERSION) \
+                true
+          fi
+          deactivate
+
+      - name: Check whether grapl_analyzerlib version has been bumped
+        run: |
+          . venv/bin/activate
+          if [[ "$CHANNEL" == "latest" ]]; then
+              python etc/build_scripts/check_pypi_version.py \
+                grapl_analyzerlib \
+                $(cat src/python/grapl_analyzerlib/VERSION)
+          else
+              python etc/build_scripts/check_pypi_version.py \
+                grapl_analyzerlib \
+                $(cat src/python/grapl_analyzerlib/VERSION) \
+                true
+          fi
+          deactivate
 
       - name: Build Grapl
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 src/js/grapl-cdk/edge_ux_package/*
+src/rust/graph-descriptions/grapl_graph_descriptions
 
 grapl-cdk/cdk.out/
 lambda/

--- a/etc/build_scripts/check_pypi_version.py
+++ b/etc/build_scripts/check_pypi_version.py
@@ -26,7 +26,7 @@ def needs_version_bumped(package, current_version, test_pypi):
 
     project_files = client.get_project_files(package)
     latest_version = sorted(
-        project_files,
+        (f for f in project_files if f.yanked is None),
         key=lambda p: tuple(map(int, p.version.split('.'))),
         reverse=True
     )[0].version.strip()

--- a/etc/build_scripts/check_pypi_version.py
+++ b/etc/build_scripts/check_pypi_version.py
@@ -1,0 +1,78 @@
+# This script is meant to be used in the build system to determine
+# whether a python package needs to have its version bumped before
+# being released. You can also use it locally if you wish. It will
+# exit(0) if the version does not need to be bumped, otherwise
+# exit(1) and print a message to STDERR.
+#
+# usage:
+#   python check_pypi_version.py <package> <current_version> [<test_pypi>]
+#
+# examples:
+#   python check_pypi_version.py grapl_graph_descriptions 1.0.0 False
+#   python check_pypi_version.py grapl_analyzerlib 0.2.63
+
+import sys
+
+import pypi_simple
+
+
+def needs_version_bumped(package, current_version, test_pypi):
+    if test_pypi:
+        client = pypi_simple.PyPISimple(
+            endpoint='https://test.pypi.org/simple/'
+        )
+    else:
+        client = pypi_simple.PyPISimple()
+
+    project_files = client.get_project_files(package)
+    latest_version = sorted(
+        project_files,
+        key=lambda p: tuple(map(int, p.version.split('.'))),
+        reverse=True
+    )[0].version.strip()
+
+    current_version = current_version.strip()
+    current_version_parts = current_version.split('.')
+    latest_version_parts = latest_version.split('.')
+    if latest_version == current_version:
+        return (True, latest_version)
+    elif int(latest_version_parts[0]) > int(current_version_parts[0]):
+        return (True, latest_version)
+    elif int(latest_version_parts[1]) > int(current_version_parts[1]):
+        return (True, latest_version)
+    elif int(latest_version_parts[2]) >= int(current_version_parts[2]):
+        return (True, latest_version)
+    else:
+        return (False, latest_version)
+
+
+def main(package, current_version, test_pypi):
+    must_bump, latest_version = needs_version_bumped(
+        package=package,
+        current_version=current_version,
+        test_pypi=test_pypi
+    )
+
+    if must_bump:
+        sys.stderr.write(
+            f'{package} {current_version} needs version bump.' \
+            f' Latest version in PyPI: {latest_version}\n'
+        )
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+if __name__ == '__main__':
+    PACKAGE = sys.argv[1]
+    CURRENT_VERSION = sys.argv[2]
+    if (len(sys.argv)) > 3:
+        TEST_PYPI = bool(sys.argv[3])
+    else:
+        TEST_PYPI = False
+
+    main(
+        package=PACKAGE,
+        current_version=CURRENT_VERSION,
+        test_pypi=TEST_PYPI
+    )

--- a/etc/build_scripts/check_pypi_version.py
+++ b/etc/build_scripts/check_pypi_version.py
@@ -17,12 +17,9 @@ import pypi_simple
 
 
 def needs_version_bumped(package, current_version, test_pypi):
-    if test_pypi:
-        client = pypi_simple.PyPISimple(
-            endpoint='https://test.pypi.org/simple/'
-        )
-    else:
-        client = pypi_simple.PyPISimple()
+    client = pypi_simple.PyPISimple(
+        'https://test.pypi.org/simple/'
+    ) if test_pypi else pypi_simple.PyPISimple()
 
     project_files = client.get_project_files(package)
     latest_version = sorted(
@@ -54,9 +51,10 @@ def main(package, current_version, test_pypi):
     )
 
     if must_bump:
+        test_str = 'Test' if test_pypi else ''
         sys.stderr.write(
             f'{package} {current_version} needs version bump.' \
-            f' Latest version in PyPI: {latest_version}\n'
+            f' Latest version in {test_str} PyPI: {latest_version}\n'
         )
         sys.exit(1)
     else:
@@ -66,10 +64,7 @@ def main(package, current_version, test_pypi):
 if __name__ == '__main__':
     PACKAGE = sys.argv[1]
     CURRENT_VERSION = sys.argv[2]
-    if (len(sys.argv)) > 3:
-        TEST_PYPI = bool(sys.argv[3])
-    else:
-        TEST_PYPI = False
+    TEST_PYPI = bool(sys.argv[3]) if len(sys.argv) > 3 else False
 
     main(
         package=PACKAGE,


### PR DESCRIPTION
This PR adds a build script used in the grapl-release workflow to check whether grapl_analyzerlib or grapl_graph_descriptions need to be bumped before it attempts to build anything. The reason for this is that the PyPI upload will fail if we attempt to overwrite any existing versions.