### PR TITLE
Better LogGroup names for Fargate; reintroduce Metric Forwarder

### DIFF
--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -231,6 +231,7 @@ export class GraplCdkStack extends cdk.Stack {
                 writesTo: analyzer_executor.bucket,
                 readsFrom: analyzers_bucket,
                 ...graplProps,
+                ...enableMetricsProps,
             }
         );
 
@@ -238,11 +239,13 @@ export class GraplCdkStack extends cdk.Stack {
             writesTo: analyzer_dispatch.bucket,
             schemaTable: schema_table,
             ...graplProps,
+            ...enableMetricsProps,
         });
 
         const node_identifier = new NodeIdentifier(this, 'node-identifier', {
             writesTo: graph_merger.bucket,
             ...graplProps,
+            ...enableMetricsProps,
         });
 
         const sysmon_generator = new SysmonGraphGenerator(this, 'sysmon-subgraph-generator', {

--- a/src/js/grapl-cdk/lib/services/analyzer_dispatcher.ts
+++ b/src/js/grapl-cdk/lib/services/analyzer_dispatcher.ts
@@ -70,7 +70,7 @@ export class AnalyzerDispatch extends cdk.NestedStack {
                 file: RUST_DOCKERFILE,
             }),
             command: ["/analyzer-dispatcher"],
-            // metric_forwarder: props.metricForwarder,
+            metric_forwarder: props.metricForwarder,
         });
         analyzer_bucket.grantRead(this.service.service.service.taskDefinition.taskRole);
         analyzer_bucket.grantRead(this.service.retryService.service.taskDefinition.taskRole);

--- a/src/js/grapl-cdk/lib/services/graph_merger.ts
+++ b/src/js/grapl-cdk/lib/services/graph_merger.ts
@@ -63,7 +63,7 @@ export class GraphMerger extends cdk.NestedStack {
                 file: RUST_DOCKERFILE,
             }),
             command: ["/graph-merger"],
-            // metric_forwarder: props.metricForwarder,
+            metric_forwarder: props.metricForwarder,
         });
 
         // probably only needs 9080

--- a/src/js/grapl-cdk/lib/services/node_identifier.ts
+++ b/src/js/grapl-cdk/lib/services/node_identifier.ts
@@ -86,7 +86,7 @@ export class NodeIdentifier extends cdk.NestedStack {
             }),
             command: ["/node-identifier"],
             retryCommand: ["/node-identifier-retry-handler"],
-            // metric_forwarder: props.metricForwarder,
+            metric_forwarder: props.metricForwarder,
         });
 
         this.service.service.cluster.connections.allowToAnyIpv4(

--- a/src/js/grapl-cdk/lib/services/osquery_graph_generator.ts
+++ b/src/js/grapl-cdk/lib/services/osquery_graph_generator.ts
@@ -52,7 +52,7 @@ export class OSQueryGraphGenerator extends cdk.NestedStack {
                 file: RUST_DOCKERFILE,
             }),
             command: ["/osquery-subgraph-generator"],
-            //metric_forwarder: props.metricForwarder,
+            metric_forwarder: props.metricForwarder,
         });
 
         this.service.service.cluster.connections.allowToAnyIpv4(

--- a/src/js/grapl-cdk/lib/services/sysmon_graph_generator.ts
+++ b/src/js/grapl-cdk/lib/services/sysmon_graph_generator.ts
@@ -52,7 +52,7 @@ export class SysmonGraphGenerator extends cdk.NestedStack {
                 file: RUST_DOCKERFILE,
             }),
             command: ["/sysmon-subgraph-generator"],
-            // metric_forwarder: props.metricForwarder,
+            metric_forwarder: props.metricForwarder,
         });
 
         this.service.service.cluster.connections.allowToAnyIpv4(


### PR DESCRIPTION

results:
![Screenshot 2021-02-17 at 2 38 01 PM](https://user-images.githubusercontent.com/69007229/108288606-b9dccb80-7141-11eb-9897-960299d2fcfb.png)
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None, just existing TODOs

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Manually name the Fargate Services' log groups
- reintroduce metric forwarder props to FargateService
 
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
- I saw the lambda being triggered by these.
- However, turns out the m-f lambda is currently broken:  https://github.com/grapl-security/issue-tracker/issues/249
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
