### PR TITLE
Fargate cluster names don't have autogenerated ids

### DIFF
--- a/src/js/grapl-cdk/lib/services/analyzer_dispatcher.ts
+++ b/src/js/grapl-cdk/lib/services/analyzer_dispatcher.ts
@@ -27,6 +27,7 @@ export class AnalyzerDispatch extends cdk.NestedStack {
     ) {
         super(scope, id);
 
+        const service_name = "analyzer-dispatcher";
         const bucket_prefix = props.prefix.toLowerCase();
         const subgraphs_merged = new EventEmitter(
             this,
@@ -47,7 +48,7 @@ export class AnalyzerDispatch extends cdk.NestedStack {
         );
         dispatch_event_cache.connections.allowFromAnyIpv4(ec2.Port.allTcp());
 
-        this.service = new FargateService(this, id, {
+        this.service = new FargateService(this, service_name, {
             prefix: props.prefix,
             environment: {
                 RUST_LOG: props.analyzerDispatcherLogLevel,

--- a/src/js/grapl-cdk/lib/services/graph_merger.ts
+++ b/src/js/grapl-cdk/lib/services/graph_merger.ts
@@ -22,6 +22,7 @@ export class GraphMerger extends cdk.NestedStack {
     constructor(scope: cdk.Construct, id: string, props: GraphMergerProps) {
         super(scope, id);
 
+        const service_name = "graph-merger";
         const bucket_prefix = props.prefix.toLowerCase();
         const subgraphs_generated = new EventEmitter(
             this,
@@ -37,7 +38,7 @@ export class GraphMerger extends cdk.NestedStack {
 
         event_cache.connections.allowFromAnyIpv4(ec2.Port.allTcp());
 
-        this.service = new FargateService(this, id, {
+        this.service = new FargateService(this, service_name, {
             prefix: props.prefix,
             environment: {
                 EVENT_CACHE_CLUSTER_ADDRESS: event_cache.address,

--- a/src/js/grapl-cdk/lib/services/node_identifier.ts
+++ b/src/js/grapl-cdk/lib/services/node_identifier.ts
@@ -25,6 +25,7 @@ export class NodeIdentifier extends cdk.NestedStack {
 
         const history_db = new HistoryDb(this, 'HistoryDB', props);
 
+        const service_name = "node-identifier";
         const bucket_prefix = props.prefix.toLowerCase();
         const unid_subgraphs = new EventEmitter(
             this,

--- a/src/js/grapl-cdk/lib/services/osquery_graph_generator.ts
+++ b/src/js/grapl-cdk/lib/services/osquery_graph_generator.ts
@@ -22,6 +22,7 @@ export class OSQueryGraphGenerator extends cdk.NestedStack {
     ) {
         super(parent, id);
 
+        const service_name = "osquery-generator";
         const bucket_prefix = props.prefix.toLowerCase();
         const osquery_log = new EventEmitter(
             this,
@@ -31,7 +32,7 @@ export class OSQueryGraphGenerator extends cdk.NestedStack {
         const event_cache = new RedisCluster(this, 'OSQueryEventCache', props);
         event_cache.connections.allowFromAnyIpv4(ec2.Port.allTcp());
 
-        this.service = new FargateService(this, id, {
+        this.service = new FargateService(this, service_name, {
             prefix: props.prefix,
             environment: {
                 RUST_LOG: props.osquerySubgraphGeneratorLogLevel,

--- a/src/js/grapl-cdk/lib/services/sysmon_graph_generator.ts
+++ b/src/js/grapl-cdk/lib/services/sysmon_graph_generator.ts
@@ -22,6 +22,7 @@ export class SysmonGraphGenerator extends cdk.NestedStack {
     ) {
         super(parent, id);
 
+        const service_name = "sysmon-generator";
         const bucket_prefix = props.prefix.toLowerCase();
         const sysmon_log = new EventEmitter(
             this,
@@ -31,7 +32,7 @@ export class SysmonGraphGenerator extends cdk.NestedStack {
         const event_cache = new RedisCluster(this, 'SysmonEventCache', props);
         event_cache.connections.allowFromAnyIpv4(ec2.Port.allTcp());
 
-        this.service = new FargateService(this, id, {
+        this.service = new FargateService(this, service_name, {
             prefix: props.prefix,
             environment: {
                 RUST_LOG: props.sysmonSubgraphGeneratorLogLevel,


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
We were passing an autogenerated id to `serviceName` for FargateService when, in fact, we should just be passing the service name.
Don't worry, it adds the prefix for us :) 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I'm `make deploy`ing as we speak

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
