### PR TITLE
Found a CDK Fargate bug: a lot of things mean for ".service, .retryService" were only applied to the ".service"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ venv
 .vscode
 .github
 .git
+src/js/grapl-cdk/cdk.out

--- a/src/js/grapl-cdk/Dockerfile
+++ b/src/js/grapl-cdk/Dockerfile
@@ -36,10 +36,13 @@ COPY src/python/Dockerfile src/python/Dockerfile
 # Make fake zip files to appease the CDK tests
 WORKDIR /home/grapl/src/js/grapl-cdk/zips
 RUN touch \
+  analyzer-dispatcher-latest.zip \
+  analyzer-executor-latest.zip \
   dgraph-ttl-latest.zip \
   engagement-creator-latest.zip \
   engagement-edge-latest.zip \
   engagement-ux-latest.zip \
+  graph-merger-latest.zip \
   graphql-endpoint-latest.zip \
   metric-forwarder-latest.zip \
   model-plugin-deployer-latest.zip \

--- a/src/js/grapl-cdk/Dockerfile
+++ b/src/js/grapl-cdk/Dockerfile
@@ -31,17 +31,15 @@ FROM grapl-cdk-build AS grapl-cdk-test
 # We need the Rust Dockerfile to run the tests
 WORKDIR /home/grapl
 COPY src/rust/Dockerfile src/rust/Dockerfile
+COPY src/python/Dockerfile src/python/Dockerfile
 
 # Make fake zip files to appease the CDK tests
 WORKDIR /home/grapl/src/js/grapl-cdk/zips
 RUN touch \
-  analyzer-dispatcher-latest.zip \
-  analyzer-executor-latest.zip \
   dgraph-ttl-latest.zip \
   engagement-creator-latest.zip \
   engagement-edge-latest.zip \
   engagement-ux-latest.zip \
-  graph-merger-latest.zip \
   graphql-endpoint-latest.zip \
   metric-forwarder-latest.zip \
   model-plugin-deployer-latest.zip \
@@ -49,6 +47,7 @@ RUN touch \
   node-identifier-retry-handler-latest.zip \
   osquery-subgraph-generator-latest.zip \
   sysmon-subgraph-generator-latest.zip \
+  swarm-lifecycle-event-handler-latest.zip \
   ux-router-latest.zip
 
 WORKDIR /home/grapl/src/js/grapl-cdk

--- a/src/js/grapl-cdk/lib/dockerfile_paths.ts
+++ b/src/js/grapl-cdk/lib/dockerfile_paths.ts
@@ -1,0 +1,15 @@
+import * as path from 'path';
+import * as fs from 'fs';
+
+function ensureExists(dir: string) {
+    if(!fs.existsSync(dir)) {
+        throw new Error(`Couldn't resolve ${dir}`);
+    }
+}
+
+export const PYTHON_DIR = path.join(__dirname, '../../../../src/python/');
+export const RUST_DIR = path.join(__dirname, '../../../../src/rust/');
+
+for (const dir of [PYTHON_DIR, RUST_DIR]) {
+   ensureExists(dir);
+}

--- a/src/js/grapl-cdk/lib/fargate_service.ts
+++ b/src/js/grapl-cdk/lib/fargate_service.ts
@@ -11,6 +11,7 @@ import * as ecs_patterns from "@aws-cdk/aws-ecs-patterns";
 import {ContainerImage} from "@aws-cdk/aws-ecs";
 import {Watchful} from "cdk-watchful";
 import {EventEmitter} from "./event_emitters";
+import { IConnectable } from '@aws-cdk/aws-ec2';
 
 export class Queues {
     readonly queue: sqs.Queue;
@@ -41,7 +42,8 @@ export class Queues {
 export interface FargateServiceProps {
     prefix: string;
     version: string;
-    eventEmitter: EventEmitter;
+    // We read events from this
+    eventEmitter: EventEmitter; 
     serviceImage: ContainerImage;
     retryServiceImage?: ContainerImage | undefined;
     vpc: ec2.IVpc;
@@ -52,6 +54,7 @@ export interface FargateServiceProps {
     command?: string[] | undefined;
     retryCommand?: string[] | undefined;
     watchful?: Watchful | undefined;
+    // TODO: Reintroduce metric_forwarder
 }
 
 export class FargateService {
@@ -129,10 +132,10 @@ export class FargateService {
             });
 
         for (const q of [this.queues.queue, this.queues.retryQueue, this.queues.deadLetterQueue]) {
-            q.grantConsumeMessages(this.service.taskDefinition.taskRole);
-            q.grantConsumeMessages(this.retryService.taskDefinition.taskRole);
-            q.grantSendMessages(this.service.taskDefinition.taskRole);
-            q.grantSendMessages(this.retryService.taskDefinition.taskRole);
+            for (const taskRole of this.taskRoles()) {
+                q.grantConsumeMessages(taskRole);
+                q.grantSendMessages(taskRole);
+            }
         }
 
         if (readsFrom) {
@@ -174,7 +177,9 @@ export class FargateService {
     }
 
     writesToBucket(publishes_to: s3.IBucket) {
-        publishes_to.grantWrite(this.service.service.taskDefinition.taskRole);
+        for (const taskRole of this.taskRoles()) {
+            publishes_to.grantWrite(taskRole);
+        }
     }
 
     addSubscription(scope: cdk.Construct, topic: sns.ITopic) {
@@ -191,5 +196,19 @@ export class FargateService {
             protocol: config.protocol,
             rawMessageDelivery: true,
         });
+    }
+
+    connections(): ec2.Connections[] {
+        return [
+            this.service.service.cluster.connections,
+            this.retryService.service.cluster.connections,
+        ]
+    }
+
+    taskRoles(): iam.IRole[] {
+        return [
+            this.service.service.taskDefinition.taskRole,
+            this.retryService.service.taskDefinition.taskRole,
+        ]
     }
 }

--- a/src/js/grapl-cdk/lib/historydb.ts
+++ b/src/js/grapl-cdk/lib/historydb.ts
@@ -107,7 +107,9 @@ export class HistoryDb extends cdk.Construct {
             this.dynamic_session_table,
         ];
         for (const table of tables) {
-            table.grantReadWriteData(service.service.taskDefinition.taskRole);
+            for (const taskRole of service.taskRoles()) {
+                table.grantReadWriteData(taskRole);
+            }
         }
     }
 

--- a/src/js/grapl-cdk/lib/schemadb.ts
+++ b/src/js/grapl-cdk/lib/schemadb.ts
@@ -30,8 +30,9 @@ export class SchemaDb extends cdk.Construct {
 
     allowRead(service: Service|FargateService) {
         if (service instanceof FargateService) {
-            this.schema_table.grantReadData(service.service.taskDefinition.taskRole);
-            this.schema_table.grantReadData(service.retryService.taskDefinition.taskRole);
+            for (const taskRole of service.taskRoles()) {
+                this.schema_table.grantReadData(taskRole);
+            }
         } else {
             this.schema_table.grantReadData(service.event_handler);
             this.schema_table.grantReadData(service.event_retry_handler);

--- a/src/js/grapl-cdk/lib/services/analyzer_dispatcher.ts
+++ b/src/js/grapl-cdk/lib/services/analyzer_dispatcher.ts
@@ -1,15 +1,14 @@
-import * as path from 'path';
 import * as cdk from '@aws-cdk/core';
 import * as ec2 from '@aws-cdk/aws-ec2';
 import * as s3 from '@aws-cdk/aws-s3';
 import * as sns from '@aws-cdk/aws-sns';
-import { Service } from '../service';
 import { EventEmitter } from '../event_emitters';
 import { RedisCluster } from '../redis';
 import { GraplServiceProps } from '../grapl-cdk-stack';
 import { GraplS3Bucket } from '../grapl_s3_bucket';
 import {FargateService} from "../fargate_service";
 import {ContainerImage} from "@aws-cdk/aws-ecs";
+import { RUST_DIR } from '../dockerfile_paths';
 
 export interface AnalyzerDispatchProps extends GraplServiceProps {
     writesTo: s3.IBucket;
@@ -62,7 +61,7 @@ export class AnalyzerDispatch extends cdk.NestedStack {
             writesTo: props.writesTo,
             version: props.version,
             watchful: props.watchful,
-            serviceImage: ContainerImage.fromAsset(path.join(__dirname, '../../../../../src/rust/'), {
+            serviceImage: ContainerImage.fromAsset(RUST_DIR, {
                 target: "analyzer-dispatcher-deploy",
                 buildArgs: {
                     "CARGO_PROFILE": "debug"
@@ -72,11 +71,13 @@ export class AnalyzerDispatch extends cdk.NestedStack {
             command: ["/analyzer-dispatcher"],
             // metric_forwarder: props.metricForwarder,
         });
-        analyzer_bucket.grantRead(this.service.service.service.taskDefinition.taskRole);
-        analyzer_bucket.grantRead(this.service.retryService.service.taskDefinition.taskRole);
-        this.service.service.cluster.connections.allowToAnyIpv4(
-            ec2.Port.tcp(parseInt(dispatch_event_cache.cluster.attrRedisEndpointPort))
-        );
-
+        for (const taskRole of this.service.taskRoles()) {
+            analyzer_bucket.grantRead(taskRole);
+        }
+        for (const conn of this.service.connections()) {
+            conn.allowToAnyIpv4(
+                ec2.Port.tcp(parseInt(dispatch_event_cache.cluster.attrRedisEndpointPort))
+            );
+        }
     }
 }

--- a/src/js/grapl-cdk/lib/services/analyzer_executor.ts
+++ b/src/js/grapl-cdk/lib/services/analyzer_executor.ts
@@ -1,12 +1,13 @@
 import * as cdk from '@aws-cdk/core';
 import * as ec2 from '@aws-cdk/aws-ec2';
 import * as iam from '@aws-cdk/aws-iam';
-import * as lambda from '@aws-cdk/aws-lambda';
 import * as s3 from '@aws-cdk/aws-s3';
-import { Service } from '../service';
+import { ContainerImage } from "@aws-cdk/aws-ecs";
 import { EventEmitter } from '../event_emitters';
-import { RedisCluster } from '../redis';
+import { FargateService } from '../fargate_service';
 import { GraplServiceProps } from '../grapl-cdk-stack';
+import { PYTHON_DIR } from '../dockerfile_paths';
+import { RedisCluster } from '../redis';
 
 export interface AnalyzerExecutorProps extends GraplServiceProps {
     writesTo: s3.IBucket;
@@ -16,7 +17,7 @@ export interface AnalyzerExecutorProps extends GraplServiceProps {
 
 export class AnalyzerExecutor extends cdk.NestedStack {
     readonly bucket: s3.IBucket;
-    readonly service: Service;
+    readonly service: FargateService;
 
     constructor(
         scope: cdk.Construct,
@@ -36,7 +37,7 @@ export class AnalyzerExecutor extends cdk.NestedStack {
         const hit_cache = new RedisCluster(this, 'ExecutorHitCache', props);
         const message_cache = new RedisCluster(this, 'ExecutorMsgCache', props);
 
-        this.service = new Service(this, id, {
+        this.service = new FargateService(this, id, {
                 prefix: props.prefix,
                 environment: {
                     ANALYZER_MATCH_BUCKET: props.writesTo.bucketName,
@@ -45,7 +46,7 @@ export class AnalyzerExecutor extends cdk.NestedStack {
                     COUNTCACHE_ADDR: count_cache.cluster.attrRedisEndpointAddress,
                     COUNTCACHE_PORT: count_cache.cluster.attrRedisEndpointPort,
                     MESSAGECACHE_ADDR:
-                    message_cache.cluster.attrRedisEndpointAddress,
+                      message_cache.cluster.attrRedisEndpointAddress,
                     MESSAGECACHE_PORT: message_cache.cluster.attrRedisEndpointPort,
                     HITCACHE_ADDR: hit_cache.cluster.attrRedisEndpointAddress,
                     HITCACHE_PORT: hit_cache.cluster.attrRedisEndpointPort,
@@ -53,46 +54,36 @@ export class AnalyzerExecutor extends cdk.NestedStack {
                     GRPC_ENABLE_FORK_SUPPORT: '1',
                 },
                 vpc: props.vpc,
-                reads_from: dispatched_analyzer.bucket,
-                writes_to: props.writesTo,
-                subscribes_to: dispatched_analyzer.topic,
-                opt: {
-                    runtime: lambda.Runtime.PYTHON_3_7,
-                    py_entrypoint: "lambda_function.lambda_handler"
-                },
+                eventEmitter: dispatched_analyzer,
+                writesTo: props.writesTo,
                 version: props.version,
                 watchful: props.watchful,
-                metric_forwarder: props.metricForwarder,
+                serviceImage: ContainerImage.fromAsset(PYTHON_DIR, {
+                    target: "analyzer-executor-deploy",
+                    file: "Dockerfile",
+                }),
+                // TODO
+                //metric_forwarder: props.metricForwarder,
             },
         );
         const service = this.service;
 
-        props.dgraphSwarmCluster.allowConnectionsFrom(service.event_handler);
+        props.dgraphSwarmCluster.allowConnectionsFrom(service.service.cluster);
+        props.dgraphSwarmCluster.allowConnectionsFrom(service.retryService.cluster);
 
         // We need the List capability to find each of the analyzers
-        props.readsAnalyzersFrom.grantRead(service.event_handler);
-        props.readsAnalyzersFrom.grantRead(service.event_retry_handler);
-
-        service.readsFrom(props.modelPluginsBucket, true);
+        service.readsFromBucket(props.readsAnalyzersFrom, true)
+        service.readsFromBucket(props.modelPluginsBucket, true);
 
         // Need to be able to GetObject in order to HEAD, can be replaced with
         // a cache later, but safe so long as there is no LIST
-        const policy = new iam.PolicyStatement({
-            effect: iam.Effect.ALLOW,
-            actions: ['s3:GetObject'],
-            resources: [props.writesTo.bucketArn + '/*'],
-        });
+        service.readsFromBucket(props.writesTo, false);
 
-        service.event_handler.addToRolePolicy(policy);
-        service.event_retry_handler.addToRolePolicy(policy);
-
-        service.event_handler.connections.allowToAnyIpv4(
-            ec2.Port.allTraffic(),
-            'Allow outbound to S3'
-        );
-        service.event_retry_handler.connections.allowToAnyIpv4(
-            ec2.Port.allTraffic(),
-            'Allow outbound to S3'
-        );
+        for (const conn of service.connections()) {
+            conn.allowToAnyIpv4(
+                ec2.Port.allTraffic(),
+                'Allow outbound to S3'
+            );
+        }
     }
 }

--- a/src/js/grapl-cdk/lib/services/graph_merger.ts
+++ b/src/js/grapl-cdk/lib/services/graph_merger.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import * as cdk from '@aws-cdk/core';
 import * as ec2 from '@aws-cdk/aws-ec2';
 import * as s3 from '@aws-cdk/aws-s3';
@@ -9,6 +8,7 @@ import { SchemaDb } from '../schemadb';
 import { ContainerImage } from "@aws-cdk/aws-ecs";
 import { FargateService } from "../fargate_service";
 import { GraplS3Bucket } from '../grapl_s3_bucket';
+import { RUST_DIR } from '../dockerfile_paths';
 
 export interface GraphMergerProps extends GraplServiceProps {
     writesTo: s3.IBucket;
@@ -54,7 +54,7 @@ export class GraphMerger extends cdk.NestedStack {
             writesTo: props.writesTo,
             version: props.version,
             watchful: props.watchful,
-            serviceImage: ContainerImage.fromAsset(path.join(__dirname, '../../../../../src/rust/'), {
+            serviceImage: ContainerImage.fromAsset(RUST_DIR, {
                 target: "graph-merger-deploy",
                 buildArgs: {
                     "CARGO_PROFILE": "debug"
@@ -66,13 +66,11 @@ export class GraphMerger extends cdk.NestedStack {
         });
 
         // probably only needs 9080
-        this.service.service.cluster.connections.allowToAnyIpv4(
-            ec2.Port.allTcp()
-        );
-        // probably only needs 9080
-        this.service.retryService.cluster.connections.allowToAnyIpv4(
-            ec2.Port.allTcp()
-        );
+        for (const conn of this.service.connections()) {
+            conn.allowToAnyIpv4(
+                ec2.Port.allTcp()
+            );
+        }
         props.schemaTable.allowRead(this.service);
         props.dgraphSwarmCluster.allowConnectionsFrom(this.service.service.cluster);
         props.dgraphSwarmCluster.allowConnectionsFrom(this.service.retryService.cluster);

--- a/src/js/grapl-cdk/lib/services/sysmon_graph_generator.ts
+++ b/src/js/grapl-cdk/lib/services/sysmon_graph_generator.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import * as cdk from '@aws-cdk/core';
 import * as ec2 from '@aws-cdk/aws-ec2';
 import * as s3 from '@aws-cdk/aws-s3';
@@ -7,6 +6,7 @@ import { RedisCluster } from '../redis';
 import { GraplServiceProps } from '../grapl-cdk-stack';
 import { FargateService } from "../fargate_service";
 import { ContainerImage } from "@aws-cdk/aws-ecs";
+import { RUST_DIR } from '../dockerfile_paths';
 
 interface SysmonGraphGeneratorProps extends GraplServiceProps {
     writesTo: s3.IBucket;
@@ -43,7 +43,7 @@ export class SysmonGraphGenerator extends cdk.NestedStack {
             writesTo: props.writesTo,
             version: props.version,
             watchful: props.watchful,
-            serviceImage: ContainerImage.fromAsset(path.join(__dirname, '../../../../../src/rust/'), {
+            serviceImage: ContainerImage.fromAsset(RUST_DIR, {
                 target: "sysmon-subgraph-generator-deploy",
                 buildArgs: {
                     "CARGO_PROFILE": "debug"
@@ -54,8 +54,10 @@ export class SysmonGraphGenerator extends cdk.NestedStack {
             // metric_forwarder: props.metricForwarder,
         });
 
-        this.service.service.cluster.connections.allowToAnyIpv4(
-            ec2.Port.tcp(parseInt(event_cache.cluster.attrRedisEndpointPort))
-        );
+        for (const conn of this.service.connections()) {
+            conn.allowToAnyIpv4(
+                ec2.Port.tcp(parseInt(event_cache.cluster.attrRedisEndpointPort))
+            );
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
none

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
The primary change here is introducing FargateService `taskRoles()` and `connections()`. 
Basically, a lot of consumers accidentally only granted policies/connections to the main service, not the retry service.
These helpers help coerce programmers into granting it to both.

Also, introduced a `dockerfile_paths` because repeated "../../../../" really annoys me lol

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I'm deploying as we speak
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
