### PR TITLE
Add a 'release' step for grapl-tests-common; refactor the "upload sysmon logs" logic into this library

### DIFF
--- a/.github/workflows/grapl-lint.yml
+++ b/.github/workflows/grapl-lint.yml
@@ -117,3 +117,5 @@ jobs:
                 true
           fi
           deactivate
+      
+      # TODO: Once grapl-tests-common is on pypi, add the pypi check.

--- a/.github/workflows/grapl-release.yml
+++ b/.github/workflows/grapl-release.yml
@@ -416,6 +416,31 @@ jobs:
         run: |
           rm -rf dist
 
+      - name: Prepare grapl-tests-common dist
+        run: |
+          docker create -ti --name grapl-tests-common grapl/grapl-tests-common-python-build:latest
+          docker cp grapl-tests-common:/home/grapl/grapl-tests-common/dist .
+          docker rm -f grapl-tests-common
+
+      - name: Upload grapl-tests-common to Test PyPI
+        if: env.CHANNEL == 'beta'
+        uses: pypa/gh-action-pypi-publish@v1.1.0
+        with:
+          user: __token__
+          password: ${{ secrets.GRAPL_ANALYZERLIB_TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Upload grapl-tests-common to PyPI
+        if: env.CHANNEL == 'latest'
+        uses: pypa/gh-action-pypi-publish@v1.1.0
+        with:
+          user: __token__
+          password: ${{ secrets.GRAPL_ANALYZERLIB_PYPI_TOKEN }}
+
+      - name: Clean up grapl-tests-common dist
+        run: |
+          rm -rf dist
+
 
 
   release-js-services:

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -157,7 +157,6 @@ image=grapl-tests-common-build:
   depends:
     - python-build
     - grapl-analyzerlib-build
-    - etc-build
   tags:
     - latest
 
@@ -333,6 +332,7 @@ image=grapl-e2e-tests-build:
   target: grapl-e2e-tests-build
   depends:
     - grapl-tests-common-build
+    - etc-build  # has all the test data
   tags:
     - latest
 

--- a/etc/local_grapl/bin/upload-sysmon-logs.py
+++ b/etc/local_grapl/bin/upload-sysmon-logs.py
@@ -8,9 +8,10 @@ import sys
 from pathlib import Path
 from typing import Callable
 
+
 def hack_PATH_to_include_grapl_tests_common() -> Callable:
     """
-    Requirements: 
+    Requirements:
     - this script should be runnable from command line without Docker.
     - the logic should be exposed as a library that's callable from grapl-tests-common.
     It was either this, or forcing a `pip install .` from python code. Gross.
@@ -27,6 +28,7 @@ def hack_PATH_to_include_grapl_tests_common() -> Callable:
 
     sys.path.append(str(grapl_tests_common_path))
     from upload_sysmon_logs import upload_sysmon_logs
+
     return upload_sysmon_logs
 
 
@@ -50,7 +52,8 @@ if __name__ == "__main__":
     if args.bucket_prefix is None:
         raise Exception("Provide bucket prefix as first argument")
     else:
-        hack_PATH_to_include_grapl_tests_common().main(
+        upload_fn = hack_PATH_to_include_grapl_tests_common()
+        upload_fn(
             args.bucket_prefix,
             args.logfile,
             args.delay,

--- a/etc/local_grapl/bin/upload-sysmon-logs.py
+++ b/etc/local_grapl/bin/upload-sysmon-logs.py
@@ -4,126 +4,27 @@ Despite the path, this is *not* tied just to Local Grapl, and can also be used o
 """
 
 import argparse
-import json
-import random
-import string
-import time
-from datetime import datetime
+import sys
+from pathlib import Path
+from typing import Callable
 
-import boto3
-
-import zstd
-
-
-def rand_str(l):
-    # type: (int) -> str
-    return "".join(
-        random.choice(string.ascii_uppercase + string.digits) for _ in range(l)
-    )
-
-
-def into_sqs_message(bucket: str, key: str) -> str:
-    return json.dumps(
-        {
-            "Records": [
-                {
-                    "awsRegion": "us-east-1",
-                    "eventTime": datetime.utcnow().isoformat(),
-                    "principalId": {
-                        "principalId": None,
-                    },
-                    "requestParameters": {
-                        "sourceIpAddress": None,
-                    },
-                    "responseElements": {},
-                    "s3": {
-                        "schemaVersion": None,
-                        "configurationId": None,
-                        "bucket": {
-                            "name": bucket,
-                            "ownerIdentity": {
-                                "principalId": None,
-                            },
-                        },
-                        "object": {
-                            "key": key,
-                            "size": 0,
-                            "urlDecodedKey": None,
-                            "versionId": None,
-                            "eTag": None,
-                            "sequencer": None,
-                        },
-                    },
-                }
-            ]
-        }
-    )
-
-
-def main(prefix, logfile, delay, batch_size, use_links: bool):
+def hack_PATH_to_include_grapl_tests_common() -> Callable:
     """
-    `use_links` meaning use "s3", "sqs" as opposed to localhost
+    It was either this, or forcing a `pip install .` from python code.
     """
-    print(
-        f"Writing events to {prefix} with {delay} seconds between batches of {batch_size}"
+    this_file = Path(__file__).resolve()
+    # go to `grapl` base dir
+    grapl_repo_root = this_file
+    while grapl_repo_root.name != "grapl":
+        grapl_repo_root = grapl_repo_root.parent
+
+    grapl_tests_common_path = grapl_repo_root.joinpath(
+        "src/python/grapl-tests-common/grapl_tests_common"
     )
-    sqs = None
-    # local-grapl prefix is reserved for running Grapl locally
-    if prefix == "local-grapl":
-        s3 = boto3.client(
-            "s3",
-            endpoint_url="http://s3:9000" if use_links else "http://localhost:9000",
-            aws_access_key_id="minioadmin",
-            aws_secret_access_key="minioadmin",
-            region_name="us-east-3",
-        )
-        sqs = boto3.client(
-            "sqs",
-            endpoint_url="http://sqs:9324" if use_links else "http://localhost:9324",
-            region_name="us-east-1",
-            aws_access_key_id="dummy_cred_aws_access_key_id",
-            aws_secret_access_key="dummy_cred_aws_secret_access_key",
-        )
 
-    else:
-        s3 = boto3.client("s3")
-
-    with open(logfile, "rb") as b:
-        body = b.readlines()
-        body = [line for line in body]
-
-    def chunker(seq, size):
-        return [seq[pos : pos + size] for pos in range(0, len(seq), size)]
-
-    for chunks in chunker(body, batch_size):
-        c_body = zstd.compress(b"\n".join(chunks).replace(b"\n\n", b"\n"), 4)
-        epoch = int(time.time())
-
-        key = (
-            str(epoch - (epoch % (24 * 60 * 60)))
-            + "/sysmon/"
-            + str(epoch)
-            + rand_str(3)
-        )
-        s3.put_object(
-            Body=c_body, Bucket="{}-sysmon-log-bucket".format(prefix), Key=key
-        )
-
-        # local-grapl relies on manual eventing
-        if sqs:
-            endpoint_url = (
-                "http://sqs:9324" if use_links else "http://localhost:9324",
-            )
-            sqs.send_message(
-                QueueUrl=f"{endpoint_url}/queue/grapl-sysmon-graph-generator-queue",
-                MessageBody=into_sqs_message(
-                    bucket="{}-sysmon-log-bucket".format(prefix), key=key
-                ),
-            )
-
-        time.sleep(delay)
-
-    print(f"Completed uploading at {time.ctime()}")
+    sys.path.append(str(grapl_tests_common_path))
+    from upload_sysmon_logs import upload_sysmon_logs
+    return upload_sysmon_logs
 
 
 def parse_args():
@@ -142,12 +43,11 @@ def parse_args():
 
 
 if __name__ == "__main__":
-
     args = parse_args()
     if args.bucket_prefix is None:
         raise Exception("Provide bucket prefix as first argument")
     else:
-        main(
+        hack_PATH_to_include_grapl_tests_common().main(
             args.bucket_prefix,
             args.logfile,
             args.delay,

--- a/etc/local_grapl/bin/upload-sysmon-logs.py
+++ b/etc/local_grapl/bin/upload-sysmon-logs.py
@@ -10,7 +10,10 @@ from typing import Callable
 
 def hack_PATH_to_include_grapl_tests_common() -> Callable:
     """
-    It was either this, or forcing a `pip install .` from python code.
+    Requirements: 
+    - this script should be runnable from command line without Docker.
+    - the logic should be exposed as a library that's callable from grapl-tests-common.
+    It was either this, or forcing a `pip install .` from python code. Gross.
     """
     this_file = Path(__file__).resolve()
     # go to `grapl` base dir

--- a/src/python/grapl-tests-common/Dockerfile
+++ b/src/python/grapl-tests-common/Dockerfile
@@ -3,6 +3,5 @@ USER grapl
 WORKDIR /home/grapl
 COPY --chown=grapl . grapl-tests-common
 COPY --from=grapl/grapl-analyzerlib-python-build /home/grapl/venv venv
-COPY --from=grapl/etc-build /home/grapl/etc etc
 RUN /bin/bash -c "source venv/bin/activate && cd grapl-tests-common && pip install ."
 RUN /bin/bash -c "source venv/bin/activate && cd grapl-tests-common && python setup.py sdist bdist_wheel"

--- a/src/python/grapl-tests-common/grapl_tests_common/setup.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/setup.py
@@ -1,6 +1,8 @@
 from os import environ
 from grapl_tests_common.wait import wait_for, WaitForS3Bucket, WaitForSqsQueue
 from grapl_tests_common.sleep import verbose_sleep
+from grapl_tests_common.types import S3ServiceResource, SqsServiceResource, AnalyzerUpload
+from grapl_tests_common.upload_test_data import UploadTestData
 from sys import stdout
 from typing import Any, NamedTuple, Sequence
 import boto3  # type: ignore
@@ -9,21 +11,8 @@ import pytest
 import subprocess
 import sys
 
-# mypy later maybe
-S3ServiceResource = Any
-SqsServiceResource = Any
-
 BUCKET_PREFIX = environ["BUCKET_PREFIX"]
 assert BUCKET_PREFIX == "local-grapl"
-
-AnalyzerUpload = NamedTuple(
-    "AnalyzerUpload",
-    (
-        ("local_path", str),
-        ("s3_key", str),
-    ),
-)
-
 
 def _upload_analyzers(
     s3_client: S3ServiceResource, analyzers: Sequence[AnalyzerUpload]
@@ -41,26 +30,12 @@ def _upload_analyzers(
 
 
 def _upload_test_data(
-    s3_client: S3ServiceResource, test_data_paths: Sequence[str]
+    s3_client: S3ServiceResource, test_data: Sequence[UploadTestData]
 ) -> None:
-    logging.info(f"Running upload-sysmon-logs")
+    logging.info(f"Uploading test data...")
 
-    # i hate this lol
-    # but it's probably better than mucking with path and importing that module...
-    for path in test_data_paths:
-        logging.info(f"S3 uploading test data from {path}")
-        subprocess.run(
-            [
-                "python3",
-                "/home/grapl/etc/local_grapl/bin/upload-sysmon-logs.py",
-                "--bucket_prefix",
-                BUCKET_PREFIX,
-                "--logfile",
-                path,
-                "--use-links",
-                "True",
-            ]
-        )
+    for datum in test_data:
+        datum.upload(s3_client)
 
 
 def _create_s3_client() -> S3ServiceResource:
@@ -85,7 +60,7 @@ def _create_sqs_client() -> SqsServiceResource:
 
 def setup(
     analyzers: Sequence[AnalyzerUpload],
-    test_data_paths: Sequence[str],
+    test_data: Sequence[UploadTestData],
 ) -> None:
     logging.basicConfig(stream=stdout, level=logging.INFO)
     verbose_sleep(10, "awaiting local aws")
@@ -104,7 +79,7 @@ def setup(
     )
 
     _upload_analyzers(s3_client, analyzers)
-    _upload_test_data(s3_client, test_data_paths)
+    _upload_test_data(s3_client, test_data)
 
     verbose_sleep(60, "let the pipeline do its thing")
 

--- a/src/python/grapl-tests-common/grapl_tests_common/setup.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/setup.py
@@ -1,7 +1,11 @@
 from os import environ
 from grapl_tests_common.wait import wait_for, WaitForS3Bucket, WaitForSqsQueue
 from grapl_tests_common.sleep import verbose_sleep
-from grapl_tests_common.types import S3ServiceResource, SqsServiceResource, AnalyzerUpload
+from grapl_tests_common.types import (
+    S3ServiceResource,
+    SqsServiceResource,
+    AnalyzerUpload,
+)
 from grapl_tests_common.upload_test_data import UploadTestData
 from sys import stdout
 from typing import Any, NamedTuple, Sequence
@@ -13,6 +17,7 @@ import sys
 
 BUCKET_PREFIX = environ["BUCKET_PREFIX"]
 assert BUCKET_PREFIX == "local-grapl"
+
 
 def _upload_analyzers(
     s3_client: S3ServiceResource, analyzers: Sequence[AnalyzerUpload]

--- a/src/python/grapl-tests-common/grapl_tests_common/types.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/types.py
@@ -1,0 +1,14 @@
+from typing import Any, NamedTuple
+
+# mypy later maybe
+S3ServiceResource = Any
+SqsServiceResource = Any
+
+AnalyzerUpload = NamedTuple(
+    "AnalyzerUpload",
+    (
+        ("local_path", str),
+        ("s3_key", str),
+    ),
+)
+

--- a/src/python/grapl-tests-common/grapl_tests_common/types.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/types.py
@@ -11,4 +11,3 @@ AnalyzerUpload = NamedTuple(
         ("s3_key", str),
     ),
 )
-

--- a/src/python/grapl-tests-common/grapl_tests_common/upload_sysmon_logs.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/upload_sysmon_logs.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+"""
+Despite the path, this is *not* tied just to Local Grapl, and can also be used on true S3 buckets.
+"""
+
+import argparse
+import json
+import random
+import string
+import time
+from typing import List
+from datetime import datetime
+
+import boto3  # type: ignore
+
+import zstd  # type: ignore
+
+
+def rand_str(l: int) -> str:
+    return "".join(
+        random.choice(string.ascii_uppercase + string.digits) for _ in range(l)
+    )
+
+
+def into_sqs_message(bucket: str, key: str) -> str:
+    return json.dumps(
+        {
+            "Records": [
+                {
+                    "awsRegion": "us-east-1",
+                    "eventTime": datetime.utcnow().isoformat(),
+                    "principalId": {
+                        "principalId": None,
+                    },
+                    "requestParameters": {
+                        "sourceIpAddress": None,
+                    },
+                    "responseElements": {},
+                    "s3": {
+                        "schemaVersion": None,
+                        "configurationId": None,
+                        "bucket": {
+                            "name": bucket,
+                            "ownerIdentity": {
+                                "principalId": None,
+                            },
+                        },
+                        "object": {
+                            "key": key,
+                            "size": 0,
+                            "urlDecodedKey": None,
+                            "versionId": None,
+                            "eTag": None,
+                            "sequencer": None,
+                        },
+                    },
+                }
+            ]
+        }
+    )
+
+
+def upload_sysmon_logs(
+    prefix: str, 
+    logfile: str, 
+    delay: int = 0, 
+    batch_size: int = 100, 
+    use_links: bool = False,
+) -> None:
+    """
+    `use_links` meaning use "s3", "sqs" as opposed to localhost
+    """
+    print(
+        f"Writing events to {prefix} with {delay} seconds between batches of {batch_size}"
+    )
+    sqs = None
+    # local-grapl prefix is reserved for running Grapl locally
+    if prefix == "local-grapl":
+        s3 = boto3.client(
+            "s3",
+            endpoint_url="http://s3:9000" if use_links else "http://localhost:9000",
+            aws_access_key_id="minioadmin",
+            aws_secret_access_key="minioadmin",
+            region_name="us-east-3",
+        )
+        sqs = boto3.client(
+            "sqs",
+            endpoint_url="http://sqs:9324" if use_links else "http://localhost:9324",
+            region_name="us-east-1",
+            aws_access_key_id="dummy_cred_aws_access_key_id",
+            aws_secret_access_key="dummy_cred_aws_secret_access_key",
+        )
+
+    else:
+        s3 = boto3.client("s3")
+
+    with open(logfile, "rb") as b:
+        body = b.readlines()
+        body = [line for line in body]
+
+    def chunker(seq: List[bytes], size: int) -> List[List[bytes]]:
+        return [seq[pos : pos + size] for pos in range(0, len(seq), size)]
+
+    for chunks in chunker(body, batch_size):
+        c_body = zstd.compress(b"\n".join(chunks).replace(b"\n\n", b"\n"), 4)
+        epoch = int(time.time())
+
+        key = (
+            str(epoch - (epoch % (24 * 60 * 60)))
+            + "/sysmon/"
+            + str(epoch)
+            + rand_str(3)
+        )
+        s3.put_object(
+            Body=c_body, Bucket="{}-sysmon-log-bucket".format(prefix), Key=key
+        )
+
+        # local-grapl relies on manual eventing
+        if sqs:
+            endpoint_url = (
+                "http://sqs:9324" if use_links else "http://localhost:9324",
+            )
+            sqs.send_message(
+                QueueUrl=f"{endpoint_url}/queue/grapl-sysmon-graph-generator-queue",
+                MessageBody=into_sqs_message(
+                    bucket="{}-sysmon-log-bucket".format(prefix), key=key
+                ),
+            )
+
+        time.sleep(delay)
+
+    print(f"Completed uploading at {time.ctime()}")

--- a/src/python/grapl-tests-common/grapl_tests_common/upload_sysmon_logs.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/upload_sysmon_logs.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-"""
-Despite the path, this is *not* tied just to Local Grapl, and can also be used on true S3 buckets.
-"""
-
 import argparse
 import json
 import random
@@ -61,10 +56,10 @@ def into_sqs_message(bucket: str, key: str) -> str:
 
 
 def upload_sysmon_logs(
-    prefix: str, 
-    logfile: str, 
-    delay: int = 0, 
-    batch_size: int = 100, 
+    prefix: str,
+    logfile: str,
+    delay: int = 0,
+    batch_size: int = 100,
     use_links: bool = False,
 ) -> None:
     """

--- a/src/python/grapl-tests-common/grapl_tests_common/upload_test_data.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/upload_test_data.py
@@ -1,5 +1,6 @@
 from typing_extensions import Protocol
 from grapl_tests_common.types import S3ServiceResource
+from grapl_tests_common.upload_sysmon_logs import upload_sysmon_logs
 import logging
 import subprocess
 
@@ -15,17 +16,8 @@ class UploadSysmonLogsTestData(UploadTestData):
     
     def upload(self, s3_client: S3ServiceResource) -> None:
         logging.info(f"S3 uploading test data from {self.path}")
-        # i hate this lol
-        # but it's probably better than mucking with path and importing that module...
-        subprocess.run(
-            [
-                "python3",
-                "/home/grapl/etc/local_grapl/bin/upload-sysmon-logs.py",
-                "--bucket_prefix",
-                BUCKET_PREFIX,
-                "--logfile",
-                self.path,
-                "--use-links",
-                "True",
-            ]
+        upload_sysmon_logs(
+            prefix=BUCKET_PREFIX,
+            logfile=self.path,
+            use_links=True,
         )

--- a/src/python/grapl-tests-common/grapl_tests_common/upload_test_data.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/upload_test_data.py
@@ -6,14 +6,16 @@ import subprocess
 
 BUCKET_PREFIX = "local-grapl"
 
+
 class UploadTestData(Protocol):
     def upload(self, s3_client: S3ServiceResource) -> None:
         pass
 
+
 class UploadSysmonLogsTestData(UploadTestData):
     def __init__(self, path: str) -> None:
         self.path = path
-    
+
     def upload(self, s3_client: S3ServiceResource) -> None:
         logging.info(f"S3 uploading test data from {self.path}")
         upload_sysmon_logs(

--- a/src/python/grapl-tests-common/grapl_tests_common/upload_test_data.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/upload_test_data.py
@@ -1,0 +1,31 @@
+from typing_extensions import Protocol
+from grapl_tests_common.types import S3ServiceResource
+import logging
+import subprocess
+
+BUCKET_PREFIX = "local-grapl"
+
+class UploadTestData(Protocol):
+    def upload(self, s3_client: S3ServiceResource) -> None:
+        pass
+
+class UploadSysmonLogsTestData(UploadTestData):
+    def __init__(self, path: str) -> None:
+        self.path = path
+    
+    def upload(self, s3_client: S3ServiceResource) -> None:
+        logging.info(f"S3 uploading test data from {self.path}")
+        # i hate this lol
+        # but it's probably better than mucking with path and importing that module...
+        subprocess.run(
+            [
+                "python3",
+                "/home/grapl/etc/local_grapl/bin/upload-sysmon-logs.py",
+                "--bucket_prefix",
+                BUCKET_PREFIX,
+                "--logfile",
+                self.path,
+                "--use-links",
+                "True",
+            ]
+        )

--- a/src/python/grapl-tests-common/grapl_tests_common/wait.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/wait.py
@@ -64,7 +64,9 @@ class WaitForCondition(WaitForResource):
 
 
 def wait_for(
-    resources: Sequence[WaitForResource], timeout_secs: int = 30
+    resources: Sequence[WaitForResource], 
+    timeout_secs: int = 30,
+    sleep_secs: int = 5,
 ) -> Mapping[WaitForResource, Any]:
     completed: Dict[WaitForResource, Any] = {}
 
@@ -85,15 +87,14 @@ def wait_for(
 
         secs_remaining = int((timeout_after - now).total_seconds())
         # print an update every 5 secs
-        if secs_remaining % 5 == 0:
-            logging.info(
-                f"Waiting for resource ({secs_remaining} secs remain): {resource}"
-            )
+        logging.info(
+            f"Waiting for resource ({secs_remaining} secs remain): {resource}"
+        )
 
         result = resource.acquire()
         if result is not None:
             completed[resource] = result
         else:
-            sleep(1)
+            sleep(sleep_secs)
 
     return completed

--- a/src/python/grapl-tests-common/grapl_tests_common/wait.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/wait.py
@@ -64,7 +64,7 @@ class WaitForCondition(WaitForResource):
 
 
 def wait_for(
-    resources: Sequence[WaitForResource], 
+    resources: Sequence[WaitForResource],
     timeout_secs: int = 30,
     sleep_secs: int = 5,
 ) -> Mapping[WaitForResource, Any]:
@@ -87,9 +87,7 @@ def wait_for(
 
         secs_remaining = int((timeout_after - now).total_seconds())
         # print an update every 5 secs
-        logging.info(
-            f"Waiting for resource ({secs_remaining} secs remain): {resource}"
-        )
+        logging.info(f"Waiting for resource ({secs_remaining} secs remain): {resource}")
 
         result = resource.acquire()
         if result is not None:

--- a/src/python/grapl-tests-common/setup.py
+++ b/src/python/grapl-tests-common/setup.py
@@ -41,6 +41,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "typing_extensions",
+        "zstd",
     ],
     # We'll probably have some dataclasses in here in the future
     python_requires=">=3.6",

--- a/src/python/grapl_e2e_tests/main.py
+++ b/src/python/grapl_e2e_tests/main.py
@@ -1,6 +1,7 @@
 from os import environ
 import grapl_tests_common
 from grapl_tests_common.setup import AnalyzerUpload
+from grapl_tests_common.upload_test_data import UploadSysmonLogsTestData
 
 BUCKET_PREFIX = environ["BUCKET_PREFIX"]
 assert BUCKET_PREFIX == "local-grapl"
@@ -17,9 +18,15 @@ def main() -> None:
             "analyzers/unique_cmd_parent/main.py",
         ),
     )
+
+    test_data = (
+        UploadSysmonLogsTestData(
+            "/home/grapl/etc/sample_data/eventlog.xml",
+        ),
+    )
     grapl_tests_common.setup.setup(
         analyzers=analyzers,
-        test_data_paths=("/home/grapl/etc/sample_data/eventlog.xml",),
+        test_data=test_data,
     )
     grapl_tests_common.setup.exec_pytest()
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
#231 

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Add github release steps for the grapl-tests-common
- Migrate the upload-sysmon-logs stuff into the grapl-tests-common library
- Add an awful awful hack that lets us import from this library from `upload-sysmon-logs.py`

### How were these changes tested?
ran upload-sysmon-logs from command line