### PR TITLE
Rename the profile env var

### DIFF
--- a/src/js/grapl-cdk/deploy_all.sh
+++ b/src/js/grapl-cdk/deploy_all.sh
@@ -2,10 +2,12 @@
 
 set -e  # Quit upon any failure
 
-if [ -z ${PROFILE} ]; then
+#####
+# Set `AWS_PROFILE=` for multi-profile support
+if [ -z ${AWS_PROFILE} ]; then
     PROFILE_FLAG=""
 else 
-    PROFILE_FLAG="--profile=$PROFILE"
+    PROFILE_FLAG="--profile=$AWS_PROFILE"
 fi
 
 ##########


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
We had a flag conflict between Cargo and `deploy_all` both using the `PROFILE=` env var.
We already renamed the cargo one to CARGO_PROFILE, so the bug is fixed ( https://github.com/grapl-security/grapl/pull/569 ) - but it makes sense to specialize the AWS profile to AWS_PROFILE= as well.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
locally
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
