### PR TITLE
Bump EngView timeout to every 5 seconds. Bump graphql lambda timeout to 30s.

### DIFF
--- a/src/js/engagement_view/src/components/EngagementViewContent.tsx
+++ b/src/js/engagement_view/src/components/EngagementViewContent.tsx
@@ -129,7 +129,7 @@ function ToggleLensTable( {setLens}: ToggleLensTableProps ) {
                     }
                 }
             )
-        }, 1000);
+        }, 5000);
         return () => clearInterval(interval);
     });
 

--- a/src/js/grapl-cdk/lib/graphql.ts
+++ b/src/js/grapl-cdk/lib/graphql.ts
@@ -40,7 +40,7 @@ export class GraphQLEndpoint extends cdk.Construct {
                 BUCKET_PREFIX: props.prefix,
                 UX_BUCKET_URL: 'https://' + ux_bucket.bucketRegionalDomainName,
             },
-            timeout: cdk.Duration.seconds(25),
+            timeout: cdk.Duration.seconds(30),
             memorySize: 128,
             description: props.version,
         });


### PR DESCRIPTION
EngView timeout is because every 1s was kinda polluting our network console
Graphql lambda timeout is because, the timeout at 25 seconds is just a silent kill; bumping it to 30s puts us here:
https://grapl-internal.slack.com/archives/G017L03AE0L/p1607389929303800
```
so, basically, my theory is
lambda takes more than 25 seconds -> silent failure
<then I upped the lambda to accept 5 minute runs>
now if it takes more than 30 seconds -> {"message": "Endpoint request timed out"}
5:13
and, once in a blue moon, we do get results in like 26 seconds
```