### PR TITLE
Add a .dockerignore for CDK to exclude zips and cdk.out, both of which

### DIFF
--- a/src/js/grapl-cdk/.dockerignore
+++ b/src/js/grapl-cdk/.dockerignore
@@ -1,0 +1,2 @@
+zips
+cdk.out


### PR DESCRIPTION
# What changes does this PR make to Grapl? Why?

This creates a .dockerignore for the grapl CDK. the zips and cdk.out dirs can get fairly large over time when deploying from there.

### How were these changes tested?

Built the cdk image (`dobi build-grapl-cdk`) and created a container to verify they were no longer copied.