### PR TITLE
put docker data-root in /dgraph partition

### DIFF
--- a/src/js/grapl-cdk/lib/swarm.ts
+++ b/src/js/grapl-cdk/lib/swarm.ts
@@ -121,9 +121,6 @@ export class Swarm extends cdk.Construct {
         swarmUserData.addCommands(...[
             'yum install -y docker amazon-cloudwatch-agent python3',
             'amazon-cloudwatch-agent-ctl -m ec2 -a start',
-            'systemctl enable docker.service',
-            'systemctl start docker.service',
-            'usermod -a -G docker ec2-user',
             '# create LUKS key',
             'head -c 256 /dev/urandom > /root/luks_key',
             'cryptsetup -v -q luksFormat /dev/nvme0n1 /root/luks_key',
@@ -135,6 +132,10 @@ export class Swarm extends cdk.Construct {
             'mkdir /dgraph',
             'echo -e "/dev/mapper/dgraph\t/dgraph\txfs\tdefaults,nofail\t0\t2" >> /etc/fstab',
             'mount /dgraph',
+            'echo -e "{\n    \"data-root\": \"/dgraph\"\n}" > /etc/docker/daemon.json',
+            'systemctl enable docker.service',
+            'systemctl start docker.service',
+            'usermod -a -G docker ec2-user',
         ]);
 
         // Configure a Route53 Hosted Zone for the Swarm cluster.


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/126
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
This PR sets the docker root directory to `/dgraph` on the Swarm nodes, which is mounted on a larger drive.
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
These changes were tested in AWS sandbox.
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
