### PR TITLE
Bugfix for "push staging images to dockerhub" workflow

### DIFF
--- a/.github/workflows/grapl-staging-release.yml
+++ b/.github/workflows/grapl-staging-release.yml
@@ -3,7 +3,7 @@ name: Grapl Staging Release
 on:
   # Every time we push to staging,
   # release that to Dockerhub with the tag 'staging'.
-  push:
+  pull_request:  # TODO reverting asap
     branches:
     - staging
 

--- a/.github/workflows/grapl-staging-release.yml
+++ b/.github/workflows/grapl-staging-release.yml
@@ -92,7 +92,6 @@ jobs:
           echo "::set-env name=TAG::staging"
 
       - name: Build JS services
-        env:
         run: |
           GRAPL_RELEASE_TARGET=release ./dobi-linux --no-bind-mount js
 
@@ -101,8 +100,6 @@ jobs:
           echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login --username grapl --password-stdin
 
       - name: Publish JS images to DockerHub
-        env:
-          VERSION: ${{ github.event.release.tag_name }}
         run: |
           docker push grapl/grapl-engagement-view:$TAG
           docker push grapl/grapl-graphql-endpoint:$TAG

--- a/.github/workflows/grapl-staging-release.yml
+++ b/.github/workflows/grapl-staging-release.yml
@@ -3,7 +3,7 @@ name: Grapl Staging Release
 on:
   # Every time we push to staging,
   # release that to Dockerhub with the tag 'staging'.
-  pull_request:  # TODO reverting asap
+  push:
     branches:
     - staging
 


### PR DESCRIPTION
Minor bug in the yaml - it didn't like an empty `env:`
