### PR TITLE
Remove unused dependencies from generic-subgraph-generator crate

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -127,17 +127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,12 +173,6 @@ name = "base-x"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
-name = "base16"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d608a38535c371b2a9149159f6dd2259af379f71e50c24d54a842de44bc5b19"
 
 [[package]]
 name = "base64"
@@ -342,17 +325,6 @@ dependencies = [
  "owo-colors",
  "tracing-core",
  "tracing-error",
-]
-
-[[package]]
-name = "colored"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -946,7 +918,6 @@ version = "1.0.0"
 dependencies = [
  "async-trait",
  "aws_lambda_events",
- "base16",
  "chrono",
  "eyre",
  "failure",
@@ -959,7 +930,6 @@ dependencies = [
  "lazy_static",
  "log",
  "prost 0.7.0",
- "rayon",
  "regex",
  "rusoto_core",
  "rusoto_s3",
@@ -967,7 +937,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "simple_logger",
  "sqs-lambda",
  "stopwatch",
  "tokio 0.2.24",
@@ -2917,19 +2886,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "simple_logger"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd57f17c093ead1d4a1499dc9acaafdd71240908d64775465543b8d9a9f1d198"
-dependencies = [
- "atty",
- "chrono",
- "colored",
- "log",
- "winapi 0.3.9",
 ]
 
 [[package]]

--- a/src/rust/generators/generic-subgraph-generator/Cargo.toml
+++ b/src/rust/generators/generic-subgraph-generator/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1"
 aws_lambda_events = "0.4"
-base16 = "0.1"
 chrono = "0.4"
 eyre = "0.6"
 failure = "0.1"
@@ -20,7 +19,6 @@ lambda_runtime = "0.2"
 lazy_static = "1.2.0"
 log = "0"
 prost = "0.7"
-rayon = "1"
 regex = "1"
 rusoto_core = { version="0.45.0", default_features = false, features=["rustls"] }
 rusoto_s3 = { version="0.45.0", default_features = false, features=["rustls"] }
@@ -28,7 +26,6 @@ rusoto_sqs = { version="0.45.0", default_features = false, features=["rustls"] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-simple_logger = "1"
 sqs-lambda = { path = "../../sqs-lambda/" }
 stopwatch = "0"
 tokio-compat = "0.1"

--- a/src/rust/generators/generic-subgraph-generator/Cargo.toml
+++ b/src/rust/generators/generic-subgraph-generator/Cargo.toml
@@ -5,45 +5,38 @@ authors = ["Insanitybit <insanitybit@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-graph-generator-lib = {path = "../graph-generator-lib/", version="*"}
-grapl-graph-descriptions = { path="../../graph-descriptions", version="*"}
-grapl-config = {path="../../grapl-config", version="*"}
-
-sqs-lambda = { path = "../../sqs-lambda/" }
-grapl-observe = { path = "../../grapl-observe/" }
-serde = "1"
-serde_json = "1"
-serde_derive = "1"
-failure = "0.1"
-prost = "0.7"
-log = "0"
-base16 = "0.1"
-regex = "1"
-lazy_static = "1.2.0"
-
-chrono = "0.4"
-rayon = "1"
-stopwatch = "0"
-
-rusoto_s3 = { version="0.45.0", default_features = false, features=["rustls"] }
-rusoto_core = { version="0.45.0", default_features = false, features=["rustls"] }
-rusoto_sqs = { version="0.45.0", default_features = false, features=["rustls"] }
-
-futures = "0.3"
-aws_lambda_events = "0.4"
-simple_logger = "1"
-lambda_runtime = "0.2"
 async-trait = "0.1"
-zstd = "0.6"
-tokio = { version = "0.2", features = ["sync", "rt-core", "macros", "time", "rt-threaded"] }
-
+aws_lambda_events = "0.4"
+base16 = "0.1"
+chrono = "0.4"
+eyre = "0.6"
+failure = "0.1"
+futures = "0.3"
+graph-generator-lib = {path = "../graph-generator-lib/", version="*"}
+grapl-config = {path="../../grapl-config", version="*"}
+grapl-graph-descriptions = { path="../../graph-descriptions", version="*"}
+grapl-observe = { path = "../../grapl-observe/" }
+lambda_runtime = "0.2"
+lazy_static = "1.2.0"
+log = "0"
+prost = "0.7"
+rayon = "1"
+regex = "1"
+rusoto_core = { version="0.45.0", default_features = false, features=["rustls"] }
+rusoto_s3 = { version="0.45.0", default_features = false, features=["rustls"] }
+rusoto_sqs = { version="0.45.0", default_features = false, features=["rustls"] }
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
+simple_logger = "1"
+sqs-lambda = { path = "../../sqs-lambda/" }
+stopwatch = "0"
 tokio-compat = "0.1"
+tokio = { version = "0.2", features = ["sync", "rt-core", "macros", "time", "rt-threaded"] }
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2"
-eyre = "0.6"
-#openssl-probe = "0.1.2"
-
+zstd = "0.6"
 
 [dependencies.uuid]
 version = "*"

--- a/src/rust/generators/generic-subgraph-generator/Cargo.toml
+++ b/src/rust/generators/generic-subgraph-generator/Cargo.toml
@@ -36,8 +36,5 @@ tokio = { version = "0.2", features = ["sync", "rt-core", "macros", "time", "rt-
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2"
+uuid = { version = "*", features = ["v4"]}
 zstd = "0.6"
-
-[dependencies.uuid]
-version = "*"
-features = ["v4"]


### PR DESCRIPTION
They're not being used, so there's no reason to keep them around.

Also organized the `Cargo.toml` file while I was at it. Looking at only the final diff of `Cargo.toml` is a bit confusing, so I recommend looking at the sequence of individual changes to get a better feel for how the changes progressed.