### PR TITLE
Rust zips (just Metric Forwarder) now use Amazon Linux 2, which provides glibc

### DIFF
--- a/src/js/grapl-cdk/lib/service.ts
+++ b/src/js/grapl-cdk/lib/service.ts
@@ -78,7 +78,8 @@ export class Service {
         const runtime =
             opt && opt.runtime
                 ? opt.runtime
-                : new lambda.Runtime('provided', undefined, {
+                // amazon linux - comes with glibc etc
+                : new lambda.Runtime('provided.al2', lambda.RuntimeFamily.OTHER, {
                       supportsInlineCode: true,
                   });
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/249
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Change the runtime to Amazon Linux 2
We removed musl and now depend on glibc, which `provided` doesnt provide but `provided.al2` does

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
aws deploy - I saw the lambda running and i saw results showing up in cloudwatch.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
