### PR TITLE
Fix cargo audit Github Actions workflow

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -27,13 +27,13 @@ jobs:
       # can remove this configuration. See
       # https://github.com/grapl-security/issue-tracker/issues/224
       - uses: actions/checkout@v2
-        if: ${{ github.event_name == "schedule" }}
+        if: ${{ github.event_name == 'schedule' }}
         with:
           ref: staging
 
       # If we're not scheduled, then just run on whatever branch we should be running on
       - uses: actions/checkout@v2
-        if: ${{ github.event_name != "schedule" }}
+        if: ${{ github.event_name != 'schedule' }}
 
       - uses: actions-rs/audit-check@v1
         with:


### PR DESCRIPTION
TIL strings must be single-quoted in Github Actions

![](https://media.giphy.com/media/FSnwQf1mPhN2o/giphy.gif)

Signed-off-by: Christopher Maier <chris@graplsecurity.com>