### PR TITLE
Notebook fix

### DIFF
--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -412,7 +412,7 @@ RUN source venv/bin/activate && \
 
 # Set up jupyter-notebook stuff
 RUN mkdir -p grapl-notebook/model_plugins
-COPY --chown=grapl python/grapl-notebook/jupyter_notebook_config.py /.jupyter/
+COPY --chown=grapl python/grapl-notebook/jupyter_notebook_config.py /home/grapl/.jupyter/
 COPY --chown=grapl python/grapl-notebook/Demo_Engagement.ipynb grapl-notebook/
 
 ## Run it


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This restores the Jupyter notebook config for local Grapl, which broke when switching to the new Dockerfile from https://github.com/grapl-security/grapl/pull/524.

### How were these changes tested?

I ran local Grapl and successfully logged in to the UI.