### PR TITLE
Rename the Rust Docker param PROFILE to CARGO_PROFILE

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -84,7 +84,7 @@ version and/or branch information for tracking purposes (ex:
 `v1.2.3-my_feature`). This value corresponds to the `graplVersion` parameter in
 the CDK project for deploying to AWS, and is used to name the zip files in the
 Make `zip` target.
-- `PROFILE` (default: `debug`) - Can either be `debug` or `release`. These
+- `CARGO_PROFILE` (default: `debug`) - Can either be `debug` or `release`. These
   roughly translate to the [Cargo
 profiles](https://doc.rust-lang.org/cargo/reference/profiles.html) to be used
 for Rust builds.
@@ -188,7 +188,7 @@ image.
       context: src/rust
       target: sysmon-subgraph-generator-deploy
       args:
-        - PROFILE=${PROFILE:-debug}
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
 ...
 ```
 
@@ -217,7 +217,7 @@ services:
       context: ${PWD}/src/rust
       target: build-test-unit
       args:
-        - PROFILE=debug
+        - CARGO_PROFILE=debug
     command: cargo test
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 -include .env
 TAG ?= latest
-PROFILE ?= debug
+CARGO_PROFILE ?= debug
 UID = $(shell id -u)
 GID = $(shell id -g)
 DOCKER_BUILDX_BAKE_OPTS ?=
@@ -174,7 +174,7 @@ clean-mount-cache: ## Prune all docker mount cache (used by sccache)
 
 .PHONY: release
 release: ## 'make build-services' with cargo --release
-	$(MAKE) PROFILE=release build-services
+	$(MAKE) CARGO_PROFILE=release build-services
 
 .PHONY: zip
 zip: build-aws ## Generate zips for deploying to AWS (src/js/grapl-cdk/zips/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,7 @@ services:
       context: src/rust
       target: metric-forwarder-deploy
       args:
-        - PROFILE=${PROFILE:-debug}
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
     tty: false
     environment:
       - "IS_LOCAL=True"
@@ -120,7 +120,7 @@ services:
       context: src/rust
       target: sysmon-subgraph-generator-deploy
       args:
-        - PROFILE=${PROFILE:-debug}
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
     tty: false
     environment:
       - "BUCKET_PREFIX=local-grapl"
@@ -146,7 +146,7 @@ services:
       context: src/rust
       target: osquery-subgraph-generator-deploy
       args:
-        - PROFILE=${PROFILE:-debug}
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
     tty: false
     environment:
       - "BUCKET_PREFIX=local-grapl"
@@ -172,7 +172,7 @@ services:
       context: src/rust
       target: node-identifier-deploy
       args:
-        - PROFILE=${PROFILE:-debug}
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
     environment:
       - "BUCKET_PREFIX=local-grapl"
       - "IS_LOCAL=True"
@@ -210,7 +210,7 @@ services:
       context: src/rust
       target: node-identifier-retry-handler-deploy
       args:
-        - PROFILE=${PROFILE:-debug}
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
     environment:
       - "BUCKET_PREFIX=local-grapl"
       - "IS_LOCAL=True"
@@ -248,7 +248,7 @@ services:
       context: src/rust
       target: graph-merger-deploy
       args:
-        - PROFILE=${PROFILE:-debug}
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
     environment:
       - "BUCKET_PREFIX=local-grapl"
       - "IS_LOCAL=True"
@@ -279,7 +279,7 @@ services:
       context: src/rust
       target: analyzer-dispatcher-deploy
       args:
-        - PROFILE=${PROFILE:-debug}
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
     environment:
       - "BUCKET_PREFIX=local-grapl"
       - "IS_LOCAL=True"

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1-slim-buster AS base
 
-ARG PROFILE=debug
+ARG CARGO_PROFILE=debug
 
 SHELL ["/bin/bash", "-c"]
 
@@ -33,13 +33,13 @@ FROM base AS build
 RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
     --mount=type=secret,id=rust_env,dst=/grapl/env \
     source /grapl/env; \
-    case "${PROFILE}" in \
+    case "${CARGO_PROFILE}" in \
       debug) \
         cargo build ;; \
       release) \
         cargo build --release ;; \
       *) \
-        echo "ERROR: Unknown profile: ${PROFILE}"; \
+        echo "ERROR: Unknown profile: ${CARGO_PROFILE}"; \
         exit 1 ;; \
     esac
 
@@ -68,54 +68,54 @@ RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
 #
 FROM debian:buster-slim AS rust-dist
 
-ARG PROFILE=debug
+ARG CARGO_PROFILE=debug
 
 USER nobody
 
 # analyzer-dispatcher
 FROM rust-dist AS analyzer-dispatcher-deploy
 
-COPY --from=build "/grapl/target/${PROFILE}/analyzer-dispatcher" /
+COPY --from=build "/grapl/target/${CARGO_PROFILE}/analyzer-dispatcher" /
 CMD ["/analyzer-dispatcher"]
 
 # generic-subgraph-generator
 FROM rust-dist AS generic-subgraph-generator-deploy
 
-COPY --from=build "/grapl/target/${PROFILE}/generic-subgraph-generator" /
+COPY --from=build "/grapl/target/${CARGO_PROFILE}/generic-subgraph-generator" /
 CMD ["/generic-subgraph-generator"]
 
 # graph-merger
 FROM rust-dist AS graph-merger-deploy
 
-COPY --from=build "/grapl/target/${PROFILE}/graph-merger" /
+COPY --from=build "/grapl/target/${CARGO_PROFILE}/graph-merger" /
 CMD ["/graph-merger"]
 
 # metric-forwarder
 FROM rust-dist AS metric-forwarder-deploy
 
-COPY --from=build "/grapl/target/${PROFILE}/metric-forwarder" /
+COPY --from=build "/grapl/target/${CARGO_PROFILE}/metric-forwarder" /
 CMD ["/metric-forwarder"]
 
 # node-identifier
 FROM rust-dist AS node-identifier-deploy
 
-COPY --from=build "/grapl/target/${PROFILE}/node-identifier" /
+COPY --from=build "/grapl/target/${CARGO_PROFILE}/node-identifier" /
 CMD ["/node-identifier"]
 
 # node-identifier-retry-handler
 FROM rust-dist AS node-identifier-retry-handler-deploy
 
-COPY --from=build "/grapl/target/${PROFILE}/node-identifier-retry-handler" /
+COPY --from=build "/grapl/target/${CARGO_PROFILE}/node-identifier-retry-handler" /
 CMD ["/node-identifier-retry-handler"]
 
 # sysmon-subgraph-generator
 FROM rust-dist AS sysmon-subgraph-generator-deploy
 
-COPY --from=build "/grapl/target/${PROFILE}/sysmon-subgraph-generator" /
+COPY --from=build "/grapl/target/${CARGO_PROFILE}/sysmon-subgraph-generator" /
 CMD ["/sysmon-subgraph-generator"]
 
 # osquery-subgraph-generator
 FROM rust-dist AS osquery-subgraph-generator-deploy
 
-COPY --from=build "/grapl/target/${PROFILE}/osquery-subgraph-generator" /
+COPY --from=build "/grapl/target/${CARGO_PROFILE}/osquery-subgraph-generator" /
 CMD ["/osquery-subgraph-generator"]

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -10,7 +10,7 @@ services:
       context: ${PWD}/src/rust
       target: build-test-integration
       args:
-        - PROFILE=debug
+        - CARGO_PROFILE=debug
     command: bash -c "
       wait-for-it grapl-provision:8126 --timeout=180 &&
       cargo test --manifest-path node-identifier/Cargo.toml --features integration"

--- a/test/docker-compose.unit-tests-rust.yml
+++ b/test/docker-compose.unit-tests-rust.yml
@@ -10,5 +10,5 @@ services:
       context: ${PWD}/src/rust
       target: build-test-unit
       args:
-        - PROFILE=debug
+        - CARGO_PROFILE=debug
     command: cargo test


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

The Rust Dockerfile had a param named `PROFILE`, which AWS tooling also uses for it's own purposes. This renames to help avoid name collision.

### How were these changes tested?

tested locally by running `make test` after having first ran `make clean`.
