### PR TITLE
Histogram now supports seconds and microseconds. 

### DIFF
--- a/src/python/grapl-common/grapl_common/metrics/metric_reporter.py
+++ b/src/python/grapl-common/grapl_common/metrics/metric_reporter.py
@@ -23,6 +23,15 @@ class Writeable(Protocol):
         pass
 
 
+_RESERVED_UNIT_TAG = "_unit"
+
+
+class HistogramUnit(str, Enum):
+    MILLIS = "millis"
+    MICROS = "micros"
+    SECONDS = "seconds"
+
+
 class MetricReporter:
     """
     Print metrics to stdout that are picked up by Metric Forwarder later.
@@ -116,6 +125,23 @@ class MetricReporter:
             typ="h",
             tags=tags,
         )
+
+    def histogram_with_units(
+        self,
+        metric_name: str,
+        value: int,
+        unit: HistogramUnit,
+        tags: Sequence[TagPair] = (),
+    ) -> None:
+        """
+        A histogram is a measure of the distribution of timer values over time, calculated at the
+        server. As the data exported for timers and histograms is the same,
+        this is currently an alias for a timer.
+
+        example: the time to complete rendering of a web page for a user.
+        """
+        tags = [TagPair(_RESERVED_UNIT_TAG, unit.value)] + tags
+        self.histogram(metric_name, value, tags)
 
     @contextmanager
     def histogram_ctx(

--- a/src/python/grapl-common/grapl_common/metrics/metric_reporter.py
+++ b/src/python/grapl-common/grapl_common/metrics/metric_reporter.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from enum import Enum
 from sys import stdout
 from typing import Callable, Iterator, Optional, Sequence, TextIO, Union
 
@@ -111,6 +112,7 @@ class MetricReporter:
         metric_name: str,
         value: MillisDuration,
         tags: Sequence[TagPair] = (),
+        unit: Optional[HistogramUnit] = None,
     ) -> None:
         """
         A histogram is a measure of the distribution of timer values over time, calculated at the
@@ -119,29 +121,14 @@ class MetricReporter:
 
         example: the time to complete rendering of a web page for a user.
         """
+        if unit:
+            tags = [TagPair(_RESERVED_UNIT_TAG, unit.value)] + [t for t in tags]
         self.write_metric(
             metric_name=metric_name,
             value=value,
             typ="h",
             tags=tags,
         )
-
-    def histogram_with_units(
-        self,
-        metric_name: str,
-        value: int,
-        unit: HistogramUnit,
-        tags: Sequence[TagPair] = (),
-    ) -> None:
-        """
-        A histogram is a measure of the distribution of timer values over time, calculated at the
-        server. As the data exported for timers and histograms is the same,
-        this is currently an alias for a timer.
-
-        example: the time to complete rendering of a web page for a user.
-        """
-        tags = [TagPair(_RESERVED_UNIT_TAG, unit.value)] + tags
-        self.histogram(metric_name, value, tags)
 
     @contextmanager
     def histogram_ctx(

--- a/src/rust/grapl-observe/src/metric_reporter.rs
+++ b/src/rust/grapl-observe/src/metric_reporter.rs
@@ -19,6 +19,7 @@ pub enum HistogramUnit {
     Millis,
     Micros,
 }
+const RESERVED_UNIT_TAG: &'static str = "_unit";
 
 type NowGetter = fn() -> DateTime<Utc>;
 
@@ -140,7 +141,7 @@ where
     ) -> Result<(), MetricError> {
         let mut tags_with_unit: Vec<TagPair> = tags.to_vec();
         tags_with_unit.push(TagPair(
-            "_unit",
+            RESERVED_UNIT_TAG,
             match unit {
                 HistogramUnit::Micros => "micros",
                 HistogramUnit::Millis => "millis",

--- a/src/rust/grapl-observe/src/metric_reporter.rs
+++ b/src/rust/grapl-observe/src/metric_reporter.rs
@@ -12,6 +12,14 @@ pub mod common_strs {
     pub const FAIL: &'static str = "fail";
 }
 
+pub enum HistogramUnit {
+    // Notably, we should not support nanoseconds for the foreseeable future.
+    // See https://github.com/grapl-security/issue-tracker/issues/132
+    Seconds,
+    Millis,
+    Micros,
+}
+
 type NowGetter = fn() -> DateTime<Utc>;
 
 pub struct MetricReporter<W: std::io::Write> {
@@ -112,9 +120,33 @@ where
     pub fn histogram(
         &mut self,
         metric_name: &str,
-        value: f64,
+        value_millis: f64,
         tags: &[TagPair],
     ) -> Result<(), MetricError> {
+        self.write_metric(metric_name, value_millis, MetricType::Histogram, None, tags)
+    }
+
+    /**
+     * In order to shoehorn units into the statsd protocol, we specify a
+     * special "_unit" tag that will
+     * be popped off in the metric forwarder.
+     */
+    pub fn histogram_with_units(
+        &mut self,
+        metric_name: &str,
+        value: f64,
+        unit: HistogramUnit,
+        tags: &[TagPair],
+    ) -> Result<(), MetricError> {
+        let mut tags_with_unit: Vec<TagPair> = tags.to_vec();
+        tags_with_unit.push(TagPair(
+            "_unit",
+            match unit {
+                HistogramUnit::Micros => "micros",
+                HistogramUnit::Millis => "millis",
+                HistogramUnit::Seconds => "seconds",
+            },
+        ));
         self.write_metric(metric_name, value, MetricType::Histogram, None, tags)
     }
 }
@@ -141,6 +173,7 @@ impl Clone for MetricReporter<Stdout> {
     }
 }
 
+#[derive(Clone)]
 pub struct TagPair<'a>(pub &'a str, pub &'a str);
 
 impl TagPair<'_> {

--- a/src/rust/grapl-observe/src/metric_reporter.rs
+++ b/src/rust/grapl-observe/src/metric_reporter.rs
@@ -132,14 +132,14 @@ where
      * special "_unit" tag that will
      * be popped off in the metric forwarder.
      */
-    pub fn histogram_with_units(
+    pub fn histogram_with_units<'a>(
         &mut self,
         metric_name: &str,
         value: f64,
         unit: HistogramUnit,
-        tags: &[TagPair],
+        tags: impl Into<Vec<TagPair<'a>>>,
     ) -> Result<(), MetricError> {
-        let mut tags_with_unit: Vec<TagPair> = tags.to_vec();
+        let mut tags_with_unit: Vec<TagPair> = tags.into();
         tags_with_unit.push(TagPair(
             RESERVED_UNIT_TAG,
             match unit {
@@ -148,7 +148,13 @@ where
                 HistogramUnit::Seconds => "seconds",
             },
         ));
-        self.write_metric(metric_name, value, MetricType::Histogram, None, tags)
+        self.write_metric(
+            metric_name,
+            value,
+            MetricType::Histogram,
+            None,
+            &tags_with_unit,
+        )
     }
 }
 

--- a/src/rust/metric-forwarder/src/accumulate_metrics.rs
+++ b/src/rust/metric-forwarder/src/accumulate_metrics.rs
@@ -124,7 +124,7 @@ impl<'a> From<&'a Option<Vec<Dimension>>> for WrappedDimensions<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cloudwatch_send::units;
+    use crate::cloudwatch_send::cw_units;
     use hmap::hmap;
 
     const TS: &str = "2020-01-01T01:23:45.000Z";
@@ -137,7 +137,7 @@ mod tests {
         MetricDatum {
             metric_name: "metric_name".to_string(),
             timestamp: TS.to_string().into(),
-            unit: units::COUNT.to_string().into(),
+            unit: cw_units::COUNT.to_string().into(),
             value: value.into(),
             counts: None,
             values: None,
@@ -249,7 +249,7 @@ mod tests {
             metric(1.0),
             {
                 let mut m = metric(1.0);
-                m.unit = units::MILLIS.to_string().into();
+                m.unit = cw_units::MILLIS.to_string().into();
                 m
             },
             metric(1.0),

--- a/src/rust/metric-forwarder/src/cloudwatch_send.rs
+++ b/src/rust/metric-forwarder/src/cloudwatch_send.rs
@@ -12,7 +12,7 @@ use statsd_parser;
 use statsd_parser::Metric;
 use std::collections::BTreeMap;
 
-pub mod units {
+pub mod CloudwatchUnits {
     // strings accepted by CloudWatch MetricDatum.unit
     pub const COUNT: &'static str = "Count";
     pub const MILLIS: &'static str = "Milliseconds";
@@ -143,9 +143,9 @@ impl From<&BTreeMap<String, String>> for Dimensions {
 fn statsd_as_cloudwatch_metric(stat: Stat) -> MetricDatum {
     let (unit, value, _sample_rate) = match stat.msg.metric {
         // Yes, gauge and counter are - for our purposes - basically both Count
-        Metric::Gauge(g) => (units::COUNT, g.value, g.sample_rate),
-        Metric::Counter(c) => (units::COUNT, c.value, c.sample_rate),
-        Metric::Histogram(h) => (units::MILLIS, h.value, h.sample_rate),
+        Metric::Gauge(g) => (CloudwatchUnits::COUNT, g.value, g.sample_rate),
+        Metric::Counter(c) => (CloudwatchUnits::COUNT, c.value, c.sample_rate),
+        Metric::Histogram(h) => (CloudwatchUnits::MILLIS, h.value, h.sample_rate),
         _ => panic!("How the heck did you get an unsupported metric type in here?"),
     };
     let Dimensions(dims) = stat
@@ -207,7 +207,7 @@ mod tests {
         assert_eq!(&datum.metric_name, &name);
         assert_eq!(&datum.timestamp.expect(""), &ts);
         assert_eq!(datum.value.expect(""), 12.3);
-        assert_eq!(datum.unit.expect(""), units::COUNT);
+        assert_eq!(datum.unit.expect(""), CloudwatchUnits::COUNT);
         assert_eq!(datum.dimensions, None);
     }
 

--- a/src/rust/metric-forwarder/src/cloudwatch_send.rs
+++ b/src/rust/metric-forwarder/src/cloudwatch_send.rs
@@ -160,7 +160,7 @@ fn override_unit_from_dims(mut unit: &'static str, dims: &mut Dimensions) -> &'s
     // assumption of milliseconds.
     // Remove the _unit dimension from dimensions.
 
-    let units_dimension_option = dims.find_dimension(RESERVED_UNIT_FLAG);
+    let units_dimension_option = dims.find_dimension(RESERVED_UNIT_TAG);
     if let Some(units_dimension) = units_dimension_option {
         // Right now, we only specify `_unit` for histograms.
         assert_eq!(unit, cw_units::MILLIS);

--- a/src/rust/metric-forwarder/src/cloudwatch_send.rs
+++ b/src/rust/metric-forwarder/src/cloudwatch_send.rs
@@ -12,10 +12,12 @@ use statsd_parser;
 use statsd_parser::Metric;
 use std::collections::BTreeMap;
 
-pub mod CloudwatchUnits {
+pub mod cw_units {
     // strings accepted by CloudWatch MetricDatum.unit
     pub const COUNT: &'static str = "Count";
     pub const MILLIS: &'static str = "Milliseconds";
+    pub const MICROS: &'static str = "Microseconds";
+    pub const SECONDS: &'static str = "Seconds";
 }
 
 type PutResult = Result<(), RusotoError<PutMetricDataError>>;
@@ -140,24 +142,65 @@ impl From<&BTreeMap<String, String>> for Dimensions {
     }
 }
 
+impl Dimensions {
+    fn find_dimension(&self, dimension_name: &str) -> Option<Dimension> {
+        let found = self.0.iter().find(|ref d| d.name == dimension_name);
+        return found.map(Dimension::clone)
+    }
+
+    fn remove_dimension(&mut self, dimension: &Dimension) {
+        self.0.retain(|d| d != dimension)
+    }
+}
+
+fn override_unit_from_dims(mut unit: &'static str, dims: &mut Dimensions) -> &'static str {
+    // https://github.com/grapl-security/issue-tracker/issues/132
+    // Read the optional `_unit` dimension and use it to override the default
+    // assumption of milliseconds.
+    // Remove the _unit dimension from dimensions.
+
+    let units_dimension_option = dims.find_dimension("_unit");
+    if let Some(units_dimension) = units_dimension_option {
+        // Right now, we only specify `_unit` for histograms.
+        assert_eq!(unit, cw_units::MILLIS);
+
+        unit = match &units_dimension.value[..] {
+            "millis" => cw_units::MILLIS,
+            "micros" => cw_units::MICROS,
+            "seconds" => cw_units::SECONDS,
+            _ => {
+                warn!("Unexpected unit: {}", units_dimension.value);
+                unit
+            }
+        };
+        dims.remove_dimension(&units_dimension);
+    }
+    unit
+}
+
 fn statsd_as_cloudwatch_metric(stat: Stat) -> MetricDatum {
-    let (unit, value, _sample_rate) = match stat.msg.metric {
+    let (mut unit, value, _sample_rate) = match stat.msg.metric {
         // Yes, gauge and counter are - for our purposes - basically both Count
-        Metric::Gauge(g) => (CloudwatchUnits::COUNT, g.value, g.sample_rate),
-        Metric::Counter(c) => (CloudwatchUnits::COUNT, c.value, c.sample_rate),
-        Metric::Histogram(h) => (CloudwatchUnits::MILLIS, h.value, h.sample_rate),
+        Metric::Gauge(g) => (cw_units::COUNT, g.value, g.sample_rate),
+        Metric::Counter(c) => (cw_units::COUNT, c.value, c.sample_rate),
+        Metric::Histogram(h) => (cw_units::MILLIS, h.value, h.sample_rate),
         _ => panic!("How the heck did you get an unsupported metric type in here?"),
     };
-    let Dimensions(dims) = stat
+
+    let mut dims: Dimensions = stat
         .msg
         .tags
         .as_ref()
         .map(|tags| tags.into())
         .unwrap_or_default();
+
+    unit = override_unit_from_dims(unit, &mut dims);
+
+    let Dimensions(dims_vec) = dims;
     // AWS doesn't like sending it an empty list
-    let dims_option = match dims.is_empty() {
+    let dims_option = match dims_vec.is_empty() {
         true => None,
-        false => Some(dims),
+        false => Some(dims_vec),
     };
 
     let datum = MetricDatum {
@@ -207,7 +250,7 @@ mod tests {
         assert_eq!(&datum.metric_name, &name);
         assert_eq!(&datum.timestamp.expect(""), &ts);
         assert_eq!(datum.value.expect(""), 12.3);
-        assert_eq!(datum.unit.expect(""), CloudwatchUnits::COUNT);
+        assert_eq!(datum.unit.expect(""), cw_units::COUNT);
         assert_eq!(datum.dimensions, None);
     }
 
@@ -228,6 +271,24 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn test_convert_one_stat_with_unit_tags_into_datum() {
+        // Test the behavior specified in https://github.com/grapl-security/issue-tracker/issues/132
+        let stat = some_histogram_stat_with_unit_tag();
+        let datum: MetricDatum = stat.into();
+        assert_eq!(
+            &datum.dimensions.expect(""),
+            &vec![
+                Dimension {
+                    name: "tag1".into(),
+                    value: "val1".into()
+                },
+                // Resulting vec has no "_unit"
+            ]
+        );
+        assert_eq!(&datum.unit.expect(""), &cw_units::MICROS);
     }
 
     pub struct MockCloudwatchClient {
@@ -283,6 +344,24 @@ mod tests {
             msg: statsd_parser::Message {
                 name: "msg".into(),
                 metric: statsd_parser::Metric::Counter(statsd_parser::Counter {
+                    value: 123.45,
+                    sample_rate: None,
+                }),
+                tags: tags.into(),
+            },
+            service_name: SERVICE_NAME.into(),
+        }
+    }
+
+    fn some_histogram_stat_with_unit_tag() -> Stat {
+        let mut tags = BTreeMap::<String, String>::new();
+        tags.insert("tag1".into(), "val1".into());
+        tags.insert("_unit".into(), "micros".into());
+        Stat {
+            timestamp: "ts".into(),
+            msg: statsd_parser::Message {
+                name: "msg".into(),
+                metric: statsd_parser::Metric::Histogram(statsd_parser::Histogram {
                     value: 123.45,
                     sample_rate: None,
                 }),

--- a/src/rust/metric-forwarder/src/cloudwatch_send.rs
+++ b/src/rust/metric-forwarder/src/cloudwatch_send.rs
@@ -19,6 +19,7 @@ pub mod cw_units {
     pub const MICROS: &'static str = "Microseconds";
     pub const SECONDS: &'static str = "Seconds";
 }
+const RESERVED_UNIT_TAG: &'static str = "_unit";
 
 type PutResult = Result<(), RusotoError<PutMetricDataError>>;
 
@@ -145,7 +146,7 @@ impl From<&BTreeMap<String, String>> for Dimensions {
 impl Dimensions {
     fn find_dimension(&self, dimension_name: &str) -> Option<Dimension> {
         let found = self.0.iter().find(|ref d| d.name == dimension_name);
-        return found.map(Dimension::clone)
+        return found.map(Dimension::clone);
     }
 
     fn remove_dimension(&mut self, dimension: &Dimension) {
@@ -159,7 +160,7 @@ fn override_unit_from_dims(mut unit: &'static str, dims: &mut Dimensions) -> &'s
     // assumption of milliseconds.
     // Remove the _unit dimension from dimensions.
 
-    let units_dimension_option = dims.find_dimension("_unit");
+    let units_dimension_option = dims.find_dimension(RESERVED_UNIT_FLAG);
     if let Some(units_dimension) = units_dimension_option {
         // Right now, we only specify `_unit` for histograms.
         assert_eq!(unit, cw_units::MILLIS);
@@ -356,7 +357,7 @@ mod tests {
     fn some_histogram_stat_with_unit_tag() -> Stat {
         let mut tags = BTreeMap::<String, String>::new();
         tags.insert("tag1".into(), "val1".into());
-        tags.insert("_unit".into(), "micros".into());
+        tags.insert(RESERVED_UNIT_TAG.into(), "micros".into());
         Stat {
             timestamp: "ts".into(),
             msg: statsd_parser::Message {


### PR DESCRIPTION


### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/132

### What changes does this PR make to Grapl? Why?
Now we shoehorn unit data into <tags / dimensions> on the `metric_reporter.py|rs` side
and we optionally pop that data off and consume it on the `metric_forwarder` side, to send the requisite units to Cloudwatch.

### How were these changes tested?
I didn't test the reporter side, since it's pretty straightforward piggybacking off of existing, well-tested tag infrastructure.
I did unit test the `metric_forwarder` side.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
