### PR TITLE
Update cacheT interface to return cacheable alongside cacheresponse

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1234,7 +1234,7 @@ dependencies = [
 name = "grapl-utils"
 version = "0.1.0"
 dependencies = [
- "tokio 0.2.24",
+ "tokio 0.2.25",
 ]
 
 [[package]]

--- a/src/rust/sqs-executor/src/cache.rs
+++ b/src/rust/sqs-executor/src/cache.rs
@@ -33,19 +33,19 @@ pub enum CacheResponse {
 pub trait Cache: Clone {
     type CacheErrorT: CheckedError + Send + Sync + 'static;
 
-    async fn get<CA: Cacheable + Send + Sync + 'static>(
+    async fn get<CA: Cacheable + Send + Sync + Clone + 'static>(
         &mut self,
         cacheable: CA,
     ) -> Result<CacheResponse, Self::CacheErrorT>;
 
-    async fn get_all<CA: Cacheable + Send + Sync + 'static>(
+    async fn get_all<CA: Cacheable + Send + Sync + Clone + 'static>(
         &mut self,
         cacheables: Vec<CA>,
-    ) -> Result<Vec<CacheResponse>, Self::CacheErrorT> {
+    ) -> Result<Vec<(CA, CacheResponse)>, Self::CacheErrorT> {
         let mut results = Vec::with_capacity(cacheables.len());
 
         for cacheable in cacheables {
-            results.push(self.get(cacheable).await?);
+            results.push((cacheable.clone(), self.get(cacheable).await?));
         }
 
         Ok(results)
@@ -80,7 +80,7 @@ pub struct NopCache {}
 impl Cache for NopCache {
     type CacheErrorT = NopCacheError;
 
-    async fn get<CA: Cacheable + Send + Sync + 'static>(
+    async fn get<CA: Cacheable + Send + Sync + Clone + 'static>(
         &mut self,
         _cacheable: CA,
     ) -> Result<CacheResponse, Self::CacheErrorT> {


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

Internally requested: Update the `Cache` trait `get_all` method to return `Vec<(Cacheable, CacheResponse)>` instead of just `Vec<CacheResponse>` to make it easier to determine which elements need to be actioned on.