### PR TITLE
Fix the Github Workflow for e2e - which is still flaky lol

### DIFF
--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -144,7 +144,7 @@ jobs:
           GRAPL_LOG_LEVEL=DEBUG \
           DUMP_ARTIFACTS=True \
           TAG=latest \
-          ./dobi-linux run-e2e-integration-tests
+          ./dobi-linux run-e2e-tests
        
       # NOTE: This requires >= py37
       - name: 'Collect e2e test artifacts'

--- a/docs/development/vscode_debugger.rst
+++ b/docs/development/vscode_debugger.rst
@@ -50,7 +50,7 @@ Run the tests with the following. (Again, this example is strictly about the E2E
 
 .. code-block:: bash
 
-    TAG=latest DEBUG_SERVICES=grapl_e2e_tests dobi run-e2e-integration-tests
+    TAG=latest DEBUG_SERVICES=grapl_e2e_tests dobi run-e2e-tests
 
 You'll see the test start up and output the following:
 


### PR DESCRIPTION
woops, the most important reference to `run-e2e-integration-tests` was not replaced, and we allow it to fail anyways since it's flaky. 