### PR TITLE
Fix all urls to point to new docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ you specified a different tag in your build step above you would want
 to specify that same tag here.
 
 See [these
-docs](https://grapl-analyzerlib.readthedocs.io/en/latest/setup/local/)
+docs](https://grapl.readthedocs.io/en/latest/setup/local.html#local-grapl)
 for a more in-depth guide to operating Grapl locally.
 
 We heartily welcome code contributions, but we request for the sake of

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ view all of the information for it by selecting the node.
 
 
 **Analyzers**
-https://grapl-analyzerlib.readthedocs.io/en/latest/analyzers/Implementing%20An%20Analyzer/
+https://grapl.readthedocs.io/en/latest/analyzers/implementing.html
 
 Analyzers are your attacker signatures. They’re Python modules,
 deployed to Grapl’s S3 bucket, that are orchestrated to execute upon
@@ -160,9 +160,4 @@ querying capabilities.
 ## Setup
 Grapl can run locally on your computer, or you can deploy to AWS.
 
-### Local Grapl
-https://grapl-analyzerlib.readthedocs.io/en/latest/setup/local/
-
-### AWS
-
-https://grapl-analyzerlib.readthedocs.io/en/latest/setup/aws/
+https://grapl.readthedocs.io/en/latest/setup/local.html

--- a/docs/setup/local.md
+++ b/docs/setup/local.md
@@ -29,7 +29,7 @@ docker-compose up
 
 **Uploading Your Analyzer**
 
-Next, we’ll upload a basic [Analyzer (Grapl’s attack signatures)](https://grapl-analyzerlib.readthedocs.io/en/latest/analyzers/Implementing%20An%20Analyzer/), which searches for processes named "svchost" without a whitelisted parent process. We've provided a demo Analyzer in the Grapl repository. If you're interested in the code, see our Analyzer docs.
+Next, we’ll upload a basic [Analyzer (Grapl’s attack signatures)](https://grapl.readthedocs.io/en/latest/analyzers/implementing.html), which searches for processes named "svchost" without a whitelisted parent process. We've provided a demo Analyzer in the Grapl repository. If you're interested in the code, see our Analyzer docs.
 
 To upload the Analyzer to Grapl, navigate to the root of the cloned grapl repository and run the following command: 
 
@@ -108,7 +108,7 @@ As we pivot off of the data that we have, our graph expands to visually display 
 
 We’ve kept the data in our demo light so users to become familiar with Grapl’s core features, but you can keep expanding the graph using the notebook to get the full story of what the attacker did.
 
-Check out [our docs](https://grapl-analyzerlib.readthedocs.io/en/latest/) to see other ways to interact with your data.
+Check out [our docs](https://grapl.readthedocs.io/en/latest/) to see other ways to interact with your data.
 
 
 

--- a/src/python/grapl_analyzerlib/README.md
+++ b/src/python/grapl_analyzerlib/README.md
@@ -1,7 +1,7 @@
 # grapl_analyzerlib
 A library for working with [Grapl](https://github.com/insanitybit/grapl)
 
-[readthedocs](https://grapl-analyzerlib.readthedocs.io/en/latest/)
+[readthedocs](https://grapl.readthedocs.io/en/latest/)
 
 # Development Setup
 ```


### PR DESCRIPTION
### Which issue does this PR correspond to?
https://github.com/grapl-security/grapl/issues/214

### What changes does this PR make to Grapl? Why?
Change the docs urls.

### How were these changes tested?
I visited the doc urls.
