### PR TITLE
Dump logs for all services to Github after running e2e integration tests

### DIFF
--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -132,6 +132,7 @@ jobs:
       - name: 'Collect e2e test logs'
         if: ${{ always() }}
         run: |
+          python3 -V &&
           python3 ./etc/ci_scripts/dump_compose_logs.py --compose-project "grapl-integration-tests"
 
       - name: Prepare Github Actions CI

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -127,6 +127,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+       
+      # NOTE: This requires >= py37
+      - name: 'Collect e2e test logs'
+        if: ${{ always() }}
+        run: |
+          python3.7 ./etc/ci_scripts/dump_compose_logs.py --compose-project "grapl-integration-tests"
 
       - name: Prepare Github Actions CI
         run: |
@@ -140,13 +146,7 @@ jobs:
       - name: Run end-to-end integration tests
         run: |
           GRAPL_RELEASE_TARGET=debug TAG=latest ./dobi-linux --no-bind-mount run-e2e-integration-tests
-            
-      # NOTE: This requires >= py37
-      - name: 'Collect e2e test logs'
-        if: ${{ always() }}
-        run: |
-          python ./etc/ci_scripts/dump_compose_logs.py --compose-project "grapl-integration-tests"
-
+           
       - name: 'Upload e2e test logs'
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -127,6 +127,15 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+n
+      - name: TEMP TO BE REVERTED - print Python version
+        run: python -c "import sys; print(sys.version);"
+      
+      - name: TEMP TO BE REVERTED - print Python compare
+        run: python -c "import sys; print(sys.version_info >= (3, 7));"
+        
+      - name: TEMP TO BE REVERTED - what if i call it with Python
+        run: python ./etc/ci_scripts/dump_compose_logs.sh"
 
       - name: Prepare Github Actions CI
         run: |

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -128,6 +128,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: 'Debug: what py3 version'
+        if: ${{ always() }}
+        run: |
+          python3 -V
 
       - name: Prepare Github Actions CI
         run: |
@@ -146,6 +150,7 @@ jobs:
       - name: 'Collect e2e test logs'
         if: ${{ always() }}
         run: |
+          python3 -V &&
           python3 ./etc/ci_scripts/dump_compose_logs.py --compose-project "grapl-integration-tests"
            
       - name: 'Upload e2e test logs'

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -132,7 +132,7 @@ jobs:
       - name: 'Collect e2e test logs'
         if: ${{ always() }}
         run: |
-          python3.7 ./etc/ci_scripts/dump_compose_logs.py --compose-project "grapl-integration-tests"
+          python3 ./etc/ci_scripts/dump_compose_logs.py --compose-project "grapl-integration-tests"
 
       - name: Prepare Github Actions CI
         run: |

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -110,6 +110,7 @@ jobs:
         run: |
           GRAPL_RELEASE_TARGET=debug TAG=latest ./dobi-linux --no-bind-mount integration-tests
 
+
   # In the future, this should probably be merged back into `dobi integration-tests`, but
   # since it's so timing-dependent I'm going to treat it separately until it stabilizes a bit.
   end-to-end-integration-tests:
@@ -130,3 +131,19 @@ jobs:
       - name: Run end-to-end integration tests
         run: |
           GRAPL_RELEASE_TARGET=debug TAG=latest ./dobi-linux --no-bind-mount run-e2e-integration-tests
+            
+      # always() allows this to run even if 'run tests' failed
+      - name: 'Collect e2e test logs'
+        if: ${{ always() }}
+        run: |
+          ./etc/ci_scripts/dump_compose_logs.py --compose-project "grapl-integration-tests"
+
+      # always() allows this to run even if 'run integration tests' failed
+      - name: 'Upload e2e test logs'
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: e2e-test-logs
+          # this path is specified in dump_compose_logs.py
+          path: /tmp/log_artifacts/
+          retention-days: 7

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -127,7 +127,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-n
+          
       - name: TEMP TO BE REVERTED - print Python version
         run: python -c "import sys; print(sys.version);"
       

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -116,8 +116,17 @@ jobs:
   end-to-end-integration-tests:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: [3.7]
+
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Prepare Github Actions CI
         run: |
@@ -132,13 +141,12 @@ jobs:
         run: |
           GRAPL_RELEASE_TARGET=debug TAG=latest ./dobi-linux --no-bind-mount run-e2e-integration-tests
             
-      # always() allows this to run even if 'run tests' failed
+      # NOTE: This requires >= py37
       - name: 'Collect e2e test logs'
         if: ${{ always() }}
         run: |
           ./etc/ci_scripts/dump_compose_logs.py --compose-project "grapl-integration-tests"
 
-      # always() allows this to run even if 'run integration tests' failed
       - name: 'Upload e2e test logs'
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -127,15 +127,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-          
-      - name: TEMP TO BE REVERTED - print Python version
-        run: python -c "import sys; print(sys.version);"
-      
-      - name: TEMP TO BE REVERTED - print Python compare
-        run: python -c "import sys; print(sys.version_info >= (3, 7));"
-        
-      - name: TEMP TO BE REVERTED - what if i call it with Python
-        run: python ./etc/ci_scripts/dump_compose_logs.sh"
 
       - name: Prepare Github Actions CI
         run: |
@@ -154,7 +145,7 @@ jobs:
       - name: 'Collect e2e test logs'
         if: ${{ always() }}
         run: |
-          ./etc/ci_scripts/dump_compose_logs.py --compose-project "grapl-integration-tests"
+          python ./etc/ci_scripts/dump_compose_logs.py --compose-project "grapl-integration-tests"
 
       - name: 'Upload e2e test logs'
         if: ${{ always() }}

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -123,20 +123,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: 'Debug: what py3 version'
-        if: ${{ always() }}
-        run: |
-          python3 -V
-
       - name: Prepare Github Actions CI
         run: |
           ./etc/ci_scripts/clean_gh_actions_space.sh
           ./etc/ci_scripts/install_requirements.sh
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Build Grapl
         run: |

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -127,13 +127,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-       
-      # NOTE: This requires >= py37
-      - name: 'Collect e2e test logs'
-        if: ${{ always() }}
-        run: |
-          python3 -V &&
-          python3 ./etc/ci_scripts/dump_compose_logs.py --compose-project "grapl-integration-tests"
+
 
       - name: Prepare Github Actions CI
         run: |
@@ -147,6 +141,12 @@ jobs:
       - name: Run end-to-end integration tests
         run: |
           GRAPL_RELEASE_TARGET=debug TAG=latest ./dobi-linux --no-bind-mount run-e2e-integration-tests
+       
+      # NOTE: This requires >= py37
+      - name: 'Collect e2e test logs'
+        if: ${{ always() }}
+        run: |
+          python3 ./etc/ci_scripts/dump_compose_logs.py --compose-project "grapl-integration-tests"
            
       - name: 'Upload e2e test logs'
         if: ${{ always() }}

--- a/etc/ci_scripts/dump_compose_logs.py
+++ b/etc/ci_scripts/dump_compose_logs.py
@@ -5,15 +5,10 @@ from tempfile import TemporaryDirectory
 from pathlib import Path
 import os
 import subprocess
+import sys
 
-
-def _go_to_grapl_repo_root() -> None:
-    this_file = Path(__file__).resolve()
-    # go to `grapl` base dir
-    grapl_repo_root = this_file
-    while grapl_repo_root.name != "grapl":
-        grapl_repo_root = grapl_repo_root.parent
-    os.chdir(grapl_repo_root)
+# need minimum 3.7 for capture_output=True
+assert sys.version_info >= (3, 7)
 
 
 def _name_of_all_containers(compose_project: str) -> List[str]:
@@ -63,7 +58,6 @@ LOG_ARTIFACTS_PATH = Path("/tmp/log_artifacts").resolve()
 
 
 def dump_all_logs(compose_project: str) -> None:
-    _go_to_grapl_repo_root()
     containers = _name_of_all_containers(compose_project)
     os.makedirs(LOG_ARTIFACTS_PATH, exist_ok=True)
     for container in containers:

--- a/etc/ci_scripts/dump_compose_logs.py
+++ b/etc/ci_scripts/dump_compose_logs.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
 from typing import Any, List
-from tempfile import TemporaryDirectory
 from pathlib import Path
 import os
 import subprocess

--- a/etc/ci_scripts/dump_compose_logs.py
+++ b/etc/ci_scripts/dump_compose_logs.py
@@ -5,7 +5,10 @@ import subprocess
 import sys
 
 # need minimum 3.7 for capture_output=True
-assert sys.version_info >= (3, 7), f"Expected version info to be gt, but was {sys.version_info}"
+assert sys.version_info >= (
+    3,
+    7,
+), f"Expected version info to be gt, but was {sys.version_info}"
 
 
 def _name_of_all_containers(compose_project: str) -> List[str]:

--- a/etc/ci_scripts/dump_compose_logs.py
+++ b/etc/ci_scripts/dump_compose_logs.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python3
+
+from typing import Any, List
+from tempfile import TemporaryDirectory
+from pathlib import Path
+import os
+import subprocess
+
+
+def _go_to_grapl_repo_root() -> None:
+    this_file = Path(__file__).resolve()
+    # go to `grapl` base dir
+    grapl_repo_root = this_file
+    while grapl_repo_root.name != "grapl":
+        grapl_repo_root = grapl_repo_root.parent
+    os.chdir(grapl_repo_root)
+
+
+def _name_of_all_containers(compose_project: str) -> List[str]:
+    """
+    compose_project meaning the `project: <thing>` in the `compose=` section
+    of your dobi.yaml
+    """
+    run_result = subprocess.run(
+        [
+            "docker",
+            "ps",
+            "--all",
+            "--filter",
+            f"name={compose_project}",
+            "--format",
+            "table {{.Names}}",
+        ],
+        capture_output=True,
+    )
+    containers: List[str] = run_result.stdout.decode("utf-8").split("\n")
+    containers = containers[1:]  # remove the table column header
+    containers = [c for c in containers if c]  # filter empty
+    if not containers:
+        raise ValueError(f"Couldn't find any containers for '{compose_project}'")
+    return containers
+
+
+def _dump_docker_log(container_name: str, dir: Path) -> None:
+    """
+    run `docker logs` and dump to $DIR/$CONTAINER_NAME.log
+    """
+    destination = dir / f"{container_name}.log"
+    with open(destination, "wb") as out_stream:
+        popen = subprocess.Popen(
+            [
+                "docker",
+                "logs",
+                "--timestamps",
+                container_name,
+            ],
+            stdout=out_stream,
+        )
+        popen.wait()
+
+
+LOG_ARTIFACTS_PATH = Path("/tmp/log_artifacts").resolve()
+
+
+def dump_all_logs(compose_project: str) -> None:
+    _go_to_grapl_repo_root()
+    containers = _name_of_all_containers(compose_project)
+    os.makedirs(LOG_ARTIFACTS_PATH, exist_ok=True)
+    for container in containers:
+        _dump_docker_log(container_name=container, dir=LOG_ARTIFACTS_PATH)
+
+
+def parse_args() -> Any:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Dump all Docker logs for a given Dobi Compose"
+    )
+    parser.add_argument("--compose-project", dest="compose_project", required=True)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    dump_all_logs(compose_project=args.compose_project)

--- a/etc/ci_scripts/dump_compose_logs.py
+++ b/etc/ci_scripts/dump_compose_logs.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 from typing import Any, List
 from pathlib import Path
 import os
@@ -7,7 +5,7 @@ import subprocess
 import sys
 
 # need minimum 3.7 for capture_output=True
-assert sys.version_info >= (3, 7)
+assert sys.version_info >= (3, 7), f"Expected version info to be gt, but was {sys.version_info}"
 
 
 def _name_of_all_containers(compose_project: str) -> List[str]:


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
#231 

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Introduce a new script that just collects all `docker logs` for a given dobi `compose=` task
- Run that new script after an e2e test run
- Upload results of script to Github artifacts - learn more here! https://docs.github.com/en/free-pro-team@latest/actions/guides/storing-workflow-data-as-artifacts

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
by submitting this very diff!!!

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
