### PR TITLE
Proof-of-concept: split up analyzer_executor into multiple files

### DIFF
--- a/dobi.yaml
+++ b/dobi.yaml
@@ -630,6 +630,15 @@ job=run-analyzer-executor-unit-tests:
   use: analyzer-executor-build
   command: /bin/bash -c "source venv/bin/activate && cd analyzer_executor && py.test -n auto -m 'not integration_test'"
 
+job=typecheck-analyzer-executor:
+  use: analyzer-executor-build
+  command: |
+    /bin/bash -c "
+      source venv/bin/activate &&
+      pip install mypy && 
+      mypy analyzer_executor/**/*.py
+      "
+
 job=build-engagement-creator:
   use: engagement-creator-build
   mounts:
@@ -850,5 +859,6 @@ alias=python-typecheck:
     - run-e2e-integration-tests-typecheck
     - run-engagement-creator-typecheck
     - run-model-plugin-deployer-typecheck
+    - typecheck-analyzer-executor
   annotations:
     description: "Run mypy or pytype type checks on a subset of our Python libs/services"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,7 +233,7 @@ services:
 
   grapl-analyzer-executor:
     image: grapl/grapl-analyzer-executor:${TAG:-latest}
-    command: /bin/sh -c '. venv/bin/activate && python3 analyzer_executor/src/analyzer-executor.py'
+    command: /bin/sh -c '. venv/bin/activate && python3 analyzer_executor/src/run_local.py'
     environment:
       - "IS_LOCAL=True"
       - GRPC_ENABLE_FORK_SUPPORT=1

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -353,11 +353,13 @@ class AnalyzerExecutor extends cdk.NestedStack {
             subscribes_to: dispatched_analyzer.topic,
             opt: {
                 runtime: lambda.Runtime.PYTHON_3_7,
+                py_entrypoint: "lambda_function.lambda_handler"
             },
             version: props.version,
             watchful: props.watchful,
             metric_forwarder: props.metricForwarder,
-        });
+        },
+        );
 
         props.dgraphSwarmCluster.allowConnectionsFrom(service.event_handler);
 

--- a/src/js/grapl-cdk/lib/service.ts
+++ b/src/js/grapl-cdk/lib/service.ts
@@ -37,6 +37,11 @@ class Queues {
     }
 }
 
+export interface ServicePropsOptions {
+    runtime?: lambda.Runtime;
+    py_entrypoint?: string;
+}
+
 export interface ServiceProps {
     version: string;
     prefix: string;
@@ -46,7 +51,7 @@ export interface ServiceProps {
     writes_to?: s3.IBucket;
     subscribes_to?: sns.ITopic;
     retry_code_name?: string;
-    opt?: any;
+    opt?: ServicePropsOptions;
     watchful?: Watchful;
 
     /**
@@ -74,15 +79,23 @@ export class Service {
         const runtime =
             opt && opt.runtime
                 ? opt.runtime
-                : {
-                      name: 'provided',
+                : new lambda.Runtime('provided', undefined, {
                       supportsInlineCode: true,
-                  };
+                  });
 
-        const handler =
-            runtime === lambda.Runtime.PYTHON_3_7
-                ? `${name}.lambda_handler`
-                : name;
+        const handler = (function(): string {
+            if(runtime === lambda.Runtime.PYTHON_3_7) {
+                if (opt && opt.py_entrypoint) {
+                    // Set opt.py_entrypoint to manually specify how to resolve the `lambda_handler` function.
+                    return opt.py_entrypoint
+                } else {
+                    // For one-file python services, where we assume everything is in <name>.py
+                    return `${name}.lambda_handler`
+                }
+            } else {
+                return name
+            }
+        })()
 
         const queues = new Queues(scope, serviceName.toLowerCase());
 

--- a/src/python/analyzer_executor/Dockerfile
+++ b/src/python/analyzer_executor/Dockerfile
@@ -5,7 +5,8 @@ COPY --chown=grapl . analyzer_executor
 COPY --from=grapl/grapl-analyzerlib-python-build /home/grapl/venv venv
 RUN /bin/bash -c "source venv/bin/activate && cd analyzer_executor && pip install ."
 RUN cd venv/lib/python3.7/site-packages/ && zip --quiet -9r ~/lambda.zip ./
-RUN cd analyzer_executor/src/ && zip -g ~/lambda.zip ./analyzer-executor.py
+# cannot for the life of me figure out how to get **/* to work with this
+RUN cd analyzer_executor/src/ && zip -v -g ~/lambda.zip ./*.py ./analyzer_executor_lib/*.py
 RUN mkdir -p dist/analyzer-executor && cp ~/lambda.zip dist/analyzer-executor/lambda.zip
 
 FROM grapl/grapl-python-deploy AS grapl-analyzer-executor

--- a/src/python/analyzer_executor/setup.py
+++ b/src/python/analyzer_executor/setup.py
@@ -2,7 +2,7 @@
 
 import os
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages  # type: ignore
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 

--- a/src/python/analyzer_executor/src/lambda_function.py
+++ b/src/python/analyzer_executor/src/lambda_function.py
@@ -1,0 +1,3 @@
+from analyzer_executor_lib.analyzer_executor import lambda_handler_fn
+
+lambda_handler = lambda_handler_fn

--- a/src/python/analyzer_executor/src/run_local.py
+++ b/src/python/analyzer_executor/src/run_local.py
@@ -1,0 +1,64 @@
+import boto3  # type: ignore
+import botocore.exceptions  # type: ignore
+import json
+import time
+import traceback
+
+from analyzer_executor_lib.analyzer_executor import IS_LOCAL, LOGGER, lambda_handler_fn
+
+if IS_LOCAL:
+    while True:
+        try:
+            sqs = boto3.client(
+                "sqs",
+                region_name="us-east-1",
+                endpoint_url="http://sqs.us-east-1.amazonaws.com:9324",
+                aws_access_key_id="dummy_cred_aws_access_key_id",
+                aws_secret_access_key="dummy_cred_aws_secret_access_key",
+            )
+
+            alive = False
+            while not alive:
+                try:
+                    if "QueueUrls" not in sqs.list_queues(
+                        QueueNamePrefix="grapl-analyzer-executor-queue"
+                    ):
+                        LOGGER.info(
+                            "Waiting for grapl-analyzer-executor-queue to be created"
+                        )
+                        time.sleep(2)
+                        continue
+                except (
+                    botocore.exceptions.BotoCoreError,
+                    botocore.exceptions.ClientError,
+                    botocore.parsers.ResponseParserError,
+                ):
+                    LOGGER.info("Waiting for SQS to become available")
+                    time.sleep(2)
+                    continue
+                alive = True
+
+            res = sqs.receive_message(
+                QueueUrl="http://sqs.us-east-1.amazonaws.com:9324/queue/grapl-analyzer-executor-queue",
+                WaitTimeSeconds=3,
+                MaxNumberOfMessages=10,
+            )
+
+            messages = res.get("Messages", [])
+            if not messages:
+                LOGGER.warning("queue was empty")
+
+            s3_events = [
+                (json.loads(msg["Body"]), msg["ReceiptHandle"]) for msg in messages
+            ]
+            for s3_event, receipt_handle in s3_events:
+                lambda_handler_fn(s3_event, {})
+
+                sqs.delete_message(
+                    QueueUrl="http://sqs.us-east-1.amazonaws.com:9324/queue/grapl-analyzer-executor-queue",
+                    ReceiptHandle=receipt_handle,
+                )
+
+        except Exception as e:
+            LOGGER.error(traceback.format_exc())
+            time.sleep(2)


### PR DESCRIPTION
### Which issue does this PR correspond to?
none
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- fun fact: NONE of our python lambdas are >1 file. while that's _okay_ for now, I want to rip the bandaid off before we end up with 5000 line files
- makes the `analyzer_executor` lib something that can actually be tested now (previously, a filename with a `-` is not a valid Python module and cannot be imported)
- enables us to split files up further in the future
- also, splits apart the entrypoint for the 'run local' stuff versus the lambda handler stuff

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
- put it on AWS and sent a test event (poorly formatted one). it failed, but not due to import error - instead, due to json stuff
![Screenshot 2020-10-22 at 4 22 45 PM](https://user-images.githubusercontent.com/69007229/96940258-1bd34000-1484-11eb-8d0f-ae0fa80b2849.png)
- locally: just gonna ran e2e tests 


<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
