### PR TITLE
Consolidate the .dockerignore files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,0 @@
-target
-*/target
-venv
-.idea
-.vscode
-.github
-.git

--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -1,0 +1,9 @@
+# node modules found in any project
+**/node_modules
+
+rust/target
+
+js/grapl-cdk/zips
+js/grapl-cdk/cdk.out
+
+js/engagement_view/build

--- a/src/js/engagement_view/.dockerignore
+++ b/src/js/engagement_view/.dockerignore
@@ -1,3 +1,0 @@
-node_modules
-build
-

--- a/src/js/graphql_endpoint/.dockerignore
+++ b/src/js/graphql_endpoint/.dockerignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/src/js/grapl-cdk/.dockerignore
+++ b/src/js/grapl-cdk/.dockerignore
@@ -1,3 +1,0 @@
-zips
-cdk.out
-node_modules

--- a/src/python/graplinc-grapl-api/.dockerignore
+++ b/src/python/graplinc-grapl-api/.dockerignore
@@ -1,5 +1,0 @@
-build/
-dist/
-grapl_graph_descriptions/
-*.egg-info
-venv/

--- a/src/rust/.dockerignore
+++ b/src/rust/.dockerignore
@@ -1,2 +1,0 @@
-target
-*/target


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/236

### What changes does this PR make to Grapl? Why?

This unifies our .dockerignore files.

### How were these changes tested?

I ran a clean build and verified the context size transferred for the Rust build didn't include my `target` directory. Verified by compared sizes.