### PR TITLE
Remove unnecessary grapl_common dependence in analyzerlib

### DIFF
--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -149,6 +149,11 @@ FROM grapl-python-build AS analyzer-executor-build
 COPY --chown=grapl python/analyzer_executor analyzer_executor
 COPY --chown=grapl --from=grapl-analyzerlib-build /home/grapl/venv venv
 
+# HACK: We actually depend on grapl-common, but code structure makes
+# it difficult to express this.
+COPY --chown=grapl python/grapl-common grapl-common
+RUN /bin/bash -c "source venv/bin/activate && cd grapl-common && pip install ."
+
 RUN source venv/bin/activate && \
     cd analyzer_executor && \
     pip install .
@@ -190,6 +195,11 @@ FROM grapl-python-build AS engagement-creator-build
 
 COPY --chown=grapl python/engagement-creator engagement-creator
 COPY --chown=grapl --from=grapl-analyzerlib-build /home/grapl/venv venv
+
+# HACK: We actually depend on grapl-common, but code structure makes
+# it difficult to express this.
+COPY --chown=grapl python/grapl-common grapl-common
+RUN /bin/bash -c "source venv/bin/activate && cd grapl-common && pip install ."
 
 RUN source venv/bin/activate && \
     cd engagement-creator && \
@@ -449,6 +459,11 @@ COPY --chown=grapl --from=grapl-analyzerlib-build /home/grapl/venv venv
 COPY --from=python-test-deps /home/grapl/python_test_deps python_test_deps
 
 RUN python_test_deps/install_requirements.sh
+
+# HACK: We actually depend on grapl-common, but code structure makes
+# it difficult to express this.
+COPY --chown=python/grapl grapl-common grapl-common
+RUN /bin/bash -c "source venv/bin/activate && cd grapl-common && pip install ."
 
 COPY --chown=grapl python/grapl-tests-common grapl-tests-common
 RUN source venv/bin/activate && \

--- a/src/python/grapl_analyzerlib/setup.py
+++ b/src/python/grapl_analyzerlib/setup.py
@@ -47,7 +47,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "boto3",
-        "grapl_common",
         "grapl_graph_descriptions==1.0.*",
         "pydgraph",
         "typing_extensions",


### PR DESCRIPTION
None of the code in `grapl_analyzerlib` actually calls anything in
`grapl_common`, so we can remove the bespoke build bits that claim
otherwise.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>