### PR TITLE
Making Risk node alarm name depend on Grapl deployment name.

### DIFF
--- a/src/js/grapl-cdk/lib/alarms.ts
+++ b/src/js/grapl-cdk/lib/alarms.ts
@@ -37,11 +37,16 @@ class AlarmSink extends cdk.Construct {
     }
 }
 
+interface RiskNodeAlarmProps {
+    prefix: string;
+    alarm_sink: AlarmSink;
+}
+
 class RiskNodeAlarm extends cdk.Construct {
     constructor(
         scope: cdk.Construct,
         id: string,
-        alarm_sink: AlarmSink,
+        props: RiskNodeAlarmProps,
     ) {
         super(scope, id);
         const metric = new cloudwatch.Metric({
@@ -53,7 +58,7 @@ class RiskNodeAlarm extends cdk.Construct {
             this,
             "alarm",
             {
-                alarmName: "Risk node alarm",
+                alarmName: props.prefix + " - Risk node alarm",
                 // TODO: Add some verbiage to the alarm description on how to actually look at what's causing the alarm.
                 alarmDescription: undefined,
                 threshold: 1,
@@ -61,7 +66,7 @@ class RiskNodeAlarm extends cdk.Construct {
                 treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
             }
         );
-        alarm.addAlarmAction(alarm_sink.cloudwatch_action);
+        alarm.addAlarmAction(props.alarm_sink.cloudwatch_action);
     }
 }
 
@@ -78,16 +83,23 @@ export class OperationalAlarms extends cdk.Construct {
     }
 }
 
+export interface SecurityAlarmsProps {
+    prefix: string;
+    email: string;
+}
 
 export class SecurityAlarms extends cdk.Construct {
     // Alarms meant for the consumer of the Grapl stack - for example, alarms triggered by analyzers.
     constructor(
         scope: cdk.Construct,
         id: string,
-        email: string,
+        props: SecurityAlarmsProps,
     ) {
         super(scope, id);
-        const alarm_sink = new AlarmSink(this, "alarm_sink", email);
-        const risk_node_alarm = new RiskNodeAlarm(this, "risk_node_alarm", alarm_sink);
+        const alarm_sink = new AlarmSink(this, "alarm_sink", props.email);
+        const risk_node_alarm = new RiskNodeAlarm(this, "risk_node_alarm", {
+            prefix: props.prefix,
+            alarm_sink: alarm_sink
+        });
     }
 }

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -979,7 +979,10 @@ export class GraplCdkStack extends cdk.Stack {
             new OperationalAlarms(this, "operation_alarms", props.operationalAlarmsEmail);
         }
         if (props.securityAlarmsEmail) {
-            new SecurityAlarms(this, "security_alarms", props.securityAlarmsEmail);
+            new SecurityAlarms(this, "security_alarms", {
+                prefix: this.prefix,
+                email: props.securityAlarmsEmail
+            });
         }
 
         new PipelineDashboard(this, "pipeline_dashboard", {


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

The CDK creates a CloudWatch alarm for Grapl Risk nodes with a static name, which breaks multiple deployments within an AWS account. This makes that name depend on deployment name.

### How were these changes tested?

Tested by completing a second deployment that had previously failed due alarm name collision.