### PR TITLE
restore cmd to run for engagement-view in local grapl.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -390,6 +390,7 @@ services:
         wait-for-it s3:9000 &&
         wait-for-it dynamodb:8000 &&
         wait-for-it grapl-master-graph-db:8080 &&
+        wait-for-it grapl-engagement-view:1234 &&
         . venv/bin/activate && 
         python /home/grapl/grapl_local_provision/provision_local_identity_table.py &&
         python /home/grapl/grapl_local_provision/grapl_provision.py &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -348,6 +348,7 @@ services:
 
   grapl-engagement-view:
     image: grapl/grapl-engagement-view:${TAG:-latest}
+    command: "serve -dir /var/www"
     environment:
       - PORT=1234
     ports:


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/grapl/issues/393

### What changes does this PR make to Grapl? Why?

This restores the command to run in the engagement-view container for local grapl. We were using the default from the base image, which was recently overwritten in a build stage. This tells docker-compose to use the original command, the original default from base image.

### How were these changes tested?

Ran `docker-compose up` and saw the engagement view restored.