### PR TITLE
Name and expose the docker-compose network

### DIFF
--- a/dobi.yaml
+++ b/dobi.yaml
@@ -447,7 +447,7 @@ job=run-rust-unit-tests:
 
 job=run-node-identifier-integration-tests:
   use: rust-build
-  net-mode: grapl-integration-tests_default
+  net-mode: grapl-network
   command: |
     /bin/bash -c "
       wait-for-it grapl-provision:8126 --timeout=60 &&
@@ -563,7 +563,7 @@ job=run-grapl-analyzerlib-unit-tests:
 
 job=run-grapl-analyzerlib-integration-tests:
   use: grapl-analyzerlib-build
-  net-mode: grapl-integration-tests_default
+  net-mode: grapl-network
   command: |
     /bin/bash -c "
       wait-for-it grapl-provision:8126 --timeout=60 &&
@@ -592,7 +592,7 @@ job=run-analyzer-deployer-unit-tests:
 
 job=run-analyzer-deployer-integration-tests:
   use: analyzer-deployer-build
-  net-mode: grapl-integration-tests_default
+  net-mode: grapl-network
   command: |
     /bin/bash -c "
       wait-for-it grapl-provision:8126 --timeout=60 &&
@@ -609,7 +609,7 @@ job=run-analyzer-deployer-integration-tests:
 
 job=run-e2e-integration-tests:
   use: grapl-e2e-tests-build
-  net-mode: grapl-integration-tests_default
+  net-mode: grapl-network
   command: | 
     /bin/bash -c "
       wait-for-it grapl-provision:8126 --timeout=60 &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -407,3 +407,8 @@ services:
       - s3
       - sqs
       - dynamodb
+
+networks:
+  default:
+    name: grapl
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,10 @@ services:
       - IMAGE_NAME=localstack/localstack:0.11.5
     ports:
       - "9324:9324"
+    networks:
+      default:
+        aliases:
+          - sqs.us-east-1.amazonaws.com
     logging:
       driver: none
 
@@ -60,6 +64,10 @@ services:
     command: server /data
     ports:
       - "9000:9000"
+    networks:
+      default:
+        aliases:
+          - minio
     logging:
       driver: none
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -418,5 +418,5 @@ services:
 
 networks:
   default:
-    name: grapl
+    name: grapl-network
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -419,4 +419,3 @@ services:
 networks:
   default:
     name: grapl-network
-    external: true


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This names the docker-compose network and makes it easier for us to `docker-compose up` from a generator in another location/repo by joining the network.

### How were these changes tested?

Tested with local version of CloudTrail generator compose file.