### PR TITLE
Dedicated Python "-test" images, for tests/typechecking; strip pytest/etc out of build/deploy images

### DIFF
--- a/dobi.yaml
+++ b/dobi.yaml
@@ -718,14 +718,8 @@ job=typecheck-model-plugin-deployer:
 
 job=typecheck-engagement-edge:
   use: engagement-edge-test
-<<<<<<< HEAD
-  # the `touch` is a hack for mypy until https://github.com/aws/chalice/pull/1500 is in	
-  command: | 
-=======
-  # since there's no setup.py, I have an explicit `pip install mypy` instead of `.[typecheck]`
   # the `touch` is a hack for mypy until https://github.com/aws/chalice/pull/1500 is in
   command: |
->>>>>>> Proof of concept - quicker typechecks
     /bin/bash -c "
       source venv/bin/activate &&
       touch venv/lib/python3.7/site-packages/chalice/py.typed &&

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -151,6 +151,15 @@ image=python-build:
   tags:
     - latest
 
+image=python-test-deps:
+  image: grapl/python-test-deps
+  context: src/python/python_test_deps
+  dockerfile: Dockerfile
+  tags:
+    - latest
+  depends:
+    - python-build
+
 image=python-deploy:
   image: grapl/grapl-python-deploy
   context: src/python/grapl-python-deploy/
@@ -169,13 +178,33 @@ image=graph-descriptions-build:
   tags:
     - latest
 
+image=graph-descriptions-test:
+  image: grapl/grapl-graph-descriptions-test
+  context: src/rust/graph-descriptions/
+  dockerfile: tests.Dockerfile
+  target: grapl-graph-descriptions-test
+  depends:
+    - graph-descriptions-build
+    - python-test-deps
+  tags:
+    - latest
+
 image=grapl-common-build:
   image: grapl/grapl-common-python-build
   context: src/python/grapl-common/
   dockerfile: Dockerfile
-  target: grapl-common-python-build
   depends:
     - python-build
+  tags:
+    - latest
+
+image=grapl-common-test:
+  image: grapl/grapl-common-test
+  context: src/python/grapl-common/
+  dockerfile: tests.Dockerfile
+  depends:
+    - grapl-common-build
+    - python-test-deps
   tags:
     - latest
 
@@ -185,8 +214,9 @@ image=grapl-tests-common-build:
   dockerfile: Dockerfile
   target: grapl-tests-common-python-build
   depends:
-    - python-build
     - grapl-analyzerlib-build
+    - python-build
+    - python-test-deps
   tags:
     - latest
 
@@ -199,6 +229,16 @@ image=grapl-analyzerlib-build:
     - python-build
     - graph-descriptions-build
     - grapl-common-build
+  tags:
+    - latest
+
+image=grapl-analyzerlib-test:
+  image: grapl/grapl-analyzerlib-test
+  context: src/python/grapl_analyzerlib/
+  dockerfile: tests.Dockerfile
+  depends:
+    - grapl-analyzerlib-build
+    - python-test-deps
   tags:
     - latest
 
@@ -235,6 +275,16 @@ image=analyzer-executor-build:
   tags:
     - latest
 
+image=analyzer-executor-test:
+  image: grapl/analyzer-executor-test
+  context: src/python/analyzer_executor/
+  dockerfile: tests.Dockerfile
+  depends:
+    - analyzer-executor-build
+    - python-test-deps
+  tags:
+    - latest
+
 image=analyzer-executor:
   image: grapl/grapl-analyzer-executor
   context: src/python/analyzer_executor/
@@ -257,6 +307,14 @@ image=engagement-creator-build:
     - grapl-analyzerlib-build
   tags:
     - latest
+
+image=engagement-creator-test:
+  image: grapl/engagement-creator-test
+  context: src/python/engagement-creator
+  dockerfile: tests.Dockerfile
+  depends:
+    - engagement-creator-build
+    - python-test-deps
 
 image=engagement-creator:
   image: grapl/grapl-engagement-creator
@@ -289,6 +347,7 @@ image=engagement-edge-test:
   depends:
     - engagement-edge-build
     - grapl-tests-common-build
+    - python-test-deps
   tags:
     - latest
 
@@ -315,6 +374,16 @@ image=dgraph-ttl-build:
   tags:
     - latest
 
+image=dgraph-ttl-test:
+  image: grapl/grapl-dgraph-ttl-test
+  context: src/python/grapl-dgraph-ttl
+  dockerfile: tests.Dockerfile
+  depends:
+    - dgraph-ttl-build
+    - python-test-deps
+  tags:
+    - latest
+
 image=dgraph-ttl:
   image: grapl/grapl-dgraph-ttl
   context: src/python/grapl-dgraph-ttl
@@ -335,6 +404,16 @@ image=model-plugin-deployer-build:
     - python-build
     - graph-descriptions-build
     - grapl-analyzerlib-build
+  tags:
+    - latest
+
+image=model-plugin-deployer-test:
+  image: grapl/grapl-model-plugin-deployer-test
+  context: src/python/grapl-model-plugin-deployer
+  dockerfile: tests.Dockerfile
+  depends:
+    - model-plugin-deployer-build
+    - python-test-deps
   tags:
     - latest
 
@@ -568,22 +647,21 @@ job=run-node-identifier-integration-tests:
 # python jobs
 
 job=run-grapl-common-unit-tests:
-  use: grapl-common-build
+  use: grapl-common-test
   command: /bin/bash -c "source venv/bin/activate && cd grapl_common/tests && ls && py.test -n auto -m 'not integration_test'"
 
 
 job=typecheck-engagement-creator:
-  use: engagement-creator-build
+  use: engagement-creator-test
   command: |
     /bin/bash -c "
       source venv/bin/activate &&
       cd engagement-creator &&
-      pip install '.[typecheck]' &&
       mypy .
       "
 
 job=typecheck-grapl-common:
-  use: grapl-common-build
+  use: grapl-common-test
   command: |
     /bin/bash -c "
       source venv/bin/activate &&
@@ -626,7 +704,7 @@ job=typecheck-analyzer-deployer:
       "
 
 job=typecheck-model-plugin-deployer:
-  use: model-plugin-deployer-build
+  use: model-plugin-deployer-test
   # since there's no setup.py, I have an explicit `pip install mypy` instead of `.[typecheck]`
   # the `touch` is a hack for mypy until https://github.com/aws/chalice/pull/1500 is in
   command: |
@@ -640,8 +718,14 @@ job=typecheck-model-plugin-deployer:
 
 job=typecheck-engagement-edge:
   use: engagement-edge-test
+<<<<<<< HEAD
   # the `touch` is a hack for mypy until https://github.com/aws/chalice/pull/1500 is in	
   command: | 
+=======
+  # since there's no setup.py, I have an explicit `pip install mypy` instead of `.[typecheck]`
+  # the `touch` is a hack for mypy until https://github.com/aws/chalice/pull/1500 is in
+  command: |
+>>>>>>> Proof of concept - quicker typechecks
     /bin/bash -c "
       source venv/bin/activate &&
       touch venv/lib/python3.7/site-packages/chalice/py.typed &&
@@ -650,7 +734,7 @@ job=typecheck-engagement-edge:
       "
 
 job=typecheck-grapl-analyzerlib:
-  use: grapl-analyzerlib-build
+  use: grapl-analyzerlib-test
   command: |
     /bin/bash -c "
       source venv/bin/activate &&
@@ -660,11 +744,11 @@ job=typecheck-grapl-analyzerlib:
       "
 
 job=run-grapl-analyzerlib-unit-tests:
-  use: grapl-analyzerlib-build
+  use: grapl-analyzerlib-test
   command: /bin/bash -c "source venv/bin/activate && cd grapl_analyzerlib && py.test -n auto -m 'not integration_test'"
 
 job=run-grapl-analyzerlib-integration-tests:
-  use: grapl-analyzerlib-build
+  use: grapl-analyzerlib-test
   net-mode: grapl-network
   command: |
     /bin/bash -c "
@@ -710,7 +794,7 @@ job=run-analyzer-deployer-integration-tests:
     - integration-env
 
 job=run-analyzer-executor-integration-tests:
-  use: analyzer-executor-build
+  use: analyzer-executor-test
   net-mode: grapl-network
   command: |
     /bin/bash -c '
@@ -782,7 +866,7 @@ job=build-analyzer-executor:
     - ./dist/analyzer-executor/lambda.zip
 
 job=run-analyzer-executor-unit-tests:
-  use: analyzer-executor-build
+  use: analyzer-executor-test
   command: |
     /bin/bash -c "
       source venv/bin/activate &&
@@ -795,7 +879,7 @@ job=run-analyzer-executor-unit-tests:
     - IS_RETRY=False
 
 job=typecheck-analyzer-executor:
-  use: analyzer-executor-build
+  use: analyzer-executor-test
   command: |
     /bin/bash -c "
       source venv/bin/activate &&
@@ -811,7 +895,7 @@ job=build-engagement-creator:
     - ./dist/engagement-creator/lambda.zip
 
 job=run-engagement-creator-unit-tests:
-  use: engagement-creator-build
+  use: engagement-creator-test
   command: /bin/bash -c "source venv/bin/activate && cd engagement-creator && py.test -n auto -m 'not integration_test'"
 
 job=build-engagement-edge:
@@ -837,7 +921,7 @@ job=build-dgraph-ttl:
     - ./dist/dgraph-ttl/lambda.zip
 
 job=run-dgraph-ttl-unit-tests:
-  use: dgraph-ttl-build
+  use: dgraph-ttl-test
   command: /bin/bash -c "source venv/bin/activate && cd dgraph-ttl && py.test -n auto -m 'not integration_test'"
 
 job=build-model-plugin-deployer:
@@ -848,7 +932,7 @@ job=build-model-plugin-deployer:
     - ./dist/model-plugin-deployer/lambda.zip
 
 job=run-model-plugin-deployer-unit-tests:
-  use: model-plugin-deployer-build
+  use: model-plugin-deployer-test
   command: /bin/bash -c "source venv/bin/activate && cd model-plugin-deployer && py.test -n auto -m 'not integration_test'"
 
 job=build-swarm-lifecycle-event-handler:
@@ -944,13 +1028,21 @@ alias=clean-python-build:
   tasks:
     - "analyzer-deployer-build:rm"
     - "analyzer-executor-build:rm"
+    - "analyzer-executor-test:rm"
     - "engagement-creator-build:rm"
+    - "engagement-creator-test:rm"
     - "engagement-edge-build:rm"
+    - "engagement-edge-test:rm"
     - "dgraph-ttl-build:rm"
+    - "dgraph-ttl-test:rm"
     - "model-plugin-deployer-build:rm"
+    - "model-plugin-deployer-test:rm"
     - "grapl-analyzerlib-build:rm"
+    - "grapl-analyzerlib-test:rm"
     - "grapl-common-build:rm"
+    - "grapl-common-test:rm"
     - "graph-descriptions-build:rm"
+    - "graph-descriptions-test:rm"
     - "python-build:rm"
     - "swarm-lifecycle-event-handler-build:rm"
   annotations:
@@ -958,6 +1050,7 @@ alias=clean-python-build:
 
 alias=python-unit-tests:
   tasks:
+    - graph-descriptions-test  # Test is baked into the Dockerfile
     - run-grapl-common-unit-tests
     - run-grapl-analyzerlib-unit-tests
     - run-analyzer-deployer-unit-tests

--- a/src/python/analyzer_executor/tests.Dockerfile
+++ b/src/python/analyzer_executor/tests.Dockerfile
@@ -1,0 +1,5 @@
+FROM grapl/analyzer-executor-build
+
+# Install test requirements
+COPY --from=grapl/python-test-deps /home/grapl/python_test_deps python_test_deps
+RUN /bin/bash -c "python_test_deps/install_requirements.sh"

--- a/src/python/engagement-creator/tests.Dockerfile
+++ b/src/python/engagement-creator/tests.Dockerfile
@@ -1,0 +1,14 @@
+FROM grapl/grapl-python-build:latest AS engagement-creator-test
+USER grapl
+WORKDIR /home/grapl
+
+# Grab venv
+COPY --from=grapl/engagement-creator-build /home/grapl/venv venv
+
+# Install test requirements
+COPY --from=grapl/python-test-deps /home/grapl/python_test_deps python_test_deps
+RUN /bin/bash -c "python_test_deps/install_requirements.sh"
+
+# Grab and run source
+COPY --from=grapl/engagement-creator-build /home/grapl/engagement-creator engagement-creator
+RUN /bin/bash -c "source venv/bin/activate && cd engagement-creator && pip install .[typecheck]"

--- a/src/python/engagement_edge/tests.Dockerfile
+++ b/src/python/engagement_edge/tests.Dockerfile
@@ -1,16 +1,10 @@
-# Motivation for a different `-test` image:
-# I'd like to install stuff into the virtualenv that is only used for tests
-# and quality checks, but not deployed to AWS.
-
-# And you can't define this image in the same Dockerfile, because:
-# dobi evaluates the full Dockerfile when building the first stage of the image; and if
-# grapl-tests-common isn't built yet (as it need not be for engagement-edge-build), it'll fail.
-
 FROM grapl/engagement-edge-build AS engagement-edge-test
 USER grapl
 WORKDIR /home/grapl
+
+COPY --from=grapl/python-test-deps /home/grapl/python_test_deps python_test_deps
+RUN /bin/bash -c "python_test_deps/install_requirements.sh"
+
 # Steal and install grapl-tests-common
 COPY --from=grapl/grapl-tests-common-python-build /home/grapl/grapl-tests-common grapl-tests-common
 RUN /bin/bash -c "source venv/bin/activate && cd grapl-tests-common && pip install ."
-# Install typechecking stuff
-RUN /bin/bash -c "source venv/bin/activate && cd engagement_edge && pip install .[typecheck]"

--- a/src/python/grapl-common/Dockerfile
+++ b/src/python/grapl-common/Dockerfile
@@ -1,4 +1,4 @@
-FROM grapl/grapl-python-build:latest AS grapl-common-python-build
+FROM grapl/grapl-python-build:latest
 USER grapl
 WORKDIR /home/grapl
 COPY --chown=grapl . grapl_common

--- a/src/python/grapl-common/tests.Dockerfile
+++ b/src/python/grapl-common/tests.Dockerfile
@@ -1,0 +1,7 @@
+FROM grapl/grapl-common-python-build
+USER grapl
+WORKDIR /home/grapl
+
+# Install test requirements
+COPY --from=grapl/python-test-deps /home/grapl/python_test_deps python_test_deps
+RUN /bin/bash -c "python_test_deps/install_requirements.sh"

--- a/src/python/grapl-dgraph-ttl/tests.Dockerfile
+++ b/src/python/grapl-dgraph-ttl/tests.Dockerfile
@@ -1,0 +1,5 @@
+FROM grapl/grapl-dgraph-ttl-build
+
+# Install test requirements
+COPY --from=grapl/python-test-deps /home/grapl/python_test_deps python_test_deps
+RUN /bin/bash -c "python_test_deps/install_requirements.sh"

--- a/src/python/grapl-model-plugin-deployer/tests.Dockerfile
+++ b/src/python/grapl-model-plugin-deployer/tests.Dockerfile
@@ -1,0 +1,5 @@
+FROM grapl/grapl-model-plugin-deployer-build
+
+# Install test requirements
+COPY --from=grapl/python-test-deps /home/grapl/python_test_deps python_test_deps
+RUN /bin/bash -c "python_test_deps/install_requirements.sh"

--- a/src/python/grapl-python-build/Dockerfile
+++ b/src/python/grapl-python-build/Dockerfile
@@ -8,7 +8,7 @@ ENV USER grapl
 WORKDIR /home/grapl
 RUN python3 -mvenv venv
 RUN /bin/bash -c "source venv/bin/activate && pip install --upgrade pip"
-RUN /bin/bash -c "source venv/bin/activate && pip install wheel grpcio chalice hypothesis pytest pytest-xdist"
+RUN /bin/bash -c "source venv/bin/activate && pip install wheel grpcio chalice"
 
 # no-op the base image, so it doesn't exec python3 as a repl
 CMD :

--- a/src/python/grapl-tests-common/Dockerfile
+++ b/src/python/grapl-tests-common/Dockerfile
@@ -1,7 +1,17 @@
 FROM grapl/grapl-python-build:latest AS grapl-tests-common-python-build
 USER grapl
 WORKDIR /home/grapl
-COPY --chown=grapl . grapl-tests-common
+
+# Steal a mostly-populated venv
 COPY --from=grapl/grapl-analyzerlib-python-build /home/grapl/venv venv
+
+# Install test requirements
+COPY --from=grapl/python-test-deps /home/grapl/python_test_deps python_test_deps
+RUN /bin/bash -c "python_test_deps/install_requirements.sh"
+
+# Install this library into the venv
+COPY --chown=grapl . grapl-tests-common
 RUN /bin/bash -c "source venv/bin/activate && cd grapl-tests-common && pip install ."
 RUN /bin/bash -c "source venv/bin/activate && cd grapl-tests-common && python setup.py sdist bdist_wheel"
+
+# Consumers of this library should then COPY this venv.

--- a/src/python/grapl_analyzerlib/tests.Dockerfile
+++ b/src/python/grapl_analyzerlib/tests.Dockerfile
@@ -1,0 +1,5 @@
+FROM grapl/grapl-analyzerlib-python-build
+
+# Install test requirements
+COPY --from=grapl/python-test-deps /home/grapl/python_test_deps python_test_deps
+RUN /bin/bash -c "python_test_deps/install_requirements.sh"

--- a/src/python/grapl_e2e_tests/Dockerfile
+++ b/src/python/grapl_e2e_tests/Dockerfile
@@ -3,6 +3,7 @@ CMD "/bin/bash"
 USER grapl
 WORKDIR /home/grapl
 COPY --chown=grapl . grapl_e2e_tests
+
 # Expose the `etc/` dir with all its test data in /home/grapl/etc
 COPY --from=grapl/etc-build /home/grapl/etc etc
 

--- a/src/python/python_test_deps/Dockerfile
+++ b/src/python/python_test_deps/Dockerfile
@@ -1,0 +1,5 @@
+FROM grapl/grapl-python-build:latest AS python-testing-deps
+USER grapl
+WORKDIR /home/grapl
+COPY --chown=grapl . python_test_deps
+RUN /bin/bash -c "python_test_deps/download_requirements.sh"

--- a/src/python/python_test_deps/README.md
+++ b/src/python/python_test_deps/README.md
@@ -1,0 +1,5 @@
+Based off https://stackoverflow.com/a/14447068
+
+Basically:
+- Build an image that has test dependencies downloaded
+- Expose a script for "client images" to pull them into their venv

--- a/src/python/python_test_deps/download_requirements.sh
+++ b/src/python/python_test_deps/download_requirements.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eu
+THIS_DIR="/home/grapl/python_test_deps"
+cd /home/grapl
+source venv/bin/activate 
+
+cd $THIS_DIR
+pip download -r requirements.txt

--- a/src/python/python_test_deps/install_requirements.sh
+++ b/src/python/python_test_deps/install_requirements.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+THIS_DIR="/home/grapl/python_test_deps"
+
+source /home/grapl/venv/bin/activate
+pip install --no-index --find-links $THIS_DIR -r $THIS_DIR/requirements.txt

--- a/src/python/python_test_deps/requirements.txt
+++ b/src/python/python_test_deps/requirements.txt
@@ -1,0 +1,7 @@
+pytest
+pytest-xdist
+hypothesis
+
+mypy
+pytype
+boto3-stubs[essential]

--- a/src/python/python_test_deps/requirements.txt
+++ b/src/python/python_test_deps/requirements.txt
@@ -4,4 +4,4 @@ hypothesis
 
 mypy
 pytype
-boto3-stubs[essential]
+boto3-stubs[essential,sagemaker]

--- a/src/rust/graph-descriptions/Dockerfile
+++ b/src/rust/graph-descriptions/Dockerfile
@@ -4,5 +4,4 @@ WORKDIR /home/grapl
 COPY --chown=grapl . graph-descriptions
 COPY --from=grapl/grapl-python-build /home/grapl/venv venv
 RUN /bin/bash -c "source venv/bin/activate && cd graph-descriptions && pip install ."
-RUN /bin/bash -c "source venv/bin/activate && cd graph-descriptions && py.test -n auto -m 'not integration_test'"
 RUN /bin/bash -c "source venv/bin/activate && cd graph-descriptions && python setup.py sdist bdist_wheel"

--- a/src/rust/graph-descriptions/tests.Dockerfile
+++ b/src/rust/graph-descriptions/tests.Dockerfile
@@ -1,0 +1,8 @@
+FROM grapl/grapl-graph-descriptions-python-build:latest AS grapl-graph-descriptions-test
+
+# Install test requirements
+COPY --from=grapl/python-test-deps /home/grapl/python_test_deps python_test_deps
+RUN /bin/bash -c "python_test_deps/install_requirements.sh"
+
+# Run tests
+RUN /bin/bash -c "source venv/bin/activate && cd graph-descriptions && py.test -n auto -m 'not integration_test'"


### PR DESCRIPTION


### Which issue does this PR correspond to?
none

### What changes does this PR make to Grapl? Why?
Remove some of our test-only dependencies (pytest, xdist, hypothesis) from the zips we upload to Lambda.
Make new images that _do_ include them, which include other QA-helper libraries, like mypy, boto stubs, etc

### How were these changes tested?
its all about the tests baby