### PR TITLE
Fix Rust context for zip creation, which changed recently.

### DIFF
--- a/docker-compose.zips.yml
+++ b/docker-compose.zips.yml
@@ -9,7 +9,8 @@ services:
   grapl-rust-zips:
     image: grapl/rust-zip:${TAG:-latest}
     build:
-      context: src/rust
+      context: src
+      dockerfile: rust/Dockerfile
       target: zip
       args:
         - CARGO_PROFILE=${CARGO_PROFILE:-debug}


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

Make target `zip` broke recently with docker context changes. This fixes that.

### How were these changes tested?

I can `make deploy`, which first calls the `zip` target, which now succeeds.
