### PR TITLE
Begin to migrate python S3/SQS clients to a FromEnv equivalent

### DIFF
--- a/dobi.yaml
+++ b/dobi.yaml
@@ -842,6 +842,12 @@ job=run-e2e-tests:
     - "MG_ALPHAS=grapl-master-graph-db:9080"
     - DEBUG_SERVICES={env.DEBUG_SERVICES:}
     - DUMP_ARTIFACTS={env.DUMP_ARTIFACTS:-False}
+    - "SQS_ENDPOINT=http://sqs.us-east-1.amazonaws.com:9324"
+    - "SQS_ACCESS_KEY_ID=dummy_cred_aws_access_key_id"
+    - "SQS_ACCESS_KEY_SECRET=dummy_cred_aws_secret_access_key"
+    - "S3_ENDPOINT=http://s3:9000"
+    - "S3_ACCESS_KEY_ID=minioadmin"
+    - "S3_ACCESS_KEY_SECRET=minioadmin"
   depends:
     - integration-env
   mounts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,12 +78,15 @@ services:
     command: server /data
     ports:
       - "9000:9000"
+    environment:
+      - MINIO_ACCESS_KEY=minioadmin
+      - MINIO_SECRET_KEY=minioadmin
+      # Explicitly _dont_ specify MINIO_REGION_NAME - it breaks things for some reason.
+      # Default is us-east-1 anyway
     networks:
       default:
         aliases:
           - minio
-    logging:
-      driver: none
 
   dynamodb:
     image: amazon/dynamodb-local
@@ -297,6 +300,12 @@ services:
       - "BUCKET_PREFIX=local-grapl"
       - GRAPL_LOG_LEVEL=${GRAPL_LOG_LEVEL:-ERROR}
       - "SOURCE_QUEUE_URL=http://sqs.us-east-1.amazonaws.com:9324/queue/grapl-analyzer-executor-queue"
+      - "SQS_ENDPOINT=http://sqs.us-east-1.amazonaws.com:9324"
+      - "SQS_ACCESS_KEY_ID=dummy_cred_aws_access_key_id"
+      - "SQS_ACCESS_KEY_SECRET=dummy_cred_aws_secret_access_key"
+      - "S3_ENDPOINT=http://s3:9000"
+      - "S3_ACCESS_KEY_ID=minioadmin"
+      - "S3_ACCESS_KEY_SECRET=minioadmin"
     links:
       - s3:minio
       - sqs:sqs.us-east-1.amazonaws.com
@@ -465,6 +474,7 @@ services:
       - s3
       - sqs
       - dynamodb
+      - grapl-engagement-view
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,8 @@ services:
       default:
         aliases:
           - minio
+    logging:	
+      driver: none	
 
   dynamodb:
     image: amazon/dynamodb-local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,8 +87,8 @@ services:
       default:
         aliases:
           - minio
-    logging:	
-      driver: none	
+    logging:
+      driver: none
 
   dynamodb:
     image: amazon/dynamodb-local

--- a/etc/local_grapl/bin/upload-osquery-logs.py
+++ b/etc/local_grapl/bin/upload-osquery-logs.py
@@ -32,6 +32,17 @@ def hack_PATH_to_include_grapl_tests_common() -> Callable:
     return upload_osquery_logs
 
 
+def setup_env(bucket_prefix: str):
+    if bucket_prefix == "local-grapl":
+        os.putenv("S3_ENDPOINT", "http://localhost:9000")
+        os.putenv("S3_ACCESS_KEY_ID", "minioadmin")
+        os.putenv("S3_ACCESS_KEY_SECRET", "minioadmin")
+
+        os.putenv("SQS_ENDPOINT", "http://localhost:9234")
+        os.putenv("SQS_ACCESS_KEY_ID", "dummy_cred_aws_access_key_id")
+        os.putenv("SQS_ACCESS_KEY_ID", "dummy_cred_aws_access_key_id")
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Send osquery logs to Grapl")
     parser.add_argument("--bucket_prefix", dest="bucket_prefix", required=True)
@@ -43,7 +54,6 @@ def parse_args():
     )
     parser.add_argument("--delay", dest="delay", default=0, type=int)
     parser.add_argument("--batch-size", dest="batch_size", default=100, type=int)
-    parser.add_argument("--use-links", dest="use_links", default=False, type=bool)
     return parser.parse_args()
 
 
@@ -51,12 +61,12 @@ if __name__ == "__main__":
     args = parse_args()
     if args.bucket_prefix is None:
         raise Exception("Provide bucket prefix as first argument")
-    else:
-        upload_fn = hack_PATH_to_include_grapl_tests_common()
-        upload_fn(
-            args.bucket_prefix,
-            args.logfile,
-            delay=args.delay,
-            batch_size=args.batch_size,
-            use_links=args.use_links,
-        )
+
+    setup_env(args.bucket_prefix)
+    upload_fn = hack_PATH_to_include_grapl_tests_common()
+    upload_fn(
+        args.bucket_prefix,
+        args.logfile,
+        delay=args.delay,
+        batch_size=args.batch_size,
+    )

--- a/etc/local_grapl/bin/upload-sysmon-logs.py
+++ b/etc/local_grapl/bin/upload-sysmon-logs.py
@@ -1,10 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Despite the path, this is *not* tied just to Local Grapl, and can also be used on true S3 buckets.
 """
 
 import argparse
 import sys
+import os
 from pathlib import Path
 from typing import Callable
 
@@ -30,6 +31,17 @@ def hack_PATH_to_include_grapl_tests_common() -> Callable:
     return upload_sysmon_logs
 
 
+def setup_env(bucket_prefix: str):
+    if bucket_prefix == "local-grapl":
+        os.putenv("S3_ENDPOINT", "http://localhost:9000")
+        os.putenv("S3_ACCESS_KEY_ID", "minioadmin")
+        os.putenv("S3_ACCESS_KEY_SECRET", "minioadmin")
+
+        os.putenv("SQS_ENDPOINT", "http://localhost:9234")
+        os.putenv("SQS_ACCESS_KEY_ID", "dummy_cred_aws_access_key_id")
+        os.putenv("SQS_ACCESS_KEY_ID", "dummy_cred_aws_access_key_id")
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Send sysmon logs to Grapl")
     parser.add_argument("--bucket_prefix", dest="bucket_prefix", required=True)
@@ -41,7 +53,6 @@ def parse_args():
     )
     parser.add_argument("--delay", dest="delay", default=0, type=int)
     parser.add_argument("--batch-size", dest="batch_size", default=100, type=int)
-    parser.add_argument("--use-links", dest="use_links", default=False, type=bool)
     return parser.parse_args()
 
 
@@ -49,12 +60,12 @@ if __name__ == "__main__":
     args = parse_args()
     if args.bucket_prefix is None:
         raise Exception("Provide bucket prefix as first argument")
-    else:
-        upload_fn = hack_PATH_to_include_grapl_tests_common()
-        upload_fn(
-            args.bucket_prefix,
-            args.logfile,
-            delay=args.delay,
-            batch_size=args.batch_size,
-            use_links=args.use_links,
-        )
+
+    setup_env(args.bucket_prefix)
+    upload_fn = hack_PATH_to_include_grapl_tests_common()
+    upload_fn(
+        args.bucket_prefix,
+        args.logfile,
+        delay=args.delay,
+        batch_size=args.batch_size,
+    )

--- a/src/python/analyzer_executor/src/analyzer_executor_lib/analyzer_executor.py
+++ b/src/python/analyzer_executor/src/analyzer_executor_lib/analyzer_executor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import hashlib
 import inspect
@@ -12,10 +14,11 @@ from multiprocessing import Pipe, Process
 from multiprocessing.connection import Connection
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import boto3  # type: ignore
 import redis
+from grapl_common.env_helpers import S3ResourceFactory, SQSClientFactory
 from grapl_common.metrics.metric_reporter import MetricReporter, TagPair
 
 from grapl_analyzerlib.analyzer import Analyzer
@@ -25,6 +28,11 @@ from grapl_analyzerlib.nodes.base import BaseView
 from grapl_analyzerlib.plugin_retriever import load_plugins
 from grapl_analyzerlib.queryable import Queryable
 from grapl_analyzerlib.subgraph_view import SubgraphView
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client, S3ServiceResource
+    from mypy_boto3_sqs import SQSClient
+
 
 # Set up logger (this is for the whole file, including static methods)
 LOGGER = logging.getLogger(__name__)
@@ -189,10 +197,12 @@ class AnalyzerExecutor:
 
         client = GraphClient()
 
-        s3 = get_s3_client(self.is_local)
+        s3 = S3ResourceFactory(boto3).from_env()
 
         load_plugins(
-            os.environ["BUCKET_PREFIX"], s3, os.path.abspath(MODEL_PLUGINS_DIR)
+            os.environ["BUCKET_PREFIX"],
+            s3.meta.client,
+            os.path.abspath(MODEL_PLUGINS_DIR),
         )
 
         for event in events["Records"]:
@@ -363,15 +373,15 @@ class AnalyzerExecutor:
             raise
 
 
-def parse_s3_event(s3, event) -> str:
+def parse_s3_event(s3: S3ServiceResource, event) -> str:
     bucket = event["s3"]["bucket"]["name"]
     key = event["s3"]["object"]["key"]
     return download_s3_file(s3, bucket, key)
 
 
-def download_s3_file(s3, bucket: str, key: str) -> str:
+def download_s3_file(s3: S3ServiceResource, bucket: str, key: str) -> str:
     obj = s3.Object(bucket, key)
-    return obj.get()["Body"].read()
+    return obj.get()["Body"].read().decode("utf-8")
 
 
 def is_analyzer(analyzer_name, analyzer_cls):
@@ -397,7 +407,7 @@ def chunker(seq, size):
     return [seq[pos : pos + size] for pos in range(0, len(seq), size)]
 
 
-def emit_event(s3, event: ExecutionHit, is_local: bool) -> None:
+def emit_event(s3: S3ServiceResource, event: ExecutionHit, is_local: bool) -> None:
     LOGGER.info(f"emitting event for: {event.analyzer_name, event.nodes}")
 
     event_s = json.dumps(
@@ -416,16 +426,10 @@ def emit_event(s3, event: ExecutionHit, is_local: bool) -> None:
     obj = s3.Object(
         f"{os.environ['BUCKET_PREFIX']}-analyzer-matched-subgraphs-bucket", key
     )
-    obj.put(Body=event_s)
+    obj.put(Body=event_s.encode("utf-8"))
 
     if is_local:
-        sqs = boto3.client(
-            "sqs",
-            region_name="us-east-1",
-            endpoint_url="http://sqs.us-east-1.amazonaws.com:9324",
-            aws_access_key_id="dummy_cred_aws_access_key_id",
-            aws_secret_access_key="dummy_cred_aws_secret_access_key",
-        )
+        sqs = SQSClientFactory(boto3).from_env()
         send_s3_event(
             sqs,
             "http://sqs.us-east-1.amazonaws.com:9324/queue/grapl-engagement-creator-queue",
@@ -475,7 +479,7 @@ def into_sqs_message(bucket: str, key: str) -> str:
 
 
 def send_s3_event(
-    sqs_client: Any,
+    sqs_client: SQSClient,
     queue_url: str,
     output_bucket: str,
     output_path: str,
@@ -487,16 +491,3 @@ def send_s3_event(
             key=output_path,
         ),
     )
-
-
-def get_s3_client(is_local: bool):
-    if is_local:
-        return boto3.resource(
-            "s3",
-            endpoint_url="http://s3:9000",
-            aws_access_key_id="minioadmin",
-            aws_secret_access_key="minioadmin",
-        )
-
-    else:
-        return boto3.resource("s3")

--- a/src/python/analyzer_executor/src/run_local.py
+++ b/src/python/analyzer_executor/src/run_local.py
@@ -5,18 +5,13 @@ import traceback
 import boto3  # type: ignore
 import botocore.exceptions  # type: ignore
 from analyzer_executor_lib.analyzer_executor import LOGGER, AnalyzerExecutor
+from grapl_common.env_helpers import SQSClientFactory
 
 ANALYZER_EXECUTOR = AnalyzerExecutor.singleton()
 
 while True:
     try:
-        sqs = boto3.client(
-            "sqs",
-            region_name="us-east-1",
-            endpoint_url="http://sqs.us-east-1.amazonaws.com:9324",
-            aws_access_key_id="dummy_cred_aws_access_key_id",
-            aws_secret_access_key="dummy_cred_aws_secret_access_key",
-        )
+        sqs = SQSClientFactory(boto3).from_env()
 
         alive = False
         while not alive:

--- a/src/python/grapl-common/grapl_common/env_helpers.py
+++ b/src/python/grapl-common/grapl_common/env_helpers.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, TypeVar
+
+from typing_extensions import Protocol
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client, S3ServiceResource
+    from mypy_boto3_sqs import SQSClient
+
+T = TypeVar("T", covariant=True)
+
+
+class FromEnv(Protocol[T]):
+    def from_env(self) -> T:
+        pass
+
+
+class FromEnvException(Exception):
+    pass
+
+
+ClientGetParams = NamedTuple(
+    "ClientGetParams",
+    (
+        ("boto3_client_name", str),  # e.g. "s3" or "sqs"
+        ("endpoint_url_key", str),  # e.g. "SQS_ENDPOINT"
+        ("access_key_id_key", str),
+        ("access_key_secret_key", str),
+    ),
+)
+
+
+def _client_get(client_create_fn: Callable[..., Any], params: ClientGetParams) -> Any:
+    """
+    :param client_create_fn: the `boto3.client` or `boto3.resource` function
+    """
+    which_service = params.boto3_client_name
+    endpoint_url = os.getenv(params.endpoint_url_key)
+    access_key_id = os.getenv(params.access_key_id_key)
+    access_key_secret = os.getenv(params.access_key_secret_key)
+    region = os.getenv("AWS_REGION")
+
+    # Not needed long term, more to help migrate to `env_helpers`.
+    # Notably, when `is_local` is not set, it won't break anything.
+    is_local = os.getenv("IS_LOCAL", None)
+
+    # Unlike Rust FromEnv, we rely on boto3's built in region handling.
+
+    if all((endpoint_url, access_key_id, access_key_secret)):
+        # Local, all are passed in from docker-compose.yml
+        logging.info(f"Creating a local client for {which_service}")
+        assert (
+            is_local != False
+        ), f"You must pass in credentials for a local {which_service} client"
+        return client_create_fn(
+            params.boto3_client_name,
+            endpoint_url=endpoint_url,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=access_key_secret,
+            region_name=region or "us-east-1",
+        )
+    elif endpoint_url and not any((access_key_id, access_key_secret)):
+        # Local or AWS doing cross-region stuff
+        return client_create_fn(
+            params.boto3_client_name,
+            endpoint_url=endpoint_url,
+        )
+    elif not any((endpoint_url, access_key_id, access_key_secret)):
+        # AWS
+        logging.info("Creating a prod client")
+        assert (
+            is_local != True
+        ), f"You can't pass in credentials for a prod {which_service} client"
+        return client_create_fn(params.boto3_client_name)
+    else:
+        raise FromEnvException(
+            f"You specified access key but not endpoint for {params.boto3_client_name}?"
+        )
+
+
+_SQSParams = ClientGetParams(
+    boto3_client_name="sqs",
+    endpoint_url_key="SQS_ENDPOINT",
+    access_key_id_key="SQS_ACCESS_KEY_ID",
+    access_key_secret_key="SQS_ACCESS_KEY_SECRET",
+)
+
+
+class SQSClientFactory(FromEnv["SQSClient"]):
+    def __init__(self, boto3_module: Any):
+        self.client_create_fn = boto3_module.client
+
+    def from_env(self) -> SQSClient:
+        client: SQSClient = _client_get(self.client_create_fn, _SQSParams)
+        return client
+
+
+_S3Params = ClientGetParams(
+    boto3_client_name="s3",
+    endpoint_url_key="S3_ENDPOINT",
+    access_key_id_key="S3_ACCESS_KEY_ID",
+    access_key_secret_key="S3_ACCESS_KEY_SECRET",
+)
+
+
+class S3ClientFactory(FromEnv["S3Client"]):
+    def __init__(self, boto3_module: Any):
+        self.client_create_fn = boto3_module.client
+
+    def from_env(self) -> S3Client:
+        client: S3Client = _client_get(self.client_create_fn, _S3Params)
+        return client
+
+
+class S3ResourceFactory(FromEnv["S3ServiceResource"]):
+    def __init__(self, boto3_module: Any):
+        self.client_create_fn = boto3_module.resource
+
+    def from_env(self) -> S3ServiceResource:
+        client: S3ServiceResource = _client_get(self.client_create_fn, _S3Params)
+        return client

--- a/src/python/grapl-tests-common/grapl_tests_common/setup.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/setup.py
@@ -1,13 +1,16 @@
+from __future__ import annotations
+
 import logging
 import subprocess
 import sys
 from os import environ
 from sys import stdout
-from typing import Any, NamedTuple, Sequence
+from typing import TYPE_CHECKING, Any, NamedTuple, Sequence
 
 import boto3  # type: ignore
 import pytest
 import requests
+from grapl_common.env_helpers import S3ClientFactory, SQSClientFactory
 from grapl_tests_common.dump_dynamodb import dump_dynamodb
 from grapl_tests_common.sleep import verbose_sleep
 from grapl_tests_common.types import (
@@ -17,6 +20,10 @@ from grapl_tests_common.types import (
 )
 from grapl_tests_common.upload_test_data import UploadTestData
 from grapl_tests_common.wait import WaitForS3Bucket, WaitForSqsQueue, wait_for
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+    from mypy_boto3_sqs import SQSClient
 
 BUCKET_PREFIX = environ["BUCKET_PREFIX"]
 assert BUCKET_PREFIX == "local-grapl"
@@ -43,32 +50,22 @@ def _upload_analyzers(
 
 
 def _upload_test_data(
-    s3_client: S3ServiceResource, test_data: Sequence[UploadTestData]
+    s3_client: S3ServiceResource,
+    sqs_client: SQSClient,
+    test_data: Sequence[UploadTestData],
 ) -> None:
     logging.info(f"Uploading test data...")
 
     for datum in test_data:
-        datum.upload(s3_client)
+        datum.upload(s3_client, sqs_client)
 
 
-def _create_s3_client() -> S3ServiceResource:
-    return boto3.client(
-        "s3",
-        endpoint_url="http://s3:9000",
-        aws_access_key_id="minioadmin",
-        aws_secret_access_key="minioadmin",
-    )
+def _create_s3_client() -> S3Client:
+    return S3ClientFactory(boto3).from_env()
 
 
-def _create_sqs_client() -> SqsServiceResource:
-    # mostly cribbed from upload-sysmon-logs
-    return boto3.client(
-        "sqs",
-        endpoint_url="http://sqs:9324",
-        region_name="us-east-1",
-        aws_access_key_id="minioadmin",
-        aws_secret_access_key="minioadmin",
-    )
+def _create_sqs_client() -> SQSClient:
+    return SQSClientFactory(boto3).from_env()
 
 
 def setup(
@@ -91,7 +88,7 @@ def setup(
     )
 
     _upload_analyzers(s3_client, analyzers)
-    _upload_test_data(s3_client, test_data)
+    _upload_test_data(s3_client, sqs_client, test_data)
     # You may want to sleep(30) to let the pipeline do its thing, but setup won't force it.
 
 

--- a/src/python/grapl-tests-common/grapl_tests_common/upload_logs.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/upload_logs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import random
 import string
@@ -5,7 +7,13 @@ import time
 from dataclasses import dataclass
 from datetime import datetime
 from sys import maxsize
-from typing import Callable, Iterator, List, Optional, cast
+from typing import TYPE_CHECKING, Callable, Iterator, List, Optional, cast
+
+from grapl_common.env_helpers import S3ClientFactory, SQSClientFactory
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+    from mypy_boto3_sqs import SQSClient
 
 import boto3  # type: ignore
 import zstd  # type: ignore
@@ -97,10 +105,10 @@ def upload_logs(
     generator_options: GeneratorOptions,
     delay: int = 0,
     batch_size: Optional[int] = 100,
-    use_links: bool = False,
+    s3_client: Optional[S3Client] = None,
+    sqs_client: Optional[SQSClient] = None,
 ) -> None:
     """
-    `use_links` meaning use "s3", "sqs" as opposed to localhost
     set `batch_size` to None to disable batching
     """
     print(
@@ -110,27 +118,9 @@ def upload_logs(
     # Ugly hack to cheaply disable batching
     batch_size = batch_size if batch_size is not None else maxsize
 
-    sqs = None
-    local_sqs_endpoint_url = "http://sqs:9324" if use_links else "http://localhost:9324"
-    # local-grapl prefix is reserved for running Grapl locally
-    if prefix == "local-grapl":
-        s3 = boto3.client(
-            "s3",
-            endpoint_url="http://s3:9000" if use_links else "http://localhost:9000",
-            aws_access_key_id="minioadmin",
-            aws_secret_access_key="minioadmin",
-            region_name="us-east-3",
-        )
-        sqs = boto3.client(
-            "sqs",
-            endpoint_url=local_sqs_endpoint_url,
-            region_name="us-east-1",
-            aws_access_key_id="dummy_cred_aws_access_key_id",
-            aws_secret_access_key="dummy_cred_aws_secret_access_key",
-        )
-
-    else:
-        s3 = boto3.client("s3")
+    requires_manual_eventing = prefix == "local-grapl"
+    s3 = s3_client or S3ClientFactory(boto3).from_env()
+    sqs = sqs_client or SQSClientFactory(boto3).from_env()
 
     with open(logfile, "rb") as b:
         body = b.readlines()
@@ -154,9 +144,10 @@ def upload_logs(
         s3.put_object(Body=chunk_body, Bucket=bucket, Key=key)
 
         # local-grapl relies on manual eventing
-        if sqs:
+        if requires_manual_eventing:
+            endpoint_url = sqs._endpoint.host  # type: ignore
             sqs.send_message(
-                QueueUrl=f"{local_sqs_endpoint_url}/queue/{generator_options.queue_name}",
+                QueueUrl=f"{endpoint_url}/queue/{generator_options.queue_name}",
                 MessageBody=into_sqs_message(bucket=bucket, key=key),
             )
 
@@ -170,7 +161,8 @@ def upload_sysmon_logs(
     logfile: str,
     delay: int = 0,
     batch_size: int = 100,
-    use_links: bool = False,
+    s3_client: Optional[S3Client] = None,
+    sqs_client: Optional[SQSClient] = None,
 ) -> None:
 
     upload_logs(
@@ -179,7 +171,8 @@ def upload_sysmon_logs(
         generator_options=SysmonGeneratorOptions(),
         delay=delay,
         batch_size=batch_size,
-        use_links=use_links,
+        s3_client=s3_client,
+        sqs_client=sqs_client,
     )
 
 
@@ -188,7 +181,8 @@ def upload_osquery_logs(
     logfile: str,
     delay: int = 0,
     batch_size: int = 100,
-    use_links: bool = False,
+    s3_client: Optional[S3Client] = None,
+    sqs_client: Optional[SQSClient] = None,
 ) -> None:
     upload_logs(
         prefix=prefix,
@@ -196,5 +190,6 @@ def upload_osquery_logs(
         generator_options=OSQueryGeneratorOptions(),
         delay=delay,
         batch_size=batch_size,
-        use_links=use_links,
+        s3_client=s3_client,
+        sqs_client=sqs_client,
     )

--- a/src/python/grapl-tests-common/grapl_tests_common/upload_test_data.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/upload_test_data.py
@@ -1,15 +1,20 @@
-import logging
-import subprocess
+from __future__ import annotations
 
-from grapl_tests_common.types import S3ServiceResource
+import logging
+from typing import TYPE_CHECKING
+
 from grapl_tests_common.upload_logs import upload_sysmon_logs
 from typing_extensions import Protocol
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+    from mypy_boto3_sqs import SQSClient
 
 BUCKET_PREFIX = "local-grapl"
 
 
 class UploadTestData(Protocol):
-    def upload(self, s3_client: S3ServiceResource) -> None:
+    def upload(self, s3_client: S3Client, sqs_client: SQSClient) -> None:
         pass
 
 
@@ -17,10 +22,11 @@ class UploadSysmonLogsTestData(UploadTestData):
     def __init__(self, path: str) -> None:
         self.path = path
 
-    def upload(self, s3_client: S3ServiceResource) -> None:
+    def upload(self, s3_client: S3Client, sqs_client: SQSClient) -> None:
         logging.info(f"S3 uploading test data from {self.path}")
         upload_sysmon_logs(
             prefix=BUCKET_PREFIX,
             logfile=self.path,
-            use_links=True,
+            s3_client=s3_client,
+            sqs_client=sqs_client,
         )

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/grapl_client.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/grapl_client.py
@@ -19,10 +19,6 @@ class GraphClient(DgraphClient):
             *(DgraphClientStub(f"{host}:{port}") for host, port in mg_alphas())
         )
 
-    @classmethod
-    def from_host_port(cls, host: str, port: int) -> "GraphClient":
-        return cls(*(DgraphClientStub(f"{host}:{port}"),))
-
     @contextmanager
     def txn_context(self, read_only: bool = False) -> Iterator[Txn]:
         """

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/prelude.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/prelude.py
@@ -48,4 +48,4 @@ from grapl_analyzerlib.grapl_client import (
     LocalMasterGraphClient,
 )
 
-from grapl_analyzerlib.plugin_retriever import load_plugins, load_plugins_local
+from grapl_analyzerlib.plugin_retriever import load_plugins

--- a/src/python/grapl_provision/grapl_provision.py
+++ b/src/python/grapl_provision/grapl_provision.py
@@ -166,7 +166,7 @@ def store_schema(table, schema: "Schema"):
 
         table.put_item(Item={"f_edge": f_edge, "r_edge": r_edge})
         table.put_item(Item={"f_edge": r_edge, "r_edge": f_edge})
-        print(f"stored edge mapping: {f_edge} {r_edge}")
+        LOGGER.info(f"stored edge mapping: {f_edge} {r_edge}")
 
 
 def provision_mg(mclient) -> None:
@@ -398,7 +398,7 @@ if __name__ == "__main__":
     sqs_t.start()
     s3_t.start()
 
-    print("Starting to provision master graph")
+    LOGGER.info("Starting to provision master graph")
     for i in range(0, 150):
         try:
             if not mg_succ:
@@ -407,13 +407,13 @@ if __name__ == "__main__":
                     local_dg_provision_client,
                 )
                 mg_succ = True
-                print("Provisioned master graph")
+                LOGGER.info("Provisioned master graph")
                 break
         except Exception as e:
             if i > 10:
                 LOGGER.error("mg provision failed with: ", e)
 
-    print("Starting to provision Secrets Manager")
+    LOGGER.info("Starting to provision Secrets Manager")
     for i in range(0, 150):
         try:
             client = boto3.client(
@@ -424,7 +424,7 @@ if __name__ == "__main__":
                 aws_secret_access_key="dummy_cred_aws_secret_access_key",
             )
             create_secret(client)
-            print("Done provisioning Secrets Manager")
+            LOGGER.info("Done provisioning Secrets Manager")
             break
         except botocore.exceptions.ClientError as e:
             if "ResourceExistsException" in e.__class__.__name__:
@@ -436,20 +436,20 @@ if __name__ == "__main__":
                 LOGGER.error(e)
             time.sleep(1)
 
-    print("Starting to provision Grapl user")
+    LOGGER.info("Starting to provision Grapl user")
     for i in range(0, 150):
         try:
             create_user("grapluser", "graplpassword")
-            print("Done provisioning Grapl user")
+            LOGGER.info("Done provisioning Grapl user")
             break
         except Exception as e:
             if i >= 50:
                 LOGGER.error(e)
             time.sleep(1)
 
-    print("Ensuring S3/SQS completed...")
+    LOGGER.info("Ensuring S3/SQS completed...")
     sqs_t.join(timeout=300)
     s3_t.join(timeout=300)
-    print("S3/SQS completed")
+    LOGGER.info("S3/SQS completed")
 
-    print("Completed provisioning")
+    LOGGER.info("Completed provisioning")

--- a/src/python/python_test_deps/requirements.txt
+++ b/src/python/python_test_deps/requirements.txt
@@ -4,4 +4,4 @@ hypothesis
 
 mypy
 pytype
-boto3-stubs[essential,sagemaker]
+boto3-stubs[essential,sagemaker]==1.16.54.0

--- a/src/python/python_test_deps/requirements.txt
+++ b/src/python/python_test_deps/requirements.txt
@@ -1,7 +1,7 @@
-pytest
-pytest-xdist
-hypothesis
+pytest==6.2.1
+pytest-xdist==2.2.0
+hypothesis==6.0.2
 
-mypy
-pytype
+mypy==0.790
+pytype==2021.1.14
 boto3-stubs[essential,sagemaker]==1.16.54.0


### PR DESCRIPTION
compare with env_helpers.rs in Colin's big PR:

https://github.com/grapl-security/grapl/pull/515/files#diff-fcad1f6e2e3eb8c0bc18e7372dd0734d2b6c2d72f8c87b12bc580c82c8a74d80

I migrated Analyzer Executor to this, and I ripped a bunch of complexity out of the Upload Logs code.

Testing: I tested the CLI `upload-sysmon-logs` script and I actually got e2e tests to run a few times