### PR TITLE
Add #[derive(Eq, PartialEq)] to sqs-excutor::cache::CacheResponse.

### DIFF
--- a/src/rust/sqs-executor/src/cache.rs
+++ b/src/rust/sqs-executor/src/cache.rs
@@ -23,7 +23,7 @@ where
     }
 }
 
-#[derive(Clone)]
+#[derive(Eq, PartialEq, Clone)]
 pub enum CacheResponse {
     Hit,
     Miss,


### PR DESCRIPTION
### Which issue does this PR correspond to?

Not sure if it's worth creating an issue to track time spent on this PR.

### What changes does this PR make to Grapl? Why?

This adds `#[derive(Eq, PartialEq)]` to `sqs-excutor::cache::CacheResponse`. This should enable us to do things like:

```
resp == CacheResponse::Miss
```

### How were these changes tested?

I ran `make test-unit-rust`.