### PR TITLE
[CI] Ensure Docker builds obey .cargo/config.toml settings

### DIFF
--- a/src/rust/.dockerignore
+++ b/src/rust/.dockerignore
@@ -1,3 +1,2 @@
 target
 */target
-.cargo

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -100,7 +100,8 @@ COPY --chown=grapl Cargo.lock .
 COPY --chown=grapl Cargo.toml .
 # vendor all the deps
 RUN mkdir -p /home/grapl/.cargo
-RUN cargo vendor --versioned-dirs --locked > /home/grapl/.cargo/config
+COPY --chown=grapl .cargo/config.toml .cargo/config.toml
+RUN cargo vendor --versioned-dirs --locked >> /home/grapl/.cargo/config.toml
 # debug build of all the deps
 RUN cargo build --target=x86_64-unknown-linux-musl
 


### PR DESCRIPTION
Previously, `.cargo` was specifically excluded from Docker
builds. This seems to be related to how we use `cargo vendor` builds.

In particular, the output of `cargo vendor` was saved to
`.cargo/config`. This file was the name of the configuration file
prior to Rust 1.39, but the current preferred name is `cargo.toml`. If
both files are present, `config` is used and `config.toml` is ignored.

Because of this, the configuration added in #544 was not being honored
in any of the container-based build systems.

Here, we stop ignoring `.cargo` in builds, allowing us to copy
`.cargo/config.toml` into the container. Then, we append the output of
`cargo vendor` to this file.

For reference, this is what that appended output looks like:

    [source.crates-io]
    replace-with = "vendored-sources"

    [source.vendored-sources]
    directory = "vendor"

The end result is the same vendoring behavior as before, but with
compilation flags honored.

<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
