### PR TITLE
Add MG_ALPHAS env variable to notebook in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -346,6 +346,8 @@ services:
 
   grapl-notebook:
     image: grapl/grapl-notebook:${TAG:-latest}
+    environment:
+      - MG_ALPHAS=master_graph:9080
     links:
       - grapl-master-graph-db:master_graph
     ports:


### PR DESCRIPTION
### Which issue does this PR correspond to?

No Grapl issue (yet?) but when trying to run a simple query in local grapl I'd get a connection.

```
q = ProcessQuery()
q.query(mclient, first=500)
```

```
debug_error_string = "{"created":"@1601954099.726020446","description":"Failed to pick subchannel","file":"src/core/ext/filters/client_channel/client_channel.cc","file_line":4133,"referenced_errors":[{"created":"@1601954099.726014048","description":"failed to connect to all addresses","file":"src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc","file_line":397,"grpc_status":14}]}"
```

### What changes does this PR make to Grapl? Why?

I'm adding the MG_ALPHAS env var to the notebook container in docker-compose.

### How were these changes tested?

Ran `docker-compose up` with this diff and ran the same query with no issue. The query returned empty list, as expected.