### PR TITLE
Docker Swarm CDK and provision

### DIFF
--- a/etc/Grapl Provision.ipynb
+++ b/etc/Grapl Provision.ipynb
@@ -6,6 +6,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip install pydgraph\n",
+    "#!pip install grapl_analyzerlib\n",
+    "!pip install --index-url https://test.pypi.org/simple/ grapl_analyzerlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deployment_name = <YOUR_DEPLOYMENT>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import json\n",
     "import pydgraph\n",
     "\n",
@@ -49,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mclient = DgraphClient(DgraphClientStub('alpha0.master-graph.grapl:9080'))"
+    "mclient = DgraphClient(DgraphClientStub(deployment_name.lower() + '.dgraph.grapl:9080'))"
    ]
   },
   {
@@ -112,7 +132,7 @@
     "def create_user(username, cleartext):\n",
     "    assert cleartext\n",
     "    dynamodb = boto3.resource('dynamodb')\n",
-    "    table = dynamodb.Table('user_auth_table')\n",
+    "    table = dynamodb.Table(deployment_name + '-user_auth_table')\n",
     "    \n",
     "    # We hash before calling 'hashed_password' because the frontend will also perform\n",
     "    # client side hashing\n",
@@ -194,7 +214,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/src/js/grapl-cdk/README.md
+++ b/src/js/grapl-cdk/README.md
@@ -176,9 +176,10 @@ docker stack deploy -c docker-compose-multi.yml dgraph
 # add A records to route53 to make the alpha nodes discoverable
 AWS02_IP=$(docker-machine ip "$AWS02_NAME")
 AWS03_IP=$(docker-machine ip "$AWS03_NAME")
-HOSTED_ZONES_RESPONSE=$(aws route53 list-hosted-zones-by-name --dns-name "alpha.dgraph.graplsecurity.com")
+DNS_NAME=$(echo $GRAPL_DEPLOYMENT | awk '{print tolower($0)}').dgraph.grapl
+HOSTED_ZONES_RESPONSE=$(aws route53 list-hosted-zones-by-name --dns-name "$DNS_NAME")
 HOSTED_ZONE_ID=$(echo $HOSTED_ZONES_RESPONSE | python -c 'import json; import sys; print(json.load(sys.stdin)["HostedZones"][0]["Id"]);')
-echo {\"Changes\": [{\"Action\": \"UPSERT\", \"ResourceRecordSet\": {\"Name\": \"alpha.dgraph.graplsecurity.com\", \"Type\": \"A\", \"TTL\": 300, \"ResourceRecords\": [{\"Value\": \"$AWS01_IP\"}, {\"Value\": \"$AWS02_IP\"}, {\"Value\": \"$AWS03_IP\"}]}}]} > $HOME/batch.json
+echo {\"Changes\": [{\"Action\": \"UPSERT\", \"ResourceRecordSet\": {\"Name\": \"$DNS_NAME\", \"Type\": \"A\", \"TTL\": 300, \"ResourceRecords\": [{\"Value\": \"$AWS01_IP\"}, {\"Value\": \"$AWS02_IP\"}, {\"Value\": \"$AWS03_IP\"}]}}]} > $HOME/batch.json
 aws route53 change-resource-record-sets --hosted-zone-id $HOSTED_ZONE_ID --change-batch file://$HOME/batch.json
 
 # check that all the services are running

--- a/src/js/grapl-cdk/README.md
+++ b/src/js/grapl-cdk/README.md
@@ -109,6 +109,7 @@ base=https://github.com/docker/machine/releases/download/v0.16.2 &&
 curl -L $base/docker-machine-$(uname -s)-$(uname -m) >/tmp/docker-machine &&
 sudo mv /tmp/docker-machine /usr/local/bin/docker-machine &&
 chmod +x /usr/local/bin/docker-machine
+export PATH=/usr/local/bin:$PATH
 
 # extract AWS creds into environment variables
 ROLE=$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials/)
@@ -135,9 +136,9 @@ SWARM_SUBNET_ID=$(curl http://169.254.169.254/latest/meta-data/network/interface
 # spin up ec2 resources with docker-machine
 # see https://dgraph.io/docs//deploy/multi-host-setup/#cluster-setup-using-docker-swarm
 alias dm='/usr/local/bin/docker-machine create --driver "amazonec2" --amazonec2-private-address-only --amazonec2-vpc-id "$SWARM_VPC_ID" --amazonec2-security-group "$SWARM_SECURITY_GROUP" --amazonec2-keypair-name "$KEYPAIR_NAME" --amazonec2-ssh-keypath "$HOME/docker-machine-key.pem" --amazonec2-subnet-id "$SWARM_SUBNET_ID" --amazonec2-instance-type "t3a.medium" --amazonec2-region "$AWS_DEFAULT_REGION"'
-AWS01_NAME=${GRAPL_DEPLOYMENT}-aws01
-AWS02_NAME=${GRAPL_DEPLOYMENT}-aws02
-AWS03_NAME=${GRAPL_DEPLOYMENT}-aws03
+export AWS01_NAME=${GRAPL_DEPLOYMENT}-aws01
+export AWS02_NAME=${GRAPL_DEPLOYMENT}-aws02
+export AWS03_NAME=${GRAPL_DEPLOYMENT}-aws03
 dm "$AWS01_NAME"
 dm "$AWS02_NAME"
 dm "$AWS03_NAME"
@@ -167,9 +168,6 @@ docker swarm join --token $WORKER_JOIN_TOKEN "$AWS01_IP:2377"
 # get DGraph compose template
 cd $HOME
 wget https://github.com/grapl-security/grapl/raw/staging/src/js/grapl-cdk/docker-compose-multi.yml
-sed -e 's/aws01/'"${AWS01_NAME}"'/g' -i docker-compose-multi.yml
-sed -e 's/aws02/'"${AWS02_NAME}"'/g' -i docker-compose-multi.yml
-sed -e 's/aws03/'"${AWS03_NAME}"'/g' -i docker-compose-multi.yml
 
 # start DGraph
 eval $(docker-machine env "$AWS01_NAME" --shell sh)

--- a/src/js/grapl-cdk/README.md
+++ b/src/js/grapl-cdk/README.md
@@ -52,9 +52,9 @@ export const graplVersion = 'YOUR_VERSION';
 
 Some tips for choosing a deployment name:
 
-  - Keep "Grapl" as prefix. This isn't necessary, but will help
+-   Keep "Grapl" as prefix. This isn't necessary, but will help
     identify Grapl resources in your AWS account.
-  - Choose a globally unique name, as this will be used to name S3
+-   Choose a globally unique name, as this will be used to name S3
     buckets, which have this requiement. Using a name that includes
     your AWS account number and deployment region should work.
 
@@ -86,13 +86,16 @@ AWS Console.
 
 To provision DGraph:
 
-  1. Navigate to the [AWS Session Manager
-     console](https://us-east-1.console.aws.amazon.com/systems-manager/session-manager)
-     and click *Start session*. A new window will open in your browser
-     with a terminal prompt on the bastion host.
-  2. Execute the following commands:
+1. Navigate to the [AWS Session Manager
+   console](https://us-east-1.console.aws.amazon.com/systems-manager/session-manager)
+   and click _Start session_. A new window will open in your browser
+   with a terminal prompt on the bastion host.
+2. Execute the following commands:
 
-``` bash
+```bash
+# The Grapl deployment name we used in the CDK
+GRAPL_DEPLOYMENT=<YOUR_DEPLOYMENT>
+
 # install docker
 sudo yum install -y docker
 
@@ -113,7 +116,8 @@ AWS_SESSION_TOKEN=$(echo $RESPONSE | python -c 'import json; import sys; print(j
 AWS_DEFAULT_REGION=$(curl http://169.254.169.254/latest/meta-data/placement/region)
 
 # create a key pair
-aws --region $AWS_DEFAULT_REGION ec2 create-key-pair --key-name docker-machine-key --query 'KeyMaterial' --output text > $HOME/docker-machine-key.pem
+KEYPAIR_NAME=${GRAPL_DEPLOYMENT}-docker
+aws --region $AWS_DEFAULT_REGION ec2 create-key-pair --key-name "$KEYPAIR_NAME" --query 'KeyMaterial' --output text > $HOME/docker-machine-key.pem
 chmod 400 $HOME/docker-machine-key.pem
 ssh-keygen -y -f $HOME/docker-machine-key.pem > $HOME/docker-machine-key.pem.pub
 
@@ -125,9 +129,13 @@ SWARM_SUBNET_ID=$(curl http://169.254.169.254/latest/meta-data/network/interface
 
 # spin up ec2 resources with docker-machine
 # see https://dgraph.io/docs//deploy/multi-host-setup/#cluster-setup-using-docker-swarm
-docker-machine create --driver "amazonec2" --amazonec2-private-address-only --amazonec2-vpc-id "$SWARM_VPC_ID" --amazonec2-security-group "$SWARM_SECURITY_GROUP" --amazonec2-keypair-name "docker-machine-key-pair" --amazonec2-ssh-keypath "$HOME/docker-machine-key.pem" --amazonec2-subnet-id "$SWARM_SUBNET_ID" --amazonec2-instance-type "t3a.medium" aws01
-docker-machine create --driver "amazonec2" --amazonec2-private-address-only --amazonec2-vpc-id "$SWARM_VPC_ID" --amazonec2-security-group "$SWARM_SECURITY_GROUP" --amazonec2-keypair-name "docker-machine-key-pair" --amazonec2-ssh-keypath "$HOME/docker-machine-key.pem" --amazonec2-subnet-id "$SWARM_SUBNET_ID" --amazonec2-instance-type "t3a.medium" aws02
-docker-machine create --driver "amazonec2" --amazonec2-private-address-only --amazonec2-vpc-id "$SWARM_VPC_ID" --amazonec2-security-group "$SWARM_SECURITY_GROUP" --amazonec2-keypair-name "docker-machine-key-pair" --amazonec2-ssh-keypath "$HOME/docker-machine-key.pem" --amazonec2-subnet-id "$SWARM_SUBNET_ID" --amazonec2-instance-type "t3a.medium" aws03
+alias dm='docker-machine create --driver "amazonec2" --amazonec2-private-address-only --amazonec2-vpc-id "$SWARM_VPC_ID" --amazonec2-security-group "$SWARM_SECURITY_GROUP" --amazonec2-keypair-name "$KEYPAIR_NAME" --amazonec2-ssh-keypath "$HOME/docker-machine-key.pem" --amazonec2-subnet-id "$SWARM_SUBNET_ID" --amazonec2-instance-type "t3a.medium" --amazonec2-region "$AWS_DEFAULT_REGION"'
+AWS01_NAME=${GRAPL_DEPLOYMENT}-aws01
+AWS02_NAME=${GRAPL_DEPLOYMENT}-aws02
+AWS03_NAME=${GRAPL_DEPLOYMENT}-aws03
+dm "$AWS01_NAME"
+dm "$AWS02_NAME"
+dm "$AWS03_NAME"
 
 #
 # refer to the DGraph docs for more details about the rest of the setup
@@ -137,28 +145,33 @@ docker-machine create --driver "amazonec2" --amazonec2-private-address-only --am
 #
 
 # create a Docker Swarm cluster
-AWS01_IP=$(docker-machine ip aws01)
-eval $(docker-machine env aws01 --shell sh)
+AWS01_IP=$(docker-machine ip "$AWS01_NAME")
+eval $(docker-machine env "$AWS01_NAME" --shell sh)
 docker swarm init --advertise-addr $AWS01_IP
 
 # extract the join token
 WORKER_JOIN_TOKEN=$(docker swarm join-token worker -q)
 
 # make aws02 and aws03 join the swarm
-eval $(docker-machine env aws02 --shell sh)
+eval $(docker-machine env "$AWS02_NAME" --shell sh)
 docker swarm join --token $WORKER_JOIN_TOKEN "$AWS01_IP:2377"
-eval $(docker-machine env aws03 --shell sh)
+eval $(docker-machine env "$AWS03_NAME" --shell sh)
 docker swarm join --token $WORKER_JOIN_TOKEN "$AWS01_IP:2377"
 
-# start DGraph
+# get DGraph compose template
 cd $HOME
 wget https://github.com/dgraph-io/dgraph/raw/master/contrib/config/docker/docker-compose-multi.yml
-eval $(docker-machine env aws01 --shell sh)
+sed -e 's/aws01/'"${AWS01_NAME}"'/g' -i docker-compose-multi.yml
+sed -e 's/aws02/'"${AWS02_NAME}"'/g' -i docker-compose-multi.yml
+sed -e 's/aws03/'"${AWS03_NAME}"'/g' -i docker-compose-multi.yml
+
+# start DGraph
+eval $(docker-machine env "$AWS01_NAME" --shell sh)
 docker stack deploy -c docker-compose-multi.yml dgraph
 
 # add A records to route53 to make the alpha nodes discoverable
-AWS02_IP=$(docker-machine ip aws02)
-AWS03_IP=$(docker-machine ip aws03)
+AWS02_IP=$(docker-machine ip "$AWS02_NAME")
+AWS03_IP=$(docker-machine ip "$AWS03_NAME")
 HOSTED_ZONES_RESPONSE=$(aws route53 list-hosted-zones-by-name --dns-name "alpha.dgraph.graplsecurity.com")
 HOSTED_ZONE_ID=$(echo $HOSTED_ZONES_RESPONSE | python -c 'import json; import sys; print(json.load(sys.stdin)["HostedZones"][0]["Id"]);')
 echo {\"Changes\": [{\"Action\": \"UPSERT\", \"ResourceRecordSet\": {\"Name\": \"alpha.dgraph.graplsecurity.com\", \"Type\": \"A\", \"TTL\": 300, \"ResourceRecords\": [{\"Value\": \"$AWS01_IP\"}, {\"Value\": \"$AWS02_IP\"}, {\"Value\": \"$AWS03_IP\"}]}}]} > $HOME/batch.json
@@ -173,7 +186,7 @@ docker service ls
 Now that we have DGraph provisioned, it's important to be aware of
 some operational details.
 
-First, *don't lose the key pair*. If, for example, your bastion host
+First, _don't lose the key pair_. If, for example, your bastion host
 crashes and you somehow lost the key pair
 (e.g. `docker-machine-key-pair.pem` from the previous section) then
 `docker-machine` will no longer be able to connect to the DGraph

--- a/src/js/grapl-cdk/README.md
+++ b/src/js/grapl-cdk/README.md
@@ -166,7 +166,7 @@ docker swarm join --token $WORKER_JOIN_TOKEN "$AWS01_IP:2377"
 
 # get DGraph compose template
 cd $HOME
-wget https://github.com/dgraph-io/dgraph/raw/master/contrib/config/docker/docker-compose-multi.yml
+wget https://github.com/grapl-security/grapl/raw/staging/src/js/grapl-cdk/docker-compose-multi.yml
 sed -e 's/aws01/'"${AWS01_NAME}"'/g' -i docker-compose-multi.yml
 sed -e 's/aws02/'"${AWS02_NAME}"'/g' -i docker-compose-multi.yml
 sed -e 's/aws03/'"${AWS03_NAME}"'/g' -i docker-compose-multi.yml

--- a/src/js/grapl-cdk/README.md
+++ b/src/js/grapl-cdk/README.md
@@ -55,7 +55,7 @@ Some tips for choosing a deployment name:
 -   Keep "Grapl" as prefix. This isn't necessary, but will help
     identify Grapl resources in your AWS account.
 -   Choose a globally unique name, as this will be used to name S3
-    buckets, which have this requiement. Using a name that includes
+    buckets, which have this requirement. Using a name that includes
     your AWS account number and deployment region should work.
 
 To enable [Watchful](https://github.com/eladb/cdk-watchful) for

--- a/src/js/grapl-cdk/README.md
+++ b/src/js/grapl-cdk/README.md
@@ -93,11 +93,16 @@ To provision DGraph:
 2. Execute the following commands:
 
 ```bash
-# The Grapl deployment name we used in the CDK
-GRAPL_DEPLOYMENT=<YOUR_DEPLOYMENT>
-
 # install docker
 sudo yum install -y docker
+sudo systemctl enable docker.service
+sudo systemctl start docker.service
+sudo usermod -a -G docker ec2-user
+sudo su ec2-user
+cd
+
+# The Grapl deployment name we used in the CDK
+GRAPL_DEPLOYMENT=<YOUR_DEPLOYMENT>
 
 # install docker-machine
 base=https://github.com/docker/machine/releases/download/v0.16.2 &&
@@ -129,7 +134,7 @@ SWARM_SUBNET_ID=$(curl http://169.254.169.254/latest/meta-data/network/interface
 
 # spin up ec2 resources with docker-machine
 # see https://dgraph.io/docs//deploy/multi-host-setup/#cluster-setup-using-docker-swarm
-alias dm='docker-machine create --driver "amazonec2" --amazonec2-private-address-only --amazonec2-vpc-id "$SWARM_VPC_ID" --amazonec2-security-group "$SWARM_SECURITY_GROUP" --amazonec2-keypair-name "$KEYPAIR_NAME" --amazonec2-ssh-keypath "$HOME/docker-machine-key.pem" --amazonec2-subnet-id "$SWARM_SUBNET_ID" --amazonec2-instance-type "t3a.medium" --amazonec2-region "$AWS_DEFAULT_REGION"'
+alias dm='/usr/local/bin/docker-machine create --driver "amazonec2" --amazonec2-private-address-only --amazonec2-vpc-id "$SWARM_VPC_ID" --amazonec2-security-group "$SWARM_SECURITY_GROUP" --amazonec2-keypair-name "$KEYPAIR_NAME" --amazonec2-ssh-keypath "$HOME/docker-machine-key.pem" --amazonec2-subnet-id "$SWARM_SUBNET_ID" --amazonec2-instance-type "t3a.medium" --amazonec2-region "$AWS_DEFAULT_REGION"'
 AWS01_NAME=${GRAPL_DEPLOYMENT}-aws01
 AWS02_NAME=${GRAPL_DEPLOYMENT}-aws02
 AWS03_NAME=${GRAPL_DEPLOYMENT}-aws03
@@ -148,6 +153,7 @@ dm "$AWS03_NAME"
 AWS01_IP=$(docker-machine ip "$AWS01_NAME")
 eval $(docker-machine env "$AWS01_NAME" --shell sh)
 docker swarm init --advertise-addr $AWS01_IP
+
 
 # extract the join token
 WORKER_JOIN_TOKEN=$(docker swarm join-token worker -q)

--- a/src/js/grapl-cdk/docker-compose-multi.yml
+++ b/src/js/grapl-cdk/docker-compose-multi.yml
@@ -23,7 +23,7 @@ services:
     deploy:
       placement:
         constraints:
-          - node.hostname == aws01
+          - node.hostname == ${AWS01_NAME}
     command: dgraph zero --my=zero:5080 --replicas 3
   alpha1:
     image: dgraph/dgraph:latest
@@ -38,7 +38,7 @@ services:
     deploy:
       placement:
         constraints:
-          - node.hostname == aws01
+          - node.hostname == ${AWS01_NAME}
     command: dgraph alpha --my=alpha1:7080 --lru_mb=2048 --zero=zero:5080 --whitelist=10.0.0.0/8
   alpha2:
     image: dgraph/dgraph:latest
@@ -54,7 +54,7 @@ services:
       replicas: 1
       placement:
         constraints:
-          - node.hostname == aws02
+          - node.hostname == ${AWS02_NAME}
     command: dgraph alpha --my=alpha2:7081 --lru_mb=2048 --zero=zero:5080 -o 1 --whitelist=10.0.0.0/8
   alpha3:
     image: dgraph/dgraph:latest
@@ -70,7 +70,7 @@ services:
       replicas: 1
       placement:
         constraints:
-          - node.hostname == aws03
+          - node.hostname == ${AWS03_NAME}
     command: dgraph alpha --my=alpha3:7082 --lru_mb=2048 --zero=zero:5080 -o 2 --whitelist=10.0.0.0/8
   ratel:
     image: dgraph/dgraph:latest

--- a/src/js/grapl-cdk/docker-compose-multi.yml
+++ b/src/js/grapl-cdk/docker-compose-multi.yml
@@ -1,0 +1,84 @@
+# This file can be used to setup a Dgraph cluster with 3 Dgraph Alphas and 1 Dgraph Zero node on a
+# Docker Swarm with replication.to
+# It expects three virtual machines with hostnames aws01, aws02, and aws03 to be part of the swarm.
+# There is a constraint to make sure that each Dgraph Alpha runs on a particular host.
+
+# Data would be persisted to a Docker volume called data-volume on the virtual machines which are
+# part of the swarm.
+# Run `docker stack deploy -c docker-compose-multi.yml` on the Swarm leader to start the cluster.
+
+version: "3.2"
+networks:
+  dgraph:
+services:
+  zero:
+    image: dgraph/dgraph:latest
+    volumes:
+      - data-volume:/dgraph
+    ports:
+      - 5080:5080
+      - 6080:6080
+    networks:
+      - dgraph
+    deploy:
+      placement:
+        constraints:
+          - node.hostname == aws01
+    command: dgraph zero --my=zero:5080 --replicas 3
+  alpha1:
+    image: dgraph/dgraph:latest
+    hostname: "alpha1"
+    volumes:
+      - data-volume:/dgraph
+    ports:
+      - 8080:8080
+      - 9080:9080
+    networks:
+      - dgraph
+    deploy:
+      placement:
+        constraints:
+          - node.hostname == aws01
+    command: dgraph alpha --my=alpha1:7080 --lru_mb=2048 --zero=zero:5080 --whitelist=10.0.0.0/8
+  alpha2:
+    image: dgraph/dgraph:latest
+    hostname: "alpha2"
+    volumes:
+      - data-volume:/dgraph
+    ports:
+      - 8081:8081
+      - 9081:9081
+    networks:
+      - dgraph
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.hostname == aws02
+    command: dgraph alpha --my=alpha2:7081 --lru_mb=2048 --zero=zero:5080 -o 1 --whitelist=10.0.0.0/8
+  alpha3:
+    image: dgraph/dgraph:latest
+    hostname: "alpha3"
+    volumes:
+      - data-volume:/dgraph
+    ports:
+      - 8082:8082
+      - 9082:9082
+    networks:
+      - dgraph
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.hostname == aws03
+    command: dgraph alpha --my=alpha3:7082 --lru_mb=2048 --zero=zero:5080 -o 2 --whitelist=10.0.0.0/8
+  ratel:
+    image: dgraph/dgraph:latest
+    hostname: "ratel"
+    ports:
+      - 8000:8000
+    networks:
+      - dgraph
+    command: dgraph-ratel
+volumes:
+  data-volume:

--- a/src/js/grapl-cdk/lib/engagement.ts
+++ b/src/js/grapl-cdk/lib/engagement.ts
@@ -225,7 +225,7 @@ export class EngagementEdge extends cdk.NestedStack {
 }
 
 export interface EngagementNotebookProps extends GraplServiceProps {
-    model_plugins_bucket: s3.IBucket,
+    model_plugins_bucket: s3.IBucket;
 }
 
 export class EngagementNotebook extends cdk.NestedStack {
@@ -256,7 +256,6 @@ export class EngagementNotebook extends cdk.NestedStack {
 
         props.userAuthTable.allowReadWriteFromRole(role);
         props.model_plugins_bucket.grantRead(role);
-
 
         new sagemaker.CfnNotebookInstance(this, 'SageMakerEndpoint', {
             notebookInstanceName: props.prefix + '-Notebook',

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -691,7 +691,7 @@ export class GraplCdkStack extends cdk.Stack {
         });
 
         const user_auth_table = new UserAuthDb(this, 'UserAuthTable', {
-            table_name: this.prefix.toLowerCase() + '-user_auth_table',
+            table_name: this.prefix + '-user_auth_table',
         });
 
         let watchful = undefined;

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -304,7 +304,7 @@ class AnalyzerExecutor extends cdk.NestedStack {
                 MESSAGECACHE_PORT: message_cache.cluster.attrRedisEndpointPort,
                 HITCACHE_ADDR: hit_cache.cluster.attrRedisEndpointAddress,
                 HITCACHE_PORT: hit_cache.cluster.attrRedisEndpointPort,
-                GRAPL_LOG_LEVEL: "INFO",
+                GRAPL_LOG_LEVEL: 'INFO',
                 GRPC_ENABLE_FORK_SUPPORT: '1',
             },
             vpc: props.vpc,
@@ -409,22 +409,25 @@ export class DGraphSwarmCluster extends cdk.NestedStack {
     private readonly dgraphSwarmCluster: Swarm;
 
     constructor(
-        parent: cdk.Construct, id: string, props: DGraphSwarmClusterProps
+        parent: cdk.Construct,
+        id: string,
+        props: DGraphSwarmClusterProps
     ) {
         super(parent, id);
 
         this.dgraphAlphaZone = new route53.PrivateHostedZone(
             this,
-            id + "-DGraphSwarmZone",
+            'DGraphSwarmZone',
             {
                 vpc: props.vpc,
-                zoneName: "alpha.dgraph.graplsecurity.com"
+                zoneName: 'alpha.dgraph.graplsecurity.com',
             }
         );
 
-        this.dgraphSwarmCluster = new Swarm(this, props.prefix + "-DGraphSwarmCluster", {
+        this.dgraphSwarmCluster = new Swarm(this, 'DGraphSwarmCluster', {
+            prefix: props.prefix,
             vpc: props.vpc,
-            internalServicePorts: [ec2.Port.tcp(5080), ec2.Port.tcp(7080)]
+            internalServicePorts: [ec2.Port.tcp(5080), ec2.Port.tcp(7080)],
         });
     }
 
@@ -474,7 +477,7 @@ class DGraphTtl extends cdk.NestedStack {
             timeout: cdk.Duration.seconds(600),
             memorySize: 128,
             description: props.version,
-            role
+            role,
         });
         event_handler.currentVersion.addAlias('live');
 
@@ -702,9 +705,11 @@ export class GraplCdkStack extends cdk.Stack {
         }
 
         const dgraphSwarmCluster = new DGraphSwarmCluster(
-            this, 'dgraph-swarm-cluster', {
+            this,
+            'dgraph-swarm-cluster',
+            {
                 prefix: this.prefix,
-                vpc: grapl_vpc
+                vpc: grapl_vpc,
             }
         );
 

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -427,7 +427,7 @@ export class DGraphSwarmCluster extends cdk.NestedStack {
         this.dgraphSwarmCluster = new Swarm(this, 'DGraphSwarmCluster', {
             prefix: props.prefix,
             vpc: props.vpc,
-            internalServicePorts: [ec2.Port.tcp(5080), ec2.Port.tcp(6080), ec2.Port.tcp(7080), ec2.Port.tcp(7081), ec2.Port.tcp(7082), ec2.Port.tcp(9080), ec2.Port.tcp(9081), ec2.Port.tcp(9082)],
+            internalServicePorts: [ec2.Port.tcp(5080), ec2.Port.tcp(7080), ec2.Port.tcp(7081), ec2.Port.tcp(7082)],
         });
     }
 
@@ -437,6 +437,8 @@ export class DGraphSwarmCluster extends cdk.NestedStack {
 
     public allowConnectionsFrom(other: ec2.IConnectable): void {
         this.dgraphSwarmCluster.allowConnectionsFrom(other, ec2.Port.tcp(9080));
+        this.dgraphSwarmCluster.allowConnectionsFrom(other, ec2.Port.tcp(9081));
+        this.dgraphSwarmCluster.allowConnectionsFrom(other, ec2.Port.tcp(9082));
     }
 }
 

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -420,7 +420,7 @@ export class DGraphSwarmCluster extends cdk.NestedStack {
             'DGraphSwarmZone',
             {
                 vpc: props.vpc,
-                zoneName: 'alpha.dgraph.graplsecurity.com',
+                zoneName: props.prefix.toLowerCase() + '.dgraph.grapl',
             }
         );
 

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -427,7 +427,7 @@ export class DGraphSwarmCluster extends cdk.NestedStack {
         this.dgraphSwarmCluster = new Swarm(this, 'DGraphSwarmCluster', {
             prefix: props.prefix,
             vpc: props.vpc,
-            internalServicePorts: [ec2.Port.tcp(5080), ec2.Port.tcp(7080)],
+            internalServicePorts: [ec2.Port.tcp(5080), ec2.Port.tcp(6080), ec2.Port.tcp(7080), ec2.Port.tcp(7081), ec2.Port.tcp(7082), ec2.Port.tcp(9080), ec2.Port.tcp(9081), ec2.Port.tcp(9082)],
         });
     }
 

--- a/src/js/grapl-cdk/lib/swarm.ts
+++ b/src/js/grapl-cdk/lib/swarm.ts
@@ -1,7 +1,6 @@
 import * as cdk from '@aws-cdk/core';
 import * as ec2 from '@aws-cdk/aws-ec2';
 import * as iam from '@aws-cdk/aws-iam';
-import { PropagatedTagSource } from '@aws-cdk/aws-ecs';
 
 export interface SwarmProps {
     // Grapl deployment name prefix

--- a/src/js/grapl-cdk/lib/swarm.ts
+++ b/src/js/grapl-cdk/lib/swarm.ts
@@ -1,8 +1,11 @@
 import * as cdk from '@aws-cdk/core';
 import * as ec2 from '@aws-cdk/aws-ec2';
 import * as iam from '@aws-cdk/aws-iam';
+import { PropagatedTagSource } from '@aws-cdk/aws-ecs';
 
 export interface SwarmProps {
+    // Grapl deployment name prefix
+    readonly prefix: String;
 
     // The VPC where the Docker Swarm cluster will run
     readonly vpc: ec2.IVpc;
@@ -15,16 +18,14 @@ export interface SwarmProps {
 export class Swarm extends cdk.Construct {
     private readonly swarmSecurityGroup: ec2.ISecurityGroup;
 
-    constructor(
-        scope: cdk.Construct,
-        id: string,
-        swarmProps: SwarmProps
-    ) {
+    constructor(scope: cdk.Construct, id: string, swarmProps: SwarmProps) {
         super(scope, id);
 
-        const swarmSecurityGroup = new ec2.SecurityGroup(scope, id + "-swarm-security-group", {
+        const swarmSecurityGroup = new ec2.SecurityGroup(scope, 'Swarm', {
+            securityGroupName: swarmProps.prefix + '-Swarm',
+            description: `${swarmProps.prefix} DGraph Swarm security group`,
             vpc: swarmProps.vpc,
-            allowAllOutbound: false
+            allowAllOutbound: false,
         });
         // allow the bastion machine to make outbound connections to
         // the Internet for these services:
@@ -49,17 +50,17 @@ export class Swarm extends cdk.Construct {
 
         // allow hosts in the swarm security group to communicate
         // internally on the given service ports.
-        swarmProps.internalServicePorts.forEach(
-            (port, _) => swarmSecurityGroup.connections.allowInternally(port)
+        swarmProps.internalServicePorts.forEach((port, _) =>
+            swarmSecurityGroup.connections.allowInternally(port)
         );
 
         this.swarmSecurityGroup = swarmSecurityGroup;
 
-        const bastion = new ec2.BastionHostLinux(this, id + 'bastion', {
+        const bastion = new ec2.BastionHostLinux(this, 'Bastion', {
             vpc: swarmProps.vpc,
             securityGroup: swarmSecurityGroup,
-            instanceType: new ec2.InstanceType("t3a.nano"),
-            instanceName: "SwarmBastion"
+            instanceType: new ec2.InstanceType('t3a.nano'),
+            instanceName: swarmProps.prefix + '-SwarmBastion',
         });
 
         /* configure a bunch of AWS permissions to enable
@@ -129,33 +130,34 @@ export class Swarm extends cdk.Construct {
         const statement = new iam.PolicyStatement({
             effect: iam.Effect.ALLOW,
             actions: [
-                "ec2:DescribeSecurityGroups",
-                "ec2:CreateSecurityGroup",
-                "ec2:DescribeSubnets",
-                "ec2:DescribeKeyPairs",
-                "ec2:CreateKeyPair",
-                "ec2:DescribeSpotInstances",
-                "ec2:DescribeSpotInstanceRequests",
-                "ec2:RequestSpotInstances",
-                "ec2:CancelSpotInstanceRequests",
-                "ec2:DescribeInstances",
-                "ec2:RunInstances",
-                "ec2:StartInstances",
-                "ec2:StopInstances",
-                "ec2:RebootInstances",
-                "ec2:TerminateInstances",
-                "ec2:CreateTags",
-                "route53:ListHostedZonesByName",
-                "route53:ChangeResourceRecordSets"
+                'ec2:DescribeSecurityGroups',
+                'ec2:CreateSecurityGroup',
+                'ec2:DescribeSubnets',
+                'ec2:DescribeKeyPairs',
+                'ec2:CreateKeyPair',
+                'ec2:DescribeSpotInstances',
+                'ec2:DescribeSpotInstanceRequests',
+                'ec2:RequestSpotInstances',
+                'ec2:CancelSpotInstanceRequests',
+                'ec2:DescribeInstances',
+                'ec2:RunInstances',
+                'ec2:StartInstances',
+                'ec2:StopInstances',
+                'ec2:RebootInstances',
+                'ec2:TerminateInstances',
+                'ec2:CreateTags',
+                'route53:ListHostedZonesByName',
+                'route53:ChangeResourceRecordSets',
             ],
-            resources: ["*"]
+            resources: ['*'],
         });
 
         bastion.role.addToPrincipalPolicy(statement);
     }
 
     public allowConnectionsFrom(
-        other: ec2.IConnectable, portRange: ec2.Port
+        other: ec2.IConnectable,
+        portRange: ec2.Port
     ): void {
         this.swarmSecurityGroup.connections.allowFrom(other, portRange);
     }


### PR DESCRIPTION
### Which issue does this PR correspond to?

There were a couple issues this resolves:

1. Grapl Jupyter provision from wasn't working due to DGraph not whitelisting IPs
2. Docker Swarm AWS resources need deployment prefix in their names to support multiple deployments within an AWS environment.

### What changes does this PR make to Grapl? Why?

1. The DGraph alphas now whitelist 10.0.0.0/8
2. DGraph AWS resources now have Grapl deployment name prefixed
3. Docker/DGraph provision now enables the docker systemctl service, and we run the provision as `ec2-user` instead of `ssm-user`.

### How were these changes tested?

Tested by running a single deployment in AWS sandbox account and running all provision steps, as well as deployed AWS plugin and uploaded model plugin via Grapl UI.
