### PR TITLE
Add script to clean up Github Actions CI before builds

### DIFF
--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install dobi
+      - name: Prepare Github Actions CI
         run: |
-          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
-          chmod +x dobi-linux
+          ./etc/ci_scripts/clean_gh_actions_space.sh
+          ./etc/ci_scripts/install_requirements.sh
 
       - name: Build Rust services
         run: |
@@ -44,10 +44,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install dobi
+      - name: Prepare Github Actions CI
         run: |
-          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
-          chmod +x dobi-linux
+          ./etc/ci_scripts/clean_gh_actions_space.sh
+          ./etc/ci_scripts/install_requirements.sh
 
       - name: Build Python services
         run: |
@@ -63,10 +63,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install dobi
+      - name: Prepare Github Actions CI
         run: |
-          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
-          chmod +x dobi-linux
+          ./etc/ci_scripts/clean_gh_actions_space.sh
+          ./etc/ci_scripts/install_requirements.sh
 
       - name: Run dobi python-typecheck
         run: |
@@ -78,10 +78,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install dobi
+      - name: Prepare Github Actions CI
         run: |
-          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
-          chmod +x dobi-linux
+          ./etc/ci_scripts/clean_gh_actions_space.sh
+          ./etc/ci_scripts/install_requirements.sh
 
       - name: Build JS services
         run: |
@@ -97,10 +97,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install dobi
+      - name: Prepare Github Actions CI
         run: |
-          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
-          chmod +x dobi-linux
+          ./etc/ci_scripts/clean_gh_actions_space.sh
+          ./etc/ci_scripts/install_requirements.sh
 
       - name: Build Grapl
         run: |
@@ -118,10 +118,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install dobi
+      - name: Prepare Github Actions CI
         run: |
-          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
-          chmod +x dobi-linux
+          ./etc/ci_scripts/clean_gh_actions_space.sh
+          ./etc/ci_scripts/install_requirements.sh
 
       - name: Build Grapl
         run: |

--- a/.github/workflows/grapl-release.yml
+++ b/.github/workflows/grapl-release.yml
@@ -12,10 +12,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Install dobi
+      - name: Prepare Github Actions CI
         run: |
-          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
-          chmod +x dobi-linux
+          ./etc/ci_scripts/clean_gh_actions_space.sh
+          ./etc/ci_scripts/install_requirements.sh
 
       - name: Run unit tests
         run: |
@@ -28,10 +28,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Install dobi
+      - name: Prepare Github Actions CI
         run: |
-          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
-          chmod +x dobi-linux
+          ./etc/ci_scripts/clean_gh_actions_space.sh
+          ./etc/ci_scripts/install_requirements.sh
 
       - name: Run integration tests
         run: |
@@ -112,10 +112,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Install dobi
+      - name: Prepare Github Actions CI
         run: |
-          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
-          chmod +x dobi-linux
+          ./etc/ci_scripts/clean_gh_actions_space.sh
+          ./etc/ci_scripts/install_requirements.sh
       
       - name: Determine release channel
         run: |
@@ -232,10 +232,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Install dobi
+      - name: Prepare Github Actions CI
         run: |
-          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
-          chmod +x dobi-linux
+          ./etc/ci_scripts/clean_gh_actions_space.sh
+          ./etc/ci_scripts/install_requirements.sh
 
       - name: Determine release channel
         run: |
@@ -426,10 +426,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Install dobi
+      - name: Prepare Github Actions CI
         run: |
-          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
-          chmod +x dobi-linux
+          ./etc/ci_scripts/clean_gh_actions_space.sh
+          ./etc/ci_scripts/install_requirements.sh
 
       - name: Determine release channel
         run: |

--- a/.github/workflows/grapl-staging-release.yml
+++ b/.github/workflows/grapl-staging-release.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install dobi
+      - name: Prepare Github Actions CI
         run: |
-          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
-          chmod +x dobi-linux
+          ./etc/ci_scripts/clean_gh_actions_space.sh
+          ./etc/ci_scripts/install_requirements.sh
 
       - name: Export tag
         run: |
@@ -45,10 +45,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install dobi
+      - name: Prepare Github Actions CI
         run: |
-          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
-          chmod +x dobi-linux
+          ./etc/ci_scripts/clean_gh_actions_space.sh
+          ./etc/ci_scripts/install_requirements.sh
 
       - name: Export tag
         run: |
@@ -77,10 +77,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install dobi
+      - name: Prepare Github Actions CI
         run: |
-          wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
-          chmod +x dobi-linux
+          ./etc/ci_scripts/clean_gh_actions_space.sh
+          ./etc/ci_scripts/install_requirements.sh
     
       - name: Export tag
         run: |

--- a/etc/ci_scripts/clean_gh_actions_space.sh
+++ b/etc/ci_scripts/clean_gh_actions_space.sh
@@ -1,7 +1,7 @@
 # Clean up some of the stuff pre-installed on Github Actions boxes 
 # so we have >10GB to work with.
 
-echo "Starting space: $(df -h | grep " /$")"
+echo "Starting space: $(df -h | grep ' /$')"
 
 # Based on https://github.com/actions/virtual-environments/issues/709
 # Removes 5GB
@@ -14,4 +14,4 @@ sudo apt-get clean
 # a tad aggressive. I'll leave this not about it here, though.
 # https://github.com/scikit-hep/pyhf/pull/819#issuecomment-616055763
 
-echo "Ending space: $(df -h | grep /dev/sda1)"
+echo "Ending space: $(df -h | grep ' /$')"

--- a/etc/ci_scripts/clean_gh_actions_space.sh
+++ b/etc/ci_scripts/clean_gh_actions_space.sh
@@ -1,0 +1,17 @@
+# Clean up some of the stuff pre-installed on Github Actions boxes 
+# so we have >10GB to work with.
+
+echo "Starting space: $(df -h | grep /dev/sda1)"
+
+# Based on https://github.com/actions/virtual-environments/issues/709
+# Removes 5GB
+sudo rm -rf "/usr/local/share/boost"
+sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
+sudo apt-get clean
+
+# Another thing I've seen was to remove /swapfile, but that's
+# a tad aggressive. I'll leave this not about it here, though.
+# https://github.com/scikit-hep/pyhf/pull/819#issuecomment-616055763
+
+echo "Ending space: $(df -h | grep /dev/sda1)"

--- a/etc/ci_scripts/clean_gh_actions_space.sh
+++ b/etc/ci_scripts/clean_gh_actions_space.sh
@@ -1,7 +1,7 @@
 # Clean up some of the stuff pre-installed on Github Actions boxes 
 # so we have >10GB to work with.
 
-echo "Starting space: $(df -h | grep /dev/sda1)"
+echo "Starting space: $(df -h | grep " /$")"
 
 # Based on https://github.com/actions/virtual-environments/issues/709
 # Removes 5GB

--- a/etc/ci_scripts/install_requirements.sh
+++ b/etc/ci_scripts/install_requirements.sh
@@ -1,0 +1,3 @@
+
+wget https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-linux
+chmod +x dobi-linux


### PR DESCRIPTION
Should save a minimum of 5GB.

![image](https://user-images.githubusercontent.com/69007229/95609245-44ceec00-0a13-11eb-8547-bfe3ece63f19.png)
