### PR TITLE
Add a 'dobi python-typecheck' and corresponding Github Actions workflow

### DIFF
--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -57,6 +57,21 @@ jobs:
         run: |
           GRAPL_RELEASE_TARGET=debug TAG=latest ./dobi-linux --no-bind-mount python-unit-tests
 
+  python-typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dobi
+        run: |
+          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
+          chmod +x dobi-linux
+
+      - name: Build Python services
+        run: |
+          GRAPL_RELEASE_TARGET=debug TAG=latest ./dobi-linux python-typecheck
+
   js-unit-tests:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -68,7 +68,7 @@ jobs:
           wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
           chmod +x dobi-linux
 
-      - name: Build Python services
+      - name: Run dobi python-typecheck
         run: |
           GRAPL_RELEASE_TARGET=debug TAG=latest ./dobi-linux python-typecheck
 

--- a/.github/workflows/grapl-lint.yml
+++ b/.github/workflows/grapl-lint.yml
@@ -51,13 +51,6 @@ jobs:
           source .venv/bin/activate
           black --check .
 
-      # NOTE: this task always succeeds because '|| true'
-      # TODO: fix this.
-      - name: Run Mypy (Always Pass)
-        run: |
-          source .venv/bin/activate
-          mypy . || true
-
   check-pypi:
     runs-on: ubuntu-latest
 

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -708,7 +708,10 @@ alias=integration-tests:
   annotations:
     description: "Run all the integration tests"
 
-alias=typecheck:
+alias=python-typecheck:
   tasks:
+    # TODO: Add more and more here!
     - run-grapl-common-typecheck
     - run-analyzer-deployer-typecheck
+  annotations:
+    description: "Run mypy or pytype type checks on a subset of our Python libs/services"

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -435,6 +435,24 @@ job=run-grapl-common-unit-tests:
   use: grapl-common-build
   command: /bin/bash -c "source venv/bin/activate && cd grapl_common/tests && ls && py.test -n auto -m 'not integration_test'"
 
+job=run-grapl-common-typecheck:
+  use: grapl-common-build
+  command: /bin/bash -c "
+    source venv/bin/activate &&
+    pip install mypy &&
+    cd grapl_common &&
+    mypy ."
+
+job=run-analyzer-deployer-typecheck:
+  use: analyzer-deployer-build
+  # the `touch` is a hack for mypy until https://github.com/aws/chalice/pull/1500 is in
+  command: /bin/bash -c "
+    source venv/bin/activate &&
+    pip install mypy &&
+    touch venv/lib/python3.7/site-packages/chalice/py.typed &&
+    cd analyzer-deployer &&
+    mypy ."
+
 job=run-grapl-analyzerlib-unit-tests:
   use: grapl-analyzerlib-build
   command: /bin/bash -c "source venv/bin/activate && cd grapl_analyzerlib && py.test -n auto -m 'not integration_test'"
@@ -689,3 +707,8 @@ alias=integration-tests:
     # TODO: js integration tests
   annotations:
     description: "Run all the integration tests"
+
+alias=typecheck:
+  tasks:
+    - run-grapl-common-typecheck
+    - run-analyzer-deployer-typecheck

--- a/src/python/analyzer-deployer/analyzer_deployer/app.py
+++ b/src/python/analyzer-deployer/analyzer_deployer/app.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import List
+from typing import List, Optional
 
 import boto3
 
@@ -11,8 +11,8 @@ app = Chalice(app_name="analyzer-deployer")
 
 
 def _create_queue(queue_name: str):
-    client: sqs.Client = boto3.resource("sqs")
-    client.create_queue()
+    client: sqs.SQSServiceResource = boto3.resource("sqs")
+    client.create_queue(QueueName=queue_name)
     pass
 
 
@@ -40,16 +40,16 @@ class TableConfig:
 @dataclasses.dataclass
 class SecretConfig:
     SecretId: str
-    VersionId: str = None
-    VersionStage: str = None
+    VersionId: Optional[str] = None
+    VersionStage: Optional[str] = None
 
 
 @dataclasses.dataclass
 class AnalyzerConfig:
-    requires_external_internet: List[PortConfig] = None
-    requires_dynamodb: List[TableConfig] = None
+    requires_external_internet: Optional[List[PortConfig]] = None
+    requires_dynamodb: Optional[List[TableConfig]] = None
     requires_graph: bool = False
-    requires_secrets: List[SecretConfig] = None
+    requires_secrets: Optional[List[SecretConfig]] = None
 
 
 @dataclasses.dataclass
@@ -58,8 +58,8 @@ class AnalyzerDeployment:
     analyzer_version: int
     s3_key: str
     currently_deployed: bool
-    last_deployed_time: int = None
-    analyzer_configuration: AnalyzerConfig = None
+    last_deployed_time: Optional[int] = None
+    analyzer_configuration: Optional[AnalyzerConfig] = None
 
 
 @dataclasses.dataclass
@@ -72,7 +72,7 @@ class CreateAnalyzerResponse:
 def _create_analyzer(
     dynamodb_client: dynamodb.DynamoDBServiceResource,
 ) -> CreateAnalyzerResponse:
-    analyzer = Analyzer()
+    analyzer = Analyzer()  # type: ignore
     analyzers_table = dynamodb_client.Table("Analyzers")
     return CreateAnalyzerResponse("id", 0, "key")  # FIXME
 

--- a/src/python/analyzer-deployer/tests/test_app.py
+++ b/src/python/analyzer-deployer/tests/test_app.py
@@ -24,18 +24,21 @@ from analyzer_deployer.app import (
 def _analyzers() -> st.SearchStrategy[Analyzer]:
     return st.builds(
         Analyzer,
-        **{
-            "analyzer_id": st.text(),
-            "analyzer_versions": st.lists(st.integers()),
-            "analyzer_active": st.booleans(),
-            "created_time": st.integers(),
-            "last_update_time": st.integers(),
-        }
+        st.builds(
+            dict,
+            analyzer_id=st.text(),
+            analyzer_versions=st.lists(st.integers()),
+            analyzer_active=st.booleans(),
+            created_time=st.integers(),
+            last_update_time=st.integers(),
+        ),
     )
 
 
 def _port_configs() -> st.SearchStrategy[PortConfig]:
-    return st.builds(PortConfig, **{"protocol": st.text(), "port": st.integers()})
+    return st.builds(
+        PortConfig, st.builds(dict, protocol=st.text(), port=st.integers(),)
+    )
 
 
 def _table_configs():
@@ -115,5 +118,5 @@ class TestApp(unittest.TestCase):
             self.assertIsNotNone(response.body)
 
     @pytest.mark.integration_test
-    def test_create_analyzer(self):
+    def test_create_analyzer_integration(self):
         pass

--- a/src/python/grapl-common/grapl_common/py.typed
+++ b/src/python/grapl-common/grapl_common/py.typed
@@ -1,0 +1,1 @@
+# PEP 561 marker file

--- a/src/python/grapl-common/mypy.ini
+++ b/src/python/grapl-common/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+python_version = 3.7
+warn_return_any = True
+warn_unused_configs = True
+# for things without type stubs, like setuptools
+ignore_missing_imports = True
+mypy_path = "./venv/lib/python3.7/site-packages/:./venv/lib/python3.7/site-packages/pydgraph/"

--- a/src/python/grapl-common/setup.py
+++ b/src/python/grapl-common/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     zip_safe=False,
     packages=find_packages(),
-    package_data={},
+    package_data={"grapl-common": ["py.typed",]},
     include_package_data=True,
     install_requires=[
         # We might want this in the future


### PR DESCRIPTION
I've added Dobi targets that will run mypy on two of our libs/services: analyzer-deployer and grapl-common.

The existing mypy typecheck workflow simply silently failed.

I chose these two, for starters, because they:
- do not depend on analyzerlib
- are easy to get down to 0 type failures