### PR TITLE
Adding missing region arg to Edge UX stack in CDK.

### DIFF
--- a/src/js/grapl-cdk/bin/grapl-cdk.ts
+++ b/src/js/grapl-cdk/bin/grapl-cdk.ts
@@ -25,4 +25,5 @@ new EngagementUx(app, 'EngagementUX', {
     edgeApi: grapl.edgeApiGateway,
     stackName: DeploymentParameters.stackName + '-EngagementUX',
     description: 'Grapl Engagement UX',
+    env: { 'region': DeploymentParameters.region },
 });


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

A region arg is supplied to the base stack, but not the Edge UX stack in CDK, so they will deploy to different regions if the region specified is not the default. This change passes the region to the Edge UX stack, as is done for the base stack.

### How were these changes tested?

The build passes, testing a deployment now.
