### PR TITLE
Fix issue with grapl-model-plugin-deployer

### DIFF
--- a/etc/local_grapl/grapl_provision.py
+++ b/etc/local_grapl/grapl_provision.py
@@ -408,8 +408,6 @@ if __name__ == "__main__":
             if i > 10:
                 LOGGER.error("mg provision failed with: ", e)
 
-    sqs_t.join(timeout=300)
-    s3_t.join(timeout=300)
 
     for i in range(0, 150):
         try:
@@ -440,5 +438,8 @@ if __name__ == "__main__":
             if i >= 50:
                 LOGGER.error(e)
             time.sleep(1)
+
+    sqs_t.join(timeout=300)
+    s3_t.join(timeout=300)
 
     print("Completed provisioning")

--- a/etc/local_grapl/grapl_provision.py
+++ b/etc/local_grapl/grapl_provision.py
@@ -408,7 +408,6 @@ if __name__ == "__main__":
             if i > 10:
                 LOGGER.error("mg provision failed with: ", e)
 
-
     for i in range(0, 150):
         try:
             client = boto3.client(

--- a/src/python/grapl-model-plugin-deployer/src/grapl_model_plugin_deployer.py
+++ b/src/python/grapl-model-plugin-deployer/src/grapl_model_plugin_deployer.py
@@ -240,7 +240,7 @@ def query_dgraph_predicate(client: "GraphClient", predicate_name: str):
 
 def meta_into_edge(schema, predicate_meta):
     if predicate_meta.get("list"):
-        return EdgeT(type(schema), BaseSchema, EdgeRelationship.OneToMany)
+        return EdgeT(type(schema), BaseSchema, EdgeRelationship.ManyToOne)
     else:
         return EdgeT(type(schema), BaseSchema, EdgeRelationship.OneToOne)
 

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/nodes/base.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/nodes/base.py
@@ -83,7 +83,6 @@ class BaseSchema(Schema):
             uid_t = "uid"
             if edge_t.is_from_many():
                 uid_t = f"[{uid_t}]"
-
             predicates.append(f"{edge_name}: {uid_t} .")
 
         return "\n".join(predicates)

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/nodes/entity.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/nodes/entity.py
@@ -41,12 +41,12 @@ class EntitySchema(BaseSchema):
         view: "Union[Type[Viewable], Callable[[], Type[Viewable]]]" = None,
     ):
         super(EntitySchema, self).__init__(
-            {**(properties or {})},
-            {
+            properties={**(properties or {})},
+            edges={
                 **default_entity_edges(),
                 **(edges or {}),
             },
-            view or EntityView,
+            view=(view or EntityView),
         )
 
     @staticmethod

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/schema.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/schema.py
@@ -54,6 +54,7 @@ class Schema(metaclass=SingletonMeta):
         edges: Dict[str, Tuple["EdgeT", str]],
         viewable: "Union[Type[Viewable], Callable[[], Type[Viewable]]]",
     ):
+        self.node_types = {"BaseNode", self.self_type()}
         self.properties: Dict[str, "PropType"] = {**default_properties(), **properties}
         self.edges: Dict[str, Tuple["EdgeT", str]] = {}
 
@@ -61,13 +62,14 @@ class Schema(metaclass=SingletonMeta):
             self.add_edge(edge_name, edge, r_edge_name)
 
         self.viewable = viewable
-        self.node_types = {"BaseNode", self.self_type()}
 
     def add_property(self, prop_name: str, prop: "PropType"):
         self.properties[prop_name] = prop
 
     def add_edge(self, edge_name: str, edge: "EdgeT", reverse_name: str):
         self.edges[edge_name] = (edge, reverse_name)
+        if not reverse_name:
+            return
         r_edge = edge.reverse()
         self.edges[reverse_name] = (r_edge, edge_name)
 
@@ -78,13 +80,6 @@ class Schema(metaclass=SingletonMeta):
             r_edge = edge.reverse()
             # The edge dest Viewable should already be constructed at this point
             edge.dest().edges[reverse_name] = (r_edge, edge_name)
-            print(
-                self.self_type(),
-                edge.dest().self_type(),
-                reverse_name,
-                r_edge,
-                edge_name,
-            )
 
     def prop_type(self, prop_name: str) -> Union[Tuple["EdgeT", str], "PropType", None]:
         return self.get_properties().get(prop_name) or self.get_edges().get(prop_name)


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
This is a hotfix. I'll create an issue for this retroactively, but I want to start the PR now.

### What changes does this PR make to Grapl? Why?
When deploying new nodes, we need to fetch the existing schemas of nodes from dgraph and reconstruct them as python
The problem is that we don't know what the reverse edges are, ie: We can know that it's a ManyToX relationship, but not if it's a ToOne or a ToMany
We basically just set the reverse edge to null and say "don't worry about it, just worry about what we know"
There was an inversion in some of the code that led to the edge being OneToMany, not ManyToOne, and so that broke some of our model plugin deployer code.

### How were these changes tested?
Tested via localgrapl.
