### PR TITLE
Add a rudimentary health check to grapl_provision; depend on this health check from tests

### DIFF
--- a/dobi.yaml
+++ b/dobi.yaml
@@ -584,7 +584,13 @@ job=run-analyzer-deployer-integration-tests:
 job=run-e2e-integration-tests:
   use: grapl-e2e-tests-build
   net-mode: grapl-integration-tests_default
-  command: /bin/bash -c "sleep 30 && source venv/bin/activate && cd grapl_e2e_tests && python3 ./main.py"
+  command: | 
+    /bin/bash -c "
+      wait-for-it grapl-provision:8126 --timeout=60 &&
+      source venv/bin/activate && 
+      cd grapl_e2e_tests && 
+      python3 ./main.py
+      "
   env:
     -  GRAPL_LOG_LEVEL={env.GRAPL_LOG_LEVEL:INFO}
     - "BUCKET_PREFIX=local-grapl"

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -447,7 +447,11 @@ job=run-rust-unit-tests:
 job=run-node-identifier-integration-tests:
   use: rust-build
   net-mode: grapl-integration-tests_default
-  command: /bin/bash -c "sleep 30 && cargo test --target=x86_64-unknown-linux-musl --manifest-path node-identifier/Cargo.toml --features integration"
+  command: |
+    /bin/bash -c "
+      wait-for-it grapl-provision:8126 --timeout=60 &&
+      cargo test --target=x86_64-unknown-linux-musl --manifest-path node-identifier/Cargo.toml --features integration
+      "
   env:
     - GRAPL_LOG_LEVEL={env.GRAPL_LOG_LEVEL:INFO}
     - RUST_LOG=INFO
@@ -550,7 +554,13 @@ job=run-grapl-analyzerlib-unit-tests:
 job=run-grapl-analyzerlib-integration-tests:
   use: grapl-analyzerlib-build
   net-mode: grapl-integration-tests_default
-  command: /bin/bash -c "sleep 30 && source venv/bin/activate && cd grapl_analyzerlib && py.test -n auto -m 'integration_test'"
+  command: |
+    /bin/bash -c "
+      wait-for-it grapl-provision:8126 --timeout=60 &&
+      source venv/bin/activate && 
+      cd grapl_analyzerlib && 
+      py.test -n auto -m 'integration_test'
+      "
   env:
     -  GRAPL_LOG_LEVEL={env.GRAPL_LOG_LEVEL:INFO}
     - "BUCKET_PREFIX=local-grapl"
@@ -573,7 +583,13 @@ job=run-analyzer-deployer-unit-tests:
 job=run-analyzer-deployer-integration-tests:
   use: analyzer-deployer-build
   net-mode: grapl-integration-tests_default
-  command: /bin/bash -c "sleep 30 && source venv/bin/activate && cd analyzer-deployer && py.test -n auto -m 'integration_test'"
+  command: |
+    /bin/bash -c "
+      wait-for-it grapl-provision:8126 --timeout=60 &&
+      source venv/bin/activate &&
+      cd analyzer-deployer && 
+      py.test -n auto -m 'integration_test'
+      "
   env:
     -  GRAPL_LOG_LEVEL={env.GRAPL_LOG_LEVEL:INFO}
     - "BUCKET_PREFIX=local-grapl"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -360,15 +360,24 @@ services:
   grapl-provision:
     image: grapl/grapl-provision:${TAG:-latest}
     command: |
-      /bin/sh -c '
+      /bin/bash -c "
+        # it doesn't seem to like waiting for sqs
+        # wait-for-it sqs:9324 &&
+        wait-for-it s3:9000 &&
+        wait-for-it dynamodb:8000 &&
+        wait-for-it grapl-master-graph-db:8080 &&
         . venv/bin/activate && 
         python /home/grapl/grapl_local_provision/provision_local_identity_table.py &&
-        python /home/grapl/grapl_local_provision/grapl_provision.py
-      '
+        python /home/grapl/grapl_local_provision/grapl_provision.py &&
+        # Host a server on this port, so that tests can wait-for-it
+        python -m http.server 8126
+      "
     environment:
       - GRAPL_LOG_LEVEL=${GRAPL_LOG_LEVEL:-ERROR}
       - MG_ALPHAS=master_graph:9080
     tty: true
+    ports:
+      - 8126:8126
     links:
       - grapl-master-graph-db:master_graph
       - s3:minio

--- a/src/python/grapl-python-build/Dockerfile
+++ b/src/python/grapl-python-build/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.7-slim-buster AS grapl-python-build
-RUN apt-get update && apt-get -y upgrade && apt-get -y install --no-install-recommends musl-dev protobuf-compiler build-essential zip bash
+RUN apt-get update && apt-get -y upgrade && apt-get -y install --no-install-recommends musl-dev protobuf-compiler build-essential zip bash wait-for-it
 ENV PROTOC /usr/bin/protoc
 ENV PROTOC_INCLUDE /usr/include
 RUN adduser --disabled-password --gecos '' --home /home/grapl --shell /bin/bash grapl

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -21,7 +21,7 @@
 #
 
 FROM rust:1-slim-buster AS grapl-rust-base
-RUN apt-get update && apt-get install -y apt-utils musl musl-dev musl-tools protobuf-compiler libzstd-dev
+RUN apt-get update && apt-get install -y apt-utils musl musl-dev musl-tools protobuf-compiler libzstd-dev wait-for-it
 ENV PROTOC /usr/bin/protoc
 ENV PROTOC_INCLUDE /usr/include
 RUN adduser --disabled-password --gecos '' --home /home/grapl --shell /bin/bash grapl


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
#363

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
I have reason to believe a number of our e2e test failures are due to the dgraph schema not being provisioned in time for the tests.


<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I ran this locally and it appears to work.
grapl-aws-provision sometimes takes 38 seconds to come up.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
