### PR TITLE
CDK - manually create Lambda execution role so we can name it

### DIFF
--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -395,6 +395,20 @@ class DGraphTtl extends cdk.NestedStack {
 
         const serviceName = props.prefix + '-DGraphTtl';
 
+        const role = new iam.Role(this, 'ExecutionRole', {
+            assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+            roleName: serviceName + '-HandlerRole',
+            description: 'Lambda execution role for: ' + serviceName,
+            managedPolicies: [
+                iam.ManagedPolicy.fromAwsManagedPolicyName(
+                    'service-role/AWSLambdaBasicExecutionRole'
+                ),
+                iam.ManagedPolicy.fromAwsManagedPolicyName(
+                    'service-role/AWSLambdaVPCAccessExecutionRole'
+                ),
+            ],
+        });
+
         const event_handler = new lambda.Function(this, 'Handler', {
             runtime: lambda.Runtime.PYTHON_3_7,
             handler: 'app.prune_expired_subgraphs',
@@ -412,6 +426,7 @@ class DGraphTtl extends cdk.NestedStack {
             timeout: cdk.Duration.seconds(600),
             memorySize: 128,
             description: props.version,
+            role
         });
         event_handler.currentVersion.addAlias('live');
 
@@ -453,6 +468,20 @@ export class ModelPluginDeployer extends cdk.NestedStack {
             props.prefix.toLowerCase() + '-engagement-ux-bucket'
         );
 
+        const role = new iam.Role(this, 'ExecutionRole', {
+            assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+            roleName: serviceName + '-HandlerRole',
+            description: 'Lambda execution role for: ' + serviceName,
+            managedPolicies: [
+                iam.ManagedPolicy.fromAwsManagedPolicyName(
+                    'service-role/AWSLambdaBasicExecutionRole'
+                ),
+                iam.ManagedPolicy.fromAwsManagedPolicyName(
+                    'service-role/AWSLambdaVPCAccessExecutionRole'
+                ),
+            ],
+        });
+
         const event_handler = new lambda.Function(this, 'Handler', {
             runtime: lambda.Runtime.PYTHON_3_7,
             handler: `grapl_model_plugin_deployer.app`,
@@ -471,6 +500,7 @@ export class ModelPluginDeployer extends cdk.NestedStack {
             timeout: cdk.Duration.seconds(25),
             memorySize: 256,
             description: props.version,
+            role,
         });
         event_handler.currentVersion.addAlias('live');
 

--- a/src/js/grapl-cdk/lib/service.ts
+++ b/src/js/grapl-cdk/lib/service.ts
@@ -177,17 +177,14 @@ export class Service {
     }
 
     publishesToTopic(publishes_to: sns.ITopic) {
-        const topicPolicy = new iam.PolicyStatement();
-
-        topicPolicy.addActions('sns:CreateTopic');
-        topicPolicy.addResources(publishes_to.topicArn);
+        const topicPolicy = new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ['sns:CreateTopic', 'sns:Publish'],
+            resources: [publishes_to.topicArn],
+        });
 
         this.event_handler.addToRolePolicy(topicPolicy);
-
         this.event_retry_handler.addToRolePolicy(topicPolicy);
-
-        publishes_to.grantPublish(this.event_handler);
-        publishes_to.grantPublish(this.event_retry_handler);
     }
 
     publishesToBucket(publishes_to: s3.IBucket) {


### PR DESCRIPTION
We refer to Lambda execution roles directly and the auto-generated names are sometimes not legible. This gives a clear name and uses a common role for both handlers.