### PR TITLE
[Chore] Temporarily allow certain compilation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ __pycache__/
 *$py.class
 
 target/
-.cargo
 
 # C extensions
 *.so

--- a/src/rust/.cargo/config.toml
+++ b/src/rust/.cargo/config.toml
@@ -1,0 +1,17 @@
+[build]
+# These compiler lints are warnings by default, but our codebase
+# currently has a number of violations of each. This causes rather
+# noisy build output, so until we can clean them up, we'll globally
+# allow them here. This ensures consistent behavior across all builds
+# (build, test, check, clippy, etc.), in all environments
+# (workstation, editor integration, CI, etc.).
+#
+# Once they've all been cleaned up, we can replace them all with
+# `--deny=warnings`.
+rustflags = [
+    "--allow=dead_code",
+    "--allow=non_snake_case",
+    "--allow=unused_imports",
+    "--allow=unused_mut",
+    "--allow=unused_variables"
+]


### PR DESCRIPTION
To silence our noisy build output for the time being, we will allow
certain classes of compiler lints that are warnings by default.

Eventually, we'll actually _fix_ these violations and allow the lints
to become warnings again. This allows us to have a nicer local build
experience today, while allowing us a structure for fixing the
violations in a principled way, at our own pace.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>