### PR TITLE
Fix incorrect env name

### DIFF
--- a/src/js/graphql_endpoint/server.js
+++ b/src/js/graphql_endpoint/server.js
@@ -14,7 +14,7 @@ let origin = true;
 let prefix = 'local-grapl';
 
 if (!IS_LOCAL) {
-    prefix = process.env.PREFIX;
+    prefix = process.env.BUCKET_PREFIX;
     origin = process.env.UX_BUCKET_URL;
     console.log("origin: " + origin);
 }


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/126

### What changes does this PR make to Grapl? Why?

Corrects a fatal bug causing the graphql_endpoint service to crash due to an improperly named environment variable. This caused the `prefix` variable to be undefined resulting in an exception when the CORS origin check regular expression was crafted.

### How were these changes tested?

Local validation
