### PR TITLE
Create edge_ux_package dir in CDK deploy_all.sh

### DIFF
--- a/src/js/grapl-cdk/deploy_all.sh
+++ b/src/js/grapl-cdk/deploy_all.sh
@@ -12,8 +12,9 @@ fi
 # A bunch of overhead to just get the directories right
 # from https://stackoverflow.com/a/246128
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd $THIS_DIR
+cd "$THIS_DIR"
 
+mkdir -p "${THIS_DIR}/edge_ux_package"
 npm run build
 cdk deploy \
     --require-approval=never \


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

The CDK reference `edge_ux_package` directory as asset for upload, so it expects to find it on first CDK deploy, before the following step to create the contents of it (`npm run create_edge_ux_package`). On a clean clone of the repo, the CDK deploy_all.sh script fails.

This creates an empty directory with the name to satisfy the first CDK deploy. 

### How were these changes tested?

Tested by running the deploy_all.sh script to deploy to AWS.