### PR TITLE
Swarm Setup: do disk alarms first + store export commands on-disk

### DIFF
--- a/src/js/grapl-cdk/swarm/swarm_setup.py
+++ b/src/js/grapl-cdk/swarm/swarm_setup.py
@@ -5,7 +5,7 @@ import json
 import logging
 import sys
 import time
-from typing import TYPE_CHECKING, Any, Iterator, List, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, Iterator, List, NamedTuple, Optional, Sequence
 
 import boto3
 
@@ -238,7 +238,7 @@ def _join_worker_nodes(
     ssm: Any,
     cloudwatch: CloudWatchClient,
     prefix: str,
-    instances: Iterator[InstanceTuple],
+    instances: Sequence[InstanceTuple],
     join_token: str,
     manager_ip: str,
 ) -> List[str]:
@@ -280,6 +280,8 @@ def main(prefix: str) -> None:
 
     LOGGER.info("Retrieving instance IDs")
     instances = list(_swarm_instances(ec2))
+    manager_instance = instances[0]
+    worker_instances = instances[1:]
 
     ssm = boto3.client("ssm")
     cloudwatch: CloudWatchClient = boto3.client("cloudwatch")
@@ -289,14 +291,14 @@ def main(prefix: str) -> None:
         _create_disk_usage_alarms(cloudwatch, instance_id, prefix)
 
     LOGGER.info("Initializing swarm manager")
-    manager_id, manager_ip, manager_hostname = instances[0]
+    manager_id, manager_ip, manager_hostname = manager_instance
     join_token = _init_docker_swarm(
         ec2, ssm, cloudwatch, prefix, manager_id, manager_ip, manager_hostname
     )
 
     LOGGER.info("Joining worker instances")
     worker_hostnames = _join_worker_nodes(
-        ec2, ssm, cloudwatch, prefix, instances[1:], join_token, manager_ip
+        ec2, ssm, cloudwatch, prefix, worker_instances, join_token, manager_ip
     )
 
     LOGGER.info("Docker swarm cluster setup complete")

--- a/src/js/grapl-cdk/swarm/swarm_setup.py
+++ b/src/js/grapl-cdk/swarm/swarm_setup.py
@@ -205,7 +205,6 @@ def _init_docker_swarm(
     necessary to attach workers to the swarm.
 
     """
-    _create_disk_usage_alarms(cloudwatch, manager_id, prefix)
     command = ssm.send_command(
         # Targets=[{"Key": "tag:Name", "Values": ["Grapl/swarm/SwarmCluster/SwarmASG"]}],
         InstanceIds=[manager_id],
@@ -247,7 +246,6 @@ def _join_worker_nodes(
     worker nodes."""
     hostnames = []
     for instance_id, _, hostname in instances:
-        _create_disk_usage_alarms(cloudwatch, instance_id, prefix)
         command = ssm.send_command(
             # Targets=[{"Key": "tag:Name", "Values": ["Grapl/swarm/SwarmCluster/SwarmASG"]}],
             InstanceIds=[instance_id],
@@ -281,20 +279,24 @@ def main(prefix: str) -> None:
     ec2 = boto3.client("ec2")
 
     LOGGER.info("Retrieving instance IDs")
-    instances = _swarm_instances(ec2)
+    instances = list(_swarm_instances(ec2))
 
     ssm = boto3.client("ssm")
     cloudwatch: CloudWatchClient = boto3.client("cloudwatch")
 
+    LOGGER.info("Creating disk usage alarms")
+    for instance_id, _, _ in instances:
+        _create_disk_usage_alarms(cloudwatch, instance_id, prefix)
+
     LOGGER.info("Initializing swarm manager")
-    manager_id, manager_ip, manager_hostname = next(instances)
+    manager_id, manager_ip, manager_hostname = instances[0]
     join_token = _init_docker_swarm(
         ec2, ssm, cloudwatch, prefix, manager_id, manager_ip, manager_hostname
     )
 
     LOGGER.info("Joining worker instances")
     worker_hostnames = _join_worker_nodes(
-        ec2, ssm, cloudwatch, prefix, instances, join_token, manager_ip
+        ec2, ssm, cloudwatch, prefix, instances[1:], join_token, manager_ip
     )
 
     LOGGER.info("Docker swarm cluster setup complete")
@@ -313,11 +315,16 @@ def main(prefix: str) -> None:
 sudo su ec2-user
 cd $HOME
 
+# Write the following exports to a file so they can be re-sourced in future
+cat >all_exports <<DELIM
 export GRAPL_DEPLOY_NAME="{prefix}"
 export AWS_LOGS_GROUP="{prefix}-grapl-dgraph"
 export AWS01_NAME="{manager_hostname}"
 export AWS02_NAME="{worker_hostnames[0]}"
 export AWS03_NAME="{worker_hostnames[1]}"
+DELIM
+
+source ./all_exports
 
 aws s3 cp s3://${{GRAPL_DEPLOY_NAME,,}}-dgraph-config-bucket/docker-compose-dgraph.yml .
 aws s3 cp s3://${{GRAPL_DEPLOY_NAME,,}}-dgraph-config-bucket/envoy.yaml .


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
none
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Move the disk alarms up before we ever send off an SSM command.
Because sometimes we'd have a situation where we set up the first node successfully, but the worker nodes' disk alarms couldn't be set up; and running swarm_setup again would fail.

Store export commands on-disk so that future docker stack deploy operations are easier. 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
on my aws sandbox

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
