### PR TITLE
Dump logs for integration tests so we can see why grapl-provision seemingly fails

### DIFF
--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Run integration tests
         run: |
           echo "unset RUSTC_WRAPPER" > rust_env.sh
-          GRAPL_RUST_ENV_FILE=rust_env.sh make test-integration
+          GRAPL_RUST_ENV_FILE=rust_env.sh GRAPL_LOG_LEVEL=DEBUG make test-integration
       
       # NOTE: This requires >= py37
       # Unlike the e2e tests, we don't dump the database contents; strictly logs.

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -83,6 +83,10 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: [3.7]
+
     steps:
       - uses: actions/checkout@v2
 
@@ -95,6 +99,22 @@ jobs:
         run: |
           echo "unset RUSTC_WRAPPER" > rust_env.sh
           GRAPL_RUST_ENV_FILE=rust_env.sh make test-integration
+      
+      # NOTE: This requires >= py37
+      # Unlike the e2e tests, we don't dump the database contents; strictly logs.
+      - name: 'Collect integration test artifacts'
+        if: ${{ always() }}
+        run: |
+          python3 ./etc/ci_scripts/dump_artifacts.py --compose-project "grapl-integration_tests"
+           
+      - name: 'Upload integration test artifacts'
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: integration-test-artifacts
+          # this path is specified in dump_artifacts.py
+          path: /tmp/dumped_artifacts/
+          retention-days: 28
 
 
   # In the future, this should probably be merged back into the integration tests, but

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -94,6 +94,11 @@ jobs:
         run: |
           ./etc/ci_scripts/clean_gh_actions_space.sh
           ./etc/ci_scripts/install_requirements.sh
+      
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Run integration tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,9 @@ test-integration: build-test-integration ## Build and run integration tests
 		-f ./test/docker-compose.integration-tests.yml \
 		-p "grapl-integration_tests"; \
 	EXIT_CODE=$$?; \
-	$(MAKE) down; \
+	# Stop the containers, but don't remove them, \
+	# so that `dump-compose-artifacts` can inspect the containers \
+	$(MAKE) stop; \
 	exit $$EXIT_CODE
 
 .PHONY: test-e2e
@@ -135,9 +137,9 @@ test-e2e: build-test-e2e ## Build and run e2e tests
 	test/docker-compose-with-error.sh \
 		-f ./test/docker-compose.e2e-tests.yml \
 		-p "grapl-e2e_tests"; \
-	EXIT_CODE=$$?;
-	# Stop the containers, but don't remove them, 
-	# so that `dump-compose-artifacts` can inspect the containers
+	EXIT_CODE=$$?; \
+	# Stop the containers, but don't remove them, \
+	# so that `dump-compose-artifacts` can inspect the containers \
 	$(MAKE) stop; \
 	exit $$EXIT_CODE
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -515,13 +515,14 @@ services:
       target: grapl-provision
     command: |
       /bin/bash -c "
+        export TIMEOUT=35 &&
         # it doesn't seem to like waiting for sqs
         # wait-for-it sqs:9324 &&
-        wait-for-it secretsmanager:4584 &&
-        wait-for-it s3:9000 &&
-        wait-for-it dynamodb:8000 &&
-        wait-for-it grapl-master-graph-db:8080 &&
-        wait-for-it grapl-engagement-view:1234 &&
+        wait-for-it s3:9000 --timeout=$$TIMEOUT &&
+        wait-for-it dynamodb:8000 --timeout=$$TIMEOUT &&
+        wait-for-it grapl-master-graph-db:8080 --timeout=$$TIMEOUT &&
+        wait-for-it grapl-engagement-view:1234 --timeout=$$TIMEOUT &&
+        wait-for-it secretsmanager:4584 --timeout=$$TIMEOUT &&
         . venv/bin/activate && 
         python /home/grapl/grapl_local_provision/provision_local_identity_table.py &&
         python /home/grapl/grapl_local_provision/grapl_provision.py &&
@@ -529,7 +530,7 @@ services:
         python -m http.server 8126
       "
     environment:
-      - GRAPL_LOG_LEVEL=${GRAPL_LOG_LEVEL:-ERROR}
+      - GRAPL_LOG_LEVEL=${GRAPL_LOG_LEVEL:-INFO}
       - MG_ALPHAS=master_graph:9080
     tty: true
     ports:

--- a/src/python/grapl_provision/grapl_provision.py
+++ b/src/python/grapl_provision/grapl_provision.py
@@ -35,11 +35,9 @@ from grapl_analyzerlib.prelude import (
 )
 from grapl_analyzerlib.schema import Schema
 
-GRAPL_LOG_LEVEL = os.getenv("GRAPL_LOG_LEVEL")
-LEVEL = "ERROR" if GRAPL_LOG_LEVEL is None else GRAPL_LOG_LEVEL
+GRAPL_LOG_LEVEL = os.getenv("GRAPL_LOG_LEVEL", "INFO")
 LOGGER = logging.getLogger(__name__)
-LOGGER.setLevel(LEVEL)
-LOGGER.addHandler(logging.StreamHandler(stream=sys.stdout))
+LOGGER.setLevel(GRAPL_LOG_LEVEL)
 
 
 def create_secret(secretsmanager):

--- a/src/python/grapl_provision/provision_local_identity_table.py
+++ b/src/python/grapl_provision/provision_local_identity_table.py
@@ -1,8 +1,14 @@
 #!/usr/bin/python3
+import logging
+import os
 import time
 
 import boto3
 import botocore
+
+GRAPL_LOG_LEVEL = os.getenv("GRAPL_LOG_LEVEL", "INFO")
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(GRAPL_LOG_LEVEL)
 
 table_names = [
     "local-grapl-process_history_table",
@@ -147,10 +153,10 @@ def try_create_loop(table_name):
             if "ResourceInUseException" in e.__class__.__name__:
                 break
             else:
-                print(table_name, e)
+                LOGGER.debug(table_name, e)
                 time.sleep(2)
         except Exception as e:
-            print(table_name, e)
+            LOGGER.error(table_name, e)
             time.sleep(2)
 
 
@@ -158,7 +164,7 @@ for table_name in table_names:
     try:
         try_create_loop(table_name)
     except Exception as e:
-        print(table_name, e)
+        LOGGER.error(table_name, e)
         raise e
 
-print("Provisioned DynamoDB")
+LOGGER.info("Provisioned DynamoDB")


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/230

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
-  Change it to a `docker-compose stop` not `down` for integ tests
- Add the dump command to the github workflow 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
CI on this build 

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
