### PR TITLE
Restore host port binding to containers for local grapl environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,10 +51,7 @@ services:
     tty: false
     image: dgraph/standalone:v20.07.1
     ports:
-      - ${DGRAPH_ZERO_GRPC_PRIVATE_PORT}
-      - ${DGRAPH_RATEL_HTTP_EXTERNAL_PUBLIC_PORT}
-      - ${DGRAPH_ALPHA_HTTP_EXTERNAL_PUBLIC_PORT}
-      - ${DGRAPH_ALPHA_GRPC_EXTERNAL_PUBLIC_PORT}
+      - ${DGRAPH_RATEL_HTTP_EXTERNAL_PUBLIC_PORT}:${DGRAPH_RATEL_HTTP_EXTERNAL_PUBLIC_PORT}
     logging:
       driver: none
     volumes:
@@ -77,8 +74,6 @@ services:
         # to disable persistence
         rm -f /data/dump.rdb && redis-server
       "
-    ports:
-      - ${REDIS_PORT}
     logging:
       driver: none
     networks:
@@ -92,8 +87,6 @@ services:
       - HOSTNAME_EXTERNAL=${SQS_HOST}
       - IMAGE_NAME=localstack/localstack:0.11.5
       - SERVICES=sqs:${SQS_PORT}
-    ports:
-      - ${SQS_PORT}
     networks:
       default:
         aliases:
@@ -109,8 +102,7 @@ services:
       - PORT_WEB_UI=${SECRETSMANAGER_WEB_UI_PORT}
       - SERVICES=secretsmanager:${SECRETSMANAGER_PORT}
     ports:
-      - ${SECRETSMANAGER_PORT}
-      - ${SECRETSMANAGER_WEB_UI_PORT}
+      - ${SECRETSMANAGER_WEB_UI_PORT}:${SECRETSMANAGER_WEB_UI_PORT}
     networks:
       default:
         aliases:
@@ -126,7 +118,7 @@ services:
       - MINIO_REGION_NAME=${AWS_REGION}
       - MINIO_SECRET_KEY=minioadmin
     ports:
-      - ${S3_PORT}
+      - ${S3_PORT}:${S3_PORT}
     networks:
       default:
         aliases:
@@ -365,7 +357,7 @@ services:
       <<: *sqs-env
     tty: true
     ports:
-      - ${VSC_DEBUGGER}
+      - ${VSC_DEBUGGER}:${VSC_DEBUGGER}
     depends_on:
       - dgraph
       - redis
@@ -385,8 +377,6 @@ services:
         cd app &&
         chalice local --no-autoreload --host=0.0.0.0 --port=${GRAPL_UX_ROUTER_PORT}
       '
-    ports:
-      - ${GRAPL_UX_ROUTER_PORT}
     environment:
       GRAPL_LOG_LEVEL: "DEBUG"
       # TODO: Once we remove IS_LOCAL, this service will need to depend on s3 and be configured appropriately
@@ -435,8 +425,6 @@ services:
         cd /home/grapl/app &&
         chalice local --no-autoreload --host=0.0.0.0 --port=${GRAPL_AUTH_PORT}
       '
-    ports:
-      - ${GRAPL_AUTH_PORT}
     networks:
       default:
         aliases:
@@ -470,8 +458,6 @@ services:
           --host=0.0.0.0 \
           --port=${GRAPL_MODEL_PLUGIN_DEPLOYER_PORT}
       '
-    ports:
-      - ${GRAPL_MODEL_PLUGIN_DEPLOYER_PORT}
     environment:
       <<: *aws-region
       <<: *dgraph-env
@@ -498,8 +484,6 @@ services:
       dockerfile: ./python/Dockerfile
       target: dgraph-ttl-deploy
     command: /bin/sh -c '. venv/bin/activate && cd /home/grapl/app && chalice local --no-autoreload --host=0.0.0.0 --port=${GRAPL_DGRAPH_TTL_PORT}'
-    ports:
-      - ${GRAPL_DGRAPH_TTL_PORT}
     environment:
       <<: *dgraph-env
       GRAPL_DGRAPH_TTL_S: "${GRAPL_DGRAPH_TTL_S:-31536000}"
@@ -569,7 +553,7 @@ services:
     depends_on:
       - dgraph
     ports:
-      - ${GRAPL_GRAPHQL_PORT}
+      - ${GRAPL_GRAPHQL_PORT}:${GRAPL_GRAPHQL_PORT}
     networks:
       default:
         aliases:
@@ -587,7 +571,7 @@ services:
     depends_on:
       - dgraph
     ports:
-      - ${GRAPL_NOTEBOOK_PORT}
+      - ${GRAPL_NOTEBOOK_PORT}:${GRAPL_NOTEBOOK_PORT}
 
   ########################################################################
   # Utility Services


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

A recent diff accidentally removed the host port binding to the local grapl environment. This restores those mappings.

Additionally, I removed `ports` specs from services that seem like they don't need to be accessible from the host. This is so the host ports won't be bound.

### How were these changes tested?

Andrea initially identified in the issue. Making similar changes resolved that for her.

Also, I ran `make test-integration` locally with great success.
