### PR TITLE
more-robust consumption of secrets manager

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,12 +49,12 @@ services:
     image: localstack/localstack:0.11.5
     environment:
       - PORT_WEB_UI=8099
-      - SERVICES=secretsmanager  # 4566 by default
+      - SERVICES=secretsmanager:4584
       - HOSTNAME_EXTERNAL=secretsmanager.us-east-1.amazonaws.com
       - IMAGE_NAME=localstack/localstack:0.11.5
 
     ports:
-      - "4566:4566"
+      - "4584:4584"
       - "8099:8099"
     # logging:
     #   driver: none
@@ -395,7 +395,7 @@ services:
       /bin/bash -c "
         # it doesn't seem to like waiting for sqs
         # wait-for-it sqs:9324 &&
-        wait-for-it secretsmanager:4566 &&
+        wait-for-it secretsmanager:4584 &&
         wait-for-it s3:9000 &&
         wait-for-it dynamodb:8000 &&
         wait-for-it grapl-master-graph-db:8080 &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,12 +49,12 @@ services:
     image: localstack/localstack:0.11.5
     environment:
       - PORT_WEB_UI=8099
-      - SERVICES=secretsmanager:4569
+      - SERVICES=secretsmanager  # 4566 by default
       - HOSTNAME_EXTERNAL=secretsmanager.us-east-1.amazonaws.com
       - IMAGE_NAME=localstack/localstack:0.11.5
 
     ports:
-      - "4568:4568"
+      - "4566:4566"
       - "8099:8099"
     # logging:
     #   driver: none
@@ -289,7 +289,13 @@ services:
 
   grapl-engagement-edge:
     image: grapl/grapl-engagement-edge:${TAG:-latest}
-    command: /bin/sh -c '. venv/bin/activate && cd /home/grapl/app && chalice local --no-autoreload --host=0.0.0.0 --port=8900'
+    command: |
+      /bin/sh -c '
+        wait-for-it grapl-provision:8126 --timeout=45 &&
+        . venv/bin/activate &&
+        cd /home/grapl/app &&
+        chalice local --no-autoreload --host=0.0.0.0 --port=8900
+      '
     ports:
       - "8900:8900"
     environment:
@@ -298,6 +304,8 @@ services:
       - "UX_BUCKET_URL=localhost:3000"
       - "USER_AUTH_TABLE=local-grapl-user_auth_table"
       - "BUCKET_PREFIX=local-grapl"
+    depends_on:
+      - grapl-provision
 
     tty: true
     links:
@@ -387,6 +395,7 @@ services:
       /bin/bash -c "
         # it doesn't seem to like waiting for sqs
         # wait-for-it sqs:9324 &&
+        wait-for-it secretsmanager:4566 &&
         wait-for-it s3:9000 &&
         wait-for-it dynamodb:8000 &&
         wait-for-it grapl-master-graph-db:8080 &&

--- a/src/js/graphql_endpoint/modules/jwt.js
+++ b/src/js/graphql_endpoint/modules/jwt.js
@@ -13,7 +13,7 @@ const secretsmanager = new AWS.SecretsManager({
     region: IS_LOCAL ? 'us-east-1' : undefined,
     accessKeyId: IS_LOCAL ? 'dummy_cred_aws_access_key_id' : undefined,
     secretAccessKey: IS_LOCAL ? 'dummy_cred_aws_secret_access_key' : undefined,
-    endpoint: IS_LOCAL ? 'http://secretsmanager.us-east-1.amazonaws.com:4566': undefined,
+    endpoint: IS_LOCAL ? 'http://secretsmanager.us-east-1.amazonaws.com:4584': undefined,
 });
 
 const fetchJwtSecret = async () => {

--- a/src/python/engagement_edge/Dockerfile
+++ b/src/python/engagement_edge/Dockerfile
@@ -9,6 +9,8 @@ RUN cd engagement_edge/src/ && zip -g ~/lambda.zip ./engagement_edge.py
 RUN mkdir -p dist/engagement-edge && cp lambda.zip dist/engagement-edge/lambda.zip
 
 FROM grapl/grapl-python-deploy AS grapl-engagement-edge
+USER root
+RUN apt-get update && apt-get install -y wait-for-it
 USER grapl
 WORKDIR /home/grapl
 COPY --from=engagement-edge-build /home/grapl/lambda.zip lambda.zip

--- a/src/python/engagement_edge/src/engagement_edge.py
+++ b/src/python/engagement_edge/src/engagement_edge.py
@@ -64,7 +64,7 @@ if IS_LOCAL:
                 region_name="us-east-1",
                 aws_access_key_id="dummy_cred_aws_access_key_id",
                 aws_secret_access_key="dummy_cred_aws_secret_access_key",
-                endpoint_url="http://secretsmanager.us-east-1.amazonaws.com:4566",
+                endpoint_url="http://secretsmanager.us-east-1.amazonaws.com:4584",
             )
 
             JWT_SECRET = secretsmanager.get_secret_value(

--- a/src/python/engagement_edge/src/engagement_edge.py
+++ b/src/python/engagement_edge/src/engagement_edge.py
@@ -73,7 +73,7 @@ if IS_LOCAL:
             LOGGER.debug(e)
             time.sleep(1)
     if not JWT_SECRET:
-        raise TimeoutError("Expected secretsmanager to be available within {TIMEOUT_SECS} seconds")
+        raise TimeoutError(f"Expected secretsmanager to be available within {TIMEOUT_SECS} seconds")
 else:
     JWT_SECRET_ID = os.environ["JWT_SECRET_ID"]
 

--- a/src/python/engagement_edge/src/engagement_edge.py
+++ b/src/python/engagement_edge/src/engagement_edge.py
@@ -35,6 +35,7 @@ from grapl_analyzerlib.nodes.lens import LensQuery
 
 if TYPE_CHECKING:
     from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource, Table
+
     Salt = bytes
 
 IS_LOCAL = bool(os.environ.get("IS_LOCAL", False))

--- a/src/python/engagement_edge/src/engagement_edge.py
+++ b/src/python/engagement_edge/src/engagement_edge.py
@@ -49,10 +49,11 @@ LOGGER.addHandler(logging.StreamHandler(stream=sys.stdout))
 JWT_SECRET: Optional[str] = None
 
 if IS_LOCAL:
-    # Theory: This whole code block is deprecated by the `wait-for-it grapl-provision`, 
+    # Theory: This whole code block is deprecated by the `wait-for-it grapl-provision`,
     # which guarantees that the JWT Secret is, now, in the secretsmanager. - wimax
 
     import time
+
     TIMEOUT_SECS = 30
 
     for _ in range(TIMEOUT_SECS):
@@ -73,7 +74,9 @@ if IS_LOCAL:
             LOGGER.debug(e)
             time.sleep(1)
     if not JWT_SECRET:
-        raise TimeoutError(f"Expected secretsmanager to be available within {TIMEOUT_SECS} seconds")
+        raise TimeoutError(
+            f"Expected secretsmanager to be available within {TIMEOUT_SECS} seconds"
+        )
 else:
     JWT_SECRET_ID = os.environ["JWT_SECRET_ID"]
 
@@ -211,6 +214,7 @@ def login(username: str, password: str) -> Optional[str]:
         return None
 
     # Use JWT to generate token
+    assert JWT_SECRET
     return jwt.encode({"username": username}, JWT_SECRET, algorithm="HS256").decode(
         "utf8"
     )
@@ -226,6 +230,7 @@ def check_jwt(headers: Dict[str, Any]) -> bool:
         LOGGER.info("encoded_jwt %s", encoded_jwt)
         return False
 
+    assert JWT_SECRET
     try:
         jwt.decode(encoded_jwt, JWT_SECRET, algorithms=["HS256"])
         return True

--- a/src/python/grapl-model-plugin-deployer/src/grapl_model_plugin_deployer.py
+++ b/src/python/grapl-model-plugin-deployer/src/grapl_model_plugin_deployer.py
@@ -61,7 +61,7 @@ if IS_LOCAL:
                 region_name="us-east-1",
                 aws_access_key_id="dummy_cred_aws_access_key_id",
                 aws_secret_access_key="dummy_cred_aws_secret_access_key",
-                endpoint_url="http://secretsmanager.us-east-1.amazonaws.com:4566",
+                endpoint_url="http://secretsmanager.us-east-1.amazonaws.com:4584",
             )
 
             JWT_SECRET = secretsmanager.get_secret_value(

--- a/src/python/grapl_provision/grapl_provision.py
+++ b/src/python/grapl_provision/grapl_provision.py
@@ -414,7 +414,7 @@ if __name__ == "__main__":
             client = boto3.client(
                 service_name="secretsmanager",
                 region_name="us-east-1",
-                endpoint_url="http://secretsmanager.us-east-1.amazonaws.com:4566",
+                endpoint_url="http://secretsmanager.us-east-1.amazonaws.com:4584",
                 aws_access_key_id="dummy_cred_aws_access_key_id",
                 aws_secret_access_key="dummy_cred_aws_secret_access_key",
             )


### PR DESCRIPTION
This solves Andrea's issue. 
- engagement edge assumes a secretmanager available on 4566 (but that port was never opened)
- engagement edge silently fails if that secretmanager is never made available (it's just in a while-loop of failure, forever)

I've:
- exposed 4566
- made it not silently fail (if it can't retrieve JWT within N seconds, raise an error)
- made it explicitly depend on the user creation in grapl-provision, instead of just wait-forever
