### PR TITLE
Immediately commit edge writes in dgraph to avoid occasional transactional failures

### DIFF
--- a/src/rust/graph-merger/src/main.rs
+++ b/src/rust/graph-merger/src/main.rs
@@ -202,9 +202,7 @@ async fn upsert_edge(
     mu: dgraph_tonic::Mutation,
 ) -> Result<(), failure::Error> {
     let mut txn = mg_client.new_mutated_txn();
-    txn.mutate(mu).await.map_err(AnyhowFailure::into_failure)?;
-
-    txn.commit().await.map_err(AnyhowFailure::into_failure)?;
+    txn.mutate_and_commit_now(mu).await.map_err(AnyhowFailure::into_failure)?;
 
     Ok(())
 }

--- a/src/rust/graph-merger/src/main.rs
+++ b/src/rust/graph-merger/src/main.rs
@@ -202,7 +202,9 @@ async fn upsert_edge(
     mu: dgraph_tonic::Mutation,
 ) -> Result<(), failure::Error> {
     let mut txn = mg_client.new_mutated_txn();
-    txn.mutate_and_commit_now(mu).await.map_err(AnyhowFailure::into_failure)?;
+    txn.mutate_and_commit_now(mu)
+        .await
+        .map_err(AnyhowFailure::into_failure)?;
 
     Ok(())
 }


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

Avoids holding a transaction open on edge mutations by using the `commit_now` feature of dgraph mutations to commit mutations immediately. This should have a very tiny performance improvement and close the most likely cause of transient write failures.

### How were these changes tested?

locally
