### PR TITLE
Fix EngagementView.get_or_create; enable analyzerlib python typechecking in CI

### DIFF
--- a/dobi.yaml
+++ b/dobi.yaml
@@ -975,7 +975,6 @@ alias=python-typecheck:
     - typecheck-engagement-edge
     - typecheck-model-plugin-deployer
     - typecheck-analyzer-executor
-    # Broken, temporarily
-    # - typecheck-grapl-analyzerlib
+    - typecheck-grapl-analyzerlib
   annotations:
     description: "Run mypy or pytype type checks on a subset of our Python libs/services"

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/nodes/base.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/nodes/base.py
@@ -126,12 +126,15 @@ class BaseView(Viewable[BV, BQ]):
     def into_view(self, v: Type["V"]) -> Optional["V"]:
         if v.node_schema().self_type() in self.node_types:
             self.queryable = v.queryable
+            node_types = self.node_types.union(self.predicates.get("node_types", set()))
+            predicates_without_node_types = self.predicates.copy()
+            predicates_without_node_types.pop("node_types", None)
             return v(
                 uid=self.uid,
                 node_key=self.node_key,
                 graph_client=self.graph_client,
-                node_types=self.node_types,
-                **self.predicates,
+                node_types=node_types,
+                **predicates_without_node_types,
             )
         return None
 

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/nodes/ip_address.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/nodes/ip_address.py
@@ -236,4 +236,4 @@ IpConnectionQuery = IpConnectionQuery.extend_self(IpAddressExtendsIpConnectionQu
 IpConnectionView = IpConnectionView.extend_self(IpAddressExtendsIpConnectionView)
 
 if TYPE_CHECKING:
-    from grapl_analyzerlib.nodes import ProcessQuery
+    from grapl_analyzerlib.nodes.process import ProcessQuery

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/nodes/ip_connection.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/nodes/ip_connection.py
@@ -298,4 +298,4 @@ IpAddressQuery = IpAddressQuery.extend_self(IpConnectionExtendsIpAddressQuery)
 IpAddressView = IpAddressView.extend_self(IpConnectionExtendsIpAddressView)
 
 if TYPE_CHECKING:
-    from grapl_analyzerlib.nodes import ProcessQuery
+    from grapl_analyzerlib.nodes.process import ProcessQuery

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/viewable.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/viewable.py
@@ -22,11 +22,9 @@ from typing import (
 if TYPE_CHECKING:
     from grapl_analyzerlib.queryable import Queryable
 
-import typing_extensions
-
 from grapl_analyzerlib.extendable import Extendable
 
-IS_LOCAL: typing_extensions.Final[bool] = bool(os.environ.get("IS_LOCAL", False))
+IS_LOCAL: bool = bool(os.environ.get("IS_LOCAL", False))
 
 GRAPL_LOG_LEVEL = os.getenv("GRAPL_LOG_LEVEL")
 LEVEL = "ERROR" if GRAPL_LOG_LEVEL is None else GRAPL_LOG_LEVEL

--- a/src/python/grapl_analyzerlib/pytype.cfg
+++ b/src/python/grapl_analyzerlib/pytype.cfg
@@ -4,7 +4,6 @@
 
 # Space-separated list of files or directories to exclude.
 exclude =
-    **/*_test.py
     test2.py  # just a super busted old test class
 
 # Space-separated list of files or directories to process.

--- a/src/python/grapl_analyzerlib/pytype.cfg
+++ b/src/python/grapl_analyzerlib/pytype.cfg
@@ -5,7 +5,7 @@
 # Space-separated list of files or directories to exclude.
 exclude =
     **/*_test.py
-    **/test_*.py
+    test2.py  # just a super busted old test class
 
 # Space-separated list of files or directories to process.
 inputs = grapl_analyzerlib

--- a/src/python/grapl_analyzerlib/test2.py
+++ b/src/python/grapl_analyzerlib/test2.py
@@ -1,13 +1,9 @@
 from typing import *
 
-from grapl_analyzerlib.nodes.types import PropertyT
-from grapl_analyzerlib.nodes.viewable import EdgeViewT, ForwardEdgeView
+from grapl_analyzerlib.nodes.viewable import ForwardEdgeView
 from grapl_analyzerlib.nodes.comparators import (
     Cmp,
-    IntCmp,
     _int_cmps,
-    StrCmp,
-    _str_cmps,
 )
 from grapl_analyzerlib.prelude import *
 
@@ -94,15 +90,6 @@ class AuidView(DynamicNodeView):
 
 from typing import *
 
-from grapl_analyzerlib.nodes.types import PropertyT
-from grapl_analyzerlib.nodes.viewable import EdgeViewT, ForwardEdgeView
-from grapl_analyzerlib.nodes.comparators import (
-    Cmp,
-    IntCmp,
-    _int_cmps,
-    StrCmp,
-    _str_cmps,
-)
 from grapl_analyzerlib.prelude import *
 
 from pydgraph import DgraphClient

--- a/src/python/grapl_analyzerlib/tests/test_comparators.py
+++ b/src/python/grapl_analyzerlib/tests/test_comparators.py
@@ -6,10 +6,9 @@ from grapl_analyzerlib.comparators import (
     Has,
     Eq,
 )
-from typing_extensions import Final
 
-PREDICATE: Final[str] = "pred"
-VALUE: Final[str] = "value"
+PREDICATE: str = "pred"
+VALUE: str = "value"
 
 
 class TestComparators(unittest.TestCase):

--- a/src/python/grapl_analyzerlib/tests/test_default.py
+++ b/src/python/grapl_analyzerlib/tests/test_default.py
@@ -1,6 +1,0 @@
-import unittest
-
-
-class TestDefault(unittest.TestCase):
-    def test_default(self):
-        assert True  # it works!

--- a/src/python/grapl_analyzerlib/tests/test_engagement.py
+++ b/src/python/grapl_analyzerlib/tests/test_engagement.py
@@ -6,6 +6,7 @@ from grapl_analyzerlib.prelude import GraphClient
 from grapl_analyzerlib.nodes.engagement import EngagementView
 from test_utils.dgraph_utils import upsert, create_edge
 
+
 @pytest.mark.integration_test
 class TestEngagement(unittest.TestCase):
     def test_get_or_create(self) -> None:

--- a/src/python/grapl_analyzerlib/tests/test_engagement.py
+++ b/src/python/grapl_analyzerlib/tests/test_engagement.py
@@ -1,0 +1,13 @@
+import unittest
+import pytest
+from hypothesis import given
+
+from grapl_analyzerlib.prelude import GraphClient
+from grapl_analyzerlib.nodes.engagement import EngagementView
+from test_utils.dgraph_utils import upsert, create_edge
+
+@pytest.mark.integration_test
+class TestEngagement(unittest.TestCase):
+    def test_get_or_create(self) -> None:
+        client = GraphClient()
+        engagement = EngagementView.get_or_create(eg_client=client, lens_name="test")


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
none in particular

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

Before this we were getting
```
~/venv/lib/python3.7/site-packages/grapl_analyzerlib/nodes/base.py in into_view(self, v)
    133                 graph_client=self.graph_client,
    134                 node_types=self.node_types,
--> 135                 **self.predicates,
    136             )
    137         return None
TypeError: ABCMeta object got multiple values for keyword argument 'node_types'
```
I pop out `node_types` from self.predicates and merge it into self.node_types.

Oh, and I enabled typechecking for analyzerlib in CI :+1:

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
wrote an integration smoke test for EngagementView.get_or_create

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
