### PR TITLE
#231, reenable Cypress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ dist/
 *.vscode
 .idea/
 *.iml
+/tags
+/tags.lock
+/tags.temp
 
 # Pants-related artifacts
 # https://www.pantsbuild.org/docs/gitignore

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,12 @@
+#######################################
+
+FROM cypress/included:5.6.0 AS grapl-cypress
+
+WORKDIR /test
+
+COPY . .
+
+RUN apt-get update && apt-get -y install --no-install-recommends wait-for-it
+
+ENTRYPOINT [""]
+CMD cypress run --browser chrome --headless

--- a/test/cypress.json
+++ b/test/cypress.json
@@ -1,4 +1,4 @@
 {
-    "baseUrl": "http://nginx:1234",
+    "baseUrl": "http://nginx:3128",
     "pageLoadTimeout": 180000
 }

--- a/test/cypress/integration/sample_spec.js
+++ b/test/cypress/integration/sample_spec.js
@@ -1,4 +1,3 @@
-const GRAPL_ENGAGEMENT_VIEW = "http://nginx:1234/";
 
 describe('basic test', () => {
   it('passes', () => {
@@ -8,14 +7,13 @@ describe('basic test', () => {
 
 describe('application loads', () => {
   it('visits the front page', () => {
-    // set cypress.json's baseUrl: to this
-    cy.visit(GRAPL_ENGAGEMENT_VIEW)
+    cy.visit('/')
   })
 })
 
 describe('authentication', () => {
   it('allows the user to log in with a valid username and password', () => {
-    cy.visit(GRAPL_ENGAGEMENT_VIEW)
+    cy.visit('/')
 
     // assert no login cookie
 
@@ -39,7 +37,7 @@ describe('authentication', () => {
 
   /*
   it('does not allow the user to log in with an invalid username or password', () => {
-    cy.visit(GRAPL_ENGAGEMENT_VIEW)
+    cy.visit('/')
 
     // click 'LOGIN' button
     var login_button = cy.contains(/login/i)

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -93,13 +93,17 @@ services:
       - BUCKET_PREFIX=local-grapl
       - UX_BUCKET_URL="ux_bucket_url"
 
-  # Resurrect asap: https://github.com/grapl-security/issue-tracker/issues/231
-  # engagement-view-integration-tests:
-    # image: cypress/included:5.6.0
-    # working_dir: /test
-    # command: --browser chrome --headless # entrypoint is: cypress run
-    # volumes: 
-      # - .:/test
+  cypress-integration-tests:
+    image: grapl/grapl-cypress:${TAG:-latest}
+    build:
+      context: ${PWD}/test
+      dockerfile: ./Dockerfile
+      target: grapl-cypress
+    command: |
+      /bin/bash -c "
+        wait-for-it grapl-provision:8126 --timeout=120 &&
+        cypress run --browser chrome --headless
+      "
 
 networks:
   default:


### PR DESCRIPTION
Re-enables Cypress, per #231.

`make test-integration` should conclude with running Cypress, within Docker.

Should run 3 tests, all of which pass.