### PR TITLE
[Chore] Add foundation for Clippy usage on Rust code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 src/rust/.cargo @christophermaier
+src/rust/bin @christophermaier

--- a/.github/workflows/grapl-lint.yml
+++ b/.github/workflows/grapl-lint.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 jobs:
-  rust-lint:
+  rust-format:
     runs-on: ubuntu-latest
 
     steps:
@@ -18,6 +18,16 @@ jobs:
         run: |
           cd src/rust
           cargo fmt -- --check
+
+  rust-lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/rust
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Clippy
+        run: bin/run-clippy.sh
 
   python-lint:
     runs-on: ubuntu-latest

--- a/src/rust/bin/run-clippy.sh
+++ b/src/rust/bin/run-clippy.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Until such time as we can specify clippy lints in a real file (like rustfmt),
+# we'll use this script to encapsulate how we want to run it. (Clippy does have
+# a configuration file, but it seems to currently be only for specifying
+# parameters for specific lints, and not for specifying what level the lints
+# should be checked at (warn, allow, etc.)).
+#
+# This script is intended to be run both locally and in CI; it is the source of
+# truth for how to run clippy for this project.
+#######################################################################
+
+# Default to human-readable format (i.e., what you get from running clippy
+# normally).
+#
+# If you wish to override this to get another format (e.g., you need
+# machine-readable JSON output for integration with your editor), pass that
+# format name as an argument to the script.
+#
+# Acceptable values correspond to the `--message-format` option (run `cargo help
+# check` for details). "json" is a common choice.
+format="${1:-human}"
+
+# For detailed information on what each lint does, see
+# https://rust-lang.github.io/rust-clippy/master/index.html
+
+# NOTE: the current batch of lints is what our codebase currently
+# *violates*. In time, we should clean these violations up and move to
+# deny most, if not all, of these lints.
+cargo clippy \
+      --all-targets \
+      --message-format="${format}" \
+      -- \
+      --allow clippy::char_lit_as_u8 \
+      --allow clippy::clone_double_ref \
+      --allow clippy::clone_on_copy \
+      --allow clippy::cmp_owned \
+      --allow clippy::collapsible_if \
+      --allow clippy::eq_op \
+      --allow clippy::expect_fun_call \
+      --allow clippy::filter_next \
+      --allow clippy::float_cmp \
+      --allow clippy::into_iter_on_ref \
+      --allow clippy::large_enum_variant \
+      --allow clippy::len_zero \
+      --allow clippy::let_and_return \
+      --allow clippy::manual_range_contains \
+      --allow clippy::needless_return \
+      --allow clippy::new_ret_no_self \
+      --allow clippy::op_ref \
+      --allow clippy::option_as_ref_deref \
+      --allow clippy::or_fun_call \
+      --allow clippy::redundant_clone \
+      --allow clippy::redundant_closure \
+      --allow clippy::redundant_field_names \
+      --allow clippy::redundant_pattern_matching \
+      --allow clippy::redundant_static_lifetimes \
+      --allow clippy::single_char_pattern \
+      --allow clippy::single_component_path_imports \
+      --allow clippy::single_match \
+      --allow clippy::too_many_arguments \
+      --allow clippy::unnecessary_lazy_evaluations \
+      --allow clippy::unused_unit \
+      --allow clippy::useless_conversion \
+      --allow clippy::write_with_newline \
+      --allow clippy::wrong_self_convention

--- a/src/rust/rust-toolchain
+++ b/src/rust/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.49.0"
-components = [ "rustfmt" ]
+components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/215

### What changes does this PR make to Grapl? Why?

This introduces the use of [Clippy](https://github.com/rust-lang/rust-clippy) for linting Rust code.

Since detailed configuration of the levels of each Clippy lint isn't currently possible, we have to manage it all at the command line. To ensure that we lint consistently everywhere, all that logic is consolidated into a single script (`run-clippy.sh`).

Basic usage is simply calling the script:

    cd src/rust
    bin/run-clippy.sh

However, this script can be integrated into editors to provide linting-on-save functionality. Editor integrations usually operate on
machine-readable output of tools, though, and so this script can be called with a formatting argument for those usecases, e.g.,

   bin/run-clippy.sh json

For example, integrating into Visual Studio Code (assuming usage of the [Rust Analyzer plugin][1]) would look something like this:

    "settings": {
        // ...
        "rust-analyzer.linkedProjects": [
            "src/rust/Cargo.toml"
        ],
        "rust-analyzer.checkOnSave.enable": true,
        "rust-analyzer.checkOnSave.overrideCommand": [
            "/path/to/your/grapl/checkout/src/rust/bin/run-clippy.sh",
            "json"
        ],
        // ...
    }

Additionally, we use this same script in a new CI job.

The currently-allowed lints are the ones that our codebase currently violates. Eventually we would deny most, if not all, of these, along with several others. By allowing them now, however, we start with a "clean slate", providing a consistent foundation for invoking Clippy anywhere, and ensuring that our code always passes Clippy going forward. In other words, it lays the groundwork for grapl-security/issue-tracker#215.

[1]: https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer

### How were these changes tested?

Run the following, and observe no violations:

    cd src/rust
    bin/run-clippy.sh


