### PR TITLE
Metric Forwarder: parsing input, converting to Cloudwatch, sneding to Cloudwatch

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1756,10 +1756,15 @@ dependencies = [
  "aws_lambda_events 0.2.7",
  "base64 0.10.1",
  "flate2",
+ "futures 0.3.5",
  "grapl-config",
  "lambda_runtime",
  "log 0.4.8",
+ "rayon",
+ "rusoto_cloudwatch",
+ "rusoto_core",
  "serde_json",
+ "statsd-parser",
  "thiserror",
  "tokio 0.2.21",
  "tokio-compat",
@@ -2600,6 +2605,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_cloudwatch"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18ab2f07f31fbaadbb4b9ac23f941dce0698d7df015a462d4aa76358b05851c"
+dependencies = [
+ "async-trait",
+ "bytes 0.5.5",
+ "futures 0.3.5",
+ "rusoto_core",
+ "serde_urlencoded",
+ "xml-rs",
+]
+
+[[package]]
 name = "rusoto_core"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3131,6 +3150,12 @@ checksum = "b0437cfb83762844799a60e1e3b489d5ceb6a650fbacb86437badc1b6d87b246"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "statsd-parser"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8f85387840bde2a5ee7d4d0ee9cb035334fdb9ed6b51ad5277063e4b7bef8f"
 
 [[package]]
 name = "stdweb"

--- a/src/rust/grapl-observe/src/statsd_formatter.rs
+++ b/src/rust/grapl-observe/src/statsd_formatter.rs
@@ -40,6 +40,7 @@ impl MetricType {
 
 /**
 Don't call statsd_format directly; instead, prefer the public functions of MetricClient.
+To go from a formatted string to usable data again, use the 'statsd-parser' crate.
 */
 #[allow(dead_code)]
 pub fn statsd_format(

--- a/src/rust/metric-forwarder/Cargo.toml
+++ b/src/rust/metric-forwarder/Cargo.toml
@@ -11,11 +11,14 @@ async-trait = "0.1.22"
 aws_lambda_events = "0.2.1"
 base64 = "0.10.1"
 flate2 = "1.0.6"
+futures = "0.3.*"
 lambda_runtime = "0.2.*"
 log = "0.4.6"
-# dont need it yet + causes openssl issues
-# rusoto_cloudwatch = "0.43.0"
+rayon = "1.0.3"
+rusoto_cloudwatch = { version="0.43.0", default_features = false, features=["rustls"] }
+rusoto_core = { version="0.43.0", default_features = false, features=["rustls"] }
 serde_json = "1.0.53"
+statsd-parser = "0.3.0"
 thiserror = "1.0.20"
 tokio-compat = "0.1.*"
 tokio = { version = "0.2.*", features = ["sync", "rt-core", "macros", "time", "rt-threaded"] }

--- a/src/rust/metric-forwarder/based_on_github_repo.md
+++ b/src/rust/metric-forwarder/based_on_github_repo.md
@@ -25,3 +25,14 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+Pieces of this code are based on this repo:
+
+https://github.com/theburningmonk/lambda-logging-metrics-demo
+(in particular, just the test example of what the Cloudwatch logs look like)
+As such, in following with the MIT license, I'm copy-pasting the below notice.
+
+MIT License
+
+Copyright (c) 2017 Yan Cui

--- a/src/rust/metric-forwarder/src/cloudwatch_logs_parse.rs
+++ b/src/rust/metric-forwarder/src/cloudwatch_logs_parse.rs
@@ -1,0 +1,144 @@
+use aws_lambda_events::event::cloudwatch_logs::{CloudwatchLogsData, CloudwatchLogsLogEvent};
+use rayon::prelude::*;
+use statsd_parser;
+
+use crate::error::MetricForwarderError;
+
+#[derive(Debug)]
+pub struct Stat {
+    pub msg: statsd_parser::Message,
+    pub timestamp: String,
+}
+
+const MONITORING_PREFIX: &'static str = "MONITORING|";
+const CLOUDWATCH_LOGS_DELIM: &'static str = "\t";
+
+pub fn parse_logs(logs_data: CloudwatchLogsData) -> Vec<Result<Stat, MetricForwarderError>> {
+    /*
+    Parse the incoming, raw logs into a platform-agnostic Stat type.
+    */
+    logs_data
+        .log_events
+        .par_iter()
+        .filter_map(|logs_log_event: &CloudwatchLogsLogEvent| logs_log_event.message.as_ref())
+        .map(|s| parse_log(s))
+        .collect()
+}
+
+fn parse_log(log_str: &str) -> Result<Stat, MetricForwarderError> {
+    /*
+    a typical CloudWatch Logs log message looks like this:
+        "2017-04-26T10:41:09.023Z\tdb95c6da-2a6c-11e7-9550-c91b65931beb\tmy log message\n"
+           <ts>                  \t         <dont care>                \t <log contents>\n
+    */
+    let split: Vec<&str> = log_str.splitn(3, CLOUDWATCH_LOGS_DELIM).collect();
+    if split.len() != 3 {
+        return Err(MetricForwarderError::PoorlyFormattedLogLine(
+            log_str.to_string(),
+        ));
+    }
+    let timestamp = split[0];
+    let statsd_component = parse_statsd_component(split[2]);
+    statsd_component.map(|statsd_message| Stat {
+        timestamp: timestamp.to_string(),
+        msg: statsd_message,
+    })
+}
+
+fn parse_statsd_component(log_str: &str) -> Result<statsd_parser::Message, MetricForwarderError> {
+    let stripped = log_str.strip_prefix(MONITORING_PREFIX);
+    match stripped {
+        Some(s) => statsd_parser::parse(s).map_err(|parse_err| {
+            MetricForwarderError::ParseStringToStatsdError(parse_err.to_string())
+        }),
+        _ => Err(MetricForwarderError::PoorlyFormattedLogLine(
+            log_str.to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cloudwatch_logs_parse::parse_log;
+    use crate::cloudwatch_logs_parse::CLOUDWATCH_LOGS_DELIM;
+    use crate::error::MetricForwarderError;
+    use statsd_parser::Counter;
+    use statsd_parser::Metric;
+
+    #[test]
+    fn test_parse_one_log() -> Result<(), MetricForwarderError> {
+        let input = [
+            "2017-04-26T10:41:09.023Z",
+            "db95c6da-2a6c-11e7-9550-c91b65931beb",
+            // you'll note I threw a gross, extra \t in the metric name as an edge case
+            "MONITORING|some_\tstr:12345.6|c|#some_key=some_value,some_key_2=some_value_2\n",
+        ];
+        let input_joined = input.join(CLOUDWATCH_LOGS_DELIM);
+        let parsed = parse_log(input_joined.as_str())?;
+        assert_eq!(parsed.msg.name, "some_\tstr");
+        assert_eq!(
+            parsed.msg.metric,
+            Metric::Counter(Counter {
+                value: 12345.6,
+                sample_rate: None
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_but_doesnt_have_three_elements_joined_by_tab() -> Result<(), String> {
+        let input = ["just two", "things separated by tab"];
+        let input_joined = input.join(CLOUDWATCH_LOGS_DELIM);
+        let parsed = parse_log(input_joined.as_str());
+        match parsed {
+            Err(e) => {
+                assert_eq!(
+                    e,
+                    MetricForwarderError::PoorlyFormattedLogLine(input_joined)
+                );
+                Ok(())
+            }
+            Ok(_) => Err(String::from("we expected an err here")),
+        }
+    }
+
+    #[test]
+    fn test_no_monitoring_prefix() -> Result<(), String> {
+        let input = [
+            "2017-04-26T10:41:09.023Z",
+            "db95c6da-2a6c-11e7-9550-c91b65931beb",
+            "some_str:12345.6|c|#some_key=some_value,some_key_2=some_value_2\n",
+        ];
+        let input_joined = input.join(CLOUDWATCH_LOGS_DELIM);
+        let parsed = parse_log(input_joined.as_str());
+        match parsed {
+            Err(e) => {
+                assert_eq!(
+                    e,
+                    MetricForwarderError::PoorlyFormattedLogLine(input[2].to_string())
+                );
+                Ok(())
+            }
+            Ok(_) => Err(String::from("we expected an err here")),
+        }
+    }
+
+    #[test]
+    fn test_couldnt_parse_statsd() -> Result<(), String> {
+        let input = [
+            "2017-04-26T10:41:09.023Z",
+            "db95c6da-2a6c-11e7-9550-c91b65931beb",
+            "MONITORING|some_str:12345.6|fake_metric_type",
+        ];
+        let input_joined = input.join(CLOUDWATCH_LOGS_DELIM);
+        let parsed = parse_log(input_joined.as_str());
+        match parsed {
+            Err(MetricForwarderError::ParseStringToStatsdError(e)) => {
+                assert_eq!(e, statsd_parser::ParseError::UnknownMetricType.to_string());
+                Ok(())
+            }
+            _ => Err(String::from("we expected an err here")),
+        }
+    }
+}

--- a/src/rust/metric-forwarder/src/cloudwatch_logs_parse.rs
+++ b/src/rust/metric-forwarder/src/cloudwatch_logs_parse.rs
@@ -42,7 +42,7 @@ fn parse_log(log_str: &str) -> Result<Stat, MetricForwarderError> {
         }
         _ => Err(MetricForwarderError::PoorlyFormattedLogLine(
             log_str.to_string(),
-        ))
+        )),
     }
 }
 

--- a/src/rust/metric-forwarder/src/cloudwatch_send.rs
+++ b/src/rust/metric-forwarder/src/cloudwatch_send.rs
@@ -1,0 +1,177 @@
+use crate::cloudwatch_logs_parse::Stat;
+use crate::error::MetricForwarderError;
+use async_trait::async_trait;
+use futures::future;
+use log::warn;
+use rayon::prelude::*;
+use rusoto_cloudwatch::PutMetricDataError;
+use rusoto_cloudwatch::{CloudWatch, CloudWatchClient, MetricDatum, PutMetricDataInput};
+use rusoto_core::RusotoError;
+use statsd_parser;
+use statsd_parser::Metric;
+use std::collections::vec_deque;
+use std::collections::VecDeque;
+
+mod units {
+    // strings accepted by CloudWatch MetricDatum.unit
+    pub const COUNT: &'static str = "Count";
+    pub const MILLIS: &'static str = "Milliseconds";
+}
+
+type PutResult = Result<(), RusotoError<PutMetricDataError>>;
+
+#[async_trait]
+pub trait CloudWatchPutter {
+    // a subset of trait CloudWatch with the 1 function we want
+    async fn put_metric_data(&self, input: PutMetricDataInput) -> PutResult;
+}
+
+#[async_trait]
+impl<T> CloudWatchPutter for T
+where
+    T: CloudWatch + Sync + Send,
+{
+    async fn put_metric_data(&self, input: PutMetricDataInput) -> PutResult {
+        self.put_metric_data(input).await
+    }
+}
+
+// Hardcoded for now to defer making a decision on how we want to do this
+const CLOUDWATCH_NAMESPACE: &'static str = "grapl";
+
+pub async fn put_metric_data(
+    client: &impl CloudWatchPutter,
+    metrics: &[MetricDatum],
+) -> Result<(), MetricForwarderError> {
+    /*
+    Call Cloudwatch to insert metric data. Does batching on our behalf.
+    */
+
+    let chunks = metrics.chunks(20).map(|chunk| chunk.to_vec());
+    let put_requests = chunks.map(|data: Vec<MetricDatum>| PutMetricDataInput {
+        // TODO: should we do different namespaces for different services?
+        namespace: CLOUDWATCH_NAMESPACE.to_string(),
+        metric_data: data,
+    });
+
+    let request_futures = put_requests.map(|input| client.put_metric_data(input));
+    let responses: Vec<PutResult> = future::join_all(request_futures).await;
+
+    // TODO: retries
+    let failures: usize = responses.iter().filter(|resp| resp.is_err()).count();
+    match failures {
+        0 => Ok(()),
+        _ => Err(MetricForwarderError::PutMetricDataError(failures)),
+    }
+}
+
+pub fn statsd_as_cloudwatch_metric_bulk(
+    parsed_stats: Vec<Result<Stat, MetricForwarderError>>,
+) -> Vec<MetricDatum> {
+    /*
+    Convert the platform-agnostic Stat type to Cloudwatch-specific type.
+    */
+    parsed_stats
+        .par_iter()
+        // You will note that we drop metrics we couldn't parse. Theoretically it should never happen, but would be nice to know.
+        // TODO: self-instrumentation around "how many stats do we drop?" Theoretically 0. We warn in the mean time.
+        .filter_map(|stat_res| match stat_res {
+            Ok(stat) => Some(statsd_as_cloudwatch_metric(stat)),
+            Err(e) => {
+                warn!("Dropped metric: {}", e);
+                None
+            }
+        })
+        .collect()
+}
+
+fn statsd_as_cloudwatch_metric(stat: &Stat) -> MetricDatum {
+    let (unit, value, _sample_rate) = match &stat.msg.metric {
+        // Yes, gauge and counter are - for our purposes - basically both Count
+        Metric::Gauge(g) => (units::COUNT, g.value, g.sample_rate),
+        Metric::Counter(c) => (units::COUNT, c.value, c.sample_rate),
+        Metric::Histogram(h) => (units::MILLIS, h.value, h.sample_rate),
+        _ => panic!("How the heck did you get an unsupported metric type in here?"),
+    };
+    MetricDatum {
+        metric_name: stat.msg.name.to_string(),
+        timestamp: stat.timestamp.to_string().into(),
+        unit: unit.to_string().into(),
+        value: value.into(),
+        // TODO dimensions == tags
+        // TODO seems like cloudwatch has no concept of sample rate, lol
+        // many of the following are useful for batching:
+        // e.g. counts: [1, 5] + values: [1.0, 2.0] means that
+        // 1.0 was observed 1x && 2.0 was observed 5x
+        counts: None,
+        values: None,
+        dimensions: None,
+        statistic_values: None,
+        storage_resolution: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cloudwatch_logs_parse::Stat;
+    use crate::cloudwatch_send::*; // TODO fix
+    use rusoto_cloudwatch::MetricDatum;
+    use statsd_parser;
+
+    #[test]
+    fn test_convert_one_datum() {
+        let ts = "im timestamp".to_string();
+        let name = "im a name".to_string();
+        let counter = statsd_parser::Counter {
+            value: 12.3,
+            sample_rate: Some(0.5),
+        };
+        let stat = Stat {
+            timestamp: ts.clone(),
+            msg: statsd_parser::Message {
+                name: name.clone(),
+                tags: None,
+                metric: statsd_parser::Metric::Counter(counter),
+            },
+        };
+
+        let datum: MetricDatum = statsd_as_cloudwatch_metric(&stat);
+        assert_eq!(&datum.metric_name, &name);
+        assert_eq!(&datum.timestamp.expect(""), &ts);
+        assert_eq!(datum.value.expect(""), 12.3);
+        assert_eq!(datum.unit.expect(""), units::COUNT);
+    }
+
+    /*
+    // TODO wimax: mannnn i just wanna mock this thing out!!!
+    pub struct MockCloudwatchClient {
+        pub put_calls: Vec<PutMetricDataInput>,
+        response_fn: Box<dyn Fn(PutMetricDataInput) -> PutResult + Send>,
+    }
+    impl MockCloudwatchClient {
+        pub fn new(response_fn: Box<dyn Fn(PutMetricDataInput) -> PutResult + Send>) -> MockCloudwatchClient {
+            MockCloudwatchClient {
+                put_calls: vec![],
+                response_fn: response_fn,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CloudWatchPutter for MockCloudwatchClient
+    {
+        async fn put_metric_data(
+            &mut self,
+            input: PutMetricDataInput,
+        ) -> PutResult
+        {
+            self.put_calls.push(input.clone());
+            return (self.response_fn)(input)
+        }
+    }
+
+
+    #[test]
+    fn test_put_metric_data() {}
+    */
+}

--- a/src/rust/metric-forwarder/src/cloudwatch_send.rs
+++ b/src/rust/metric-forwarder/src/cloudwatch_send.rs
@@ -114,8 +114,9 @@ fn statsd_as_cloudwatch_metric(stat: &Stat) -> MetricDatum {
 #[cfg(test)]
 mod tests {
     use crate::cloudwatch_logs_parse::Stat;
-    use crate::cloudwatch_send::{statsd_as_cloudwatch_metric, units};
-    use rusoto_cloudwatch::MetricDatum;
+    use crate::cloudwatch_send::{statsd_as_cloudwatch_metric, CloudWatchPutter, PutResult, units};
+    use rusoto_cloudwatch::{MetricDatum, PutMetricDataInput};
+    use rusoto_cloudwatch::PutMetricDataError;
     use statsd_parser;
 
     #[test]
@@ -142,22 +143,31 @@ mod tests {
         assert_eq!(datum.unit.expect(""), units::COUNT);
     }
 
-    /*
     // TODO wimax: mannnn i just wanna mock this thing out!!!
     use std::collections::vec_deque;
     use std::collections::VecDeque;
     pub struct MockCloudwatchClient {
-        pub put_calls: Vec<PutMetricDataInput>,
         response_fn: Box<dyn Fn(PutMetricDataInput) -> PutResult + Send>,
     }
     impl MockCloudwatchClient {
         pub fn new(response_fn: Box<dyn Fn(PutMetricDataInput) -> PutResult + Send>) -> MockCloudwatchClient {
             MockCloudwatchClient {
-                put_calls: vec![],
                 response_fn: response_fn,
             }
         }
+
+        fn return_ok(input: PutMetricDataInput) -> PutResult { 
+            Ok(())
+        }
+
+        /*
+        fn return_an_err(input: PutMetricDataInput) -> PutResult {
+            Err(RusotoError::from(PutMetricDataError::InternalServiceFault))
+
+        }
+        */
     }
+
 
     #[async_trait]
     impl CloudWatchPutter for MockCloudwatchClient
@@ -167,13 +177,14 @@ mod tests {
             input: PutMetricDataInput,
         ) -> PutResult
         {
-            self.put_calls.push(input.clone());
             return (self.response_fn)(input)
         }
     }
 
 
     #[test]
-    fn test_put_metric_data() {}
-    */
+    fn test_put_metric_data() {
+        let cw = MockCloudwatchClient { response_fn: MockCloudwatchClient::return_ok };
+    }
+    
 }

--- a/src/rust/metric-forwarder/src/cloudwatch_send.rs
+++ b/src/rust/metric-forwarder/src/cloudwatch_send.rs
@@ -5,12 +5,10 @@ use futures::future;
 use log::warn;
 use rayon::prelude::*;
 use rusoto_cloudwatch::PutMetricDataError;
-use rusoto_cloudwatch::{CloudWatch, CloudWatchClient, MetricDatum, PutMetricDataInput};
+use rusoto_cloudwatch::{CloudWatch, MetricDatum, PutMetricDataInput};
 use rusoto_core::RusotoError;
 use statsd_parser;
 use statsd_parser::Metric;
-use std::collections::vec_deque;
-use std::collections::VecDeque;
 
 mod units {
     // strings accepted by CloudWatch MetricDatum.unit
@@ -114,7 +112,7 @@ fn statsd_as_cloudwatch_metric(stat: &Stat) -> MetricDatum {
 #[cfg(test)]
 mod tests {
     use crate::cloudwatch_logs_parse::Stat;
-    use crate::cloudwatch_send::*; // TODO fix
+    use crate::cloudwatch_send::{statsd_as_cloudwatch_metric, units};
     use rusoto_cloudwatch::MetricDatum;
     use statsd_parser;
 
@@ -144,6 +142,8 @@ mod tests {
 
     /*
     // TODO wimax: mannnn i just wanna mock this thing out!!!
+    use std::collections::vec_deque;
+    use std::collections::VecDeque;
     pub struct MockCloudwatchClient {
         pub put_calls: Vec<PutMetricDataInput>,
         response_fn: Box<dyn Fn(PutMetricDataInput) -> PutResult + Send>,

--- a/src/rust/metric-forwarder/src/error.rs
+++ b/src/rust/metric-forwarder/src/error.rs
@@ -1,6 +1,4 @@
 use lambda_runtime::error::HandlerError;
-use rusoto_cloudwatch::PutMetricDataError;
-use rusoto_core::RusotoError;
 use std::fmt::Display;
 use thiserror::Error;
 
@@ -18,7 +16,6 @@ pub enum MetricForwarderError {
     PoorlyFormattedLogLine(String),
     #[error("Error parsing statsd log: {0}")]
     ParseStringToStatsdError(String),
-    //ParseStringToStatsdError(#[from] statsd_parser::ParseError), // no Clone
     #[error("PutMetricData to Cloudwatch error: this many failures {0}")]
     PutMetricDataError(usize),
 }

--- a/src/rust/metric-forwarder/src/error.rs
+++ b/src/rust/metric-forwarder/src/error.rs
@@ -17,7 +17,7 @@ pub enum MetricForwarderError {
     #[error("Error parsing statsd log: {0}")]
     ParseStringToStatsdError(String),
     #[error("PutMetricData to Cloudwatch error: this many failures {0}")]
-    PutMetricDataError(usize),
+    PutMetricDataError(String),
 }
 
 // can't impl From for HandlerError, sadly

--- a/src/rust/metric-forwarder/src/error.rs
+++ b/src/rust/metric-forwarder/src/error.rs
@@ -1,6 +1,10 @@
+use lambda_runtime::error::HandlerError;
+use rusoto_cloudwatch::PutMetricDataError;
+use rusoto_core::RusotoError;
+use std::fmt::Display;
 use thiserror::Error;
 
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, PartialEq, Clone)]
 pub enum MetricForwarderError {
     #[error("Couldn't create CloudwatchLogsData from gunzipped json: {0}")]
     ParseStringToLogsdataError(String),
@@ -10,4 +14,16 @@ pub enum MetricForwarderError {
     GunzipToStringError(String),
     #[error("Poorly formatted CloudwatchLogEvent")]
     PoorlyFormattedEventError(),
+    #[error("Poorly formatted log line: {0}")]
+    PoorlyFormattedLogLine(String),
+    #[error("Error parsing statsd log: {0}")]
+    ParseStringToStatsdError(String),
+    //ParseStringToStatsdError(#[from] statsd_parser::ParseError), // no Clone
+    #[error("PutMetricData to Cloudwatch error: this many failures {0}")]
+    PutMetricDataError(usize),
+}
+
+// can't impl From for HandlerError, sadly
+pub fn to_handler_error(err: &impl Display) -> HandlerError {
+    HandlerError::from(err.to_string().as_str())
 }

--- a/src/rust/metric-forwarder/src/main.rs
+++ b/src/rust/metric-forwarder/src/main.rs
@@ -1,52 +1,78 @@
 #![type_length_limit = "1214269"]
 // Our types are simply too powerful
 
+mod cloudwatch_logs_parse;
+mod cloudwatch_send;
 mod deser_logs_data;
 mod error;
 
-use aws_lambda_events::event::cloudwatch_logs::{CloudwatchLogsData, CloudwatchLogsEvent};
+use aws_lambda_events::event::cloudwatch_logs::CloudwatchLogsEvent;
 use lambda_runtime::error::HandlerError;
 use lambda_runtime::lambda;
 use lambda_runtime::Context;
-use log::info;
+use log::{info};
 
-use tokio::runtime::Runtime;
+use crate::cloudwatch_logs_parse::parse_logs;
+use crate::cloudwatch_send::put_metric_data;
+use crate::cloudwatch_send::statsd_as_cloudwatch_metric_bulk;
+use crate::cloudwatch_send::CloudWatchPutter;
+use crate::error::{to_handler_error, MetricForwarderError};
+use rusoto_cloudwatch::{CloudWatchClient, MetricDatum};
+use std::sync::{Arc, Mutex};
 
-// not yet, gotta solve openssl issue
-// use rusoto_cloudwatch::{CloudWatch, CloudWatchClient};
+#[derive(Debug, Clone)]
+pub struct MetricForwarder<C>
+where
+    C: CloudWatchPutter + Send + Sync + 'static,
+{
+    cloudwatch_client: Arc<C>,
+}
 
-fn handler(event: CloudwatchLogsEvent, ctx: Context) -> Result<(), HandlerError> {
+fn handler_sync(event: CloudwatchLogsEvent, _ctx: Context) -> Result<(), HandlerError> {
+    /**
+     * Do some threading magic to block on `handler_async` until it completes
+     */
+    type R = Result<(), MetricForwarderError>;
+    let result_arc: Arc<Mutex<R>> = Arc::new(Mutex::new(Ok(())));
+    let result_arc_for_thread = Arc::clone(&result_arc);
+
+    let thread = std::thread::spawn(move || {
+        tokio_compat::run_std(async move {
+            let result: R = handler_async(event).await.clone();
+             *result_arc_for_thread.lock().unwrap() = result;
+            ()
+        })
+    });
+
+    thread.join().unwrap();
+    let result = result_arc.lock().unwrap();
+    result.as_ref().map(|&_t| ()).map_err(|e| to_handler_error(&e))
+}
+
+async fn handler_async(event: CloudwatchLogsEvent) -> Result<(), MetricForwarderError> {
     info!("Handling event");
+    let cw_client = get_prod_cloudwatch_client();
 
     let logs = deser_logs_data::aws_event_to_cloudwatch_logs_data(event);
     match logs {
         Ok(logs) => {
             // Now we have the actual logs.
-            // Parse the statsd format,
-            // then forward them to CloudWatch
-            Ok(())
+            let parsed_stats = parse_logs(logs);
+            let cloudwatch_metric_data = statsd_as_cloudwatch_metric_bulk(parsed_stats);
+
+            // then forward them to CloudWatch in chunks of 20:
+            let put_result = put_metric_data(&cw_client, &cloudwatch_metric_data);
+            put_result.await
         }
-        Err(e) => Err(HandlerError::from(e.to_string().as_str())),
+        Err(e) => Err(e),
     }
 }
 
-/*
 // TODO wimax Sep'20 - need to figure out how to do a local cloudwatch...
-fn init_cloudwatch_client() -> CloudwatchClient {
-    info!("Connecting to local http://s3:9000");
-    CloudWatchClient::new_with(
-        HttpClient::new().expect("failed to create request dispatcher"),
-        rusoto_credential::StaticProvider::new_minimal(
-            "minioadmin".to_owned(),
-            "minioadmin".to_owned(),
-        ),
-        Region::Custom {
-            name: "locals3".to_string(),
-            endpoint: "http://s3:9000".to_string(),
-        },
-    )
+fn get_prod_cloudwatch_client() -> CloudWatchClient {
+    let region = grapl_config::region();
+    CloudWatchClient::new(region)
 }
-*/
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -55,7 +81,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let is_local = std::env::var("IS_LOCAL").is_ok();
 
     if is_local {
-        info!("Running locally");
+        panic!("yeah, so... this doesn't work locally yet")
 
     /*
     loop {
@@ -63,10 +89,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             error!("local_handler: {}", e);
         };
     }
-     */
+    */
     } else {
         info!("Running in AWS");
-        lambda!(handler);
+        lambda!(handler_sync);
     }
 
     Ok(())

--- a/src/rust/metric-forwarder/src/main.rs
+++ b/src/rust/metric-forwarder/src/main.rs
@@ -15,18 +15,9 @@ use log::info;
 use crate::cloudwatch_logs_parse::parse_logs;
 use crate::cloudwatch_send::put_metric_data;
 use crate::cloudwatch_send::statsd_as_cloudwatch_metric_bulk;
-use crate::cloudwatch_send::CloudWatchPutter;
 use crate::error::{to_handler_error, MetricForwarderError};
-use rusoto_cloudwatch::{CloudWatchClient, MetricDatum};
+use rusoto_cloudwatch::CloudWatchClient;
 use std::sync::{Arc, Mutex};
-
-#[derive(Debug, Clone)]
-pub struct MetricForwarder<C>
-where
-    C: CloudWatchPutter + Send + Sync + 'static,
-{
-    cloudwatch_client: Arc<C>,
-}
 
 fn handler_sync(event: CloudwatchLogsEvent, _ctx: Context) -> Result<(), HandlerError> {
     /**
@@ -48,7 +39,7 @@ fn handler_sync(event: CloudwatchLogsEvent, _ctx: Context) -> Result<(), Handler
     let result = result_arc.lock().unwrap();
     result
         .as_ref()
-        .map(|&_t| ())
+        .map(|&t| t) // silly conversion from &() to ()
         .map_err(|e| to_handler_error(&e))
 }
 


### PR DESCRIPTION

<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
#232

### What changes does this PR make to Grapl? Why?

`deser_logs_data`: deserialize the crazy gzip input from Lambda into pure strings
`cloudwatch_logs_parse`: parse those pure strings into a platform-agnostic `Stat` type
`cloudwatch_send`: turn Stat into Cloudwatch types and send it to Cloudwatch
`main.rs` please triple check my usage of Arc<Mutex

### How were these changes tested?

i have some very small unit tests, but unfortunately this is not super testable until it's complete.
I haven't added it as a service to our CDK yet, but that's up next, at which point I'll be able to test on my personal instance.
