### PR TITLE
Fix engagement-creator zip packaging for AWS

### DIFF
--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -353,7 +353,7 @@ class AnalyzerExecutor extends cdk.NestedStack {
             subscribes_to: dispatched_analyzer.topic,
             opt: {
                 runtime: lambda.Runtime.PYTHON_3_7,
-                py_entrypoint: "analyzer-executor.lambda_handler"
+                py_entrypoint: "lambda_function.lambda_handler"
             },
             version: props.version,
             watchful: props.watchful,

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -353,7 +353,7 @@ class AnalyzerExecutor extends cdk.NestedStack {
             subscribes_to: dispatched_analyzer.topic,
             opt: {
                 runtime: lambda.Runtime.PYTHON_3_7,
-                py_entrypoint: "lambda_function.lambda_handler"
+                py_entrypoint: "analyzer-executor.lambda_handler"
             },
             version: props.version,
             watchful: props.watchful,

--- a/src/js/grapl-cdk/package-lock.json
+++ b/src/js/grapl-cdk/package-lock.json
@@ -2773,7 +2773,8 @@
                 },
                 "bl": {
                     "version": "4.0.2",
-                    "resolved": "",
+                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+                    "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
                     "dev": true,
                     "requires": {
                         "buffer": "^5.5.0",
@@ -3023,7 +3024,8 @@
                         },
                         "bl": {
                             "version": "4.0.2",
-                            "resolved": "",
+                            "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+                            "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
                             "dev": true,
                             "requires": {
                                 "buffer": "^5.5.0",
@@ -3329,7 +3331,8 @@
                         },
                         "lodash": {
                             "version": "4.17.15",
-                            "resolved": "",
+                            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
                             "dev": true
                         },
                         "lodash.defaults": {

--- a/src/python/engagement-creator/Dockerfile
+++ b/src/python/engagement-creator/Dockerfile
@@ -4,8 +4,9 @@ WORKDIR /home/grapl
 COPY --chown=grapl . engagement-creator
 COPY --from=grapl/grapl-analyzerlib-python-build /home/grapl/venv venv
 RUN /bin/bash -c "source venv/bin/activate && cd engagement-creator && pip install ."
-RUN zip --quiet -9r lambda.zip venv/lib/python3.7/site-packages/
-RUN zip -g lambda.zip engagement-creator/src/engagement-creator.py
+RUN cd venv/lib/python3.7/site-packages/ && zip --quiet -9r ~/lambda.zip ./
+
+RUN cd engagement-creator/src/ && zip -v -g ~/lambda.zip engagement-creator.py
 RUN mkdir -p dist/engagement-creator && cp lambda.zip dist/engagement-creator/lambda.zip
 
 FROM grapl/grapl-python-deploy:latest AS grapl-engagement-creator


### PR DESCRIPTION
### Which issue does this PR correspond to?

Started seeing an error for engagement-creator:
```
[ERROR] Runtime.ImportModuleError: Unable to import module 'engagement-creator': No module named 'engagement-creator'
```

### What changes does this PR make to Grapl? Why?

This PR does a couple things:

1. Change the zip package layout for engagement-creator to be consistent with other packages and in a way that is expected for AWS lambda.
2. Doing a `npm i` in a fresh src/js/grapl-cdk dir resulted in the package-lock.json diff. Figured might as well include here.

### How were these changes tested?

~I tested 1. above by standard steps for build and cdk deploy. For 2. I didn't do that, I just changed the entrypoint value in the AWS Console and submitted new test data, which succeeded with an engagement created in the Grapl UI. I made sure have the value I used there match what I put in the CDK.~

Previous test was apparently on a stale build, seemingly due to not having `rm dist/` before build - https://github.com/grapl-security/grapl/issues/386. Did a rebuild after `rm -rf dist/` and deployed to AWS. Sent new test data and verified it showed up in the engagement. 👍 