### PR TITLE
Rename "e2e-integration" to just "e2e"; mark flaky tests as obviously flaky; rename the `dump_artifacts` script

### DIFF
--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -113,7 +113,7 @@ jobs:
 
   # In the future, this should probably be merged back into `dobi integration-tests`, but
   # since it's so timing-dependent I'm going to treat it separately until it stabilizes a bit.
-  end-to-end-integration-tests:
+  FLAKY-end-to-end-tests:
     runs-on: ubuntu-latest
 
     strategy:
@@ -138,7 +138,7 @@ jobs:
           GRAPL_RELEASE_TARGET=debug TAG=latest ./dobi-linux --no-bind-mount build
 
       # --no-bind-mount makes dobi screw up with volumes for some reason, and it's not really required here anyway.
-      - name: Run end-to-end integration tests
+      - name: Run end-to-end tests
         run: |
           GRAPL_RELEASE_TARGET=debug \
           GRAPL_LOG_LEVEL=DEBUG \
@@ -150,13 +150,13 @@ jobs:
       - name: 'Collect e2e test artifacts'
         if: ${{ always() }}
         run: |
-          python3 ./etc/ci_scripts/dump_compose_artifacts.py --compose-project "grapl-integration-tests"
+          python3 ./etc/ci_scripts/dump_artifacts.py --compose-project "grapl-integration-tests"
            
       - name: 'Upload e2e test artifacts'
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: e2e-artifacts
-          # this path is specified in dump_compose_artifacts.py
-          path: /tmp/compose_artifacts/
+          # this path is specified in dump_artifacts.py
+          path: /tmp/dumped_artifacts/
           retention-days: 28

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -639,6 +639,8 @@ job=run-e2e-tests:
   ports:
     # Used for debugger
     - 8400:8400
+  annotations:
+    description: "Run end-to-end tests"
 
 job=build-analyzer-executor:
   use: analyzer-executor-build

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -520,7 +520,7 @@ job=typecheck-grapl-tests-common:
       mypy .
       "
 
-job=typecheck-e2e-integration-tests:
+job=typecheck-e2e-tests:
   use: grapl-e2e-tests-build
   # since there's no setup.py, I have an explicit `pip install mypy` instead of `.[typecheck]`
   command: |
@@ -615,7 +615,7 @@ job=run-analyzer-deployer-integration-tests:
   depends:
     - integration-env
 
-job=run-e2e-integration-tests:
+job=run-e2e-tests:
   use: grapl-e2e-tests-build
   net-mode: grapl-network
   command: | 
@@ -877,7 +877,7 @@ alias=python-typecheck:
     - typecheck-grapl-common
     - typecheck-grapl-tests-common
     - typecheck-analyzer-deployer
-    - typecheck-e2e-integration-tests
+    - typecheck-e2e-tests
     - typecheck-engagement-creator
     - typecheck-model-plugin-deployer
     - typecheck-analyzer-executor

--- a/etc/ci_scripts/dump_artifacts.py
+++ b/etc/ci_scripts/dump_artifacts.py
@@ -57,7 +57,7 @@ def _dump_docker_log(container_name: str, dir: Path) -> None:
         popen.wait()
 
 
-ARTIFACTS_PATH = Path("/tmp/compose_artifacts").resolve()
+ARTIFACTS_PATH = Path("/tmp/dumped_artifacts").resolve()
 
 
 def dump_all_logs(compose_project: str) -> None:

--- a/src/python/grapl-tests-common/grapl_tests_common/setup.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/setup.py
@@ -101,8 +101,8 @@ def _after_tests() -> None:
     """
 
     # Issue a command to dgraph to export the whole database.
-    # This is then stored on a volume, `compose_artifacts`.
-    # The contents of the volume are made available to Github Actions via `dump_compose_artifacts.py`.
+    # This is then stored on a volume, `dgraph_export` (defined in docker-compose.yml)
+    # The contents of the volume are made available to Github Actions via `dump_artifacts.py`.
     if DUMP_ARTIFACTS:
         logging.info("Executing post-test database dumps")
         export_request = requests.get("http://grapl-master-graph-db:8080/admin/export")


### PR DESCRIPTION
just a renaming diff