### PR TITLE
Revert part of #590, to reduce entropy during the search for 'why does graph merger fail to connect' debugging

### DIFF
--- a/src/js/grapl-cdk/lib/historydb.ts
+++ b/src/js/grapl-cdk/lib/historydb.ts
@@ -107,9 +107,7 @@ export class HistoryDb extends cdk.Construct {
             this.dynamic_session_table,
         ];
         for (const table of tables) {
-            for (const taskRole of service.taskRoles()) {
-                table.grantReadWriteData(taskRole);
-            }
+            table.grantReadWriteData(service.service.taskDefinition.taskRole);	
         }
     }
 

--- a/src/js/grapl-cdk/lib/schemadb.ts
+++ b/src/js/grapl-cdk/lib/schemadb.ts
@@ -30,9 +30,8 @@ export class SchemaDb extends cdk.Construct {
 
     allowRead(service: Service|FargateService) {
         if (service instanceof FargateService) {
-            for (const taskRole of service.taskRoles()) {
-                this.schema_table.grantReadData(taskRole);
-            }
+            this.schema_table.grantReadData(service.service.taskDefinition.taskRole);
+            this.schema_table.grantReadData(service.retryService.taskDefinition.taskRole);
         } else {
             this.schema_table.grantReadData(service.event_handler);
             this.schema_table.grantReadData(service.event_retry_handler);

--- a/src/js/grapl-cdk/lib/services/analyzer_dispatcher.ts
+++ b/src/js/grapl-cdk/lib/services/analyzer_dispatcher.ts
@@ -72,13 +72,10 @@ export class AnalyzerDispatch extends cdk.NestedStack {
             command: ["/analyzer-dispatcher"],
             // metric_forwarder: props.metricForwarder,
         });
-        for (const taskRole of this.service.taskRoles()) {
-            analyzer_bucket.grantRead(taskRole);
-        }
-        for (const conn of this.service.connections()) {
-            conn.allowToAnyIpv4(
-                ec2.Port.tcp(parseInt(dispatch_event_cache.cluster.attrRedisEndpointPort))
-            );
-        }
+        analyzer_bucket.grantRead(this.service.service.service.taskDefinition.taskRole);
+        analyzer_bucket.grantRead(this.service.retryService.service.taskDefinition.taskRole);
+        this.service.service.cluster.connections.allowToAnyIpv4(
+            ec2.Port.tcp(parseInt(dispatch_event_cache.cluster.attrRedisEndpointPort))
+        );
     }
 }

--- a/src/js/grapl-cdk/lib/services/graph_merger.ts
+++ b/src/js/grapl-cdk/lib/services/graph_merger.ts
@@ -67,11 +67,13 @@ export class GraphMerger extends cdk.NestedStack {
         });
 
         // probably only needs 9080
-        for (const conn of this.service.connections()) {
-            conn.allowToAnyIpv4(
-                ec2.Port.allTcp()
-            );
-        }
+        this.service.service.cluster.connections.allowToAnyIpv4(
+            ec2.Port.allTcp()
+        );
+        // probably only needs 9080
+        this.service.retryService.cluster.connections.allowToAnyIpv4(
+            ec2.Port.allTcp()
+        );
         props.schemaTable.allowRead(this.service);
         props.dgraphSwarmCluster.allowConnectionsFrom(this.service.service.cluster);
         props.dgraphSwarmCluster.allowConnectionsFrom(this.service.retryService.cluster);

--- a/src/js/grapl-cdk/lib/services/node_identifier.ts
+++ b/src/js/grapl-cdk/lib/services/node_identifier.ts
@@ -41,7 +41,7 @@ export class NodeIdentifier extends cdk.NestedStack {
         );
         event_cache.connections.allowFromAnyIpv4(ec2.Port.allTcp());
 
-        this.service = new FargateService(this, id, {
+        this.service = new FargateService(this, service_name, {
             prefix: props.prefix,
             environment: {
                 RUST_LOG: props.nodeIdentifierLogLevel,
@@ -89,11 +89,9 @@ export class NodeIdentifier extends cdk.NestedStack {
             // metric_forwarder: props.metricForwarder,
         });
 
-        for (const conn of this.service.connections()) {
-            conn.allowToAnyIpv4(
-                ec2.Port.tcp(parseInt(event_cache.cluster.attrRedisEndpointPort))
-            );
-        }
+        this.service.service.cluster.connections.allowToAnyIpv4(
+            ec2.Port.tcp(parseInt(event_cache.cluster.attrRedisEndpointPort))
+        );
 
         history_db.allowReadWrite2(this.service);
     }

--- a/src/js/grapl-cdk/lib/services/osquery_graph_generator.ts
+++ b/src/js/grapl-cdk/lib/services/osquery_graph_generator.ts
@@ -55,10 +55,8 @@ export class OSQueryGraphGenerator extends cdk.NestedStack {
             //metric_forwarder: props.metricForwarder,
         });
 
-        for (const conn of this.service.connections()) {
-            conn.allowToAnyIpv4(
-                ec2.Port.tcp(parseInt(event_cache.cluster.attrRedisEndpointPort))
-            );
-        }
+        this.service.service.cluster.connections.allowToAnyIpv4(
+            ec2.Port.tcp(parseInt(event_cache.cluster.attrRedisEndpointPort))
+        );
     }
 }

--- a/src/js/grapl-cdk/lib/services/sysmon_graph_generator.ts
+++ b/src/js/grapl-cdk/lib/services/sysmon_graph_generator.ts
@@ -55,10 +55,8 @@ export class SysmonGraphGenerator extends cdk.NestedStack {
             // metric_forwarder: props.metricForwarder,
         });
 
-        for (const conn of this.service.connections()) {
-            conn.allowToAnyIpv4(
-                ec2.Port.tcp(parseInt(event_cache.cluster.attrRedisEndpointPort))
-            );
-        }
+        this.service.service.cluster.connections.allowToAnyIpv4(
+            ec2.Port.tcp(parseInt(event_cache.cluster.attrRedisEndpointPort))
+        );
     }
 }


### PR DESCRIPTION

<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
partial revert of https://github.com/grapl-security/grapl/pull/590/files
trying to investigate https://github.com/grapl-security/issue-tracker/issues/242


<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Remove the (probably good, but more entropy) connection/tcp changes made in #590. This will help us ensure that, well, these changes are not responsible for `graph-merger` failing to work: https://grapl-internal.slack.com/archives/C01870CFDEC/p1613031116031200
- But keep the Rust dockerfile changes.
- (also, fix one missed `id` swap out for `service_name`) in node-identifier

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
they were not.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
