### PR TITLE
Remove unused env vars from Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,6 @@ DOCKER_BUILDX_BAKE_OPTS += --set *.secrets=id=rust_env,src="$(GRAPL_RUST_ENV_FIL
 endif
 export
 
-export DOCKER_BUILDKIT=1
-export COMPOSE_DOCKER_CLI_BUILD=1
 export EVERY_COMPOSE_FILE=-f docker-compose.yml \
 	-f ./test/docker-compose.unit-tests-rust.yml \
 	-f ./test/docker-compose.unit-tests-python.yml \


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This removes unused environment variable from the Makefile.

### How were these changes tested?

I ran `make test-unit` locally and will rely on github tests for the rest.