### PR TITLE
Consolidate on deployment name environment variable.

### DIFF
--- a/docs/setup/aws.md
+++ b/docs/setup/aws.md
@@ -63,7 +63,7 @@ Each of these can be found in `bin/deployment_parameters.ts`:
     Note: This name must be globally (AWS) unique, as names for AWS S3
     buckets will be dervied from this.
 
-    env: `GRAPL_CDK_DEPLOYMENT_NAME`
+    env: `GRAPL_DEPLOYMENT_NAME`
 
 2. `graplVersion`
 
@@ -150,13 +150,13 @@ You can send some test data up to the service by going to the root of the grapl 
 cd $GRAPL_ROOT
 
 # whatever deployment name you defined above
-export DEPLOYMENT_NAME="Grapl-MYDEPLOYMENT"
+export GRAPL_DEPLOYMENT_NAME="Grapl-MYDEPLOYMENT"
 
 # upload analyzers
-BUCKET_PREFIX=$DEPLOYMENT_NAME etc/aws/upload_analyzer_prod.sh
+BUCKET_PREFIX=$GRAPL_DEPLOYMENT_NAME etc/aws/upload_analyzer_prod.sh
 # upload logs
 python3 etc/local_grapl/bin/upload-sysmon-logs.py \
-  --bucket_prefix $DEPLOYMENT_NAME \
+  --bucket_prefix $GRAPL_DEPLOYMENT_NAME \
   --logfile etc/sample_data/eventlog.xml 
 ```
 

--- a/src/js/grapl-cdk/bin/create_edge_ux_package.ts
+++ b/src/js/grapl-cdk/bin/create_edge_ux_package.ts
@@ -58,7 +58,7 @@ function getEdgeApiUrl(): string {
      */
     const outputFile = path.join(__dirname, '../cdk-output.json');
     const outputFileContents = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
-    // This looks like { DEPLOYMENT_NAME: { SOME_KEY: apiUrl } }
+    // This looks like { GRAPL_DEPLOYMENT_NAME: { SOME_KEY: apiUrl } }
     const entryForDeployment = outputFileContents[DeploymentParameters.stackName];
     if (entryForDeployment === undefined) {
         throw new Error(`Couldn't find an entry in cdk-output.json for ${DeploymentParameters.stackName}`);

--- a/src/js/grapl-cdk/bin/deployment_parameters.ts
+++ b/src/js/grapl-cdk/bin/deployment_parameters.ts
@@ -27,10 +27,10 @@ module HardcodedDeploymentParameters {
 }
 
 export module DeploymentParameters {
-    const deployName = process.env.GRAPL_CDK_DEPLOYMENT_NAME
+    const deployName = process.env.GRAPL_DEPLOYMENT_NAME
         || HardcodedDeploymentParameters.deployName;
     if (!deployName) {
-        throw new Error('Error: Missing Grapl deployment name. Set via bin/deployment_parameters.ts, or environment variable GRAPL_CDK_DEPLOYMENT_NAME.');
+        throw new Error('Error: Missing Grapl deployment name. Set via bin/deployment_parameters.ts, or environment variable GRAPL_DEPLOYMENT_NAME.');
     }
     export const stackName = deployName;
     export const defaultLogLevel = process.env.DEFAULT_LOG_LEVEL


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

We had three different environment variables to store the AWS deployment name across the codebase. This consolidates them to a single variable.

### How were these changes tested?

I ran `make deploy` on an existing deployment to ensure these changes didn't break the CDK. Other changes were to documentation steps, which I also ran.