### PR TITLE
Add more debuggability to accumulate_metrics tests

### DIFF
--- a/src/rust/metric-forwarder/src/accumulate_metrics.rs
+++ b/src/rust/metric-forwarder/src/accumulate_metrics.rs
@@ -182,9 +182,9 @@ mod tests {
                 assert_eq!(to_count_map(only_one_datum), expected);
                 Ok(())
             }
-            otherwise => Err(format!(
+            invalid => Err(format!(
                 "Expected exactly 1 metric, but got {:?}",
-                otherwise
+                invalid
             )),
         }
     }
@@ -210,9 +210,9 @@ mod tests {
                 assert_eq!(datum_1.metric_name, METRIC_NAME_2);
                 Ok(())
             }
-            otherwise => Err(format!(
+            invalid => Err(format!(
                 "Expected exactly 2 metrics, but got {:?}",
-                otherwise
+                invalid
             )),
         }
     }
@@ -250,9 +250,9 @@ mod tests {
                 assert_eq!(datum_1.timestamp, TS_3.to_string().into());
                 Ok(())
             }
-            otherwise => Err(format!(
+            invalid => Err(format!(
                 "Expected exactly 2 metrics, but got {:?}",
-                otherwise
+                invalid
             )),
         }
     }
@@ -284,9 +284,9 @@ mod tests {
                 assert_eq!(to_count_map(datum_millis), expected_for_millis);
                 Ok(())
             }
-            otherwise => Err(format!(
+            invalid => Err(format!(
                 "Expected exactly 2 metrics, but got {:?}",
-                otherwise
+                invalid
             )),
         }
     }
@@ -334,9 +334,9 @@ mod tests {
                 );
                 Ok(())
             }
-            otherwise => Err(format!(
+            invalid => Err(format!(
                 "Expected exactly 2 metrics, but got {:?}",
-                otherwise
+                invalid
             )),
         }
     }

--- a/src/rust/metric-forwarder/src/accumulate_metrics.rs
+++ b/src/rust/metric-forwarder/src/accumulate_metrics.rs
@@ -182,7 +182,7 @@ mod tests {
                 assert_eq!(to_count_map(only_one_datum), expected);
                 Ok(())
             }
-            invalid => Err(format!("Expected exactly 1 metric, but got {:?}", invalid)),
+            invalid => panic!("Expected exactly 1 metric, but got {:?}", invalid),
         }
     }
 
@@ -207,7 +207,7 @@ mod tests {
                 assert_eq!(datum_1.metric_name, METRIC_NAME_2);
                 Ok(())
             }
-            invalid => Err(format!("Expected exactly 2 metrics, but got {:?}", invalid)),
+            invalid => panic!("Expected exactly 2 metrics, but got {:?}", invalid),
         }
     }
 
@@ -244,7 +244,7 @@ mod tests {
                 assert_eq!(datum_1.timestamp, TS_3.to_string().into());
                 Ok(())
             }
-            invalid => Err(format!("Expected exactly 2 metrics, but got {:?}", invalid)),
+            invalid => panic!("Expected exactly 2 metrics, but got {:?}", invalid),
         }
     }
 
@@ -275,7 +275,7 @@ mod tests {
                 assert_eq!(to_count_map(datum_millis), expected_for_millis);
                 Ok(())
             }
-            invalid => Err(format!("Expected exactly 2 metrics, but got {:?}", invalid)),
+            invalid => panic!("Expected exactly 2 metrics, but got {:?}", invalid),
         }
     }
 
@@ -322,7 +322,7 @@ mod tests {
                 );
                 Ok(())
             }
-            invalid => Err(format!("Expected exactly 2 metrics, but got {:?}", invalid)),
+            invalid => panic!("Expected exactly 2 metrics, but got {:?}", invalid),
         }
     }
 }

--- a/src/rust/metric-forwarder/src/accumulate_metrics.rs
+++ b/src/rust/metric-forwarder/src/accumulate_metrics.rs
@@ -182,7 +182,10 @@ mod tests {
                 assert_eq!(to_count_map(only_one_datum), expected);
                 Ok(())
             }
-            _ => Err(">1 metric".to_string()),
+            otherwise => Err(format!(
+                "Expected exactly 1 metric, but got {:?}",
+                otherwise
+            )),
         }
     }
 
@@ -207,7 +210,10 @@ mod tests {
                 assert_eq!(datum_1.metric_name, METRIC_NAME_2);
                 Ok(())
             }
-            _ => Err("must be exactly 2 metrics".to_string()),
+            otherwise => Err(format!(
+                "Expected exactly 2 metrics, but got {:?}",
+                otherwise
+            )),
         }
     }
 
@@ -244,7 +250,10 @@ mod tests {
                 assert_eq!(datum_1.timestamp, TS_3.to_string().into());
                 Ok(())
             }
-            _ => Err("must be exactly 2 metrics".to_string()),
+            otherwise => Err(format!(
+                "Expected exactly 2 metrics, but got {:?}",
+                otherwise
+            )),
         }
     }
 
@@ -275,7 +284,10 @@ mod tests {
                 assert_eq!(to_count_map(datum_millis), expected_for_millis);
                 Ok(())
             }
-            _ => Err("must be exactly 2 metrics".to_string()),
+            otherwise => Err(format!(
+                "Expected exactly 2 metrics, but got {:?}",
+                otherwise
+            )),
         }
     }
 
@@ -301,7 +313,11 @@ mod tests {
             let value: f64 = datum.counts.as_ref().unwrap()[0];
             OrderedFloat(value)
         });
+
         match &output[..] {
+            // So we're expecting this to be [
+            //   Metrics with diff dimensions(count=2),
+            //   Metrics with default dimensions(count=3) ]
             [datum_diff_dimensions, datum_default_dimensions] => {
                 let expected_diff_dims = hmap! {
                     OrderedFloat(1.0f64) => 2f64
@@ -318,7 +334,10 @@ mod tests {
                 );
                 Ok(())
             }
-            _ => Err("must be exactly 2 metrics".to_string()),
+            otherwise => Err(format!(
+                "Expected exactly 2 metrics, but got {:?}",
+                otherwise
+            )),
         }
     }
 }

--- a/src/rust/metric-forwarder/src/accumulate_metrics.rs
+++ b/src/rust/metric-forwarder/src/accumulate_metrics.rs
@@ -182,10 +182,7 @@ mod tests {
                 assert_eq!(to_count_map(only_one_datum), expected);
                 Ok(())
             }
-            invalid => Err(format!(
-                "Expected exactly 1 metric, but got {:?}",
-                invalid
-            )),
+            invalid => Err(format!("Expected exactly 1 metric, but got {:?}", invalid)),
         }
     }
 
@@ -210,10 +207,7 @@ mod tests {
                 assert_eq!(datum_1.metric_name, METRIC_NAME_2);
                 Ok(())
             }
-            invalid => Err(format!(
-                "Expected exactly 2 metrics, but got {:?}",
-                invalid
-            )),
+            invalid => Err(format!("Expected exactly 2 metrics, but got {:?}", invalid)),
         }
     }
 
@@ -250,10 +244,7 @@ mod tests {
                 assert_eq!(datum_1.timestamp, TS_3.to_string().into());
                 Ok(())
             }
-            invalid => Err(format!(
-                "Expected exactly 2 metrics, but got {:?}",
-                invalid
-            )),
+            invalid => Err(format!("Expected exactly 2 metrics, but got {:?}", invalid)),
         }
     }
 
@@ -284,10 +275,7 @@ mod tests {
                 assert_eq!(to_count_map(datum_millis), expected_for_millis);
                 Ok(())
             }
-            invalid => Err(format!(
-                "Expected exactly 2 metrics, but got {:?}",
-                invalid
-            )),
+            invalid => Err(format!("Expected exactly 2 metrics, but got {:?}", invalid)),
         }
     }
 
@@ -334,10 +322,7 @@ mod tests {
                 );
                 Ok(())
             }
-            invalid => Err(format!(
-                "Expected exactly 2 metrics, but got {:?}",
-                invalid
-            )),
+            invalid => Err(format!("Expected exactly 2 metrics, but got {:?}", invalid)),
         }
     }
 }


### PR DESCRIPTION
A transient failure in https://grapl-internal.slack.com/archives/C0176MS6LBY/p1611158138042600 is odd and hard to repro/debug.

These fancier Err statements will help us debug why it fails in the future.