### PR TITLE
All docker-compose images are done with build context src/

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -560,8 +560,8 @@ services:
   grapl-engagement-view-uploader:
     image: grapl/grapl-engagement-view:${TAG:-latest}
     build: 
-      context: src/js/engagement_view
-      dockerfile: Dockerfile
+      context: src
+      dockerfile: js/engagement_view/Dockerfile
       target: engagement-view-local-deploy
     command: |
       /bin/bash -c "
@@ -577,8 +577,8 @@ services:
   grapl-graphql-endpoint:
     image: grapl/grapl-graphql-endpoint:${TAG:-latest}
     build: 
-      context: src/js/graphql_endpoint
-      dockerfile: Dockerfile
+      context: src
+      dockerfile: js/graphql_endpoint/Dockerfile
       target: graphql-endpoint-deploy
     command: yarn start server
     environment:

--- a/docker-compose.zips.yml
+++ b/docker-compose.zips.yml
@@ -106,8 +106,8 @@ services:
   grapl-graphql-endpoint-zip:
     image: grapl/grapl-graphql-endpoint-zip:${TAG:-latest}
     build:
-      context: src/js/graphql_endpoint
-      dockerfile: Dockerfile
+      context: src
+      dockerfile: js/graphql_endpoint/Dockerfile
       target: graphql-endpoint-zip
     volumes:
       - ./src/js/grapl-cdk/zips:/grapl

--- a/src/js/engagement_view/Dockerfile
+++ b/src/js/engagement_view/Dockerfile
@@ -4,14 +4,14 @@ RUN apk add bash yarn
 WORKDIR /grapl
 
 # install deps as separate steps to leverage build cache
-COPY package.json package.json
-COPY yarn.lock yarn.lock
-COPY .yarnrc.yml .yarnrc.yml
-COPY .yarn/releases .yarn/releases
+COPY js/engagement_view/package.json package.json
+COPY js/engagement_view/yarn.lock yarn.lock
+COPY js/engagement_view/.yarnrc.yml .yarnrc.yml
+COPY js/engagement_view/.yarn/releases .yarn/releases
 RUN yarn install
 
 # now copy all sources
-COPY . .
+COPY js/engagement_view .
 
 # create production build
 ################################################################################

--- a/src/js/graphql_endpoint/Dockerfile
+++ b/src/js/graphql_endpoint/Dockerfile
@@ -19,14 +19,14 @@ WORKDIR /home/grapl
 RUN mkdir -p lambda
 
 # Install the dependencies separately to leverage Docker cache
-COPY --chown=grapl package.json lambda/package.json
-COPY --chown=grapl package-lock.json lambda/package-lock.json
+COPY --chown=grapl js/graphql_endpoint/package.json lambda/package.json
+COPY --chown=grapl js/graphql_endpoint/package-lock.json lambda/package-lock.json
 RUN cd lambda && npm install
 RUN rm -rf lambda/node_modules/grpc/build/
 
 # Copy graphql sources
-COPY --chown=grapl modules lambda/modules
-COPY --chown=grapl server.js lambda/server.js
+COPY --chown=grapl js/graphql_endpoint/modules lambda/modules
+COPY --chown=grapl js/graphql_endpoint/server.js lambda/server.js
 
 # zip
 FROM graphql-endpoint-build AS graphql-endpoint-zip
@@ -51,7 +51,7 @@ COPY --chown=grapl --from=graphql-endpoint-build /home/grapl/lambda lambda
 
 WORKDIR /home/grapl/lambda
 
-COPY --chown=grapl package.json package.json
-COPY --chown=grapl package-lock.json package-lock.json
+COPY --chown=grapl js/graphql_endpoint/package.json package.json
+COPY --chown=grapl js/graphql_endpoint/package-lock.json package-lock.json
 
 CMD yarn start server

--- a/src/js/grapl-cdk/Dockerfile
+++ b/src/js/grapl-cdk/Dockerfile
@@ -11,14 +11,14 @@ RUN npm install --global aws-cdk
 
 # Grab all dependencies
 WORKDIR /home/grapl
-COPY src/js/grapl-cdk/package.json src/js/grapl-cdk/package.json
-COPY src/js/grapl-cdk/package-lock.json src/js/grapl-cdk/package-lock.json
+COPY js/grapl-cdk/package.json src/js/grapl-cdk/package.json
+COPY js/grapl-cdk/package-lock.json src/js/grapl-cdk/package-lock.json
 WORKDIR /home/grapl/src/js/grapl-cdk
 RUN npm install
 
 # Copy in the rest of the source
 WORKDIR /home/grapl
-COPY src/js/grapl-cdk src/js/grapl-cdk
+COPY js/grapl-cdk src/js/grapl-cdk
 
 # does typechecking, which is nice
 WORKDIR /home/grapl/src/js/grapl-cdk
@@ -30,7 +30,7 @@ FROM grapl-cdk-build AS grapl-cdk-test
 
 # We need the Rust Dockerfile to run the tests
 WORKDIR /home/grapl
-COPY src/rust/Dockerfile src/rust/Dockerfile
+COPY rust/Dockerfile src/rust/Dockerfile
 
 # Make fake zip files to appease the CDK tests
 WORKDIR /home/grapl/src/js/grapl-cdk/zips

--- a/test/docker-compose.unit-tests-js.yml
+++ b/test/docker-compose.unit-tests-js.yml
@@ -7,8 +7,8 @@ services:
   grapl-engagement-view-test:
     image: grapl/grapl-engagement-view-build:${TAG:-latest}
     build: 
-      context: ${PWD}/src/js/engagement_view
-      dockerfile: Dockerfile
+      context: ${PWD}/src
+      dockerfile: js/engagement_view/Dockerfile
       target: engagement-view-deps
     command: sh -c 'CI=true yarn test'
 
@@ -16,8 +16,8 @@ services:
     image: grapl/grapl-cdk-test:${TAG:-latest}
     build:
       context: ${PWD}
-      target: grapl-cdk-test
       dockerfile: src/js/grapl-cdk/Dockerfile
+      target: grapl-cdk-test
     command: npm run test
 
   # grapl-graphql-endpoint:

--- a/test/docker-compose.unit-tests-js.yml
+++ b/test/docker-compose.unit-tests-js.yml
@@ -15,8 +15,8 @@ services:
   grapl-cdk-test:
     image: grapl/grapl-cdk-test:${TAG:-latest}
     build:
-      context: ${PWD}
-      dockerfile: src/js/grapl-cdk/Dockerfile
+      context: ${PWD}/src
+      dockerfile: js/grapl-cdk/Dockerfile
       target: grapl-cdk-test
     command: npm run test
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
#589 failed to account for some of our build images which still used different build contexts than `src/`
By removing those `.dockerignore`s, stuff is now breaking **on developers' machines** that might have large build contexts, e.g.
```
 => CANCELED [grapl-cdk-test internal] load build context                                                                                                                          78.1s
 => => transferring context: 3.10GB   (it was getting bigger and bigger due to node_modules not being excluded)
```
Standardizing on src/ will fulfill the initial intent of 589.

some discussion around
https://grapl-internal.slack.com/archives/C0176MS6LBY/p1613083243265500
