### PR TITLE
E2E tests are no longer part of the integration-tests workflow, and are no longer required.

### DIFF
--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -109,3 +109,24 @@ jobs:
       - name: Run integration tests
         run: |
           GRAPL_RELEASE_TARGET=debug TAG=latest ./dobi-linux --no-bind-mount integration-tests
+
+  # In the future, this should probably be merged back into `dobi integration-tests`, but
+  # since it's so timing-dependent I'm going to treat it separately until it stabilizes a bit.
+  end-to-end-integration-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dobi
+        run: |
+          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
+          chmod +x dobi-linux
+
+      - name: Build Grapl
+        run: |
+          GRAPL_RELEASE_TARGET=debug TAG=latest ./dobi-linux --no-bind-mount build
+
+      - name: Run end-to-end integration tests
+        run: |
+          GRAPL_RELEASE_TARGET=debug TAG=latest ./dobi-linux --no-bind-mount run-e2e-integration-tests

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -776,7 +776,6 @@ alias=integration-tests:
   tasks:
     - rust-integration-tests
     - python-integration-tests
-    - run-e2e-integration-tests
     # TODO: js integration tests
   annotations:
     description: "Run all the integration tests"

--- a/src/python/grapl_e2e_tests/main.py
+++ b/src/python/grapl_e2e_tests/main.py
@@ -83,14 +83,15 @@ def main() -> int:
     s3_client = _create_s3_client()
     sqs_client = _create_sqs_client()
 
-    wait_for = [
-        # for uploading analyzers
-        resources.WaitForS3Bucket(s3_client, f"{BUCKET_PREFIX}-analyzers-bucket"),
-        # for upload-sysmon-logs.py
-        resources.WaitForS3Bucket(s3_client, f"{BUCKET_PREFIX}-sysmon-log-bucket"),
-        resources.WaitForSqsQueue(sqs_client, "grapl-sysmon-graph-generator-queue"),
-    ]
-    resources.wait_on_resources(wait_for)
+    resources.wait_for(
+        [
+            # for uploading analyzers
+            resources.WaitForS3Bucket(s3_client, f"{BUCKET_PREFIX}-analyzers-bucket"),
+            # for upload-sysmon-logs.py
+            resources.WaitForS3Bucket(s3_client, f"{BUCKET_PREFIX}-sysmon-log-bucket"),
+            resources.WaitForSqsQueue(sqs_client, "grapl-sysmon-graph-generator-queue"),
+        ]
+    )
 
     _upload_analyzers(s3_client)
     _upload_test_data(s3_client)

--- a/src/python/grapl_e2e_tests/resources.py
+++ b/src/python/grapl_e2e_tests/resources.py
@@ -46,7 +46,7 @@ class WaitForSqsQueue(WaitForResource):
         return f"WaitForSqsQueue({self.queue_name})"
 
 
-def wait_on_resources(
+def wait_for(
     resources: Sequence[WaitForResource], timeout_secs=30
 ) -> Mapping[WaitForResource, Any]:
     completed: Dict[WaitForResource, Any] = {}

--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -17,14 +17,14 @@ class TestEndToEnd(TestCase):
 
     def test_expected_data_in_dgraph(self) -> None:
         lens_resource = wait_for_lens()
-        wait_result = resources.wait_on_resources([lens_resource], timeout_secs=120)
+        wait_result = resources.wait_for([lens_resource], timeout_secs=120)
 
         lens: LensView = wait_result[lens_resource]
         assert lens.get_lens_name() == LENS_NAME
 
         # lens scope is not atomic
-        resources.wait_on_resources(
-            [WaitForCondition(lambda: (len(lens.get_scope()) == 4))]
+        resources.wait_for(
+            [WaitForCondition(lambda: (len(lens.get_scope()) == 4))], timeout_secs=120
         )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
#231

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
E2E tests are no longer part of the integration-tests workflow, and are no longer required.
It's highly timing dependent, and sometimes it works, and sometimes it's not.

I've bumped the timeout on "4 entities within scope" up from 30s to 120s.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
its tests
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
