### PR TITLE
Fix github workflows that depend on set-env

### DIFF
--- a/.github/workflows/grapl-release.yml
+++ b/.github/workflows/grapl-release.yml
@@ -124,13 +124,13 @@ jobs:
           else
               CHANNEL="beta"
           fi
-          echo "::set-env name=CHANNEL::$CHANNEL"
+          echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Export tag
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
-          echo "::set-env name=TAG::$VERSION-$CHANNEL"
+          echo "TAG=$VERSION-$CHANNEL" >> $GITHUB_ENV
 
       - name: Build Rust services
         run: |
@@ -254,13 +254,13 @@ jobs:
           else
               CHANNEL="beta"
           fi
-          echo "::set-env name=CHANNEL::$CHANNEL"
+          echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Export tag
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
-          echo "::set-env name=TAG::$VERSION-$CHANNEL"
+          echo "TAG=$VERSION-$CHANNEL" >> $GITHUB_ENV
 
       - name: Build Python services
         run: |
@@ -484,13 +484,13 @@ jobs:
           else
               CHANNEL="beta"
           fi
-          echo "::set-env name=CHANNEL::$CHANNEL"
+          echo "CHANNEL=$CHANNEL" >> $GITHUB_ENV
 
       - name: Export tag
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
-          echo "::set-env name=TAG::$VERSION-$CHANNEL"
+          echo "TAG=$VERSION-$CHANNEL" >> $GITHUB_ENV
 
       - name: Build JS services
         run: |

--- a/.github/workflows/grapl-staging-release.yml
+++ b/.github/workflows/grapl-staging-release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Export tag
         run: |
-          echo "::set-env name=TAG::staging"
+          echo "TAG=staging" >> $GITHUB_ENV
 
       - name: Build Rust services
         run: |
@@ -52,7 +52,7 @@ jobs:
 
       - name: Export tag
         run: |
-          echo "::set-env name=TAG::staging"
+          echo "TAG=staging" >> $GITHUB_ENV
 
       - name: Build Python services
         run: |
@@ -83,7 +83,7 @@ jobs:
           ./etc/ci_scripts/install_requirements.sh
       - name: Export tag
         run: |
-          echo "::set-env name=TAG::staging"
+          echo "TAG=staging" >> $GITHUB_ENV
 
       - name: Build JS services
         run: |


### PR DESCRIPTION
https://grapl-internal.slack.com/archives/G017L03AE0L/p1606775942132700
```

Run echo "::set-env name=TAG::staging"
Error: Unable to process command '::set-env name=TAG::staging' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

This is the new way to do that.