### PR TITLE
[Chore] Deny some lint violations

### DIFF
--- a/src/rust/.cargo/config.toml
+++ b/src/rust/.cargo/config.toml
@@ -12,6 +12,6 @@ rustflags = [
     "--deny=dead_code",
     "--deny=non_snake_case",
     "--allow=unused_imports",
-    "--allow=unused_mut",
+    "--deny=unused_mut",
     "--allow=unused_variables"
 ]

--- a/src/rust/.cargo/config.toml
+++ b/src/rust/.cargo/config.toml
@@ -11,7 +11,7 @@
 rustflags = [
     "--deny=dead_code",
     "--deny=non_snake_case",
-    "--allow=unused_imports",
+    "--deny=unused_imports",
     "--deny=unused_mut",
     "--deny=unused_variables"
 ]

--- a/src/rust/.cargo/config.toml
+++ b/src/rust/.cargo/config.toml
@@ -1,17 +1,4 @@
 [build]
-# These compiler lints are warnings by default, but our codebase
-# currently has a number of violations of each. This causes rather
-# noisy build output, so until we can clean them up, we'll globally
-# allow them here. This ensures consistent behavior across all builds
-# (build, test, check, clippy, etc.), in all environments
-# (workstation, editor integration, CI, etc.).
-#
-# Once they've all been cleaned up, we can replace them all with
-# `--deny=warnings`.
 rustflags = [
-    "--deny=dead_code",
-    "--deny=non_snake_case",
-    "--deny=unused_imports",
-    "--deny=unused_mut",
-    "--deny=unused_variables"
+    "--deny=warnings",
 ]

--- a/src/rust/.cargo/config.toml
+++ b/src/rust/.cargo/config.toml
@@ -13,5 +13,5 @@ rustflags = [
     "--deny=non_snake_case",
     "--allow=unused_imports",
     "--deny=unused_mut",
-    "--allow=unused_variables"
+    "--deny=unused_variables"
 ]

--- a/src/rust/.cargo/config.toml
+++ b/src/rust/.cargo/config.toml
@@ -10,7 +10,7 @@
 # `--deny=warnings`.
 rustflags = [
     "--deny=dead_code",
-    "--allow=non_snake_case",
+    "--deny=non_snake_case",
     "--allow=unused_imports",
     "--allow=unused_mut",
     "--allow=unused_variables"

--- a/src/rust/generators/generic-subgraph-generator/src/tests.rs
+++ b/src/rust/generators/generic-subgraph-generator/src/tests.rs
@@ -43,7 +43,8 @@ async fn test_log_event_deserialization() {
         .decode(raw_test_data)
         .expect("Failed to deserialize events.");
 
-    let (subgraph, identities, failed) = generator.convert_events_to_subgraph(generic_events).await;
+    let (_subgraph, _identities, failed) =
+        generator.convert_events_to_subgraph(generic_events).await;
 
     if let Some(report) = failed {
         panic!(

--- a/src/rust/generators/osquery-subgraph-generator/src/tests/process.rs
+++ b/src/rust/generators/osquery-subgraph-generator/src/tests/process.rs
@@ -1,8 +1,6 @@
 use crate::generator::OSQuerySubgraphGenerator;
 use crate::metrics::OSQuerySubgraphGeneratorMetrics;
-use crate::serialization::OSQueryLogDecoder;
 use crate::tests::utils;
-use regex::internal::Input;
 use sqs_lambda::cache::NopCache;
 use sqs_lambda::event_handler::Completion;
 use sqs_lambda::event_handler::EventHandler;

--- a/src/rust/generators/osquery-subgraph-generator/src/tests/utils.rs
+++ b/src/rust/generators/osquery-subgraph-generator/src/tests/utils.rs
@@ -6,7 +6,7 @@ use tokio::fs;
 pub(crate) async fn read_osquery_test_data(
     path: &str,
 ) -> Result<Vec<PartiallyDeserializedOSQueryLog>, Box<dyn std::error::Error>> {
-    let mut file_data = fs::read(format!("test_data/{}", path))
+    let file_data = fs::read(format!("test_data/{}", path))
         .await
         .expect(&format!("Failed to read test data ({}).", path));
     let mut deserializer = OSQueryLogDecoder::default();

--- a/src/rust/node-identifier/tests/assetdb_integration_tests.rs
+++ b/src/rust/node-identifier/tests/assetdb_integration_tests.rs
@@ -3,7 +3,6 @@
 use grapl_graph_descriptions::graph_description::host::*;
 use node_identifier::assetdb::AssetIdDb;
 use node_identifier::init_dynamodb_client;
-use rusoto_core::Region;
 use tokio::runtime::Runtime;
 
 // Given a hostname 'H' to asset id 'A' mapping at c_timestamp 'X'
@@ -12,10 +11,6 @@ use tokio::runtime::Runtime;
 #[test]
 fn map_hostname_to_asset_id() {
     let mut runtime = Runtime::new().unwrap();
-    let region = Region::Custom {
-        endpoint: "http://localhost:8000".to_owned(),
-        name: "us-east-9".to_owned(),
-    };
 
     let asset_id_db = AssetIdDb::new(init_dynamodb_client());
 

--- a/src/rust/node-identifier/tests/assetdb_integration_tests.rs
+++ b/src/rust/node-identifier/tests/assetdb_integration_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 use grapl_graph_descriptions::graph_description::host::*;
 use node_identifier::assetdb::AssetIdDb;
 use node_identifier::init_dynamodb_client;
@@ -8,7 +10,6 @@ use tokio::runtime::Runtime;
 // When attributing 'H' at c_timestamp 'Y', where 'Y' > 'X'
 // Then we should retrieve asset id 'A'
 #[test]
-#[cfg(feature = "integration")]
 fn map_hostname_to_asset_id() {
     let mut runtime = Runtime::new().unwrap();
     let region = Region::Custom {

--- a/src/rust/node-identifier/tests/sessiondb_integration_tests.rs
+++ b/src/rust/node-identifier/tests/sessiondb_integration_tests.rs
@@ -183,21 +183,6 @@ fn noncanon_create_update_existing_non_canon_create(asset_id: String, pid: u64) 
     assert_eq!(session_id, "SessionId");
 }
 
-// Given a timeline with two existing sessions, session A and session B
-// where A.create_time = X and B.create_time = Y
-// When a canonical creation event comes in with a creation time of 'Z'
-//      where 'X' < 'Z' < 'Y'
-// Then the new session should be created
-#[test]
-fn canon_create_on_timeline_with_surrounding_canon_sessions() {
-    let table_name = "process_history_canon_create_on_timeline_with_surrounding_canon_sessions";
-    let dynamo = init_dynamodb_client();
-
-    create_or_empty_table(&dynamo, table_name);
-
-    let session_db = SessionDb::new(dynamo, table_name);
-}
-
 // Given an empty timeline
 // When a noncanon create event comes in and 'should_default' is true
 // Then Create the new noncanon session
@@ -245,20 +230,6 @@ fn noncanon_create_on_empty_timeline_without_default() {
 
     let session_id = runtime.block_on(session_db.handle_unid_session(unid, false));
     assert!(session_id.is_err());
-}
-
-// Given a timeline with one session, where the session has a create_time
-//      of X
-// When a canon create event comes in with a create time within ~100ms of X
-// Then we should make the session create time canonical
-#[test]
-fn canon_create_on_timeline_with_existing_session_within_skew() {
-    let table_name = "process_history_canon_create_on_timeline_with_existing_session_within_skew";
-    let dynamo = init_dynamodb_client();
-
-    create_or_empty_table(&dynamo, table_name);
-
-    let session_db = SessionDb::new(dynamo, table_name);
 }
 
 #[quickcheck]


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

It makes Rust builds more strict by denying violations of the following compiler lints in our code:
- [non_snake_case](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#non-snake-case)
- [unused_mut](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#unused-mut)
- [unused_variables](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#unused-variables)
- [unused_imports](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#unused-imports)

In addition to denying these violations, any existing violations were addressed. Please see individual commits for further details.

### How were these changes tested?

Run `cargo build --all-targets` and observe a clean build.
