### PR TITLE
Try to get required CDK deployment args from environment.

### DIFF
--- a/src/js/grapl-cdk/README.md
+++ b/src/js/grapl-cdk/README.md
@@ -26,45 +26,67 @@ credentials.
 Execute a local Grapl build by running the following in Grapl's root:
 
 ```bash
-TAG=$YOUR_VERSION GRAPL_RELEASE_TARGET=release dobi --no-bind-mount build
+TAG=$GRAPL_VERSION GRAPL_RELEASE_TARGET=release dobi --no-bind-mount build
 ```
 
 Then extract the deployment artifacts from the build containers with
 the following script:
 
 ```bash
-VERSION=$YOUR_VERSION ./extract-grapl-deployment-artifacts.sh
+VERSION=$GRAPL_VERSION ./extract-grapl-deployment-artifacts.sh
 ```
 
-`YOUR_VERSION` can be any name you want. Just make note of it, we'll
+`GRAPL_VERSION` can be any name you want. Just make note of it, we'll
 use it in the next step.
 
 Your build outputs should appear in the `zips/` directory.
 
 ### Configuration
 
-Set your deployment name and version in `bin/grapl-cdk.ts`:
+There are three CDK deployment parameters:
+
+1. `deployName` (required)
+
+    Name for the deployment to AWS. We recommend prefixing the deployment name
+    with "Grapl-" to help identify Grapl resources in your AWS account, however
+    this isn't necessary.
+
+    Note: This name must be globally (AWS) unique, as names for AWS S3 buckets
+    will be dervied from this.
+
+    env: `GRAPL_CDK_DEPLOYMENT_NAME`
+
+2. `graplVersion'
+
+    The version of Grapl to deploy. This string will be used to look for the
+    appropirate filenames in the `zips/` directory.
+
+    Defaults to `latest`.
+
+    env: `GRAPL_VERSION`
+
+3. `watchfulEmail` (optional)
+
+    Setting this enables [Watchful](https://github.com/eladb/cdk-watchful) for
+    monitoring Grapl with email alerts.
+
+    env: `GRAPL_CDK_WATCHFUL_EMAIL`
+
+Each of these can be in `bin/grapl-cdk.ts`:
 
 ```
-export const deployName = 'Grapl-MYDEPLOYMENT';
-export const graplVersion = 'YOUR_VERSION';
+const deployName = undefined;
+const graplVersion = undefined;
+const watchfulEmail = undefined; 
 ```
 
-Some tips for choosing a deployment name:
+Alternatively, these can be set via the environment variables mentioned for each above. The environment variables take precedence over the values in 
+`bin/grapl-cdk.ts`.
 
--   Keep "Grapl" as prefix. This isn't necessary, but will help
-    identify Grapl resources in your AWS account.
--   Choose a globally unique name, as this will be used to name S3
-    buckets, which have this requirement. Using a name that includes
-    your AWS account number and deployment region should work.
-
-To enable [Watchful](https://github.com/eladb/cdk-watchful) for
-monitoring Grapl with email alerts, specify the email address to
-receive alerts:
-
-```
-export const watchfulEmail = 'YOUR@EMAIL';
-```
+When deploying to production we recommend *not* using environment variables for
+setting parameters, but rather set them in `bin/grapl-cdk.ts` and save the
+changes in a git branch. This should mhelp future maintenance of the
+deployment.
 
 ## Deploying
 

--- a/src/js/grapl-cdk/bin/grapl-cdk.ts
+++ b/src/js/grapl-cdk/bin/grapl-cdk.ts
@@ -6,9 +6,9 @@ import { GraplCdkStack } from '../lib/grapl-cdk-stack';
 import { EngagementUx } from '../lib/engagement';
 
 // Deployment parameters
-const deployName = undefined; // ex: 'Grapl-my-deployment'
-const graplVersion = undefined;
-const watchfulEmail = undefined;
+const deployName = undefined; // ex: 'Grapl-my-deployment' - GRAPL_CDK_DEPLOYMENT_NAME
+const graplVersion = undefined; // defaults to 'latest' - GRAPL_VERSION
+const watchfulEmail = undefined; // (optional) ex: ops@example.com - GRAPL_CDK_WATCHFUL_EMAIL
 
 const stackName = process.env.GRAPL_CDK_DEPLOYMENT_NAME || deployName;
 if (!stackName) {
@@ -18,7 +18,7 @@ if (!stackName) {
 const app = new cdk.App();
 
 const grapl = new GraplCdkStack(app, 'Grapl', {
-    version:process.env.GRAPL_CDK_VERSION ||  graplVersion || 'latest',
+    version:process.env.GRAPL_VERSION ||  graplVersion || 'latest',
     stackName: stackName,
     watchfulEmail: process.env.GRAPL_CDK_WATCHFUL_EMAIL || watchfulEmail,
     tags: { 'grapl deployment': stackName},

--- a/src/js/grapl-cdk/bin/grapl-cdk.ts
+++ b/src/js/grapl-cdk/bin/grapl-cdk.ts
@@ -30,6 +30,6 @@ new EngagementUx(app, 'EngagementUX', {
     engagement_edge: grapl.engagement_edge,
     graphql_endpoint: grapl.graphql_endpoint,
     model_plugin_deployer: grapl.model_plugin_deployer,
-    stackName: deployName + '-EngagementUX',
+    stackName: stackName + '-EngagementUX',
     description: 'Grapl Engagement UX',
 });

--- a/src/js/grapl-cdk/bin/grapl-cdk.ts
+++ b/src/js/grapl-cdk/bin/grapl-cdk.ts
@@ -5,17 +5,23 @@ import * as cdk from '@aws-cdk/core';
 import { GraplCdkStack } from '../lib/grapl-cdk-stack';
 import { EngagementUx } from '../lib/engagement';
 
-const deployName = 'Grapl-MYDEPLOYMENT';
-const graplVersion = 'latest';
+// Deployment parameters
+const deployName = undefined; // ex: 'Grapl-my-deployment'
+const graplVersion = undefined;
 const watchfulEmail = undefined;
+
+const stackName = process.env.GRAPL_CDK_DEPLOYMENT_NAME || deployName;
+if (!stackName) {
+    throw new Error("Error: Missing Grapl deployment name. Set via bin/grapl-cdk.ts, or environment variable GRAPL_CDK_DEPLOYMENT_NAME.");
+}
 
 const app = new cdk.App();
 
 const grapl = new GraplCdkStack(app, 'Grapl', {
-    version: graplVersion,
-    stackName: deployName,
-    tags: { 'grapl deployment': deployName },
-    watchfulEmail,
+    version:process.env.GRAPL_CDK_VERSION ||  graplVersion || 'latest',
+    stackName: stackName,
+    watchfulEmail: process.env.GRAPL_CDK_WATCHFUL_EMAIL || watchfulEmail,
+    tags: { 'grapl deployment': stackName},
     description: 'Grapl base deployment',
 });
 

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -719,7 +719,7 @@ export interface GraplServiceProps {
 
 export interface GraplStackProps extends cdk.StackProps {
     stackName: string;
-    version?: string;
+    version: string;
     watchfulEmail?: string;
 }
 
@@ -778,7 +778,7 @@ export class GraplCdkStack extends cdk.Stack {
 
         const graplProps: GraplServiceProps = {
             prefix: this.prefix,
-            version: props.version || 'latest',
+            version: props.version,
             jwtSecret: jwtSecret,
             vpc: grapl_vpc,
             dgraphSwarmCluster: dgraphSwarmCluster,

--- a/src/js/grapl-cdk/test/grapl-cdk.test.ts
+++ b/src/js/grapl-cdk/test/grapl-cdk.test.ts
@@ -11,6 +11,7 @@ test('Empty Stack', () => {
     // WHEN
     const stack = new GraplCdk.GraplCdkStack(app, 'MyTestStack', {
         stackName: 'Grapl-Test',
+        version: 'latest',
     });
     // THEN
     expectCDK(stack).to(


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This allows users to supply CDK deployment arguments via environment variables instead of specifying in the bin/grapl-cdk.ts file.

### How were these changes tested?

Local CDK build works, but I haven't yet tested a deploy to AWS. Can do before merging.