### PR TITLE
Fix push_py_to_docker for new provision service

### DIFF
--- a/etc/build_scripts/push_py_to_docker.sh
+++ b/etc/build_scripts/push_py_to_docker.sh
@@ -7,8 +7,7 @@ services=(
     notebook
     engagement-edge
     model-plugin-deployer
-    local-provision
-    dynamodb-provision
+    provision
     dgraph-ttl
 )
 


### PR DESCRIPTION
sadly, this is the output in the current setup:

```

00656e899bf2: Pushed
1bdb7650b726: Pushed
staging: digest: sha256:4d79fa36ae25335a3153ffe882b1dc9cea7796c297bc6ada0e87267ef38f0e72 size: 2625
An image does not exist locally with the tag: grapl/grapl-local-provision
The push refers to repository [docker.io/grapl/grapl-local-provision]
An image does not exist locally with the tag: grapl/grapl-dynamodb-provision
The push refers to repository [docker.io/grapl/grapl-dynamodb-provision]
The push refers to repository [docker.io/grapl/grapl-dgraph-ttl]
cfe427083b37: Preparing
1d6ab56bf426: Preparing
3062cf14e417: Preparing
```

wtf that should be a hard fail imo but ok docker