### PR TITLE
Grapl Pipeline dashboard refreshed for sqs fargate

### DIFF
--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -351,8 +351,8 @@ export class GraplCdkStack extends cdk.Stack {
                 osquery_generator.service,
                 node_identifier.service,
                 graph_merger.service,
-                analyzer_executor.service,
                 analyzer_dispatch.service,
+                analyzer_executor.service,
                 engagement_creator.service,
             ]
         });

--- a/src/js/grapl-cdk/lib/pipeline_dashboard.ts
+++ b/src/js/grapl-cdk/lib/pipeline_dashboard.ts
@@ -2,6 +2,16 @@ import * as cdk from '@aws-cdk/core';
 import * as cloudwatch from '@aws-cdk/aws-cloudwatch';
 import { Service } from './service';
 import {FargateService} from "./fargate_service";
+import * as sqs from '@aws-cdk/aws-sqs';
+
+// like traffic lights, from best to worst
+const GREEN_GRAPH = { color: cloudwatch.Color.GREEN };
+const ORANGE_GRAPH = { color: cloudwatch.Color.ORANGE };
+const RED_GRAPH = { color: cloudwatch.Color.RED };
+
+// 24-width grid
+const FULL_WIDTH = { width: 24 }; 
+const HALF_WIDTH = { width: 12 };
 
 function lambdaInvocationsWidget(
     service: Service,
@@ -14,14 +24,13 @@ function lambdaInvocationsWidget(
     return new cloudwatch.GraphWidget({
         title: `Invoke ${service.serviceName}${titleSuffix}`,
         left: [
-            handler.metricInvocations({ color: cloudwatch.Color.BLUE }),
-            handler.metricErrors({ color: cloudwatch.Color.RED }),
+            handler.metricInvocations(ORANGE_GRAPH),
+            handler.metricErrors(RED_GRAPH),
         ],
-        width: 12, // max of 24; we have 2 next to each other
         liveData: true,
+        ...HALF_WIDTH
     });
 }
-
 
 function fargateInvocationsWidget(
     service: FargateService,
@@ -38,8 +47,38 @@ function fargateInvocationsWidget(
             handler.service.metricCpuUtilization(),
             handler.service.metricMemoryUtilization(),
         ],
-        width: 12, // max of 24; we have 2 next to each other
         liveData: true,
+        ...HALF_WIDTH
+    });
+}
+
+function fargateQueueWidget(
+    service: FargateService,
+    isRetry?: boolean
+): cloudwatch.GraphWidget {
+    let queues: sqs.Queue[] = [
+    ]
+
+    return new cloudwatch.GraphWidget({
+        title: `Queues for ${service.serviceName}`,
+        left: [
+            // Num Messages Received is not necessarily the best 
+            // metric to examine, but it's better than cpu/mem!
+            service.queues.queue.metricNumberOfMessagesReceived({
+                ...GREEN_GRAPH,
+                label: "Queue",
+            }),
+            service.queues.retryQueue.metricNumberOfMessagesReceived({
+                ...ORANGE_GRAPH,
+                label: "Retry",
+            }),
+            service.queues.deadLetterQueue.metricNumberOfMessagesReceived({
+                ...RED_GRAPH,
+                label: "Dead"
+            }),
+        ],
+        liveData: true,
+        ...FULL_WIDTH
     });
 }
 
@@ -59,17 +98,35 @@ export class PipelineDashboard extends cdk.Construct {
         const dashboard = new cloudwatch.Dashboard(this, 'Dashboard', {
             dashboardName: props.namePrefix + '-PipelineDashboard',
         });
+        // First, add metrics around queue health
         for (const service of props.services) {
             if (service instanceof Service) {
                 const invocations = lambdaInvocationsWidget(service, false);
                 const retryInvocations = lambdaInvocationsWidget(service, true);
                 dashboard.addWidgets(invocations, retryInvocations);
             } else if (service instanceof FargateService) {
+                const queueWidget = fargateQueueWidget(service);
+                dashboard.addWidgets(queueWidget);
+            } else {
+                console.assert("service must be of type Service or FargateService", service, typeof service);
+            }
+        }
+        
+        dashboard.addWidgets(new cloudwatch.TextWidget({
+            markdown: "Fargate service health",
+            ...FULL_WIDTH,
+        }));
+
+        // Also, add metrics around service health for Fargate svcs
+        for (const service of props.services) {
+            if (service instanceof Service) {
+                // do nothing
+            } else if (service instanceof FargateService) {
                 const invocations = fargateInvocationsWidget(service, false);
                 const retryInvocations = fargateInvocationsWidget(service, true);
                 dashboard.addWidgets(invocations, retryInvocations);
             } else {
-                console.assert("service must be of type Service or FargateService", service, typeof service);
+                console.assert("service must be of type Service or FargateService, but was", typeof service);
             }
         }
     }


### PR DESCRIPTION
Current dash only shows cpu/mem for Fargate, not super useful.

The idea is that this would help operators (us) detect where in the flow stuff breaks

![image](https://user-images.githubusercontent.com/69007229/106674449-1946b300-6568-11eb-8de3-827ba84187d3.png)

(except dispatch and executor positions are switched now)

<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
