### PR TITLE
E2E integration tests - performs the setup, doesn't have any tests yet

### DIFF
--- a/dobi.yaml
+++ b/dobi.yaml
@@ -334,7 +334,6 @@ image=grapl-e2e-tests-build:
   depends:
     - grapl-analyzerlib-build
     - etc-build
-    # probably many more
   tags:
     - latest
 

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -326,6 +326,17 @@ image=dynamodb-provision:
   tags:
     - "{env.TAG}"
 
+image=grapl-e2e-tests-build:
+  image: grapl/grapl-e2e-tests-build
+  context: src/python/grapl_e2e_tests/
+  dockerfile: Dockerfile
+  target: grapl-e2e-tests-build
+  depends:
+    - grapl-analyzerlib-build
+    # probably many more
+  tags:
+    - latest
+
 # js images
 
 image=grapl-cdk-build:
@@ -522,6 +533,18 @@ job=run-analyzer-deployer-integration-tests:
     - GRAPL_LOG_LEVEL=INFO
     - "BUCKET_PREFIX=local-grapl"
     - "IS_LOCAL=True"
+  depends:
+    - integration-env
+
+job=run-e2e-integration-tests:
+  use: grapl-e2e-tests-build
+  net-mode: grapl-integration-tests_default
+  command: /bin/bash -c "sleep 5 && source venv/bin/activate && cd grapl_e2e_tests && python3 ./main.py"
+  env:
+    - GRAPL_LOG_LEVEL=INFO
+    - "BUCKET_PREFIX=local-grapl"
+    - "IS_LOCAL=True"
+    - "MG_ALPHAS=grapl-master-graph-db:9080"
   depends:
     - integration-env
 

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -333,6 +333,7 @@ image=grapl-e2e-tests-build:
   target: grapl-e2e-tests-build
   depends:
     - grapl-analyzerlib-build
+    - etc-build
     # probably many more
   tags:
     - latest
@@ -378,6 +379,15 @@ image=graphql-endpoint:
   target: grapl-graphql-endpoint
   depends:
     - graphql-endpoint-build
+  tags:
+    - "{env.TAG}"
+
+# local grapl
+image=etc-build:
+  image: grapl/etc-build
+  context: etc/
+  dockerfile: Dockerfile
+  target: etc-build
   tags:
     - "{env.TAG}"
 
@@ -539,7 +549,7 @@ job=run-analyzer-deployer-integration-tests:
 job=run-e2e-integration-tests:
   use: grapl-e2e-tests-build
   net-mode: grapl-integration-tests_default
-  command: /bin/bash -c "sleep 5 && source venv/bin/activate && cd grapl_e2e_tests && python3 ./main.py"
+  command: /bin/bash -c "sleep 30 && source venv/bin/activate && cd grapl_e2e_tests && python3 ./main.py"
   env:
     - GRAPL_LOG_LEVEL=INFO
     - "BUCKET_PREFIX=local-grapl"

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -549,7 +549,7 @@ job=run-analyzer-deployer-integration-tests:
 job=run-e2e-integration-tests:
   use: grapl-e2e-tests-build
   net-mode: grapl-integration-tests_default
-  command: /bin/bash -c "sleep 30 && source venv/bin/activate && cd grapl_e2e_tests && python3 ./main.py"
+  command: /bin/bash -c "sleep 5 && source venv/bin/activate && cd grapl_e2e_tests && python3 ./main.py"
   env:
     - GRAPL_LOG_LEVEL=INFO
     - "BUCKET_PREFIX=local-grapl"

--- a/docs/setup/local.md
+++ b/docs/setup/local.md
@@ -31,15 +31,13 @@ docker-compose up
 
 Next, we’ll upload a basic [Analyzer (Grapl’s attack signatures)](https://grapl.readthedocs.io/en/latest/analyzers/implementing.html), which searches for processes named "svchost" without a whitelisted parent process. We've provided a demo Analyzer in the Grapl repository. If you're interested in the code, see our Analyzer docs.
 
-To upload the Analyzer to Grapl, navigate to the root of the cloned grapl repository and run the following command: 
-
-`./upload_analyzer_local.sh`
 Grapl may take a couple of minutes to get started, so if you get an error similar to “could not connect to the endpoint URL”,  give Grapl a few more minutes to  finish provisioning. 
     
 
 To upload our Analyzer to Grapl, navigate to the root of the cloned `grapl` repository and run the following command: 
 
 ```bash
+cd etc/local_grapl/bin/
 ./upload_analyzer_local.sh
 ```
 
@@ -50,6 +48,7 @@ If you get an error similar to “could not connect to the endpoint URL”,  ple
 To get data into Grapl, please run the following command: 
 
 ```bash
+cd etc/local_grapl/bin/
 python3 ./upload-sysmon-logs.py --bucket_prefix=local-grapl --logfile=eventlog.xml 
 ```
 ***Logging In to Grapl:***

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -1,0 +1,7 @@
+# The point of this Dockerfile is simply to expose the
+# local_grapl scripts and sample data to grapl_e2e_tests.
+
+# doesn't have to be node alpine, but eh, it's minimal and it works
+FROM node:alpine3.10 AS etc-build
+WORKDIR /home/grapl
+COPY . etc

--- a/etc/local_grapl/bin/upload-sysmon-logs.py
+++ b/etc/local_grapl/bin/upload-sysmon-logs.py
@@ -60,7 +60,10 @@ def into_sqs_message(bucket: str, key: str) -> str:
     )
 
 
-def main(prefix, logfile, delay, batch_size):
+def main(prefix, logfile, delay, batch_size, use_links: bool):
+    """
+    `use_links` meaning use "s3", "sqs" as opposed to localhost
+    """
     print(
         f"Writing events to {prefix} with {delay} seconds between batches of {batch_size}"
     )
@@ -69,14 +72,14 @@ def main(prefix, logfile, delay, batch_size):
     if prefix == "local-grapl":
         s3 = boto3.client(
             "s3",
-            endpoint_url="http://localhost:9000",
+            endpoint_url="http://s3:9000" if use_links else "http://localhost:9000",
             aws_access_key_id="minioadmin",
             aws_secret_access_key="minioadmin",
             region_name="us-east-3",
         )
         sqs = boto3.client(
             "sqs",
-            endpoint_url="http://localhost:9324",
+            endpoint_url="http://sqs:9324" if use_links else "http://localhost:9324",
             region_name="us-east-1",
             aws_access_key_id="dummy_cred_aws_access_key_id",
             aws_secret_access_key="dummy_cred_aws_secret_access_key",
@@ -108,8 +111,11 @@ def main(prefix, logfile, delay, batch_size):
 
         # local-grapl relies on manual eventing
         if sqs:
+            endpoint_url = (
+                "http://sqs:9324" if use_links else "http://localhost:9324",
+            )
             sqs.send_message(
-                QueueUrl="http://localhost:9324/queue/grapl-sysmon-graph-generator-queue",
+                QueueUrl=f"{endpoint_url}/queue/grapl-sysmon-graph-generator-queue",
                 MessageBody=into_sqs_message(
                     bucket="{}-sysmon-log-bucket".format(prefix), key=key
                 ),
@@ -131,6 +137,7 @@ def parse_args():
     )
     parser.add_argument("--delay", dest="delay", default=0, type=int)
     parser.add_argument("--batch-size", dest="batch_size", default=100, type=int)
+    parser.add_argument("--use-links", dest="use_links", default=False, type=bool)
     return parser.parse_args()
 
 
@@ -140,4 +147,10 @@ if __name__ == "__main__":
     if args.bucket_prefix is None:
         raise Exception("Provide bucket prefix as first argument")
     else:
-        main(args.bucket_prefix, args.logfile, args.delay, args.batch_size)
+        main(
+            args.bucket_prefix,
+            args.logfile,
+            args.delay,
+            args.batch_size,
+            args.use_links,
+        )

--- a/src/python/grapl_e2e_tests/Dockerfile
+++ b/src/python/grapl_e2e_tests/Dockerfile
@@ -1,9 +1,10 @@
 FROM grapl/grapl-python-build:latest AS grapl-e2e-tests-build
+CMD "/bin/bash"
 USER grapl
 WORKDIR /home/grapl
 COPY --chown=grapl . grapl_e2e_tests
-COPY --from=grapl/grapl-analyzerlib-python-build /home/grapl/venv venv
+# Expose the `etc/` dir with all its test data in /home/grapl/local_grapl
+COPY --from=grapl/etc-build /home/grapl/etc etc
 
-COPY --from=grapl/grapl-common-python-build /home/grapl/grapl_common grapl_common
-#RUN /bin/bash -c "source venv/bin/activate && cd grapl_e2e_tests && python ./main.py"
-# we do the run in the dobi.yaml
+COPY --from=grapl/grapl-analyzerlib-python-build /home/grapl/venv venv
+RUN /bin/bash -c "source venv/bin/activate && pip install zstd"

--- a/src/python/grapl_e2e_tests/Dockerfile
+++ b/src/python/grapl_e2e_tests/Dockerfile
@@ -1,0 +1,9 @@
+FROM grapl/grapl-python-build:latest AS grapl-e2e-tests-build
+USER grapl
+WORKDIR /home/grapl
+COPY --chown=grapl . grapl_e2e_tests
+COPY --from=grapl/grapl-analyzerlib-python-build /home/grapl/venv venv
+
+COPY --from=grapl/grapl-common-python-build /home/grapl/grapl_common grapl_common
+#RUN /bin/bash -c "source venv/bin/activate && cd grapl_e2e_tests && python ./main.py"
+# we do the run in the dobi.yaml

--- a/src/python/grapl_e2e_tests/Dockerfile
+++ b/src/python/grapl_e2e_tests/Dockerfile
@@ -3,7 +3,7 @@ CMD "/bin/bash"
 USER grapl
 WORKDIR /home/grapl
 COPY --chown=grapl . grapl_e2e_tests
-# Expose the `etc/` dir with all its test data in /home/grapl/local_grapl
+# Expose the `etc/` dir with all its test data in /home/grapl/etc
 COPY --from=grapl/etc-build /home/grapl/etc etc
 
 COPY --from=grapl/grapl-analyzerlib-python-build /home/grapl/venv venv

--- a/src/python/grapl_e2e_tests/main.py
+++ b/src/python/grapl_e2e_tests/main.py
@@ -1,0 +1,2 @@
+if __name__ == "__main__":
+    print("wassup fam")

--- a/src/python/grapl_e2e_tests/main.py
+++ b/src/python/grapl_e2e_tests/main.py
@@ -1,2 +1,77 @@
+import boto3
+import subprocess
+from os import environ
+from typing import Any
+import logging
+from resources import wait_on_resources
+from sys import stdout
+
+# mypy later maybe
+S3ServiceResource = Any
+
+BUCKET_PREFIX = environ["BUCKET_PREFIX"]
+# assert BUCKET_PREFIX == "local-grapl"
+
+
+def _upload_analyzers(s3_client: S3ServiceResource) -> None:
+    """
+    Basically reimplementing upload_local_analyzers.sh
+    Janky, since Jesse will have an analyzer-uploader service pretty soon.
+    """
+    to_upload = [
+        (
+            "/home/grapl/etc/local_grapl/suspicious_svchost/main.py",
+            "analyzers/suspicious_svchost/main.py",
+        ),
+        (
+            "/home/grapl/etc/local_grapl/unique_cmd_parent/main.py",
+            "analyzers/unique_cmd_parent/main.py",
+        ),
+    ]
+    bucket = f"{BUCKET_PREFIX}-analyzers-bucket"
+    for (local_path, s3_key) in to_upload:
+        logging.info(f"S3 uploading {local_path}")
+        with open(local_path, "r") as f:
+            s3_client.put_object(Body=f.read(), Bucket=bucket, Key=s3_key)
+
+
+def _upload_test_data(s3_client: S3ServiceResource) -> None:
+    """
+    i hate this lol
+    """
+    logging.info(f"Running upload-sysmon-logs")
+
+    subprocess.run(
+        [
+            "python3",
+            "/home/grapl/etc/local_grapl/bin/upload-sysmon-logs.py",
+            "--bucket_prefix",
+            BUCKET_PREFIX,
+            "--logfile",
+            "/home/grapl/etc/sample_data/eventlog.xml",
+            "--use-links",
+            "True",
+        ]
+    )
+
+
+def _create_s3_client() -> S3ServiceResource:
+    return boto3.client(
+        "s3",
+        endpoint_url="http://s3:9000",
+        aws_access_key_id="minioadmin",
+        aws_secret_access_key="minioadmin",
+    )
+
+
+def main() -> None:
+    logging.basicConfig(stream=stdout, level=logging.INFO)
+
+    s3_client = _create_s3_client()
+    wait_on_resources(s3_client, BUCKET_PREFIX)
+    _upload_analyzers(s3_client)
+    _upload_test_data(s3_client)
+
+
 if __name__ == "__main__":
-    print("wassup fam")
+    main()

--- a/src/python/grapl_e2e_tests/main.py
+++ b/src/python/grapl_e2e_tests/main.py
@@ -84,7 +84,8 @@ def main() -> None:
     _upload_analyzers(s3_client)
     _upload_test_data(s3_client)
 
-    pytest.main()
+    import tests
+    return pytest.main(['--collect-only'])
 
 
 if __name__ == "__main__":

--- a/src/python/grapl_e2e_tests/main.py
+++ b/src/python/grapl_e2e_tests/main.py
@@ -94,8 +94,6 @@ def main() -> None:
     _upload_analyzers(s3_client)
     _upload_test_data(s3_client)
 
-    import tests
-
     return pytest.main()
 
 

--- a/src/python/grapl_e2e_tests/main.py
+++ b/src/python/grapl_e2e_tests/main.py
@@ -85,7 +85,7 @@ def main() -> None:
     _upload_test_data(s3_client)
 
     import tests
-    return pytest.main(['--collect-only'])
+    return pytest.main()
 
 
 if __name__ == "__main__":

--- a/src/python/grapl_e2e_tests/pytest.ini
+++ b/src/python/grapl_e2e_tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = test*.py

--- a/src/python/grapl_e2e_tests/resources.py
+++ b/src/python/grapl_e2e_tests/resources.py
@@ -1,0 +1,53 @@
+from time import sleep
+import logging
+import boto3
+from typing import Any, Set
+from typing_extensions import Protocol
+from itertools import cycle
+
+
+class WaitForResource(Protocol):
+    def exists(self) -> bool:
+        pass
+
+
+class WaitForS3Bucket(WaitForResource):
+    def __init__(self, s3_client: Any, bucket_name: str):
+        self.s3_client = s3_client
+        self.bucket_name = bucket_name
+
+    def exists(self) -> bool:
+        try:
+            self.s3_client.head_bucket(Bucket=self.bucket_name)
+        except self.s3_client.exceptions.NoSuchBucket:
+            return False
+        else:
+            return True
+
+    def __str__(self) -> str:
+        return f"WaitForS3Bucket({self.bucket_name})"
+
+
+def wait_on_resources(s3_client: Any, bucket_prefix: str):
+    # okay, so, as it turns out, these are instantly created, and this has no value-add
+    # but I sort of like this pattern, so, eh
+    resources = [
+        WaitForS3Bucket(s3_client, f"{bucket_prefix}-analyzers-bucket"),
+        WaitForS3Bucket(s3_client, f"{bucket_prefix}-sysmon-log-bucket"),
+    ]
+
+    completed: Set[WaitForResource] = set()
+
+    # Cycle through `resources` forever, until all resources are attained
+    for resource in cycle(resources):
+        if len(completed) == len(resources):
+            break
+        if resource in completed:
+            continue
+
+        logging.info(f"Checking resource: {resource}")
+
+        now_exists = resource.exists()
+        if now_exists:
+            completed.add(resource)
+        sleep(1)

--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -1,0 +1,3 @@
+from unittest import TestCase
+class TestEndToEnd(TestCase):
+    pass

--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -1,3 +1,10 @@
 from unittest import TestCase
 class TestEndToEnd(TestCase):
-    pass
+    def test_analyzer_deployed_properly(self) -> None:
+        pass
+
+    def test_analyzer_fired(self) -> None:
+        pass
+
+    def test_expected_data_in_dgraph(self) -> None:
+        assert True

--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+
 class TestEndToEnd(TestCase):
     def test_analyzer_deployed_properly(self) -> None:
         pass

--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -3,10 +3,10 @@ from unittest import TestCase
 
 class TestEndToEnd(TestCase):
     def test_analyzer_deployed_properly(self) -> None:
-        pass
+        assert True
 
     def test_analyzer_fired(self) -> None:
-        pass
+        assert True
 
     def test_expected_data_in_dgraph(self) -> None:
         assert True

--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+
 class TestEndToEnd(TestCase):
     def test_analyzer_deployed_properly(self) -> None:
         pass


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
#231 

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Created a skeleton framework for e2e tests with empty, useless tests.
However I'm confident that the 'setup' part of it works well.

Output:
```
Starting grapl-integration-tests_grapl-graph-provision_1               ... done
Starting grapl-integration-tests_analyzer-deployer_1                   ... done
Starting grapl-integration-tests_grapl-node-identifier-retry-handler_1 ... done
Starting grapl-integration-tests_grapl-node-identifier_1               ... done
Starting grapl-integration-tests_grapl-sysmon-subgraph-generator_1     ... done
Starting grapl-integration-tests_grapl-graph-merger_1                  ... done
[compose:up integration-env] docker-compose.yml Done
[job: run-e2e-integration-tests] /bin/bash -c "sleep 5 && source venv/bin/activate && cd grapl_e2e_tests && python3 ./main.py" Start
INFO:root:Checking resource: WaitForS3Bucket(local-grapl-analyzers-bucket)
INFO:root:Checking resource: WaitForS3Bucket(local-grapl-sysmon-log-bucket)
INFO:root:Checking resource: WaitForSqsQueue(grapl-sysmon-graph-generator-queue)
INFO:root:Checking resource: WaitForSqsQueue(grapl-sysmon-graph-generator-queue)
INFO:root:Checking resource: WaitForSqsQueue(grapl-sysmon-graph-generator-queue)
INFO:root:Checking resource: WaitForSqsQueue(grapl-sysmon-graph-generator-queue)
INFO:root:Checking resource: WaitForSqsQueue(grapl-sysmon-graph-generator-queue)
INFO:root:Checking resource: WaitForSqsQueue(grapl-sysmon-graph-generator-queue)
INFO:root:Checking resource: WaitForSqsQueue(grapl-sysmon-graph-generator-queue)
INFO:root:Checking resource: WaitForSqsQueue(grapl-sysmon-graph-generator-queue)
INFO:root:Checking resource: WaitForSqsQueue(grapl-sysmon-graph-generator-queue)
INFO:root:S3 uploading /home/grapl/etc/local_grapl/suspicious_svchost/main.py
INFO:root:S3 uploading /home/grapl/etc/local_grapl/unique_cmd_parent/main.py
INFO:root:Running upload-sysmon-logs
Writing events to local-grapl with 0 seconds between batches of 100
Completed uploading at Thu Sep 24 01:52:38 2020
============================= test session starts ==============================
platform linux -- Python 3.7.9, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/grapl/grapl_e2e_tests, configfile: pytest.ini
plugins: hypothesis-5.35.4, forked-1.3.0, xdist-2.1.0
collected 3 items

tests.py ...                                                             [100%]

============================== 3 passed in 0.02s ===============================
[job: run-e2e-integration-tests] /bin/bash -c "sleep 5 && source venv/bin/activate && cd grapl_e2e_tests && python3 ./main.py" Done
[compose:up integration-env] docker-compose.yml project stop
Stopping grapl-integration-tests_grapl-graph-merger_1                  ... done
Stopping grapl-integration-tests_grapl-sysmon-subgraph-generator_1     ... done
Stopping grapl-integration-tests_grapl-node-identifier_1               ... done
Stopping grapl-integration-tests_grapl-node-identifier-retry-handler_1 ... done
Stopping grapl-integration-tests_grapl-model-plugin-deployer_1         ... done
```

### How were these changes tested?
TAG=latest dobi run-e2e-integration-tests
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
