### PR TITLE
Ignore orphan containers in targets with multiple compose runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ test-typecheck: build-test-typecheck ## Build and run typecheck tests
 		-p grapl-typecheck_tests
 
 .PHONY: test-integration
+test-integration: export COMPOSE_IGNORE_ORPHANS=1
 test-integration: build-test-integration ## Build and run integration tests
 	$(WITH_LOCAL_GRAPL_ENV) \
 	docker-compose \
@@ -168,6 +169,7 @@ test-integration: build-test-integration ## Build and run integration tests
 		-p "grapl-integration_tests"
 
 .PHONY: test-e2e
+test-e2e: export COMPOSE_IGNORE_ORPHANS=1
 test-e2e: build-test-e2e ## Build and run e2e tests
 	$(WITH_LOCAL_GRAPL_ENV) \
 	docker-compose \


### PR DESCRIPTION
When we invoke `docker-compose` multiple times with the same project
name, but different files, we see warnings about the presence of
"orphan containers". Any time `docker-compose` runs and finds services
in a project, but that aren't defined in the file(s) it is currently
operating, it regards them as "orphans".

Since we run two compose runs (once to set up an environment, and once
to execute a series of tests within that same environment), we trigger
this "orphan" detection. In our case, this is expected and not an
issue for concern.

To remove potentially confusing warning messages, we can selectively
ignore orphans in these tasks by setting task-specific environment
variable overrides.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>