### PR TITLE
Add VSCode debugger support to Python services (but for now, just grapl-e2e-tests)

### DIFF
--- a/dobi.yaml
+++ b/dobi.yaml
@@ -612,8 +612,12 @@ job=run-e2e-integration-tests:
     - "BUCKET_PREFIX=local-grapl"
     - "IS_LOCAL=True"
     - "MG_ALPHAS=grapl-master-graph-db:9080"
+    - DEBUG_SERVICES={env.DEBUG_SERVICES}
   depends:
     - integration-env
+  ports:
+    # Used for debugger
+    - 8400:8400
 
 job=build-analyzer-executor:
   use: analyzer-executor-build

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -612,7 +612,7 @@ job=run-e2e-integration-tests:
     - "BUCKET_PREFIX=local-grapl"
     - "IS_LOCAL=True"
     - "MG_ALPHAS=grapl-master-graph-db:9080"
-    - DEBUG_SERVICES={env.DEBUG_SERVICES}
+    - DEBUG_SERVICES={env.DEBUG_SERVICES:}
   depends:
     - integration-env
   ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,9 @@
+### Port conventions (though there are many, many exceptions)
+# 81xx - grapl services (and some `wait-for-it` http servers)
+# 82xx - TBD
+# 83xx - grapl plugin services, like grapl-aws-plugins
+# 84xx - debugger ports (see vsc_debugger.py)
+
 version: "3.8"
 services:
 

--- a/src/python/grapl-common/grapl_common/debugger/vsc_debugger.py
+++ b/src/python/grapl-common/grapl_common/debugger/vsc_debugger.py
@@ -51,7 +51,7 @@ def wait_for_vsc_debugger(service: str) -> None:
         return
 
     _install_from_pip("debugpy")
-    import debugpy
+    import debugpy  # type: ignore
 
     assert (
         8400 <= port < 8500

--- a/src/python/grapl-common/grapl_common/debugger/vsc_debugger.py
+++ b/src/python/grapl-common/grapl_common/debugger/vsc_debugger.py
@@ -65,7 +65,8 @@ def wait_for_vsc_debugger(service: str) -> None:
 
 """
 Add the following as a `launch.json` debug configuration in VSCode.
-Obviously, you may want to much with the port and the path-mapping.
+You'll want a different configuration for each service you want to debug.
+As such, each configuration should likely have a different path-mapping and a different port.
 
 {
     "version": "0.2.0",

--- a/src/python/grapl-common/grapl_common/debugger/vsc_debugger.py
+++ b/src/python/grapl-common/grapl_common/debugger/vsc_debugger.py
@@ -1,0 +1,90 @@
+"""
+I arbitrarily chose `debugpy`, the VS Code debugger (formerly known as ptsvd).
+It'd be pretty easy to add the PyCharm/IntelliJ debugger too (which uses pydevd)
+"""
+import subprocess
+import sys
+import logging
+import os
+
+
+def _install_from_pip(package: str) -> None:
+    # Gross, but the suggested way to install from pip mid-python-program!
+    # Doing it this way so that <every executable that depends on grapl_common> doesn't inherently
+    # need to import debugpy
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--upgrade", package]
+    )
+
+
+# TODO: we should probably have some fixed 'services' StrEnum somewhere
+SERVICE_TO_PORT = {
+    # As you need to debug more services, add more services here.
+    # Make sure you expose the port in dobi.yaml or docker-compose.yaml.
+    "grapl_e2e_tests": 8400,
+}
+
+
+def _should_debug_service(service: str) -> bool:
+    """
+    When you set
+    DEBUG_SERVICES=grapl_e2e_tests
+    you'll start a debug listener on the `grapl_e2e_tests`
+
+    When you set
+    DEBUG_SERVICES=grapl_e2e_tests,some_future_service
+    you'll start two debug listeners - 1 for each service
+    """
+    env_var = os.getenv("DEBUG_SERVICES")
+    if not env_var:
+        return False
+    debug_services = set(env_var.split(","))
+    return service in debug_services
+
+
+def wait_for_vsc_debugger(service: str) -> None:
+    if not _should_debug_service(service):
+        return
+    port = SERVICE_TO_PORT.get(service, None)
+    if not port:
+        logging.error("Couldn't find a debug port for service {service}.")
+        return
+
+    _install_from_pip("debugpy")
+    import debugpy
+
+    assert (
+        8400 <= port < 8500
+    ), "84xx range is reserved for our debuggers. You likely want 1 per service."
+    host = "0.0.0.0"
+    logging.info(f">> Debugpy listening for client at {host}:{port}")
+    debugpy.listen((host, port))
+    debugpy.wait_for_client()
+    logging.info(f">> Debugpy connected!")
+
+
+"""
+Add the following as a `launch.json` debug configuration in VSCode.
+Obviously, you may want to much with the port and the path-mapping.
+
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug grapl_e2e_tests",
+            "type": "python",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 8400
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}/src/python/grapl_e2e_tests",
+                    "remoteRoot": "/home/grapl/grapl_e2e_tests"
+                }
+            ]
+        }
+    ]
+}
+"""

--- a/src/python/grapl_e2e_tests/main.py
+++ b/src/python/grapl_e2e_tests/main.py
@@ -1,14 +1,16 @@
-from os import environ
-import grapl_tests_common
+from grapl_common.debugger.vsc_debugger import wait_for_vsc_debugger
 from grapl_tests_common.setup import AnalyzerUpload
 from grapl_tests_common.sleep import verbose_sleep
 from grapl_tests_common.upload_test_data import UploadSysmonLogsTestData
+from os import environ
+import grapl_tests_common
 
 BUCKET_PREFIX = environ["BUCKET_PREFIX"]
 assert BUCKET_PREFIX == "local-grapl"
 
 
 def main() -> None:
+    wait_for_vsc_debugger("grapl_e2e_tests")
     analyzers = (
         AnalyzerUpload(
             "/home/grapl/etc/local_grapl/suspicious_svchost/main.py",
@@ -29,7 +31,7 @@ def main() -> None:
         analyzers=analyzers,
         test_data=test_data,
     )
-    verbose_sleep(15, "let the pipeline do its thing")
+
     grapl_tests_common.setup.exec_pytest()
 
 


### PR DESCRIPTION

### Which issue does this PR correspond to?
it sort of came up as part of #231 

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Adds a new library to grapl-common that makes it relatively simple for a service to optionally attach to the VSCode pycharm debugger.
The whole debugger code path won't trigger unless the caller specifies
DEBUG_SERVICES=service1,service2


### How were these changes tested?
![image](https://user-images.githubusercontent.com/69007229/96821289-6dc08b00-13dc-11eb-9028-cfc109b682a8.png)


<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
