### PR TITLE
Add one more sleep to e2e test

### DIFF
--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -1,3 +1,4 @@
+from time import sleep
 from unittest import TestCase
 from grapl_analyzerlib.grapl_client import MasterGraphClient
 from grapl_analyzerlib.nodes.lens import LensQuery, LensView
@@ -18,6 +19,8 @@ class TestEndToEnd(TestCase):
         lens_resource = wait_for_lens()
         wait_result = resources.wait_on_resources([lens_resource], timeout_secs=120)
         lens: LensView = wait_result[lens_resource]
+        # Adding nodes to this lens is not an atomic operation, so let's add some buffer and hope for the best
+        sleep(5)
         assert lens.get_lens_name() == LENS_NAME
         assert len(lens.get_scope()) == 3
 

--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -1,9 +1,9 @@
-from time import sleep
 from unittest import TestCase
 from grapl_analyzerlib.grapl_client import MasterGraphClient
 from grapl_analyzerlib.nodes.lens import LensQuery, LensView
 import resources
-from typing import Any, Optional
+from typing import Any, Optional, Callable
+import inspect
 
 LENS_NAME = "DESKTOP-FVSHABR"
 
@@ -18,12 +18,14 @@ class TestEndToEnd(TestCase):
     def test_expected_data_in_dgraph(self) -> None:
         lens_resource = wait_for_lens()
         wait_result = resources.wait_on_resources([lens_resource], timeout_secs=120)
+
         lens: LensView = wait_result[lens_resource]
-        # Adding nodes to this lens is not an atomic operation, so let's add some buffer and hope for the best
-        # a better solution would be to specify the specific scope in `wait_for_lens`
-        sleep(5)
         assert lens.get_lens_name() == LENS_NAME
-        assert len(lens.get_scope()) == 3
+
+        # lens scope is not atomic
+        resources.wait_on_resources(
+            [WaitForCondition(lambda: (len(lens.get_scope()) == 4))]
+        )
 
 
 def wait_for_lens():
@@ -32,13 +34,29 @@ def wait_for_lens():
     return WaitForLens(local_client, query)
 
 
+class WaitForCondition(resources.WaitForResource):
+    """ just something nice n generic """
+
+    def __init__(self, fn: Callable[[], Optional[bool]]) -> None:
+        self.fn = fn
+
+    def acquire(self) -> Optional[Any]:
+        result = self.fn()
+        if result:
+            return self  # just anything non-None
+        else:
+            return None
+
+    def __str__(self) -> str:
+        return f"WaitForCondition({inspect.getsource(self.fn)})"
+
+
 class WaitForLens(resources.WaitForResource):
-    def __init__(self, dgraph_client: Any, query: LensQuery):
+    def __init__(self, dgraph_client: Any, query: LensQuery) -> None:
         self.dgraph_client = dgraph_client
         self.query = query
 
     def acquire(self) -> Optional[Any]:
-        # result = self.query.get_count(self.dgraph_client)
         result = self.query.query_first(self.dgraph_client)
         return result
 

--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -20,6 +20,7 @@ class TestEndToEnd(TestCase):
         wait_result = resources.wait_on_resources([lens_resource], timeout_secs=120)
         lens: LensView = wait_result[lens_resource]
         # Adding nodes to this lens is not an atomic operation, so let's add some buffer and hope for the best
+        # a better solution would be to specify the specific scope in `wait_for_lens`
         sleep(5)
         assert lens.get_lens_name() == LENS_NAME
         assert len(lens.get_scope()) == 3


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
#231 

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
The e2e test failed once yesterday because the lens only had 1 node in scope instead of 3. turns out adding those edges is not atomic. 
Upon re-run it worked fine.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
by submitting this diff, yolo