### PR TITLE
Grapl metrics now report their 'service name', and Metric Forwarder uses that as a Cloudwatch Namespace

### DIFF
--- a/src/python/grapl-common/grapl_common/metrics/statsd_formatter.py
+++ b/src/python/grapl-common/grapl_common/metrics/statsd_formatter.py
@@ -18,7 +18,7 @@ class TagPair:
         self.tag_value = tag_value
 
     def statsd_serialized(self) -> str:
-        return "=".join((self.tag_key, self.tag_value))
+        return ":".join((self.tag_key, self.tag_value))
 
 
 def _reject_invalid_chars(s: str):

--- a/src/python/grapl-common/tests/metrics/test_statsd_formatter.py
+++ b/src/python/grapl-common/tests/metrics/test_statsd_formatter.py
@@ -60,7 +60,7 @@ class TestStatsdFormatter(unittest.TestCase):
             typ="ms",
             tags=TestData.TAGS,
         )
-        assert result == "some_metric:2.0|ms|#key=value,key2=value2"
+        assert result == "some_metric:2.0|ms|#key:value,key2:value2"
 
     def test_invalid_metric_names(self):
         for invalid_metric_name in TestData.INVALID_STRS:

--- a/src/rust/grapl-observe/src/metric_reporter.rs
+++ b/src/rust/grapl-observe/src/metric_reporter.rs
@@ -143,7 +143,7 @@ impl TagPair<'_> {
         let TagPair(tag_key, tag_value) = self;
         statsd_formatter::reject_invalid_chars(tag_key)?;
         statsd_formatter::reject_invalid_chars(tag_value)?;
-        Ok(write!(buf, "{}={}", tag_key, tag_value)?)
+        Ok(write!(buf, "{}:{}", tag_key, tag_value)?)
     }
 }
 
@@ -172,7 +172,7 @@ mod tests {
         reporter.histogram("metric_name", 123.45f64)?;
         reporter.counter("metric_name", 123.45f64, None)?;
         reporter.counter("metric_name", 123.45f64, 0.75)?;
-        reporter.gauge("metric_name", 123.45f64, &[])?;
+        reporter.gauge("metric_name", 123.45f64, &[TagPair("key", "value")])?;
         let vec = reporter.out.release();
 
         let written = String::from_utf8(vec)?;
@@ -180,7 +180,7 @@ mod tests {
             "MONITORING|test_service|2020-01-01T01:23:45.000Z|metric_name:123.45|h",
             "MONITORING|test_service|2020-01-01T01:23:45.000Z|metric_name:123.45|c",
             "MONITORING|test_service|2020-01-01T01:23:45.000Z|metric_name:123.45|c|@0.75",
-            "MONITORING|test_service|2020-01-01T01:23:45.000Z|metric_name:123.45|g",
+            "MONITORING|test_service|2020-01-01T01:23:45.000Z|metric_name:123.45|g|#key:value",
         ];
         let actual: Vec<&str> = written.split("\n").collect();
         for (expected, actual) in expected.iter().zip(actual.iter()) {

--- a/src/rust/grapl-observe/src/statsd_formatter.rs
+++ b/src/rust/grapl-observe/src/statsd_formatter.rs
@@ -193,7 +193,7 @@ mod tests {
         )?;
         assert_eq!(
             buf,
-            "some_str:12345.6|c|#some_key=some_value,some_key_2=some_value_2"
+            "some_str:12345.6|c|#some_key:some_value,some_key_2:some_value_2"
         );
         Ok(())
     }

--- a/src/rust/metric-forwarder/src/cloudwatch_logs_parse.rs
+++ b/src/rust/metric-forwarder/src/cloudwatch_logs_parse.rs
@@ -25,7 +25,7 @@ pub fn parse_logs(logs_data: CloudwatchLogsData) -> Vec<Result<Stat, MetricForwa
         .collect()
 }
 
-fn parse_log(log_str: &str) -> Result<Stat, MetricForwarderError> {
+pub fn parse_log(log_str: &str) -> Result<Stat, MetricForwarderError> {
     /*
     The input will look like
     MONITORING|timestamp|statsd|stuff|goes|here\n

--- a/src/rust/metric-forwarder/src/cloudwatch_logs_parse.rs
+++ b/src/rust/metric-forwarder/src/cloudwatch_logs_parse.rs
@@ -8,6 +8,7 @@ use crate::error::MetricForwarderError;
 pub struct Stat {
     pub msg: statsd_parser::Message,
     pub timestamp: String,
+    pub service_name: String,
 }
 
 const MONITORING_DELIM: &'static str = "|";
@@ -29,14 +30,15 @@ fn parse_log(log_str: &str) -> Result<Stat, MetricForwarderError> {
     The input will look like
     MONITORING|timestamp|statsd|stuff|goes|here\n
      */
-    let split: Vec<&str> = log_str.trim_end().splitn(3, MONITORING_DELIM).collect();
+    let split: Vec<&str> = log_str.trim_end().splitn(4, MONITORING_DELIM).collect();
     match &split[..] {
-        [_monitoring, timestamp, statsd_component] => {
+        [_monitoring, service_name, timestamp, statsd_component] => {
             let statsd_msg = statsd_parser::parse(statsd_component.to_string());
             statsd_msg
                 .map(|msg| Stat {
-                    timestamp: timestamp.to_string(),
                     msg: msg,
+                    timestamp: timestamp.to_string(),
+                    service_name: service_name.to_string(),
                 })
                 .map_err(|parse_err| {
                     MetricForwarderError::ParseStringToStatsdError(
@@ -72,6 +74,7 @@ mod tests {
     fn test_parse_one_log() -> Result<(), MetricForwarderError> {
         let input = [
             "MONITORING",
+            "cool_service",
             "2017-04-26T10:41:09.023Z",
             // you'll note I threw a gross, extra \t in the metric name as an edge case
             "some_\tstr:12345.6|c|#some_key=some_value,some_key_2=some_value_2\n",
@@ -82,6 +85,7 @@ mod tests {
         });
         let parsed = expect_metric(&input, expected)?;
         assert_eq!(parsed.msg.name, "some_\tstr");
+        assert_eq!(parsed.service_name, "cool_service");
         Ok(())
     }
 
@@ -89,6 +93,7 @@ mod tests {
     fn test_gauge() -> Result<(), MetricForwarderError> {
         let input = [
             "MONITORING",
+            "cool_service",
             "2017-04-26T10:41:09.023Z",
             "some_\tstr:12345.6|g",
         ];
@@ -105,6 +110,7 @@ mod tests {
     fn test_trim_end() -> Result<(), MetricForwarderError> {
         let input = [
             "MONITORING",
+            "cool_service",
             "2017-04-26T10:41:09.023Z",
             "sysmon-generator-started:1|g\n",
         ];
@@ -138,6 +144,7 @@ mod tests {
     fn test_couldnt_parse_statsd() -> Result<(), String> {
         let input = [
             "MONITORING",
+            "cool_service",
             "2017-04-26T10:41:09.023Z",
             "some_str:12345.6|fake_metric_type",
         ];

--- a/src/rust/metric-forwarder/src/error.rs
+++ b/src/rust/metric-forwarder/src/error.rs
@@ -18,6 +18,10 @@ pub enum MetricForwarderError {
     ParseStringToStatsdError(String, String),
     #[error("PutMetricData to Cloudwatch error: one example: {0}")]
     PutMetricDataError(String),
+    #[error("No logs in this Log Group")]
+    NoLogsError(),
+    #[error("More than one namespace - see `get_namespace` docs: Expected {0}, found {1}")]
+    MoreThanOneNamespaceError(String, String),
 }
 
 // can't impl From for HandlerError, sadly

--- a/src/rust/sysmon-subgraph-generator/src/main.rs
+++ b/src/rust/sysmon-subgraph-generator/src/main.rs
@@ -668,7 +668,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let env = grapl_config::init_grapl_env!();
     info!("Starting sysmon-subgraph-generator");
 
-    let metrics = SysmonSubgraphGeneratorMetrics::new();
+    let metrics = SysmonSubgraphGeneratorMetrics::new(&env.service_name);
 
     if env.is_local {
         let generator = SysmonSubgraphGenerator::new(NopCache {}, metrics);

--- a/src/rust/sysmon-subgraph-generator/src/metrics.rs
+++ b/src/rust/sysmon-subgraph-generator/src/metrics.rs
@@ -9,9 +9,9 @@ pub struct SysmonSubgraphGeneratorMetrics {
 }
 
 impl SysmonSubgraphGeneratorMetrics {
-    pub fn new() -> SysmonSubgraphGeneratorMetrics {
+    pub fn new(service_name: &str) -> SysmonSubgraphGeneratorMetrics {
         SysmonSubgraphGeneratorMetrics {
-            metric_reporter: MetricReporter::<Stdout>::new(),
+            metric_reporter: MetricReporter::<Stdout>::new(service_name),
         }
     }
 }


### PR DESCRIPTION

<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
#232

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
When reporting metrics to stdout, include the name of the service.
When reading those metrics and sending them to Cloudwatch, use the service name as the Namespace.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I added a few tests, and I'm about to CDK it up