### PR TITLE
revert cargo update.

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2,18 +2,18 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.13.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
+checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "0.2.3"
+name = "adler32"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
 
 [[package]]
 name = "aho-corasick"
@@ -31,7 +31,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c0850d73364db1c5af4e0b508ce1459b9df19c53e1ca00e16d3b37d1f50c668"
 dependencies = [
  "async-trait",
- "tokio 0.2.22",
+ "tokio 0.2.21",
 ]
 
 [[package]]
@@ -42,7 +42,7 @@ dependencies = [
  "aws_lambda_events 0.2.7",
  "base16",
  "base64 0.10.1",
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "chrono",
  "dgraph-rs 0.1.2",
  "failure",
@@ -51,10 +51,10 @@ dependencies = [
  "grapl-graph-descriptions",
  "grpc",
  "lambda_runtime",
- "log 0.4.11",
+ "log 0.4.8",
  "prost",
- "rusoto_core 0.43.0",
- "rusoto_credential 0.43.0",
+ "rusoto_core",
+ "rusoto_credential",
  "rusoto_s3",
  "rusoto_sns",
  "rusoto_sqs",
@@ -65,9 +65,9 @@ dependencies = [
  "simple_logger",
  "sqs-lambda",
  "stopwatch",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "tokio-compat",
- "uuid 0.8.1",
+ "uuid 0.6.5",
  "zstd",
 ]
 
@@ -76,15 +76,6 @@ name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -125,9 +116,9 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a265e3abeffdce30b2e26b7a11b222fe37c6067404001b434101457d0385eb92"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -183,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.50"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
+checksum = "05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -330,15 +321,18 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+checksum = "118cf036fbb97d0816e3c34b2d7a1e8cfc60f68fcf63d550ddbe9bd5f59c213b"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "cc"
-version = "1.0.58"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
+checksum = "77c1f1d60091c1b73e2b1f4560ab419204b178e625fa945ded7b660becd2bd46"
 dependencies = [
  "jobserver",
 ]
@@ -351,9 +345,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.13"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -387,7 +381,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aaa5f071a62a9c06ebab653ec2e2ba76cb936548a83e7af7f0c5dac525067ff"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term",
  "backtrace",
  "color-backtrace",
  "color-spantrace",
@@ -399,11 +393,11 @@ dependencies = [
 
 [[package]]
 name = "color-spantrace"
-version = "0.1.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a99aa4aa18448eef4c7d3f86d2720d2d8cad5c860fe9ff9b279293efdc8f5be"
+checksum = "058b1bb1ea9b128049d3aa4cfbf166c6c8e53f3eade5f40ebb2d2a51cef65058"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term",
  "tracing-core",
  "tracing-error",
 ]
@@ -443,12 +437,12 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
+checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -536,7 +530,7 @@ checksum = "543a9863ece4fc217b8d0397117cd75264e6685973cea47e31f4e4172cbd1ffe"
 dependencies = [
  "futures 0.3.5",
  "quick-error",
- "tokio 0.2.22",
+ "tokio 0.2.21",
 ]
 
 [[package]]
@@ -557,10 +551,10 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
  "strsim",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -571,7 +565,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -584,8 +578,8 @@ dependencies = [
  "async-trait",
  "futures 0.3.5",
  "quote 1.0.7",
- "syn 1.0.35",
- "tokio 0.2.22",
+ "syn 1.0.33",
+ "tokio 0.2.21",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -598,7 +592,7 @@ version = "1.0.0"
 dependencies = [
  "grapl-config",
  "grapl-graph-descriptions",
- "log 0.4.11",
+ "log 0.4.8",
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "serde",
@@ -616,9 +610,9 @@ checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
  "darling",
  "derive_builder_core",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -628,9 +622,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -741,7 +735,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.8",
  "regex",
 ]
 
@@ -779,9 +773,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
  "synstructure 0.12.4",
 ]
 
@@ -927,9 +921,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -979,6 +973,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add72f17bb81521258fcc8a7a3245b1e184e916bfbe34f0ea89558f440df5c68"
+dependencies = [
+ "cc",
+ "libc",
+ "log 0.4.8",
+ "rustc_version",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,11 +1019,11 @@ dependencies = [
  "grapl-graph-descriptions",
  "lambda_runtime",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.8",
  "prost",
  "rayon",
  "regex",
- "rusoto_core 0.43.0",
+ "rusoto_core",
  "rusoto_s3",
  "rusoto_sqs",
  "serde",
@@ -1025,12 +1032,12 @@ dependencies = [
  "simple_logger",
  "sqs-lambda",
  "stopwatch",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "tokio-compat",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
- "uuid 0.8.1",
+ "uuid 0.6.5",
  "zstd",
 ]
 
@@ -1047,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.22.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
 name = "glob"
@@ -1069,10 +1076,10 @@ dependencies = [
  "grapl-config",
  "grapl-graph-descriptions",
  "lambda_runtime",
- "log 0.4.11",
+ "log 0.4.8",
  "prost",
- "rusoto_core 0.43.0",
- "rusoto_credential 0.43.0",
+ "rusoto_core",
+ "rusoto_credential",
  "rusoto_s3",
  "rusoto_sqs",
  "rusoto_sts",
@@ -1080,7 +1087,7 @@ dependencies = [
  "serde_json",
  "sha2 0.7.1",
  "sqs-lambda",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "tokio-compat",
  "zstd",
 ]
@@ -1102,11 +1109,11 @@ dependencies = [
  "grpc",
  "itertools 0.8.2",
  "lambda_runtime",
- "log 0.4.11",
+ "log 0.4.8",
  "prost",
  "rand 0.6.5",
- "rusoto_core 0.43.0",
- "rusoto_credential 0.43.0",
+ "rusoto_core",
+ "rusoto_credential",
  "rusoto_s3",
  "rusoto_sns",
  "rusoto_sqs",
@@ -1117,7 +1124,7 @@ dependencies = [
  "simple_logger",
  "sqs-lambda",
  "stopwatch",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "tokio-compat",
  "uuid 0.8.1",
  "zstd",
@@ -1129,12 +1136,12 @@ version = "0.0.2"
 dependencies = [
  "color-eyre",
  "eyre",
- "log 0.4.11",
- "rusoto_core 0.43.0",
+ "log 0.4.8",
+ "rusoto_core",
  "rusoto_s3",
  "rusoto_sqs",
  "sqs-lambda",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -1145,7 +1152,7 @@ name = "grapl-graph-descriptions"
 version = "0.2.10"
 dependencies = [
  "derive_builder",
- "log 0.4.11",
+ "log 0.4.8",
  "prost",
  "prost-build",
  "prost-derive",
@@ -1168,7 +1175,7 @@ dependencies = [
  "futures 0.1.29",
  "futures-cpupool",
  "httpbis",
- "log 0.4.11",
+ "log 0.4.8",
  "protobuf",
  "tls-api",
  "tls-api-stub",
@@ -1199,7 +1206,7 @@ dependencies = [
  "futures 0.1.29",
  "http 0.1.21",
  "indexmap",
- "log 0.4.11",
+ "log 0.4.8",
  "slab 0.4.2",
  "string",
  "tokio-io",
@@ -1207,30 +1214,21 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
+checksum = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
  "http 0.2.1",
  "indexmap",
+ "log 0.4.8",
  "slab 0.4.2",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
-dependencies = [
- "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -1244,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
 dependencies = [
  "libc",
 ]
@@ -1300,7 +1298,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "fnv",
  "itoa",
 ]
@@ -1323,7 +1321,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "http 0.2.1",
 ]
 
@@ -1342,7 +1340,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
  "futures-cpupool",
- "log 0.4.11",
+ "log 0.4.8",
  "net2",
  "tls-api",
  "tls-api-stub",
@@ -1370,7 +1368,7 @@ dependencies = [
  "httparse",
  "iovec",
  "itoa",
- "log 0.4.11",
+ "log 0.4.8",
  "net2",
  "rustc_version",
  "time 0.1.43",
@@ -1387,25 +1385,25 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.7"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
+checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.2.6",
+ "h2 0.2.5",
  "http 0.2.1",
  "http-body 0.3.1",
  "httparse",
  "itoa",
+ "log 0.4.8",
  "pin-project",
  "socket2",
  "time 0.1.43",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "tower-service",
- "tracing",
  "want 0.3.0",
 ]
 
@@ -1415,14 +1413,14 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "ct-logs",
  "futures-util",
- "hyper 0.13.7",
- "log 0.4.11",
+ "hyper 0.13.6",
+ "log 0.4.8",
  "rustls",
  "rustls-native-certs",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "tokio-rustls",
  "webpki",
 ]
@@ -1452,12 +1450,11 @@ checksum = "e0bd112d44d9d870a6819eb505d04dd92b5e4d94bb8c304924a0872ae7016fb5"
 
 [[package]]
 name = "indexmap"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
+checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 dependencies = [
  "autocfg 1.0.0",
- "hashbrown",
 ]
 
 [[package]]
@@ -1524,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.42"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52732a3d3ad72c58ad2dc70624f9c17b46ecd0943b9a4f1ee37c4c18c5d983e2"
+checksum = "c4b9172132a62451e56142bff9afc91c8e4a4500aa5b847da36815b63bfda916"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1549,7 +1546,7 @@ checksum = "077b8819fe6998266342efdc5154192551143f390ab758007cc7421992e61b07"
 dependencies = [
  "failure",
  "lambda_runtime_core",
- "log 0.4.11",
+ "log 0.4.8",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1566,7 +1563,7 @@ dependencies = [
  "http 0.1.21",
  "hyper 0.12.35",
  "lambda_runtime_errors",
- "log 0.4.11",
+ "log 0.4.8",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1585,7 +1582,7 @@ dependencies = [
  "hyper 0.12.35",
  "lambda_runtime_client",
  "lambda_runtime_errors",
- "log 0.4.11",
+ "log 0.4.8",
  "rustc_version",
  "tokio 0.1.22",
 ]
@@ -1598,7 +1595,7 @@ checksum = "93b63ea3688df164aaa5643c5f3291cc481366d624729deb3c4dc85ee65ac20a"
 dependencies = [
  "failure",
  "lambda_runtime_errors_derive",
- "log 0.4.11",
+ "log 0.4.8",
  "serde_json",
 ]
 
@@ -1628,9 +1625,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.73"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
+checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "lock_api"
@@ -1647,16 +1644,27 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.8",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "loom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ecc775857611e1df29abba5c41355cdf540e7e9d4acfdf0f355eefee82330b7"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
 ]
 
 [[package]]
@@ -1694,20 +1702,20 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.5"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 dependencies = [
  "autocfg 1.0.0",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.0"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
 dependencies = [
- "adler",
+ "adler32",
 ]
 
 [[package]]
@@ -1722,7 +1730,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.11",
+ "log 0.4.8",
  "miow 0.2.1",
  "net2",
  "slab 0.4.2",
@@ -1736,7 +1744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
- "log 0.4.11",
+ "log 0.4.8",
  "mio",
  "slab 0.4.2",
 ]
@@ -1747,7 +1755,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.8",
  "mio",
  "miow 0.3.5",
  "winapi 0.3.9",
@@ -1811,7 +1819,7 @@ dependencies = [
  "aws_lambda_events 0.2.7",
  "base58",
  "base64 0.9.3",
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "chrono",
  "failure",
  "futures 0.3.5",
@@ -1820,14 +1828,14 @@ dependencies = [
  "hex",
  "hmap",
  "lambda_runtime",
- "log 0.4.11",
+ "log 0.4.8",
  "prost",
  "prost-types",
  "quickcheck",
  "quickcheck_macros",
- "rusoto_core 0.43.0",
- "rusoto_credential 0.43.0",
- "rusoto_dynamodb 0.43.0",
+ "rusoto_core",
+ "rusoto_credential",
+ "rusoto_dynamodb",
  "rusoto_s3",
  "rusoto_sqs",
  "serde",
@@ -1839,7 +1847,7 @@ dependencies = [
  "simple_logger",
  "sqs-lambda",
  "stopwatch",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "tokio-compat",
  "tracing",
  "uuid 0.6.5",
@@ -2035,9 +2043,9 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -2081,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -2094,7 +2102,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "prost-derive",
 ]
 
@@ -2104,10 +2112,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "heck",
  "itertools 0.8.2",
- "log 0.4.11",
+ "log 0.4.8",
  "multimap",
  "petgraph",
  "prost",
@@ -2124,9 +2132,9 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools 0.8.2",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -2135,7 +2143,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "prost",
 ]
 
@@ -2163,7 +2171,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d9500ea1488a61aa96da139039b78a92eef64a0f3c82d38173729f0ad73cf8"
 dependencies = [
- "log 0.4.11",
+ "log 0.3.9",
 ]
 
 [[package]]
@@ -2204,7 +2212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
 dependencies = [
  "env_logger",
- "log 0.4.11",
+ "log 0.4.8",
  "rand 0.7.3",
  "rand_core 0.5.1",
 ]
@@ -2215,9 +2223,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608c156fd8e97febc07dc9c2e2c80bf74cfc6ef26893eae3daf8bc2bc94a4b7f"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -2241,7 +2249,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
 ]
 
 [[package]]
@@ -2458,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "redox_users"
@@ -2533,53 +2541,24 @@ checksum = "3a8d624cb48fcaca612329e4dd544380aa329ef338e83d3a90f5b7897e631971"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "futures 0.3.5",
  "hmac 0.7.1",
  "http 0.2.1",
- "hyper 0.13.7",
+ "hyper 0.13.6",
  "hyper-rustls",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.8",
  "md5",
  "percent-encoding",
  "pin-project",
- "rusoto_credential 0.43.0",
- "rusoto_signature 0.43.0",
+ "rusoto_credential",
+ "rusoto_signature",
  "rustc_version",
  "serde",
  "serde_json",
  "sha2 0.8.2",
- "tokio 0.2.22",
- "xml-rs",
-]
-
-[[package]]
-name = "rusoto_core"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841ca8f73e7498ba39146ab43acea906bbbb807d92ec0b7ea4b6293d2621f80d"
-dependencies = [
- "async-trait",
- "base64 0.12.3",
- "bytes 0.5.6",
- "futures 0.3.5",
- "hmac 0.7.1",
- "http 0.2.1",
- "hyper 0.13.7",
- "hyper-rustls",
- "lazy_static",
- "log 0.4.11",
- "md5",
- "percent-encoding",
- "pin-project",
- "rusoto_credential 0.44.0",
- "rusoto_signature 0.44.0",
- "rustc_version",
- "serde",
- "serde_json",
- "sha2 0.8.2",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "xml-rs",
 ]
 
@@ -2593,33 +2572,13 @@ dependencies = [
  "chrono",
  "dirs",
  "futures 0.3.5",
- "hyper 0.13.7",
+ "hyper 0.13.6",
  "pin-project",
  "regex",
  "serde",
  "serde_json",
  "shlex",
- "tokio 0.2.22",
- "zeroize",
-]
-
-[[package]]
-name = "rusoto_credential"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60669ddc1bdbb83ce225593649d36b4c5f6bf9db47cc1ab3e81281abffc853f4"
-dependencies = [
- "async-trait",
- "chrono",
- "dirs",
- "futures 0.3.5",
- "hyper 0.13.7",
- "pin-project",
- "regex",
- "serde",
- "serde_json",
- "shlex",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "zeroize",
 ]
 
@@ -2630,23 +2589,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686192bf4c9dbaa4514e9eed71c082b6a62ab458a20dec944ed245b731bbf0d3"
 dependencies = [
  "async-trait",
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "futures 0.3.5",
- "rusoto_core 0.43.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "rusoto_dynamodb"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a485bf81a63fd92a4e011b76daed2731b363a6f2b6279b8b26b389699bcf1525"
-dependencies = [
- "async-trait",
- "bytes 0.5.6",
- "futures 0.3.5",
- "rusoto_core 0.44.0",
+ "rusoto_core",
  "serde",
  "serde_json",
 ]
@@ -2658,9 +2603,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6bc3221ae5a2c036d5757eee68a2ffb6b7f87b8a83adbf4271c8133fdee01c"
 dependencies = [
  "async-trait",
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "futures 0.3.5",
- "rusoto_core 0.43.0",
+ "rusoto_core",
  "xml-rs",
 ]
 
@@ -2671,47 +2616,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62940a2bd479900a1bf8935b8f254d3e19368ac3ac4570eb4bd48eb46551a1b7"
 dependencies = [
  "base64 0.12.3",
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "futures 0.3.5",
  "hex",
  "hmac 0.7.1",
  "http 0.2.1",
- "hyper 0.13.7",
- "log 0.4.11",
+ "hyper 0.13.6",
+ "log 0.4.8",
  "md5",
  "percent-encoding",
  "pin-project",
- "rusoto_credential 0.43.0",
+ "rusoto_credential",
  "rustc_version",
  "serde",
  "sha2 0.8.2",
  "time 0.2.16",
- "tokio 0.2.22",
-]
-
-[[package]]
-name = "rusoto_signature"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eddff187ac18c5a91d9ccda9353f30cf531620dce437c4db661dfe2e23b2029"
-dependencies = [
- "base64 0.12.3",
- "bytes 0.5.6",
- "futures 0.3.5",
- "hex",
- "hmac 0.7.1",
- "http 0.2.1",
- "hyper 0.13.7",
- "log 0.4.11",
- "md5",
- "percent-encoding",
- "pin-project",
- "rusoto_credential 0.44.0",
- "rustc_version",
- "serde",
- "sha2 0.8.2",
- "time 0.2.16",
- "tokio 0.2.22",
+ "tokio 0.2.21",
 ]
 
 [[package]]
@@ -2721,9 +2641,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030d55e2942eeb338cd338810ed1a7e5dbe5886b4a11d5acdaec806fbbf6c28b"
 dependencies = [
  "async-trait",
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "futures 0.3.5",
- "rusoto_core 0.43.0",
+ "rusoto_core",
  "serde_urlencoded",
  "xml-rs",
 ]
@@ -2735,9 +2655,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c357b6cbd33dbaab191eeb52f031ec2e6e63b7616f82d299659dd52233060ae2"
 dependencies = [
  "async-trait",
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "futures 0.3.5",
- "rusoto_core 0.43.0",
+ "rusoto_core",
  "serde_urlencoded",
  "xml-rs",
 ]
@@ -2749,10 +2669,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83d166cfb294672db98a60159c4a81a8169c6c91054a275cb812158c73815e5"
 dependencies = [
  "async-trait",
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "chrono",
  "futures 0.3.5",
- "rusoto_core 0.43.0",
+ "rusoto_core",
  "serde_urlencoded",
  "tempfile",
  "xml-rs",
@@ -2798,7 +2718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
 dependencies = [
  "base64 0.11.0",
- "log 0.4.11",
+ "log 0.4.8",
  "ring",
  "sct",
  "webpki",
@@ -2923,7 +2843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d98dfc234faa8532d66c837de56bf4276a259a43dd10ef96feb2fb7ab333b1"
 dependencies = [
  "error-chain",
- "log 0.4.11",
+ "log 0.4.8",
  "serde",
  "xml-rs",
 ]
@@ -2934,19 +2854,19 @@ version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
 name = "serde_dynamodb"
-version = "0.5.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ceb0b8298ba5707f1c2573109d16ca31434b4449ab07a6e064d9f60fa20d7a"
+checksum = "75a1f686cda0ebc312298829c7236d0d7638637ca3077cc5fc8c13d3c699f861"
 dependencies = [
- "bytes 0.5.6",
- "rusoto_dynamodb 0.44.0",
+ "bytes 0.5.5",
+ "rusoto_dynamodb",
  "serde",
 ]
 
@@ -3048,7 +2968,7 @@ dependencies = [
  "atty",
  "chrono",
  "colored",
- "log 0.4.11",
+ "log 0.4.8",
  "winapi 0.3.9",
 ]
 
@@ -3075,9 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "socket2"
@@ -3116,20 +3036,20 @@ dependencies = [
  "futures-retry",
  "hex",
  "lambda_runtime",
- "log 0.4.11",
+ "log 0.4.8",
  "notify",
  "num_cpus",
  "prost",
  "rand 0.7.3",
  "rand_xorshift 0.2.0",
- "rusoto_core 0.43.0",
+ "rusoto_core",
  "rusoto_s3",
  "rusoto_sqs",
  "serde",
  "serde_json",
  "simple_logger",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -3166,11 +3086,11 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
  "serde",
  "serde_derive",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -3180,13 +3100,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -3249,11 +3169,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.35"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7f4c519df8c117855e19dd8cc851e89eb746fe7a73f0157e0d95fdec5369b0"
+checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
 ]
@@ -3285,9 +3205,9 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
  "unicode-xid 0.2.1",
 ]
 
@@ -3322,12 +3242,12 @@ dependencies = [
  "grapl-graph-descriptions",
  "lambda_runtime",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.8",
  "prost",
  "rayon",
  "regex",
- "rusoto_core 0.43.0",
- "rusoto_credential 0.43.0",
+ "rusoto_core",
+ "rusoto_credential",
  "rusoto_s3",
  "rusoto_sqs",
  "serde",
@@ -3337,12 +3257,12 @@ dependencies = [
  "sqs-lambda",
  "stopwatch",
  "sysmon",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "tokio-compat",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
- "uuid 0.8.1",
+ "uuid 0.6.5",
  "zstd",
 ]
 
@@ -3394,9 +3314,9 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -3450,10 +3370,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
  "standback",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -3468,7 +3388,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049c03787a0595182357fbd487577947f4351b78ce20c3668f6d49f17feb13d1"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.8",
 ]
 
 [[package]]
@@ -3502,16 +3422,16 @@ dependencies = [
  "tokio-threadpool",
  "tokio-timer 0.2.13",
  "tokio-udp",
- "tokio-uds 0.2.7",
+ "tokio-uds 0.2.6",
 ]
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "fnv",
  "futures-core",
  "iovec",
@@ -3561,7 +3481,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "tokio-current-thread",
  "tokio-executor",
  "tokio-reactor",
@@ -3577,7 +3497,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
  "iovec",
- "log 0.4.11",
+ "log 0.4.8",
  "mio",
  "scoped-tls",
  "tokio 0.1.22",
@@ -3626,7 +3546,7 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
- "log 0.4.11",
+ "log 0.4.8",
 ]
 
 [[package]]
@@ -3635,9 +3555,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -3649,7 +3569,7 @@ dependencies = [
  "crossbeam-utils",
  "futures 0.1.29",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.8",
  "mio",
  "num_cpus",
  "parking_lot",
@@ -3667,7 +3587,7 @@ checksum = "15cb62a0d2770787abc96e99c1cd98fcf17f94959f3af63ca85bdfb203f051b4"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio 0.2.22",
+ "tokio 0.2.21",
  "webpki",
 ]
 
@@ -3706,7 +3626,7 @@ dependencies = [
  "crossbeam-utils",
  "futures 0.1.29",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.8",
  "num_cpus",
  "slab 0.4.2",
  "tokio-executor",
@@ -3753,7 +3673,7 @@ checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
- "log 0.4.11",
+ "log 0.4.8",
  "mio",
  "tokio-codec",
  "tokio-io",
@@ -3779,15 +3699,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-uds"
-version = "0.2.7"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0"
+checksum = "5076db410d6fdc6523df7595447629099a1fdc47b3d9f896220780fa48faf798"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
  "iovec",
  "libc",
- "log 0.4.11",
+ "log 0.4.8",
  "mio",
  "mio-uds",
  "tokio-codec",
@@ -3801,12 +3721,12 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 0.5.5",
  "futures-core",
  "futures-sink",
- "log 0.4.11",
+ "log 0.4.8",
  "pin-project-lite",
- "tokio 0.2.22",
+ "tokio 0.2.21",
 ]
 
 [[package]]
@@ -3817,32 +3737,31 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.17"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbdf4ccd1652592b01286a5dbe1e2a77d78afaa34beadd9872a5f7396f92aaa9"
+checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
 dependencies = [
  "cfg-if",
- "log 0.4.11",
  "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0693bf8d6f2bf22c690fc61a9d21ac69efdbb894a17ed596b9af0f01e64b84b"
+checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.11"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ae75f0d28ae10786f3b1895c55fe72e79928fd5ccdebb5438c75e93fec178f"
+checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
 dependencies = [
  "lazy_static",
 ]
@@ -3874,7 +3793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
 dependencies = [
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.8",
  "tracing-core",
 ]
 
@@ -3890,11 +3809,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.8"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafe899b943f5433c6cab468d75a17ea92948fe9fe60b00f41e13d5e0d4fd054"
+checksum = "04a11b459109e38ff6e1b580bafef4142a11d44889f5d07424cbce2fd2a2a119"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "chrono",
  "lazy_static",
  "matchers",
@@ -3902,7 +3821,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.4.1",
+ "smallvec 1.4.0",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
@@ -3910,9 +3829,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 
 [[package]]
 name = "typenum"
@@ -4048,7 +3967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
  "futures 0.1.29",
- "log 0.4.11",
+ "log 0.4.8",
  "try-lock",
 ]
 
@@ -4058,7 +3977,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.8",
  "try-lock",
 ]
 
@@ -4070,9 +3989,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.65"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edbcc9536ab7eababcc6d2374a0b7bfe13a2b6d562c5e07f370456b1a8f33d"
+checksum = "6a634620115e4a229108b71bde263bb4220c483b3f07f5ba514ee8d15064c4c2"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4080,24 +3999,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.65"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ed2fb8c84bfad20ea66b26a3743f3e7ba8735a69fe7d95118c33ec8fc1244d"
+checksum = "3e53963b583d18a5aa3aaae4b4c1cb535218246131ba22a71f05b518098571df"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.11",
- "proc-macro2 1.0.19",
+ "log 0.4.8",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.65"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb071268b031a64d92fc6cf691715ca5a40950694d8f683c5bb43db7c730929e"
+checksum = "3fcfd5ef6eec85623b4c6e844293d4516470d8f19cd72d0d12246017eb9060b8"
 dependencies = [
  "quote 1.0.7",
  "wasm-bindgen-macro-support",
@@ -4105,28 +4024,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.65"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf592c807080719d1ff2f245a687cbadb3ed28b2077ed7084b47aba8b691f2c6"
+checksum = "9adff9ee0e94b926ca81b57f57f86d5545cdcb1d259e21ec9bdd95b901754c75"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.35",
+ "syn 1.0.33",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.65"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b6c0220ded549d63860c78c38f3bcc558d1ca3f4efa74942c536ddbbb55e87"
+checksum = "7f7b90ea6c632dd06fd765d44542e234d5e63d9bb917ecd64d79778a13bd79ae"
 
 [[package]]
 name = "web-sys"
-version = "0.3.42"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be2398f326b7ba09815d0b403095f34dd708579220d099caae89be0b32137b2"
+checksum = "863539788676619aac1a23e2df3655e96b32b0e05eb72ca34ba045ad573c625d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",


### PR DESCRIPTION
It seems a recent update to Cargo.lock broke staging and got passed the github build.