### PR TITLE
Run `cargo audit` job on a schedule

### DIFF
--- a/.github/etc/cargo-audit/Dockerfile
+++ b/.github/etc/cargo-audit/Dockerfile
@@ -1,5 +1,0 @@
-FROM rust:alpine AS grapl-cargo-audit
-RUN apk add --no-cache musl-dev libc6-compat openssl-dev
-RUN RUSTFLAGS="-C target-feature=-crt-static" cargo install cargo-audit
-COPY . .
-CMD [ "cargo", "audit" ]

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,40 @@
+name: Cargo Audit
+
+on:
+  schedule:
+    # Every Sunday at 00:00 UTC
+    - cron: "0 0 * * SUN"
+  # In case we want to manually run the audit
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - staging
+      - master
+    paths:
+      # Only audit dependencies on PRs when we actually change dependencies.
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+
+jobs:
+  cargo-audit:
+    runs-on: ubuntu-latest
+    steps:
+      # Scheduled actions operate on the default branch. In order to use
+      # "staging", we have to specify it like this.
+      #
+      # Once we switch over to using the master branch for all development, we
+      # can remove this configuration. See
+      # https://github.com/grapl-security/issue-tracker/issues/224
+      - uses: actions/checkout@v2
+        if: ${{ github.event_name == "schedule" }}
+        with:
+          ref: staging
+
+      # If we're not scheduled, then just run on whatever branch we should be running on
+      - uses: actions/checkout@v2
+        if: ${{ github.event_name != "schedule" }}
+
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -8,17 +8,6 @@ on:
       - master
 
 jobs:
-  cargo-audit:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Cargo Audit
-        run: |
-          docker build -f .github/etc/cargo-audit/Dockerfile -t grapl/grapl-cargo-audit:latest src/rust
-          docker run -t grapl/grapl-cargo-audit:latest cargo audit
-
   rust-unit-tests:
     runs-on: ubuntu-latest
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -269,14 +269,17 @@ three workflow definitions:
   - [grapl-build.yml](./.github/workflows/grapl-build.yml) -- This
     workflow also runs on every PR and every PR update. It runs all
     build and test targets, and performs some additional
-    analysis on the codebase (e.g. [LGTM](https://lgtm.com/) checks
-    and [cargo-audit](https://github.com/RustSec/cargo-audit)).
+    analysis on the codebase (e.g. [LGTM](https://lgtm.com/) checks).
   - [grapl-release.yml](./github/workflows/grapl-release.yml) -- This
     workflow runs every time we cut a [Github
     Release](https://github.com/grapl-security/grapl/releases). It
     builds all the release artifacts, runs all the tests, publishes
     all the Grapl images to Dockerhub so folks can run local Grapl
     easily and publishes Python libraries to PyPI.
+  - [cargo-audit.yml](./github/workflows/cargo-audit.yml) -- Runs [cargo
+    audit](https://github.com/RustSec/cargo-audit) to check our Rust
+    dependencies for security vulnerabilities on every PR when Rust dependencies
+    are changed. Also periodically runs over _all_ Rust dependencies unconditionally.
 
 ## A philosophical note
 


### PR DESCRIPTION
We don't want failing `cargo audit` jobs to block our regular builds,
and we also don't need them running all the time.

Here, we schedule it to run every week.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>