### PR TITLE
Bump the version of sqs-lambda lib to 0.20.21.

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -3019,9 +3019,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sqs-lambda"
-version = "0.20.20"
+version = "0.20.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71591691eeb01f85cebdec79a742f8a507f8171f7ba756d4185a82162245c2e2"
+checksum = "55a9ae8ea2a90bf6e8ed7d1e54b5ef2b58924b6f80061f3aefbcb5ad324a2b7d"
 dependencies = [
  "aktors",
  "async-trait",


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This bumps the version of the sqs-lambda used by our Rust services to incorporate a fix we were seeing in an AWS deployment. That fix can be found here: https://github.com/grapl-security/sqs-lambda/commit/b4713e8a45c08ba813bef2f7ecfc56581652a7c2.

### How were these changes tested?

The changes were tested in an AWS deployment using the CloudTrail generator.