### PR TITLE
Fix S3 Origin regex in model plugin deployer.

### DIFF
--- a/src/python/grapl-model-plugin-deployer/src/grapl_model_plugin_deployer.py
+++ b/src/python/grapl-model-plugin-deployer/src/grapl_model_plugin_deployer.py
@@ -272,7 +272,7 @@ def upload_plugin(s3_client: BaseClient, key: str, contents: str) -> None:
 
 
 origin_re = re.compile(
-    f'https://{os.environ["BUCKET_PREFIX"]}-engagement-ux-bucket.s3[.\w\-]{1,14}amazonaws.com/',
+    f'https://{os.environ["BUCKET_PREFIX"]}-engagement-ux-bucket.s3.[\w-]+.amazonaws.com',
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

I was unable to upload model plugins, receiving HTTP 400 response with `{error: "Unexpected Error"}`. Upon checking logs on the backend I noticed "Origin did not match" log lines and found the regex indeed did not match the origin. After making this fix, I was able to upload plugins again.

### How were these changes tested?

Tested these changes in AWS in sandbox environment with AWS plugin.
