### PR TITLE
CDK: Pass Fargate service for allowing Security Group connections instead of Cluster

### DIFF
--- a/src/js/grapl-cdk/lib/services/graph_merger.ts
+++ b/src/js/grapl-cdk/lib/services/graph_merger.ts
@@ -75,7 +75,7 @@ export class GraphMerger extends cdk.NestedStack {
             ec2.Port.allTcp()
         );
         props.schemaTable.allowRead(this.service);
-        props.dgraphSwarmCluster.allowConnectionsFrom(this.service.service.cluster);
-        props.dgraphSwarmCluster.allowConnectionsFrom(this.service.retryService.cluster);
+        props.dgraphSwarmCluster.allowConnectionsFrom(this.service.service.service);
+        props.dgraphSwarmCluster.allowConnectionsFrom(this.service.retryService.service);
     }
 }


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

We observed connection issues between the graph merger and DGraph swarm. @wimax-grapl noticed the swarm security group didn't have inbound rules to allow connections from the graph merger Fargate service, even though it looked like we should: https://github.com/grapl-security/grapl/blob/ebe6e805366a8232763f703a57a8f5d74d059af2/src/js/grapl-cdk/lib/services/graph_merger.ts#L78.

I'd tried passing the Fargate service itself as an argument instead of the Cluster, which also implements `IConnectable`, thinking there may be two different Security Group definitions under the hood. That seems to have worked.

### How were these changes tested?

I'd update my deployment with this diff and noticed my swarm SG now had entries for the graph merger services. I then uploaded the `etc/sample_data/events6.xml` sample data file, which I hadn't done in this deployment before. It looks like the service is now able to connect:
- The merger graph is all green, i'm not seeing the retry service do work
- Previously i was getting the error message: `"message": "upsert_error: deadline has elapsed"`, and I'm no longer seeing that. However, I am seeing a few `"message": "upsert_error: Dgraph: gRPC communication Error.",` errors come up, but I think we've seen this before and is not new with this PR.