### PR TITLE
Promote Metric Forwarder to a true CDK service (and a bunch of random fixes I found along the way)

### DIFF
--- a/dobi.yaml
+++ b/dobi.yaml
@@ -386,7 +386,7 @@ compose=integration-env:
     # rust images
     - analyzer-dispatcher
     - generic-subgraph-generator
-    - metric-forwarder # TODO should I???
+    - metric-forwarder  # though, not currently used in integration
     - graph-merger
     - node-identifier
     - node-identifier-retry-handler

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -39,6 +39,18 @@ image=analyzer-dispatcher:
   depends:
     - rust-build
 
+image=metric-forwarder:
+  image: grapl/metric-forwarder
+  context: src/rust/metric-forwarder
+  dockerfile: Dockerfile
+  args:
+    release_target: "{env.GRAPL_RELEASE_TARGET:debug}"
+  target: grapl-metric-forwarder
+  tags:
+    - "{env.TAG}"
+  depends:
+    - rust-build
+
 image=generic-subgraph-generator:
   image: grapl/grapl-generic-subgraph-generator
   context: src/rust/generic-subgraph-generator
@@ -374,6 +386,7 @@ compose=integration-env:
     # rust images
     - analyzer-dispatcher
     - generic-subgraph-generator
+    - metric-forwarder # TODO should I???
     - graph-merger
     - node-identifier
     - node-identifier-retry-handler
@@ -599,6 +612,7 @@ alias=rust:
     - "analyzer-dispatcher:tag"
     - "generic-subgraph-generator:tag"
     - "graph-merger:tag"
+    - "metric-forwarder:tag"
     - "node-identifier:tag"
     - "node-identifier-retry-handler:tag"
     - "sysmon-subgraph-generator:tag"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,16 @@ services:
   # Rust services
   #
 
+  grapl-metric-forwarder:
+    image: grapl/metric-forwarder:${TAG:-latest}
+    tty: false
+    environment:
+      - "IS_LOCAL=True"
+      - GRAPL_LOG_LEVEL=${GRAPL_LOG_LEVEL:-ERROR}
+      - RUST_LOG=${RUST_LOG:-ERROR}
+    extra_hosts:
+      - amazonaws:127.0.0.1
+
   grapl-sysmon-subgraph-generator:
     image: grapl/grapl-sysmon-subgraph-generator:${TAG:-latest}
     tty: false

--- a/etc/local_grapl/bin/upload-sysmon-logs.py
+++ b/etc/local_grapl/bin/upload-sysmon-logs.py
@@ -123,7 +123,12 @@ def main(prefix, logfile, delay, batch_size):
 def parse_args():
     parser = argparse.ArgumentParser(description="Send sysmon logs to Grapl")
     parser.add_argument("--bucket_prefix", dest="bucket_prefix", required=True)
-    parser.add_argument("--logfile", dest="logfile", required=True, help="ie $GRAPLROOT/etc/sample_data/eventlog.xml")
+    parser.add_argument(
+        "--logfile",
+        dest="logfile",
+        required=True,
+        help="ie $GRAPLROOT/etc/sample_data/eventlog.xml",
+    )
     parser.add_argument("--delay", dest="delay", default=0, type=int)
     parser.add_argument("--batch-size", dest="batch_size", default=100, type=int)
     return parser.parse_args()

--- a/etc/local_grapl/bin/upload-sysmon-logs.py
+++ b/etc/local_grapl/bin/upload-sysmon-logs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Despite the path, this is *not* tied just to Local Grapl, and can also be used on prod S3 buckets.
+Despite the path, this is *not* tied just to Local Grapl, and can also be used on true S3 buckets.
 """
 
 import argparse
@@ -123,7 +123,7 @@ def main(prefix, logfile, delay, batch_size):
 def parse_args():
     parser = argparse.ArgumentParser(description="Send sysmon logs to Grapl")
     parser.add_argument("--bucket_prefix", dest="bucket_prefix", required=True)
-    parser.add_argument("--logfile", dest="logfile", required=True, help="ie ~/src/grapl/etc/sample_data/eventlog.xml")
+    parser.add_argument("--logfile", dest="logfile", required=True, help="ie $GRAPLROOT/etc/sample_data/eventlog.xml")
     parser.add_argument("--delay", dest="delay", default=0, type=int)
     parser.add_argument("--batch-size", dest="batch_size", default=100, type=int)
     return parser.parse_args()

--- a/etc/local_grapl/bin/upload-sysmon-logs.py
+++ b/etc/local_grapl/bin/upload-sysmon-logs.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+"""
+Despite the path, this is *not* tied just to Local Grapl, and can also be used on prod S3 buckets.
+"""
 
 import argparse
 import json
@@ -120,7 +123,7 @@ def main(prefix, logfile, delay, batch_size):
 def parse_args():
     parser = argparse.ArgumentParser(description="Send sysmon logs to Grapl")
     parser.add_argument("--bucket_prefix", dest="bucket_prefix", required=True)
-    parser.add_argument("--logfile", dest="logfile", required=True)
+    parser.add_argument("--logfile", dest="logfile", required=True, help="ie ~/src/grapl/etc/sample_data/eventlog.xml")
     parser.add_argument("--delay", dest="delay", default=0, type=int)
     parser.add_argument("--batch-size", dest="batch_size", default=100, type=int)
     return parser.parse_args()

--- a/src/js/grapl-cdk/extract-grapl-deployment-artifacts.sh
+++ b/src/js/grapl-cdk/extract-grapl-deployment-artifacts.sh
@@ -7,6 +7,7 @@ then
 fi
 
 function getzip_a() {
+    echo "Zipping $1"
     cp "../../../dist/$1" ./bootstrap
     zip -9 "zips/$1-$VERSION.zip" ./bootstrap
     rm ./bootstrap

--- a/src/js/grapl-cdk/extract-grapl-deployment-artifacts.sh
+++ b/src/js/grapl-cdk/extract-grapl-deployment-artifacts.sh
@@ -1,29 +1,37 @@
 #!/bin/bash
 
+# No unset vars please
+set -o nounset
+
 if [ -z "$VERSION" ]
 then
   echo "Please set VERSION="
   exit 1
 fi
 
-export GRAPLROOT=$(realpath ../../..)
-export ZIPS_DIR=$(realpath zips)
+# Directory containing this shell script
+CDK_DIR=$(realpath $(dirname "$0"))
+cd $CDK_DIR
+GRAPLROOT=$(realpath ../../..)
+ZIPS_DIR="$CDK_DIR/zips"
 
 function getzip_a() {
     echo "Zipping $1"
-
-    export TEMPDIR="/tmp/zipped_$1"
+    # Make a temp dir with './boostrap' in it
+    TEMPDIR="/tmp/zipped_$1"
     mkdir $TEMPDIR
     cd $TEMPDIR
-
     cp "$GRAPLROOT/dist/$1" ./bootstrap
-    zip -9 "$ZIPS_DIR/$1-$VERSION.zip" ./bootstrap
-    cd -
+    # zip it up into CDK/zips
+    zip -9 --quiet --display-globaldots "$ZIPS_DIR/$1-$VERSION.zip" ./bootstrap
+    # Go back home, clean up 
+    cd $CDK_DIR
     rm -r $TEMPDIR
     echo "Done zipping $1"
 }
 
 function getzip_b() {
+    echo "Copying $1"
     cp "$GRAPLROOT/dist/$1/lambda.zip" "$ZIPS_DIR/$1-$VERSION.zip"
 }
 
@@ -55,3 +63,5 @@ wait
 for b in "${bs[@]}"; do
     getzip_b $b
 done
+
+echo "Done extracting artifacts"

--- a/src/js/grapl-cdk/extract-grapl-deployment-artifacts.sh
+++ b/src/js/grapl-cdk/extract-grapl-deployment-artifacts.sh
@@ -23,6 +23,7 @@ as=(
     "node-identifier-retry-handler"
     "graph-merger"
     "analyzer-dispatcher"
+    "metric-forwarder"
 )
 
 bs=(

--- a/src/js/grapl-cdk/extract-grapl-deployment-artifacts.sh
+++ b/src/js/grapl-cdk/extract-grapl-deployment-artifacts.sh
@@ -2,19 +2,29 @@
 
 if [ -z "$VERSION" ]
 then
-  echo "Please set VERSION= (it's same as TAG= for dobi)"
+  echo "Please set VERSION="
   exit 1
 fi
 
+export GRAPLROOT=$(realpath ../../..)
+export ZIPS_DIR=$(realpath zips)
+
 function getzip_a() {
     echo "Zipping $1"
-    cp "../../../dist/$1" ./bootstrap
-    zip -9 "zips/$1-$VERSION.zip" ./bootstrap
-    rm ./bootstrap
+
+    export TEMPDIR="/tmp/zipped_$1"
+    mkdir $TEMPDIR
+    cd $TEMPDIR
+
+    cp "$GRAPLROOT/dist/$1" ./bootstrap
+    zip -9 "$ZIPS_DIR/$1-$VERSION.zip" ./bootstrap
+    cd -
+    rm -r $TEMPDIR
+    echo "Done zipping $1"
 }
 
 function getzip_b() {
-    cp "../../../dist/$1/lambda.zip" "zips/$1-$VERSION.zip"
+    cp "$GRAPLROOT/dist/$1/lambda.zip" "$ZIPS_DIR/$1-$VERSION.zip"
 }
 
 as=(
@@ -36,9 +46,11 @@ bs=(
     "graphql-endpoint"
 )
 
+# Doing the zips in parallel brings it down from 2m37s to 58s
 for a in "${as[@]}"; do
-    getzip_a $a
+    getzip_a $a &
 done
+wait
 
 for b in "${bs[@]}"; do
     getzip_b $b

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -169,6 +169,7 @@ class MetricForwarder extends cdk.NestedStack {
         const service = new Service(this, id, {
             prefix: props.prefix,
             environment: {
+                GRAPL_LOG_LEVEL: 'INFO',
             },
             vpc: props.vpc,
             version: props.version,

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -176,6 +176,15 @@ class MetricForwarder extends cdk.NestedStack {
             watchful: props.watchful,
             metric_forwarder: undefined,  // Otherwise, it'd be recursive!
         });
+
+        let policy = new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ['cloudwatch:PutMetricData'],
+            resources: ['*'],
+        });
+
+        service.event_handler.addToRolePolicy(policy);
+        service.event_retry_handler.addToRolePolicy(policy);
     }
 }
 

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -177,7 +177,7 @@ class MetricForwarder extends cdk.NestedStack {
             metric_forwarder: undefined,  // Otherwise, it'd be recursive!
         });
 
-        let policy = new iam.PolicyStatement({
+        const  policy = new iam.PolicyStatement({
             effect: iam.Effect.ALLOW,
             actions: ['cloudwatch:PutMetricData'],
             resources: ['*'],
@@ -364,7 +364,7 @@ class AnalyzerExecutor extends cdk.NestedStack {
 
         // Need to be able to GetObject in order to HEAD, can be replaced with
         // a cache later, but safe so long as there is no LIST
-        let policy = new iam.PolicyStatement({
+        const  policy = new iam.PolicyStatement({
             effect: iam.Effect.ALLOW,
             actions: ['s3:GetObject'],
             resources: [props.writesTo.bucketArn + '/*'],

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -166,7 +166,7 @@ class MetricForwarder extends cdk.NestedStack {
     constructor(scope: cdk.Construct, id: string, props: MetricForwarderProps) {
         super(scope, id);
 
-        const service = new Service(this, id, {
+        this.service = new Service(this, id, {
             prefix: props.prefix,
             environment: {
                 GRAPL_LOG_LEVEL: 'INFO',
@@ -183,8 +183,8 @@ class MetricForwarder extends cdk.NestedStack {
             resources: ['*'],
         });
 
-        service.event_handler.addToRolePolicy(policy);
-        service.event_retry_handler.addToRolePolicy(policy);
+        this.service.event_handler.addToRolePolicy(policy);
+        this.service.event_retry_handler.addToRolePolicy(policy);
     }
 }
 

--- a/src/js/grapl-cdk/lib/service.ts
+++ b/src/js/grapl-cdk/lib/service.ts
@@ -10,6 +10,7 @@ import * as sns from '@aws-cdk/aws-sns';
 import * as sqs from '@aws-cdk/aws-sqs';
 import * as subscriptions from '@aws-cdk/aws-sns-subscriptions';
 import { LambdaDestination } from '@aws-cdk/aws-logs-destinations';
+import { FilterPattern, SubscriptionFilter } from '@aws-cdk/aws-logs';
 import { SqsEventSource } from '@aws-cdk/aws-lambda-event-sources';
 import { Watchful } from './vendor/cdk-watchful/lib/watchful';
 
@@ -250,9 +251,7 @@ export class Service {
             "send_metrics_to_lambda_" + fromLambdaFn.node.uniqueId,
             {
                 destination: new LambdaDestination(toLambdaFn),
-                filterPattern: {
-                    logPatternString: "MONITORING"
-                }
+                filterPattern: FilterPattern.literal("MONITORING"),
             }
         )
     }

--- a/src/js/grapl-cdk/lib/service.ts
+++ b/src/js/grapl-cdk/lib/service.ts
@@ -56,7 +56,7 @@ export interface ServiceProps {
      and that 1 lambda should be the one that does not have it set.
      (we don't want a recursive log-processor)
      */
-    metrics_logs_ingest_lambda?: lambda.IFunction;
+    metric_forwarder?: Service;
 }
 
 export class Service {
@@ -188,9 +188,10 @@ export class Service {
             this.addSubscription(scope, props.subscribes_to);
         }
 
-        if (props.metrics_logs_ingest_lambda) {
-            this.forwardMetricsLogs(scope, event_handler, props.metrics_logs_ingest_lambda);
-            this.forwardMetricsLogs(scope, event_retry_handler, props.metrics_logs_ingest_lambda);
+        if (props.metric_forwarder) {
+            const forwarder_lambda = props.metric_forwarder.event_handler;
+            this.forwardMetricsLogs(scope, event_handler, forwarder_lambda);
+            this.forwardMetricsLogs(scope, event_retry_handler, forwarder_lambda);
         }
 
     }

--- a/src/js/grapl-cdk/lib/service.ts
+++ b/src/js/grapl-cdk/lib/service.ts
@@ -251,7 +251,7 @@ export class Service {
             {
                 destination: new LambdaDestination(toLambdaFn),
                 filterPattern: {
-                    logPatternString: "MONITORING|"
+                    logPatternString: "MONITORING"
                 }
             }
         )

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1197,6 +1197,7 @@ dependencies = [
 name = "grapl-observe"
 version = "0.0.1"
 dependencies = [
+ "chrono",
  "lazy_static",
  "log 0.4.8",
  "regex",

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -67,10 +67,12 @@ COPY --chown=grapl ./grapl-config/Cargo.toml grapl-config/
 RUN mkdir -p grapl-observe/src
 RUN touch grapl-observe/src/lib.rs
 COPY --chown=grapl ./grapl-observe/Cargo.toml grapl-observe/
+
 # copy in Cargo.toml for metric-forwarder
 RUN mkdir -p metric-forwarder/src
-RUN touch metric-forwarder/src/lib.rs
+RUN echo 'fn main() {}' > metric-forwarder/src/main.rs 
 COPY --chown=grapl ./metric-forwarder/Cargo.toml metric-forwarder/
+
 # copy in Cargo.toml for graph-merger
 RUN mkdir -p graph-merger/src
 RUN echo 'fn main() {}' > graph-merger/src/main.rs

--- a/src/rust/grapl-observe/Cargo.toml
+++ b/src/rust/grapl-observe/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = "0.4.11"
 lazy_static = "1.2.0"
 log = "0.4.*"
 regex = "1.1.0"

--- a/src/rust/grapl-observe/src/metric_reporter.rs
+++ b/src/rust/grapl-observe/src/metric_reporter.rs
@@ -1,6 +1,7 @@
 use crate::metric_error::MetricError;
 use crate::statsd_formatter;
 use crate::statsd_formatter::{statsd_format, MetricType};
+use chrono::Utc;
 use std::fmt::Write;
 
 pub mod common_strs {
@@ -47,7 +48,9 @@ impl MetricReporter {
             sample_rate,
             tags,
         )?;
-        println!("MONITORING|{}", self.buffer);
+        // TODO: dependency-inject utcnow
+        let cur_time = Utc::now().to_rfc3339();
+        println!("MONITORING|{}|{}", cur_time, self.buffer);
         Ok(())
     }
 

--- a/src/rust/grapl-observe/src/metric_reporter.rs
+++ b/src/rust/grapl-observe/src/metric_reporter.rs
@@ -18,6 +18,7 @@ pub struct MetricReporter {
     to stdout; then, later, a lambda reads in these messages and writes them to Cloudwatch.
     (originally recommended in an article by Yan Cui)
     */
+    // TODO: I think I gotta mutex or arc this; two threads grab it at once and sometimes print the wrong thing!
     buffer: String,
 }
 

--- a/src/rust/metric-forwarder/Dockerfile
+++ b/src/rust/metric-forwarder/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine AS grapl-analyzer-dispatcher
+FROM alpine AS grapl-metric-forwarder
 RUN apk add --no-cache libgcc
 ARG release_target="debug"
 COPY --from=grapl/grapl-rust-src-build /home/grapl/target/x86_64-unknown-linux-musl/${release_target}/metric-forwarder /

--- a/src/rust/metric-forwarder/src/cloudwatch_logs_parse.rs
+++ b/src/rust/metric-forwarder/src/cloudwatch_logs_parse.rs
@@ -53,8 +53,8 @@ fn parse_log(log_str: &str) -> Result<Stat, MetricForwarderError> {
 
 #[cfg(test)]
 mod tests {
-    use crate::cloudwatch_logs_parse::Stat;
     use crate::cloudwatch_logs_parse::parse_log;
+    use crate::cloudwatch_logs_parse::Stat;
     use crate::cloudwatch_logs_parse::MONITORING_DELIM;
     use crate::error::MetricForwarderError;
     use statsd_parser::Counter;
@@ -64,10 +64,7 @@ mod tests {
     fn expect_metric(input: &[&str], expected: Metric) -> Result<Stat, MetricForwarderError> {
         let input_joined = input.join(MONITORING_DELIM);
         let parsed = parse_log(input_joined.as_str())?;
-        assert_eq!(
-            parsed.msg.metric,
-            expected,
-        );
+        assert_eq!(parsed.msg.metric, expected,);
         Ok(parsed)
     }
 
@@ -104,13 +101,12 @@ mod tests {
         Ok(())
     }
 
-
     #[test]
     fn test_trim_end() -> Result<(), MetricForwarderError> {
         let input = [
             "MONITORING",
             "2017-04-26T10:41:09.023Z",
-            "sysmon-generator-started:1|g\n"
+            "sysmon-generator-started:1|g\n",
         ];
         let expected = Metric::Gauge(Gauge {
             value: 1.0,

--- a/src/rust/metric-forwarder/src/cloudwatch_send.rs
+++ b/src/rust/metric-forwarder/src/cloudwatch_send.rs
@@ -106,7 +106,7 @@ fn statsd_as_cloudwatch_metric(stat: &Stat) -> MetricDatum {
         Metric::Histogram(h) => (units::MILLIS, h.value, h.sample_rate),
         _ => panic!("How the heck did you get an unsupported metric type in here?"),
     };
-    MetricDatum {
+    let datum = MetricDatum {
         metric_name: stat.msg.name.to_string(),
         timestamp: stat.timestamp.to_string().into(),
         unit: unit.to_string().into(),
@@ -121,7 +121,8 @@ fn statsd_as_cloudwatch_metric(stat: &Stat) -> MetricDatum {
         dimensions: None,
         statistic_values: None,
         storage_resolution: None,
-    }
+    };
+    datum
 }
 
 #[cfg(test)]

--- a/src/rust/metric-forwarder/src/error.rs
+++ b/src/rust/metric-forwarder/src/error.rs
@@ -14,9 +14,9 @@ pub enum MetricForwarderError {
     PoorlyFormattedEventError(),
     #[error("Poorly formatted log line: {0}")]
     PoorlyFormattedLogLine(String),
-    #[error("Error parsing statsd log: {0}")]
-    ParseStringToStatsdError(String),
-    #[error("PutMetricData to Cloudwatch error: this many failures {0}")]
+    #[error("Error parsing statsd log. Reason: {0}, log: {1}")]
+    ParseStringToStatsdError(String, String),
+    #[error("PutMetricData to Cloudwatch error: one example: {0}")]
     PutMetricDataError(String),
 }
 

--- a/src/rust/metric-forwarder/src/main.rs
+++ b/src/rust/metric-forwarder/src/main.rs
@@ -53,6 +53,7 @@ async fn handler_async(event: CloudwatchLogsEvent) -> Result<(), MetricForwarder
             // Now we have the actual logs.
             let parsed_stats = parse_logs(logs);
             let cloudwatch_metric_data = statsd_as_cloudwatch_metric_bulk(parsed_stats);
+            info!("Received {} incoming metrics", cloudwatch_metric_data.len());
 
             // then forward them to CloudWatch in chunks of 20:
             let put_result = put_metric_data(&cw_client, &cloudwatch_metric_data);

--- a/src/rust/sysmon-subgraph-generator/src/main.rs
+++ b/src/rust/sysmon-subgraph-generator/src/main.rs
@@ -645,6 +645,7 @@ where
         }
 
         info!("Completed mapping {} subgraphs", identities.len());
+        self.metrics.report_handle_event_success(&failed);
 
         let mut completed = if let Some(ref e) = failed {
             OutputEvent::new(Completion::Partial((
@@ -668,9 +669,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     grapl_config::init_grapl_log!();
     info!("Starting sysmon-subgraph-generator");
 
-    let metrics = SysmonSubgraphGeneratorMetrics {
+    let mut metrics = SysmonSubgraphGeneratorMetrics {
         metric_reporter: MetricReporter::new(),
     };
+
+    metrics.report_started();
 
     if grapl_config::is_local() {
         let generator = SysmonSubgraphGenerator::new(NopCache {}, metrics);

--- a/src/rust/sysmon-subgraph-generator/src/main.rs
+++ b/src/rust/sysmon-subgraph-generator/src/main.rs
@@ -650,7 +650,7 @@ where
         let mut completed = if let Some(ref e) = failed {
             OutputEvent::new(Completion::Partial((
                 final_subgraph,
-                sqs_lambda::error::Error::ProcessingError((e.to_string())),
+                sqs_lambda::error::Error::ProcessingError(e.to_string()),
             )))
         } else {
             OutputEvent::new(Completion::Total(final_subgraph))
@@ -669,7 +669,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     grapl_config::init_grapl_log!();
     info!("Starting sysmon-subgraph-generator");
 
-    let mut metrics = SysmonSubgraphGeneratorMetrics {
+    let metrics = SysmonSubgraphGeneratorMetrics {
         metric_reporter: MetricReporter::new(),
     };
 

--- a/src/rust/sysmon-subgraph-generator/src/main.rs
+++ b/src/rust/sysmon-subgraph-generator/src/main.rs
@@ -673,8 +673,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         metric_reporter: MetricReporter::new(),
     };
 
-    metrics.report_started();
-
     if grapl_config::is_local() {
         let generator = SysmonSubgraphGenerator::new(NopCache {}, metrics);
 

--- a/src/rust/sysmon-subgraph-generator/src/metrics.rs
+++ b/src/rust/sysmon-subgraph-generator/src/metrics.rs
@@ -19,7 +19,6 @@ impl SysmonSubgraphGeneratorMetrics {
                 "sysmon-generator-completion",
                 1.0,
                 &[TagPair(common_strs::STATUS, reported_status)],
-            )
-            .map_err(|e| warn!("Metric failed: {}", e));
+            ).unwrap_or_else(|e| warn!("Metric failed: {}", e))
     }
 }

--- a/src/rust/sysmon-subgraph-generator/src/metrics.rs
+++ b/src/rust/sysmon-subgraph-generator/src/metrics.rs
@@ -22,4 +22,10 @@ impl SysmonSubgraphGeneratorMetrics {
             )
             .unwrap_or_else(|e| warn!("Metric failed: {}", e))
     }
+
+    pub fn report_started(&mut self) {
+        self.metric_reporter
+            .gauge("sysmon-generator-started", 1.0, &[])
+            .unwrap_or_else(|e| warn!("Metric failed: {}", e))
+    }
 }

--- a/src/rust/sysmon-subgraph-generator/src/metrics.rs
+++ b/src/rust/sysmon-subgraph-generator/src/metrics.rs
@@ -19,6 +19,7 @@ impl SysmonSubgraphGeneratorMetrics {
                 "sysmon-generator-completion",
                 1.0,
                 &[TagPair(common_strs::STATUS, reported_status)],
-            ).unwrap_or_else(|e| warn!("Metric failed: {}", e))
+            )
+            .unwrap_or_else(|e| warn!("Metric failed: {}", e))
     }
 }

--- a/src/rust/sysmon-subgraph-generator/src/metrics.rs
+++ b/src/rust/sysmon-subgraph-generator/src/metrics.rs
@@ -22,10 +22,4 @@ impl SysmonSubgraphGeneratorMetrics {
             )
             .unwrap_or_else(|e| warn!("Metric failed: {}", e))
     }
-
-    pub fn report_started(&mut self) {
-        self.metric_reporter
-            .gauge("sysmon-generator-started", 1.0, &[])
-            .unwrap_or_else(|e| warn!("Metric failed: {}", e))
-    }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
#232

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Add all the dobi/docker/cdk scaffolding for Metric Forwarder as a lambda service; also some bugfixes in the docker files
- quicker parallelized `extract-grapl-deployment-artifacts`
- Added Sysmon as a 'client' of the metric forwarder (its logs are sent to the metric forwarder)
- Completely revamped the printlns for monitoring
(Before: Assumed the Lambda runtime spit out timestamp info; it does not, so I now encode it, like `MONITORING|timestamp_here|statsd_stuff_here`)
- Add some debuggability to the metric forwarder (info!s, better errors)


<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Deployed to CDK, and it works! I see the sysmon metric in Cloudwatch.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
