### PR TITLE
Fix #348 and add some documentation on debugging e2e tests

### DIFF
--- a/dobi.yaml
+++ b/dobi.yaml
@@ -396,6 +396,8 @@ image=etc-build:
 # integration tests. It should be identical to local Grapl. The most
 # important thing here is to keep the 'depends' list up to date.
 #
+# To view the logs during an integration test, run `dobi integration-env:attach` in another tab/tmux session.
+# (also try out `GRAPL_LOG_LEVEL=DEBUG`)
 
 compose=integration-env:
   files:
@@ -447,7 +449,7 @@ job=run-node-identifier-integration-tests:
   net-mode: grapl-integration-tests_default
   command: /bin/bash -c "sleep 30 && cargo test --target=x86_64-unknown-linux-musl --manifest-path node-identifier/Cargo.toml --features integration"
   env:
-    - GRAPL_LOG_LEVEL=INFO
+    - GRAPL_LOG_LEVEL={env.GRAPL_LOG_LEVEL:INFO}
     - RUST_LOG=INFO
     - RUST_BACKTRACE=1
     - "BUCKET_PREFIX=local-grapl"
@@ -537,7 +539,7 @@ job=run-grapl-analyzerlib-integration-tests:
   net-mode: grapl-integration-tests_default
   command: /bin/bash -c "sleep 30 && source venv/bin/activate && cd grapl_analyzerlib && py.test -n auto -m 'integration_test'"
   env:
-    - GRAPL_LOG_LEVEL=INFO
+    -  GRAPL_LOG_LEVEL={env.GRAPL_LOG_LEVEL:INFO}
     - "BUCKET_PREFIX=local-grapl"
     - "IS_LOCAL=True"
     - "MG_ALPHAS=grapl-master-graph-db:9080"
@@ -560,7 +562,7 @@ job=run-analyzer-deployer-integration-tests:
   net-mode: grapl-integration-tests_default
   command: /bin/bash -c "sleep 30 && source venv/bin/activate && cd analyzer-deployer && py.test -n auto -m 'integration_test'"
   env:
-    - GRAPL_LOG_LEVEL=INFO
+    -  GRAPL_LOG_LEVEL={env.GRAPL_LOG_LEVEL:INFO}
     - "BUCKET_PREFIX=local-grapl"
     - "IS_LOCAL=True"
   depends:
@@ -571,7 +573,7 @@ job=run-e2e-integration-tests:
   net-mode: grapl-integration-tests_default
   command: /bin/bash -c "sleep 30 && source venv/bin/activate && cd grapl_e2e_tests && python3 ./main.py"
   env:
-    - GRAPL_LOG_LEVEL=INFO
+    -  GRAPL_LOG_LEVEL={env.GRAPL_LOG_LEVEL:INFO}
     - "BUCKET_PREFIX=local-grapl"
     - "IS_LOCAL=True"
     - "MG_ALPHAS=grapl-master-graph-db:9080"

--- a/etc/local_grapl/suspicious_svchost/main.py
+++ b/etc/local_grapl/suspicious_svchost/main.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from grapl_analyzerlib.analyzer import Analyzer, OneOrMany
-from grapl_analyzerlib.prelude import Not, ProcessQuery, ProcessView
+from grapl_analyzerlib.prelude import Not, AssetQuery, ProcessQuery, ProcessView
 from grapl_analyzerlib.execution import ExecutionHit
 
 
@@ -21,6 +21,7 @@ class SuspiciousSvchost(Analyzer):
             ProcessQuery()
             .with_process_name(eq=invalid_parents)
             .with_children(ProcessQuery().with_process_name(eq="svchost.exe"))
+            .with_asset(AssetQuery().with_hostname())
         )
 
     def on_response(self, response: ProcessView, output: Any):

--- a/src/python/engagement-creator/src/engagement-creator.py
+++ b/src/python/engagement-creator/src/engagement-creator.py
@@ -276,7 +276,7 @@ def _process_one_event(
     ]  # same type as `.to_adjacency_list()["nodes"]`
     edges = incident_graph["edges"]
     risk_score = incident_graph["risk_score"]
-    lens_dict = incident_graph["lenses"]
+    lens_dict: Sequence[Tuple[str, str]] = incident_graph["lenses"]
     risky_node_keys = incident_graph["risky_node_keys"]
 
     LOGGER.debug(
@@ -295,6 +295,7 @@ def _process_one_event(
         LOGGER.debug(f"Copying node: {node}")
 
         for lens_type, lens_name in lens_dict:
+            # i.e. "hostname", "DESKTOP-WHATEVER"
             LOGGER.debug(f"Getting lens for: {lens_type} {lens_name}")
             lens_id = lens_name + lens_type
             lens: LensView = lenses.get(lens_name) or LensView.get_or_create(

--- a/src/python/grapl-tests-common/grapl_tests_common/setup.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/setup.py
@@ -86,7 +86,7 @@ def setup(
     _upload_analyzers(s3_client, analyzers)
     _upload_test_data(s3_client, test_data)
 
-    verbose_sleep(60, "let the pipeline do its thing")
+    verbose_sleep(30, "let the pipeline do its thing")
 
 
 def exec_pytest() -> None:

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/execution.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/execution.py
@@ -35,6 +35,10 @@ class ExecutionHit(object):
         self.risk_score = risk_score
         self.risky_node_keys = risky_node_keys
 
+        for lens_key, lens_value in lenses:
+            if lens_key is None or lens_value is None:
+                raise TypeError(f"Found an unexpected None k/v in lenses: {lenses}")
+
 
 class ExecutionComplete(object):
     pass

--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from grapl_analyzerlib.grapl_client import MasterGraphClient
 from grapl_analyzerlib.nodes.lens import LensQuery, LensView
 from grapl_tests_common.wait import WaitForCondition, WaitForResource, wait_for
+from grapl_analyzerlib.retry import retry
 from typing import Any, Optional, Callable
 import inspect
 
@@ -42,6 +43,7 @@ class WaitForLens(WaitForResource):
         self.dgraph_client = dgraph_client
         self.query = query
 
+    @retry()
     def acquire(self) -> Optional[Any]:
         result = self.query.query_first(self.dgraph_client)
         return result


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
#348 

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- stop the suspicious-svchost from looking up a Process without an associated Asset
- throw a TypeError if we encounter a None in the lenses k/v

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
ran e2e tests a lot