### PR TITLE
Fix dgraph disk usage alarms to specify all dimensions

### DIFF
--- a/src/js/grapl-cdk/swarm/swarm_setup.py
+++ b/src/js/grapl-cdk/swarm/swarm_setup.py
@@ -1,12 +1,17 @@
 """Usage: python3 swarm_setup.py $GRAPL_DEPLOY_NAME"""
+from __future__ import annotations
+
 import json
 import logging
 import sys
 import time
+from typing import TYPE_CHECKING, Any, Iterator, List, NamedTuple
 
 import boto3
 
-from typing import Any, Iterator, List, Tuple
+if TYPE_CHECKING:
+    from mypy_boto3_cloudwatch.client import CloudWatchClient
+    from mypy_boto3_cloudwatch.type_defs import MetricTypeDef
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel("INFO")
@@ -18,8 +23,17 @@ IN_PROGRESS_STATUSES = {
     "Delayed",
 }
 
+InstanceTuple = NamedTuple(
+    "InstanceTuple",
+    (
+        ("instance_id", str),
+        ("private_ip_address", str),
+        ("private_dns_name", str),
+    ),
+)
 
-def _swarm_instances(ec2: Any) -> Iterator[Tuple[str, str, str]]:
+
+def _swarm_instances(ec2: Any) -> Iterator[InstanceTuple]:
     """Yields tuples of (instance_id, private_ip, hostname) for all the
     instances in the SwarmASG.
 
@@ -30,9 +44,11 @@ def _swarm_instances(ec2: Any) -> Iterator[Tuple[str, str, str]]:
     for reservation in result["Reservations"]:
         for instance in reservation["Instances"]:
             if instance["State"]["Name"] != "terminated":
-                yield instance["InstanceId"], instance["PrivateIpAddress"], instance[
-                    "PrivateDnsName"
-                ]
+                yield InstanceTuple(
+                    instance_id=instance["InstanceId"],
+                    private_ip_address=instance["PrivateIpAddress"],
+                    private_dns_name=instance["PrivateDnsName"],
+                )
 
 
 def _get_command_result(ssm: Any, command_id: str, instance_id: str) -> str:
@@ -60,48 +76,98 @@ def _get_command_result(ssm: Any, command_id: str, instance_id: str) -> str:
         raise Exception(f"SSM Command failed with Status: \"{invocation['Status']}\"")
 
 
-def _create_disk_usage_alarms(cloudwatch: Any, instance_id: str) -> None:
+CW_NAMESPACE = "CWAgent"
+CW_DISK_USAGE_METRIC_NAME = "disk_used_percent"
+
+
+def _find_metric_for_instance(
+    cloudwatch: CloudWatchClient,
+    instance_id: str,
+    path: str,
+) -> MetricTypeDef:
+    """
+    To define a Cloudwatch Alarm, one must specify *all* the dimensions complete with values.
+    (The dimension names are part of the identity of the metric. Gross!)
+    So, before we define an alarm, we do a quick query on path + instance id to get the
+    other dimensions.
+    """
+    metrics_result = cloudwatch.list_metrics(
+        Namespace=CW_NAMESPACE,
+        MetricName=CW_DISK_USAGE_METRIC_NAME,
+        Dimensions=[
+            {
+                "Name": "path",
+                "Value": path,
+            },
+            {
+                "Name": "InstanceId",
+                "Value": instance_id,
+            },
+            {
+                "Name": "AutoScalingGroupName",
+            },
+            {
+                "Name": "ImageId",
+            },
+            {
+                "Name": "InstanceType",
+            },
+            {
+                "Name": "device",
+            },
+            {"Name": "fstype"},
+        ],
+    )
+    metrics = metrics_result["Metrics"]
+    if len(metrics) != 1:
+        raise Exception(
+            f"Tried querying for disk metrics on {instance_id} - expected 1, got {metrics}"
+        )
+    return metrics[0]
+
+
+def _create_disk_usage_alarms(cloudwatch: CloudWatchClient, instance_id: str) -> None:
+
+    root_metric = _find_metric_for_instance(cloudwatch, instance_id, path="/")
     """Create disk usage alarms for the / and /dgraph partitions"""
     cloudwatch.put_metric_alarm(
         AlarmName=f"/ disk_used_percent ({instance_id})",
         AlarmDescription=f"Root volume disk usage percent threshold exceeded on {instance_id}",
         ActionsEnabled=False,
-        MetricName="disk_used_percent",
-        Namespace="CWAgent",
+        MetricName=root_metric["MetricName"],
+        Namespace=root_metric["Namespace"],
         Statistic="Maximum",
         Period=300,
         EvaluationPeriods=1,
         ComparisonOperator="GreaterThanOrEqualToThreshold",
         Threshold=95.0,
         Unit="Percent",
-        Dimensions=[
-            {"Name": "InstanceId", "Value": instance_id},
-            {"Name": "path", "Value": "/"},
-        ],
+        Dimensions=root_metric["Dimensions"],
+    )
+
+    dgraph_partition_metric = _find_metric_for_instance(
+        cloudwatch, instance_id, path="/dgraph"
     )
     cloudwatch.put_metric_alarm(
         AlarmName=f"/dgraph disk_used_percent ({instance_id})",
         AlarmDescription=f"DGraph volume disk usage percent threshold exceeded on {instance_id}",
         ActionsEnabled=False,
-        MetricName="disk_used_percent",
-        Namespace="CWAgent",
+        MetricName=dgraph_partition_metric["MetricName"],
+        Namespace=dgraph_partition_metric["Namespace"],
         Statistic="Maximum",
         Period=300,
         EvaluationPeriods=1,
         ComparisonOperator="GreaterThanOrEqualToThreshold",
         Threshold=95.0,
         Unit="Percent",
-        Dimensions=[
-            {"Name": "InstanceId", "Value": instance_id},
-            {"Name": "path", "Value": "/dgraph"},
-        ],
+        Dimensions=dgraph_partition_metric["Dimensions"],
     )
 
 
 def _init_docker_swarm(
     ec2: Any,
     ssm: Any,
-    cloudwatch: Any,
+    cloudwatch: CloudWatchClient,
     prefix: str,
     manager_id: str,
     manager_ip: str,
@@ -143,9 +209,9 @@ def _init_docker_swarm(
 def _join_worker_nodes(
     ec2: Any,
     ssm: Any,
-    cloudwatch: Any,
+    cloudwatch: CloudWatchClient,
     prefix: str,
-    instances: Iterator[str],
+    instances: Iterator[InstanceTuple],
     join_token: str,
     manager_ip: str,
 ) -> List[str]:
@@ -190,7 +256,7 @@ def main(prefix: str) -> None:
     instances = _swarm_instances(ec2)
 
     ssm = boto3.client("ssm")
-    cloudwatch = boto3.client("cloudwatch")
+    cloudwatch: CloudWatchClient = boto3.client("cloudwatch")
 
     LOGGER.info("Initializing swarm manager")
     manager_id, manager_ip, manager_hostname = next(instances)


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/126

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Cloudwatch alarms need *all dimensions to be specified*, so we do a quick query first

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I ran the new query function in ipython:

![Screenshot 2020-12-07 at 9 28 45 AM](https://user-images.githubusercontent.com/69007229/101384889-e46ff580-386f-11eb-84cb-e150a42ebe71.png)

and I ran mypy locally, it succeeds (i didnt make a dobi job cuz, ehh)

I'd be happy to give it a shot in AWS.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
