### PR TITLE
Fix analyzer executor

### DIFF
--- a/src/js/grapl-cdk/bin/grapl-cdk.ts
+++ b/src/js/grapl-cdk/bin/grapl-cdk.ts
@@ -5,7 +5,7 @@ import * as cdk from '@aws-cdk/core';
 import { GraplCdkStack } from '../lib/grapl-cdk-stack';
 import { EngagementUx } from '../lib/engagement';
 
-const deployName = 'Grapl-Meta-us-east-2';
+const deployName = 'Grapl-MYDEPLOYMENT';
 const graplVersion = 'latest';
 const watchfulEmail = undefined;
 

--- a/src/js/grapl-cdk/bin/grapl-cdk.ts
+++ b/src/js/grapl-cdk/bin/grapl-cdk.ts
@@ -5,7 +5,7 @@ import * as cdk from '@aws-cdk/core';
 import { GraplCdkStack } from '../lib/grapl-cdk-stack';
 import { EngagementUx } from '../lib/engagement';
 
-const deployName = 'Grapl-MYDEPLOYMENT';
+const deployName = 'Grapl-Meta-us-east-2';
 const graplVersion = 'latest';
 const watchfulEmail = undefined;
 

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -301,6 +301,7 @@ class AnalyzerExecutor extends cdk.NestedStack {
                 MESSAGECACHE_PORT: message_cache.cluster.attrRedisEndpointPort,
                 HITCACHE_ADDR: hit_cache.cluster.attrRedisEndpointAddress,
                 HITCACHE_PORT: hit_cache.cluster.attrRedisEndpointPort,
+                GRAPL_LOG_LEVEL: "INFO",
                 GRPC_ENABLE_FORK_SUPPORT: '1',
             },
             vpc: props.vpc,
@@ -317,6 +318,8 @@ class AnalyzerExecutor extends cdk.NestedStack {
         // We need the List capability to find each of the analyzers
         props.readsAnalyzersFrom.grantRead(service.event_handler);
         props.readsAnalyzersFrom.grantRead(service.event_retry_handler);
+
+        service.readsFrom(props.modelPluginsBucket, true);
 
         // Need to be able to GetObject in order to HEAD, can be replaced with
         // a cache later, but safe so long as there is no LIST

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/plugin_retriever.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/plugin_retriever.py
@@ -1,18 +1,28 @@
 import base64
+import logging
+import sys
 import os.path
+
+from typing import Optional
 from pathlib import Path
 
 import boto3
 
+GRAPL_LOG_LEVEL = os.getenv("GRAPL_LOG_LEVEL")
+LEVEL = "ERROR" if GRAPL_LOG_LEVEL is None else GRAPL_LOG_LEVEL
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(LEVEL)
+LOGGER.addHandler(logging.StreamHandler(stream=sys.stdout))
 
-def load_plugins(bucket_prefix: str, s3=None):
+
+def load_plugins(bucket_prefix: str, s3=None, path=None):
     s3 = s3 or boto3.resource("s3")
 
     PluginRetriever(
         plugin_bucket=bucket_prefix + "-model-plugins-bucket",
         plugin_directory="./model_plugins/",
         s3_client=s3.meta.client,
-    ).retrieve(overwrite=True)
+    ).retrieve(overwrite=True, path=path)
 
 
 def load_plugins_local():
@@ -33,7 +43,10 @@ class PluginRetriever(object):
         self.s3_client = s3_client
         self.plugin_directory = plugin_directory
 
-    def retrieve(self, overwrite: bool = False) -> None:
+    def retrieve(self, overwrite: bool = False, path: Optional[Path] = None) -> None:
+        path = path or "."
+        LOGGER.info(f'Writing out plugins to: {os.path.join(path, "model_plugins")}')
+
         # list plugin files
         plugin_objects = self.s3_client.list_objects(Bucket=self.plugin_bucket,).get(
             "Contents", []
@@ -44,7 +57,7 @@ class PluginRetriever(object):
             object_key = plugin_object["Key"]
             plugin_name = object_key.split("/")[0]
             local_path = os.path.join(
-                os.path.abspath("."),
+                path,
                 f"model_plugins/{plugin_name}/{base64.decodebytes(object_key.split('/')[1].encode('utf8')).decode('utf8')}",
             ).replace("-", "_")
 

--- a/src/rust/analyzer-dispatcher/src/main.rs
+++ b/src/rust/analyzer-dispatcher/src/main.rs
@@ -471,7 +471,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if is_local {
         info!("Running locally");
-        let mut runtime = Runtime::new().unwrap();
         let source_queue_url = std::env::var("SOURCE_QUEUE_URL").expect("SOURCE_QUEUE_URL");
 
         grapl_config::wait_for_sqs(
@@ -480,6 +479,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
         grapl_config::wait_for_s3(init_s3_client()).await?;
+
+        loop {
+            if let Err(e) = local_handler().await {
+                error!("local_handler: {}", e);
+            };
+        }
     } else {
         info!("Running in AWS");
         lambda!(handler);

--- a/src/rust/graph-merger/src/main.rs
+++ b/src/rust/graph-merger/src/main.rs
@@ -691,7 +691,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if is_local {
         info!("Running locally");
-        let mut runtime = Runtime::new().unwrap();
         let source_queue_url = std::env::var("SOURCE_QUEUE_URL").expect("SOURCE_QUEUE_URL");
 
         grapl_config::wait_for_sqs(
@@ -700,6 +699,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
         grapl_config::wait_for_s3(init_s3_client()).await?;
+
+        loop {
+            if let Err(e) = inner_main().await {
+                error!("inner_main: {}", e);
+            };
+        }
     } else {
         info!("Running in AWS");
         lambda!(handler);


### PR DESCRIPTION
This fixes a number of issues with how the AnalyzerExecutor loads plugins. In particular, it tried to write to paths in the lambda that are not writable, and now it writes to /tmp/, which also gets added to the sys.path .

