### PR TITLE
Fix release image push

### DIFF
--- a/.github/workflows/grapl-release.yml
+++ b/.github/workflows/grapl-release.yml
@@ -170,4 +170,4 @@ jobs:
 
       - name: Publish images to DockerHub
         run: |
-          docker-compose push
+          make push

--- a/.github/workflows/grapl-staging-release.yml
+++ b/.github/workflows/grapl-staging-release.yml
@@ -33,4 +33,4 @@ jobs:
 
       - name: Publish images to DockerHub
         run: |
-          docker-compose push
+          make push

--- a/Makefile
+++ b/Makefile
@@ -95,19 +95,18 @@ build-test-typecheck:
 	docker buildx bake -f ./test/docker-compose.typecheck-tests.yml
 
 .PHONY: build-test-integration
-build-test-integration:
+build-test-integration: build-services
 	$(WITH_LOCAL_GRAPL_ENV) \
-	$(DOCKER_BUILDX_BAKE) -f docker-compose.yml -f ./test/docker-compose.integration-tests.yml
+	$(DOCKER_BUILDX_BAKE) -f ./test/docker-compose.integration-tests.yml
 
 .PHONY: build-test-e2e
-build-test-e2e:
+build-test-e2e: build-services
 	$(WITH_LOCAL_GRAPL_ENV) \
-	$(DOCKER_BUILDX_BAKE) -f docker-compose.yml -f ./test/docker-compose.e2e-tests.yml
+	$(DOCKER_BUILDX_BAKE) -f ./test/docker-compose.e2e-tests.yml
 
 .PHONY: build-services
 build-services: ## Build Grapl services
-	$(WITH_LOCAL_GRAPL_ENV) \
-	$(DOCKER_BUILDX_BAKE) -f docker-compose.yml
+	$(DOCKER_BUILDX_BAKE) -f docker-compose.build.yml
 
 .PHONY: build-aws
 build-aws: ## Build services for Grapl in AWS (subset of all services)

--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,10 @@ zip: build-aws ## Generate zips for deploying to AWS (src/js/grapl-cdk/zips/)
 deploy: zip ## CDK deploy to AWS
 	src/js/grapl-cdk/deploy_all.sh
 
+.PHONY: push
+push: ## Push Grapl containers to Docker Hub
+	docker-compose --file=docker-compose.build.yml push
+
 .PHONY: up
 up: build-services ## Build Grapl services and launch docker-compose up
 	$(WITH_LOCAL_GRAPL_ENV) \

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,159 @@
+# This file exists solely to coordinate the build of Grapl service
+# containers.
+#
+# At the moment, these are "local" Grapl containers, and not
+# necessarily identical to the artifacts we would use in real
+# deployments.
+version: "3.8"
+
+services:
+
+  ########################################################################
+  # Rust Services
+  ########################################################################
+
+  grapl-metric-forwarder:
+    image: grapl/grapl-metric-forwarder:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: rust/Dockerfile
+      target: metric-forwarder-deploy
+      args:
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
+
+  grapl-sysmon-subgraph-generator:
+    image: grapl/grapl-sysmon-subgraph-generator:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: rust/Dockerfile
+      target: sysmon-subgraph-generator-deploy
+      args:
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
+
+  grapl-osquery-subgraph-generator:
+    image: grapl/grapl-osquery-subgraph-generator:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: rust/Dockerfile
+      target: osquery-subgraph-generator-deploy
+      args:
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
+
+  grapl-node-identifier:
+    image: grapl/grapl-node-identifier:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: rust/Dockerfile
+      target: node-identifier-deploy
+      args:
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
+
+  grapl-node-identifier-retry-handler:
+    image: grapl/grapl-node-identifier-retry-handler:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: rust/Dockerfile
+      target: node-identifier-retry-handler-deploy
+      args:
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
+
+  grapl-graph-merger:
+    image: grapl/grapl-graph-merger:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: rust/Dockerfile
+      target: graph-merger-deploy
+      args:
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
+
+  grapl-analyzer-dispatcher:
+    image: grapl/grapl-analyzer-dispatcher:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: rust/Dockerfile
+      target: analyzer-dispatcher-deploy
+      args:
+        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
+
+  ########################################################################
+  # Python Services
+  ########################################################################
+
+  grapl-analyzer-executor:
+    image: grapl/grapl-analyzer-executor:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: ./python/Dockerfile
+      target: analyzer-executor-deploy
+
+  grapl-ux-router:
+    image: grapl/grapl-ux-router:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: ./python/Dockerfile
+      target: grapl-ux-router-deploy
+
+  grapl-engagement-creator:
+    image: grapl/grapl-engagement-creator:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: ./python/Dockerfile
+      target: engagement-creator-deploy
+
+  # TODO: really, this service should be grapl-auth
+  grapl-engagement-edge:
+    image: grapl/grapl-engagement-edge:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: ./python/Dockerfile
+      target: engagement-edge-deploy
+
+  grapl-model-plugin-deployer:
+    image: grapl/grapl-model-plugin-deployer:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: ./python/Dockerfile
+      target: model-plugin-deployer-deploy
+
+  grapl-dgraph-ttl:
+    image: grapl/grapl-dgraph-ttl:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: ./python/Dockerfile
+      target: dgraph-ttl-deploy
+
+  ########################################################################
+  # Web Services
+  ########################################################################
+
+  grapl-engagement-view-uploader:
+    image: grapl/grapl-engagement-view:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: js/engagement_view/Dockerfile
+      target: engagement-view-local-deploy
+
+  grapl-graphql-endpoint:
+    image: grapl/grapl-graphql-endpoint:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: js/graphql_endpoint/Dockerfile
+      target: graphql-endpoint-deploy
+
+  grapl-notebook:
+    image: grapl/grapl-notebook:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: ./python/Dockerfile
+      target: grapl-notebook
+
+  ########################################################################
+  # Utility Services
+  ########################################################################
+
+  grapl-provision:
+    image: grapl/grapl-provision:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: ./python/Dockerfile
+      target: grapl-provision

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,12 +151,6 @@ services:
 
   grapl-metric-forwarder:
     image: grapl/grapl-metric-forwarder:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: rust/Dockerfile
-      target: metric-forwarder-deploy
-      args:
-        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
     tty: false
     environment:
       IS_LOCAL: "True"
@@ -164,12 +158,6 @@ services:
 
   grapl-sysmon-subgraph-generator:
     image: grapl/grapl-sysmon-subgraph-generator:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: rust/Dockerfile
-      target: sysmon-subgraph-generator-deploy
-      args:
-        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
     tty: false
     environment:
       <<: *aws-region
@@ -191,12 +179,6 @@ services:
 
   grapl-osquery-subgraph-generator:
     image: grapl/grapl-osquery-subgraph-generator:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: rust/Dockerfile
-      target: osquery-subgraph-generator-deploy
-      args:
-        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
     tty: false
     environment:
       <<: *aws-region
@@ -219,12 +201,6 @@ services:
 
   grapl-node-identifier:
     image: grapl/grapl-node-identifier:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: rust/Dockerfile
-      target: node-identifier-deploy
-      args:
-        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
     environment:
       <<: *aws-region
       DEAD_LETTER_QUEUE_URL: "${SQS_ENDPOINT}/queue/grapl-node-identifier-dead-letter-queue"
@@ -249,12 +225,6 @@ services:
 
   grapl-node-identifier-retry-handler:
     image: grapl/grapl-node-identifier-retry-handler:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: rust/Dockerfile
-      target: node-identifier-retry-handler-deploy
-      args:
-        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
     environment:
       <<: *aws-region
       DEAD_LETTER_QUEUE_URL: "${SQS_ENDPOINT}/queue/grapl-node-identifier-dead-letter-queue"
@@ -279,12 +249,6 @@ services:
 
   grapl-graph-merger:
     image: grapl/grapl-graph-merger:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: rust/Dockerfile
-      target: graph-merger-deploy
-      args:
-        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
     environment:
       <<: *aws-region
       DEAD_LETTER_QUEUE_URL: "${SQS_ENDPOINT}/queue/grapl-graph-merger-dead-letter-queue"
@@ -311,12 +275,6 @@ services:
 
   grapl-analyzer-dispatcher:
     image: grapl/grapl-analyzer-dispatcher:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: rust/Dockerfile
-      target: analyzer-dispatcher-deploy
-      args:
-        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
     environment:
       ANALYZER_BUCKET: "${BUCKET_PREFIX}-analyzers-bucket"
       ANALYZERS_BUCKET: "${BUCKET_PREFIX}-analyzers-bucket"
@@ -341,10 +299,6 @@ services:
 
   grapl-analyzer-executor:
     image: grapl/grapl-analyzer-executor:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: ./python/Dockerfile
-      target: analyzer-executor-deploy
     command: /bin/sh -c '. venv/bin/activate && python3 analyzer_executor/src/run_local.py'
     environment:
       <<: *aws-region
@@ -374,10 +328,6 @@ services:
 
   grapl-ux-router:
     image: grapl/grapl-ux-router:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: ./python/Dockerfile
-      target: grapl-ux-router-deploy
     command: |
       /bin/sh -c '
         wait-for-it grapl-engagement-view-uploader:${WAIT_PORT} --timeout=180 &&
@@ -402,10 +352,6 @@ services:
 
   grapl-engagement-creator:
     image: grapl/grapl-engagement-creator:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: ./python/Dockerfile
-      target: engagement-creator-deploy
     command: /bin/sh -c '. venv/bin/activate && python3 engagement-creator/src/engagement-creator.py'
     environment:
       <<: *aws-region
@@ -424,10 +370,6 @@ services:
   # TODO: really, this service should be grapl-auth
   grapl-engagement-edge:
     image: grapl/grapl-engagement-edge:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: ./python/Dockerfile
-      target: engagement-edge-deploy
     command: |
       /bin/sh -c '
         wait-for-it grapl-provision:${WAIT_PORT} --timeout=120 &&
@@ -457,10 +399,6 @@ services:
 
   grapl-model-plugin-deployer:
     image: grapl/grapl-model-plugin-deployer:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: ./python/Dockerfile
-      target: model-plugin-deployer-deploy
     command: |
       /bin/sh -c '
         . venv/bin/activate &&
@@ -493,10 +431,6 @@ services:
 
   grapl-dgraph-ttl:
     image: grapl/grapl-dgraph-ttl:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: ./python/Dockerfile
-      target: dgraph-ttl-deploy
     command: /bin/sh -c '. venv/bin/activate && cd /home/grapl/app && chalice local --no-autoreload --host=0.0.0.0 --port=${GRAPL_DGRAPH_TTL_PORT}'
     ports:
       - ${GRAPL_DGRAPH_TTL_PORT}
@@ -541,10 +475,6 @@ services:
 
   grapl-engagement-view-uploader:
     image: grapl/grapl-engagement-view:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: js/engagement_view/Dockerfile
-      target: engagement-view-local-deploy
     command: |
       /bin/bash -c "
         wait-for-it grapl-provision:${WAIT_PORT} --timeout=120 &&
@@ -556,10 +486,6 @@ services:
 
   grapl-graphql-endpoint:
     image: grapl/grapl-graphql-endpoint:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: js/graphql_endpoint/Dockerfile
-      target: graphql-endpoint-deploy
     command: yarn start server
     environment:
       <<: *dgraph-env
@@ -577,10 +503,6 @@ services:
 
   grapl-notebook:
     image: grapl/grapl-notebook:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: ./python/Dockerfile
-      target: grapl-notebook
     user: grapl
     environment:
       <<: *dgraph-env
@@ -595,10 +517,6 @@ services:
 
   grapl-provision:
     image: grapl/grapl-provision:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: ./python/Dockerfile
-      target: grapl-provision
     command: |
       /bin/bash -c "
         export TIMEOUT=35 &&


### PR DESCRIPTION
Building containers and running containers are separate tasks, and
combining them into one `docker-compose.yml` file isn't necessarily
useful.

In particular, all the environment variables declared in
`local-grapl.env` are concerned with how the containers should run,
and have nothing to do with how they are built. When we release
containers, we shouldn't need to provide a bunch of unnecessary
variables just so `docker-compose` can parse the file.

Here, we extract a `docker-compose.build.yml` file from
`docker-compose.yml`. Each service only defines a `build`
component. These are exactly the same `build` components that existed
in `docker-compose.yml` before. Additionally, no non-Grapl
services (e.g, Dgraph, Redis) are defined, since those are operational
concerns.

Correspondingly, all the `build` components were removed from
`docker-compose.yml`

The `Makefile` targets were modified to accomodate this change, as
appropriate.

This separation should allow us to better reason about our containers,
as well as how to compose them in various testing and release
activities.

Finally, a `Makefile` target is added for pushing containers built from the 
new `docker-compose.build.yml` file, and is used in our release pipelines.