### PR TITLE
Change init_grapl_log to init_grapl_env, which returns a new struct ServiceEnv

### DIFF
--- a/src/rust/analyzer-dispatcher/src/main.rs
+++ b/src/rust/analyzer-dispatcher/src/main.rs
@@ -468,11 +468,9 @@ async fn local_handler() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    grapl_config::init_grapl_log!();
+    let env = grapl_config::init_grapl_env!();
 
-    let is_local = std::env::var("IS_LOCAL").is_ok();
-
-    if is_local {
+    if env.is_local {
         info!("Running locally");
         let source_queue_url = std::env::var("SOURCE_QUEUE_URL").expect("SOURCE_QUEUE_URL");
 

--- a/src/rust/generic-subgraph-generator/src/main.rs
+++ b/src/rust/generic-subgraph-generator/src/main.rs
@@ -725,9 +725,9 @@ where
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    grapl_config::init_grapl_log!();
+    let env = grapl_config::init_grapl_env!();
     info!("Starting generic-subgraph-generator");
-    if grapl_config::is_local() {
+    if env.is_local {
         let generator = GenericSubgraphGenerator::new(NopCache {});
 
         run_graph_generator_local(generator, ZstdJsonDecoder::default()).await;

--- a/src/rust/graph-merger/src/main.rs
+++ b/src/rust/graph-merger/src/main.rs
@@ -867,11 +867,9 @@ async fn inner_main() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    grapl_config::init_grapl_log!();
+    let env = grapl_config::init_grapl_env!();
 
-    let is_local = std::env::var("IS_LOCAL").is_ok();
-
-    if is_local {
+    if env.is_local {
         info!("Running locally");
         let source_queue_url = std::env::var("SOURCE_QUEUE_URL").expect("SOURCE_QUEUE_URL");
 

--- a/src/rust/grapl-config/src/lib.rs
+++ b/src/rust/grapl-config/src/lib.rs
@@ -10,16 +10,30 @@ use std::time::Duration;
 use tracing::debug;
 
 #[macro_export]
-macro_rules! init_grapl_log {
+macro_rules! init_grapl_env {
     () => {
-        $crate::_init_grapl_log(&module_path!().replace("-", "_"));
+        $crate::_init_grapl_env(&module_path!().replace("-", "_"))
     };
     ($module_name: literal) => {
-        $crate::_init_grapl_log($module_name);
+        $crate::_init_grapl_env($module_name)
     };
 }
 
-pub fn is_local() -> bool {
+pub struct ServiceEnv {
+    pub service_name: String,
+    pub is_local: bool,
+}
+
+pub fn _init_grapl_env(service_name: &str) -> ServiceEnv {
+    let env = ServiceEnv {
+        service_name: service_name.to_string(),
+        is_local: is_local(),
+    };
+    _init_grapl_log(&env);
+    env
+}
+
+fn is_local() -> bool {
     std::env::var("IS_LOCAL")
         .map(|is_local| is_local.to_lowercase().parse().unwrap_or(false))
         .unwrap_or(false)
@@ -64,15 +78,15 @@ pub fn grapl_log_level() -> log::Level {
     }
 }
 
-pub fn _init_grapl_log(service_name: &str) {
+pub fn _init_grapl_log(env: &ServiceEnv) {
     let filter = EnvFilter::from_default_env()
         .add_directive("warn".parse().expect("Invalid directive"))
         .add_directive(
-            format!("{}={}", service_name, grapl_log_level())
+            format!("{}={}", env.service_name, grapl_log_level())
                 .parse()
                 .expect("Invalid directive"),
         );
-    if is_local() {
+    if env.is_local {
         tracing_subscriber::fmt().with_env_filter(filter).init();
     } else {
         tracing_subscriber::fmt()

--- a/src/rust/metric-forwarder/src/main.rs
+++ b/src/rust/metric-forwarder/src/main.rs
@@ -71,11 +71,9 @@ fn get_prod_cloudwatch_client() -> CloudWatchClient {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    grapl_config::init_grapl_log!();
+    let env = grapl_config::init_grapl_env!();
 
-    let is_local = std::env::var("IS_LOCAL").is_ok();
-
-    if is_local {
+    if env.is_local {
         panic!("yeah, so... this doesn't work locally yet")
 
     /*

--- a/src/rust/node-identifier/src/bin/node-identifier-retry-handler.rs
+++ b/src/rust/node-identifier/src/bin/node-identifier-retry-handler.rs
@@ -16,11 +16,9 @@ use tokio::runtime::Runtime;
 // }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    grapl_config::init_grapl_log!();
+    let env = grapl_config::init_grapl_env!();
 
-    let is_local = std::env::var("IS_LOCAL").is_ok();
-
-    if is_local {
+    if env.is_local {
         info!("Running locally");
         let mut runtime = Runtime::new().unwrap();
 

--- a/src/rust/node-identifier/src/bin/node-identifier.rs
+++ b/src/rust/node-identifier/src/bin/node-identifier.rs
@@ -11,11 +11,9 @@ use rusoto_dynamodb::DynamoDb;
 use tokio::runtime::Runtime;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    grapl_config::init_grapl_log!();
+    let env = grapl_config::init_grapl_env!();
 
-    let is_local = std::env::var("IS_LOCAL").is_ok();
-
-    if is_local {
+    if env.is_local {
         info!("Running locally");
         let mut runtime = Runtime::new().unwrap();
 

--- a/src/rust/sysmon-subgraph-generator/src/main.rs
+++ b/src/rust/sysmon-subgraph-generator/src/main.rs
@@ -666,14 +666,14 @@ where
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    grapl_config::init_grapl_log!();
+    let env = grapl_config::init_grapl_env!();
     info!("Starting sysmon-subgraph-generator");
 
     let metrics = SysmonSubgraphGeneratorMetrics {
         metric_reporter: MetricReporter::new(),
     };
 
-    if grapl_config::is_local() {
+    if env.is_local {
         let generator = SysmonSubgraphGenerator::new(NopCache {}, metrics);
 
         run_graph_generator_local(generator, ZstdDecoder::default()).await;


### PR DESCRIPTION

### Which issue does this PR correspond to?
none, but I want to easily grab service name for my MetricReporter ( #232 )


### What changes does this PR make to Grapl? Why?

init_grapl_log knew about service name, but hogged it to itself. this new struct exposes it, as well as the extremely useful and common is_local

### How were these changes tested?
cargo test