### PR TITLE
Replay data

### DIFF
--- a/etc/replay_data.py
+++ b/etc/replay_data.py
@@ -14,12 +14,13 @@ from mypy_boto3_sqs.client import SQSClient
 IS_LOCAL = bool(os.environ.get("IS_LOCAL", False))
 
 
-def into_sqs_message(bucket: str, key: str) -> str:
+def into_sqs_message(bucket: str, key: str, region: str) -> str:
     return json.dumps(
         {
             "Records": [
                 {
                     "eventTime": datetime.utcnow().isoformat(),
+                    "awsRegion": region,
                     "principalId": {
                         "principalId": None,
                     },
@@ -62,6 +63,7 @@ def send_s3_event(
         MessageBody=into_sqs_message(
             bucket=output_bucket,
             key=output_path,
+            region=sqs_client.meta.region_name,
         ),
     )
 
@@ -102,7 +104,6 @@ def main(bucket_prefix: str) -> None:
     s3, sqs = get_s3_client(), get_sqs_client()
     queue_name = bucket_prefix + "-graph-merger-queue"
     queue_url = sqs.get_queue_url(QueueName=queue_name)["QueueUrl"]
-    
 
     bucket = bucket_prefix + "-subgraphs-generated-bucket"
     for key in list_objects(s3, bucket):

--- a/etc/replay_data.py
+++ b/etc/replay_data.py
@@ -100,7 +100,9 @@ def get_s3_client() -> S3Client:
 
 def main(bucket_prefix: str) -> None:
     s3, sqs = get_s3_client(), get_sqs_client()
-    queue_url = sqs.get_queue_url(QueueName="grapl-graph-merger-queue")["QueueUrl"]
+    queue_name = bucket_prefix + "-graph-merger-queue"
+    queue_url = sqs.get_queue_url(QueueName=queue_name)["QueueUrl"]
+    
 
     bucket = bucket_prefix + "-subgraphs-generated-bucket"
     for key in list_objects(s3, bucket):


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This fixes a couple issues in the replay_data.py util we have:
1. Queue name needed to be derived from deployment prefix.
2. Region field was missing from SQS message

### How were these changes tested?

These were tested by executing our data recovery test plan.