### PR TITLE
Restore MG_ALPHA for services other than graph merger

### DIFF
--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -220,7 +220,7 @@ class GraphMerger extends cdk.NestedStack {
             environment: {
                 BUCKET_PREFIX: bucket_prefix,
                 SUBGRAPH_MERGED_BUCKET: props.writesTo.bucketName,
-                MG_ALPHAS: props.dgraphSwarmCluster.alphaHostPort(),
+                MG_ALPHAS: 'http://' + props.dgraphSwarmCluster.alphaHostPort(),
                 MERGED_CACHE_ADDR:
                     graph_merge_cache.cluster.attrRedisEndpointAddress,
                 MERGED_CACHE_PORT:
@@ -486,7 +486,7 @@ export class DGraphSwarmCluster extends cdk.NestedStack {
     }
 
     public alphaHostPort(): string {
-	return `http://${this.dgraphAlphaZone.zoneName}:9080`;
+        return `${this.dgraphAlphaZone.zoneName}:9080`;
     }
 
     public allowConnectionsFrom(other: ec2.IConnectable): void {


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

I was getting connection issues in the model-plugin-deployer. Found that a previous change[1] the CDK changed the value of MG_ALPHAS for all services, where it looks like it was meant for the graph-merger only. This PR resolves that by restoring the original function and applying the addition of the schema to the graph-merger service, similar to how this was done for the docker-compose config for running locally.

[1] https://github.com/grapl-security/grapl/commit/cc3689f746a2089e5f81b0d9ff63262b7d6f9fcd#diff-e61371fab55a097df00568e44afa96c515ff70cbbfae4317c8be6cf7c3f8e6cfL477-R477

### How were these changes tested?

I redeployed these changes on an AWS deployment in my sandbox account and noticed I had no longer had connection issues in model-plugin-deployer. Also, I noticed I was *not* getting connection errors in graph-merger, while it was processing nodes from CloudTrail generator.