### PR TITLE
Get grapl notebook url from Engagement Edge

### DIFF
--- a/dobi.yaml
+++ b/dobi.yaml
@@ -740,6 +740,10 @@ job=build-engagement-edge:
 job=run-engagement-edge-unit-tests:
   use: engagement-edge-build
   command: /bin/bash -c "source venv/bin/activate && cd engagement_edge && py.test -n auto -m 'not integration_test'"
+  env:
+    - IS_LOCAL=True
+    - BUCKET_PREFIX=local-grapl
+    - UX_BUCKET_URL="ux_bucket_url"
 
 job=build-dgraph-ttl:
   use: dgraph-ttl-build

--- a/src/js/grapl-cdk/lib/engagement.ts
+++ b/src/js/grapl-cdk/lib/engagement.ts
@@ -126,7 +126,7 @@ export class EngagementEdge extends cdk.NestedStack {
 
         this.event_handler = new lambda.Function(this, 'Handler', {
             runtime: lambda.Runtime.PYTHON_3_7,
-            handler: `engagement_edge.app`,
+            handler: `src.engagement_edge.app`,
             functionName: serviceName + '-Handler',
             code: lambda.Code.fromAsset(
                 `./zips/engagement-edge-${props.version}.zip`

--- a/src/js/grapl-cdk/lib/engagement.ts
+++ b/src/js/grapl-cdk/lib/engagement.ts
@@ -201,7 +201,7 @@ export class EngagementEdge extends cdk.NestedStack {
                             resourcePath: '/checkLogin',
                         },
                         {
-                            httpMethod: 'GET',
+                            httpMethod: 'POST',
                             resourcePath: '/getNotebook',
                         },
                         {

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -943,7 +943,7 @@ export class GraplCdkStack extends cdk.Stack {
             ...enableMetricsProps,
         });
 
-        new EngagementNotebook(this, 'engagements', {
+        const engagement_notebook = new EngagementNotebook(this, 'engagements', {
             model_plugins_bucket,
             ...graplProps,
         });
@@ -951,7 +951,10 @@ export class GraplCdkStack extends cdk.Stack {
         this.engagement_edge = new EngagementEdge(
             this,
             'EngagementEdge',
-            graplProps
+            {
+                ...graplProps, 
+                engagement_notebook: engagement_notebook
+            },
         );
 
         const ux_bucket = new s3.Bucket(this, 'EdgeBucket', {

--- a/src/python/engagement_edge/Dockerfile
+++ b/src/python/engagement_edge/Dockerfile
@@ -5,7 +5,7 @@ COPY --chown=grapl . engagement_edge
 COPY --from=grapl/grapl-analyzerlib-python-build /home/grapl/venv venv
 RUN /bin/bash -c "source venv/bin/activate && cd engagement_edge && pip install ."
 RUN cd venv/lib/python3.7/site-packages/ && zip --quiet -9r ~/lambda.zip ./
-RUN cd engagement_edge/src/ && zip -g ~/lambda.zip ./engagement_edge.py
+RUN cd engagement_edge/src/ && /bin/bash -c "zip -g ~/lambda.zip ./**/*.py"
 RUN mkdir -p dist/engagement-edge && cp lambda.zip dist/engagement-edge/lambda.zip
 
 FROM grapl/grapl-python-deploy AS grapl-engagement-edge

--- a/src/python/engagement_edge/setup.py
+++ b/src/python/engagement_edge/setup.py
@@ -29,7 +29,7 @@ setup(
     extras_require={
         "typecheck": [
             "mypy",
-            "boto3-stubs[dynamodb]",
+            "boto3-stubs[dynamodb,sagemaker]",
         ]
     },
     setup_requires=("wheel",),

--- a/src/python/engagement_edge/src/engagement_edge.py
+++ b/src/python/engagement_edge/src/engagement_edge.py
@@ -33,6 +33,8 @@ from grapl_analyzerlib.nodes.base import BaseQuery, BaseView
 from grapl_analyzerlib.nodes.entity import EntityQuery
 from grapl_analyzerlib.nodes.lens import LensQuery
 
+from src.lib import sagemaker
+
 if TYPE_CHECKING:
     from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource, Table
 
@@ -342,3 +344,5 @@ def nop_route() -> Response:
         return check_login()
 
     return respond("InvalidPath")
+
+print(sagemaker.derp())

--- a/src/python/engagement_edge/src/engagement_edge.py
+++ b/src/python/engagement_edge/src/engagement_edge.py
@@ -28,25 +28,20 @@ import jwt
 import pydgraph  # type: ignore
 from chalice import Chalice, CORSConfig, Response
 from pydgraph import DgraphClient
+from src.lib.constants import GRAPL_LOG_LEVEL, IS_LOCAL
+from src.lib.sagemaker import SagemakerNotebookUrlGetter
 
 from grapl_analyzerlib.nodes.base import BaseQuery, BaseView
 from grapl_analyzerlib.nodes.entity import EntityQuery
 from grapl_analyzerlib.nodes.lens import LensQuery
-
-from src.lib import sagemaker
 
 if TYPE_CHECKING:
     from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource, Table
 
     Salt = bytes
 
-IS_LOCAL = bool(os.environ.get("IS_LOCAL", False))
-
-
-GRAPL_LOG_LEVEL = os.getenv("GRAPL_LOG_LEVEL")
-LEVEL = "ERROR" if GRAPL_LOG_LEVEL is None else GRAPL_LOG_LEVEL
 LOGGER = logging.getLogger(__name__)
-LOGGER.setLevel(LEVEL)
+LOGGER.setLevel(GRAPL_LOG_LEVEL)
 LOGGER.addHandler(logging.StreamHandler(stream=sys.stdout))
 
 JWT_SECRET: Optional[str] = None
@@ -344,5 +339,3 @@ def nop_route() -> Response:
         return check_login()
 
     return respond("InvalidPath")
-
-print(sagemaker.derp())

--- a/src/python/engagement_edge/src/lib/constants.py
+++ b/src/python/engagement_edge/src/lib/constants.py
@@ -1,0 +1,4 @@
+import os
+
+IS_LOCAL = bool(os.environ.get("IS_LOCAL", False))
+GRAPL_LOG_LEVEL = os.environ.get("GRAPL_LOG_LEVEL", "ERROR")

--- a/src/python/engagement_edge/src/lib/env_vars.py
+++ b/src/python/engagement_edge/src/lib/env_vars.py
@@ -2,3 +2,4 @@ import os
 
 IS_LOCAL = bool(os.environ.get("IS_LOCAL", False))
 GRAPL_LOG_LEVEL = os.environ.get("GRAPL_LOG_LEVEL", "ERROR")
+BUCKET_PREFIX = os.environ["BUCKET_PREFIX"]

--- a/src/python/engagement_edge/src/lib/sagemaker.py
+++ b/src/python/engagement_edge/src/lib/sagemaker.py
@@ -1,30 +1,18 @@
 from __future__ import annotations
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING
 
 import boto3
-from chalice import Response
-from src.lib.constants import IS_LOCAL
+from src.lib.env_vars import IS_LOCAL
 
 if TYPE_CHECKING:
     from mypy_boto3_sagemaker import (
-        SageMakerClient as SagemakerClient,  # not a fan of that capital M
+        SageMakerClient as _BotoSageMakerClient,  # not a fan of that capital M
     )
 
 
-class SagemakerNotebookUrlGetter:
-    def __init__(self, client: SagemakerClient):
+class SagemakerClient:
+    def __init__(self, client: _BotoSageMakerClient):
         self.client = client
 
     def get_presigned_url(self, instance_name: str) -> str:
@@ -35,11 +23,11 @@ class SagemakerNotebookUrlGetter:
         return result["AuthorizedUrl"]
 
     @staticmethod
-    def create() -> SagemakerNotebookUrlGetter:
+    def create() -> SagemakerClient:
         if IS_LOCAL:
             # Technically, we could put in some mock that just returns the Jupyter url, but
             # at that point you're getting pretty far from the AWS implementation.
             raise NotImplementedError("There's no localstack Sagemaker yet!")
 
         client = boto3.client("sagemaker")
-        return SagemakerNotebookUrlGetter(client=client)
+        return SagemakerClient(client=client)

--- a/src/python/engagement_edge/src/lib/sagemaker.py
+++ b/src/python/engagement_edge/src/lib/sagemaker.py
@@ -12,7 +12,34 @@ from typing import (
     Union,
     cast,
 )
-from chalice import Response
 
-def derp() -> int:
-    return 3
+import boto3
+from chalice import Response
+from src.lib.constants import IS_LOCAL
+
+if TYPE_CHECKING:
+    from mypy_boto3_sagemaker import (
+        SageMakerClient as SagemakerClient,  # not a fan of that capital M
+    )
+
+
+class SagemakerNotebookUrlGetter:
+    def __init__(self, client: SagemakerClient):
+        self.client = client
+
+    def get_presigned_url(self, instance_name: str) -> str:
+        result = self.client.create_presigned_notebook_instance_url(
+            NotebookInstanceName=instance_name,
+            # defaults to 12 hours
+        )
+        return result["AuthorizedUrl"]
+
+    @staticmethod
+    def create() -> SagemakerNotebookUrlGetter:
+        if IS_LOCAL:
+            # Technically, we could put in some mock that just returns the Jupyter url, but
+            # at that point you're getting pretty far from the AWS implementation.
+            raise NotImplementedError("There's no localstack Sagemaker yet!")
+
+        client = boto3.client("sagemaker")
+        return SagemakerNotebookUrlGetter(client=client)

--- a/src/python/engagement_edge/src/lib/sagemaker.py
+++ b/src/python/engagement_edge/src/lib/sagemaker.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
+from chalice import Response
+
+def derp() -> int:
+    return 3

--- a/src/python/engagement_edge/tests/test_default.py
+++ b/src/python/engagement_edge/tests/test_default.py
@@ -1,6 +1,0 @@
-import unittest
-
-
-class TestDefault(unittest.TestCase):
-    def test_default(self):
-        assert True  # it works!

--- a/src/python/engagement_edge/tests/test_engagement_edge.py
+++ b/src/python/engagement_edge/tests/test_engagement_edge.py
@@ -12,4 +12,4 @@ class TestEngagementEdgeChalice(unittest.TestCase):
         with Client(app) as client:
             result = client.http.post("/getNotebook")
             assert result.status_code == 400
-            assert result.json_body == {'error': 'Must log in'}
+            assert result.json_body == {"error": "Must log in"}

--- a/src/python/engagement_edge/tests/test_engagement_edge.py
+++ b/src/python/engagement_edge/tests/test_engagement_edge.py
@@ -1,0 +1,15 @@
+import unittest
+
+from chalice.test import Client
+from src.engagement_edge import JWT_SECRET, app
+
+# gross hack because engagement edge is pseudo singleton
+JWT_SECRET.secret = "hey im a fake secret"
+
+
+class TestEngagementEdgeChalice(unittest.TestCase):
+    def test__a_requires_auth_path_fails_without_cookie_headers(self):
+        with Client(app) as client:
+            result = client.http.post("/getNotebook")
+            assert result.status_code == 400
+            assert result.json_body == {'error': 'Must log in'}


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/115

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Expose an endpoint on Engagement Edge that will return a URL to the Jupyter notebook.
- IAM insanity.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I tested in prod to ensure the URL is returned correctly. 

I'm going to quickly add Chalice tests (that will not be super helpful for this exact task) but u gotta start somewhere