### PR TITLE
Fix python typecheck, pin pyjwt

### DIFF
--- a/src/python/engagement_edge/requirements.txt
+++ b/src/python/engagement_edge/requirements.txt
@@ -1,5 +1,5 @@
 pydgraph==20.7.0
 boto3
-pyjwt
+pyjwt==2.0.*
 grapl_analyzerlib==0.2.*
 chalice

--- a/src/python/engagement_edge/src/engagement_edge.py
+++ b/src/python/engagement_edge/src/engagement_edge.py
@@ -216,9 +216,7 @@ def login(username: str, password: str) -> Optional[str]:
         return None
 
     # Use JWT to generate token
-    return jwt.encode(
-        {"username": username}, JWT_SECRET.get(), algorithm="HS256"
-    ).decode("utf8")
+    return jwt.encode({"username": username}, JWT_SECRET.get(), algorithm="HS256")
 
 
 def check_jwt(headers: Dict[str, Any]) -> bool:


### PR DESCRIPTION
TLDR they removed py2 support from pyjwt, meaning this object is now a `str` not a `bytes`

<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing

procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
