### PR TITLE
Add a debugging container

### DIFF
--- a/debugger/Dockerfile
+++ b/debugger/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu
+
+# Feel free to add whatever convenient testing utilities you like.
+RUN apt-get update && apt-get install --yes \
+    curl \
+    htop \
+    iputils-ping \
+    jq \
+    net-tools \
+    nmap \
+    strace \
+    wget

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -1,0 +1,2 @@
+build:
+	docker build . --tag=grapl/debugger

--- a/debugger/README.md
+++ b/debugger/README.md
@@ -1,0 +1,25 @@
+Grapl Container Debugger Container
+==================================
+
+Provides a container named `grapl/debugger` that contains various
+utilities that can be useful for debugging issues in other running
+containers.
+
+The `attach.sh` script provides the necessary Docker command to run
+this debugger container with the appropriate permissions and in the
+shared namespaces of a target container that is already running.
+
+```
+attach.sh ${NAME_OF_ANOTHER_CONTAINER}
+```
+
+Once inside, you can do things like `htop`, `strace -p 1`, `ping`
+other containers on the network, etc., just as though you were inside
+the container (which, in a very real sense, you are).
+
+The directory you invoke `attach.sh` from will be mounted inside the
+debugging container at `/from-host`, which is also your working
+directory, just in case you want to bring anything along with you on
+your debugging journey.
+
+To build the container, simply run `make`.

--- a/debugger/attach.sh
+++ b/debugger/attach.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+target_container_name="${1}"
+
+docker run \
+       --interactive \
+       --tty \
+       --rm \
+       --pid="container:${target_container_name}" \
+       --net="container:${target_container_name}" \
+       --privileged \
+       --cap-add sys_admin \
+       --cap-add sys_ptrace \
+       --volume="$(pwd):/from-host" \
+       --workdir="/from-host" \
+       grapl/debugger


### PR DESCRIPTION
Adds a container full of handy debugging tools, as well as a script to
make it easy to attach to an existing container for debugging
purposes.

Fixes https://github.com/grapl-security/issue-tracker/issues/109

Signed-off-by: Christopher Maier <chris@graplsecurity.com>

