### PR TITLE
Ensure that `cargo audit` is run from the proper directory 

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -19,6 +19,9 @@ on:
 jobs:
   cargo-audit:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/rust
     steps:
       # Scheduled actions operate on the default branch. In order to use
       # "staging", we have to specify it like this.
@@ -35,6 +38,9 @@ jobs:
       - uses: actions/checkout@v2
         if: ${{ github.event_name != 'schedule' }}
 
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # TODO: Once actions-rs/audit-check can run in an arbitrary subdirectory,
+      # let's use it instead; it has better output.
+      - name: Run cargo audit
+        run: |
+          cargo install cargo-audit
+          cargo audit


### PR DESCRIPTION
The `actions-rs/audit-check` action doesn't appear to be able to run
in a subdirectory, and Github Actions' `working-directory` doesn't
apply to `uses` steps. Until either of those change, we'll just do it
ourselves.

Longer term, it would be nice to use that action, though, because it's
got much nicer output. In the meantime, however, this will serve our
purposes.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>