### PR TITLE
Subscribe disk use alarms to Operational Alarms

### DIFF
--- a/src/js/grapl-cdk/bin/deployment_parameters.ts
+++ b/src/js/grapl-cdk/bin/deployment_parameters.ts
@@ -35,11 +35,19 @@ export module DeploymentParameters {
     export const watchfulEmail = process.env.GRAPL_CDK_WATCHFUL_EMAIL
         || HardcodedDeploymentParameters.watchfulEmail;
 
-    export const operationalAlarmsEmail = process.env.GRAPL_CDK_OPERATIONAL_ALARMS_EMAIL
+    const _operationalAlarmsEmail = process.env.GRAPL_CDK_OPERATIONAL_ALARMS_EMAIL
         || HardcodedDeploymentParameters.operationalAlarmsEmail;
+    if (!_operationalAlarmsEmail) {
+        throw new Error('Error: Missing operational alarms email. Set via bin/deployment_parameters.ts, or environment variable GRAPL_CDK_OPERATIONAL_ALARMS_EMAIL.');
+    }
+    export const operationalAlarmsEmail = _operationalAlarmsEmail;
 
-    export const securityAlarmsEmail = process.env.GRAPL_CDK_SECURITY_ALARMS_EMAIL
+    const _securityAlarmsEmail = process.env.GRAPL_CDK_SECURITY_ALARMS_EMAIL
         || HardcodedDeploymentParameters.securityAlarmsEmail;
+    if (!_securityAlarmsEmail) {
+        throw new Error('Error: Missing security alarms email. Set via bin/deployment_parameters.ts, or environment variable GRAPL_CDK_SECURITY_ALARMS_EMAIL.');
+    }
+    export const securityAlarmsEmail = _securityAlarmsEmail;
 
     const dgraphInstanceTypeName = process.env.GRAPL_DGRAPH_INSTANCE_TYPE
         || HardcodedDeploymentParameters.dgraphInstanceType

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -740,8 +740,8 @@ export interface GraplStackProps extends cdk.StackProps {
     version: string;
     dgraphInstanceType: ec2.InstanceType;
     watchfulEmail?: string;
-    operationalAlarmsEmail?: string;
-    securityAlarmsEmail?: string;
+    operationalAlarmsEmail: string;
+    securityAlarmsEmail: string;
 }
 
 export class GraplCdkStack extends cdk.Stack {
@@ -975,15 +975,15 @@ export class GraplCdkStack extends cdk.Stack {
             );
         }
 
-        if (props.operationalAlarmsEmail) {
-            new OperationalAlarms(this, "operation_alarms", props.operationalAlarmsEmail);
-        }
-        if (props.securityAlarmsEmail) {
-            new SecurityAlarms(this, "security_alarms", {
-                prefix: this.prefix,
-                email: props.securityAlarmsEmail
-            });
-        }
+        new OperationalAlarms(this, "operational_alarms", {
+            prefix: this.prefix,
+            email: props.operationalAlarmsEmail
+        });
+
+        new SecurityAlarms(this, "security_alarms", {
+            prefix: this.prefix,
+            email: props.securityAlarmsEmail
+        });
 
         new PipelineDashboard(this, "pipeline_dashboard", {
             namePrefix: this.prefix,

--- a/src/js/grapl-cdk/test/grapl-cdk.test.ts
+++ b/src/js/grapl-cdk/test/grapl-cdk.test.ts
@@ -40,6 +40,8 @@ describe('Standard GraplCdkStack', () => {
     version: 'latest',
     dgraphInstanceType: new ec2.InstanceType('t3a.medium'),
     env: ENV,
+    operationalAlarmsEmail: "fake@fake.domain",
+    securityAlarmsEmail: "fake@fake.domain",
   });
 
   const allConstructs = new CollectAllConstructs();


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/126

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- makes security / operational alarms mandatory
- gives AlarmSink topics a stable identifier
- subscribes disk_use_percent alarms to that same stable identifier for operational alarm

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I tested the `find` function just locally, and it passes my typecheck.
I'm going to kick off a cdk deploy - to my sandbox, not jgrillo's - momentarily...

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
