### PR TITLE
Cleanup unused docker images for GitHub CI

### DIFF
--- a/etc/ci_scripts/clean_gh_actions_space.sh
+++ b/etc/ci_scripts/clean_gh_actions_space.sh
@@ -10,8 +10,18 @@ sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
 sudo apt-get clean
 
+# Remove preloaded but unused docker images
+docker image rm jekyll/builder
+docker image rm mcr.microsoft.com/azure-pipelines/node8-typescript
+docker image rm buildpack-deps:stretch
+docker image rm buildpack-deps:buster
+docker image rm debian:8
+docker image rm debian:9
+docker image rm ubuntu
+
 # Another thing I've seen was to remove /swapfile, but that's
 # a tad aggressive. I'll leave this not about it here, though.
 # https://github.com/scikit-hep/pyhf/pull/819#issuecomment-616055763
 
 echo "Ending space: $(df -h | grep ' /$')"
+

--- a/etc/ci_scripts/clean_gh_actions_space.sh
+++ b/etc/ci_scripts/clean_gh_actions_space.sh
@@ -17,7 +17,7 @@ docker image rm buildpack-deps:stretch
 docker image rm buildpack-deps:buster
 docker image rm debian:8
 docker image rm debian:9
-docker image rm ubuntu
+docker image rm ubuntu:14.04
 
 # Another thing I've seen was to remove /swapfile, but that's
 # a tad aggressive. I'll leave this not about it here, though.


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

I noticed the `ubuntu-latest` that we use for GitHub CI actions comes pre-loaded with a number of docker images that we don't use, such as `jekyll/builder:latest` and `mcr.microsoft.com/azure-pipelines/node8-typescript:latest`. Seems like removing those would give us a fair amount of headroom to mitigate the disk space limits we've hit in the past.

### How were these changes tested?

Tested with this PR. From the cleanup script run for this PR:
```
Starting space: /dev/sdb1        84G   64G   21G  76% /
...
Ending space: /dev/sdb1        84G   52G   32G  62% /
```

This doesn't exactly show final space savings at tail end of all checks - it's possible docker ends up downloading layers we remove.