### PR TITLE
Fix missing ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,10 @@ services:
     tty: false
     image: dgraph/standalone:v20.07.1
     ports:
+      # required to access the RATEL interface for dgraph
       - ${DGRAPH_RATEL_HTTP_EXTERNAL_PUBLIC_PORT}:${DGRAPH_RATEL_HTTP_EXTERNAL_PUBLIC_PORT}
+      # required for RATEL interface to operate properly
+      - ${DGRAPH_ALPHA_HTTP_EXTERNAL_PUBLIC_PORT}:${DGRAPH_ALPHA_HTTP_EXTERNAL_PUBLIC_PORT}
     logging:
       driver: none
     volumes:
@@ -87,6 +90,9 @@ services:
       - HOSTNAME_EXTERNAL=${SQS_HOST}
       - IMAGE_NAME=localstack/localstack:0.11.5
       - SERVICES=sqs:${SQS_PORT}
+    ports:
+      # Used to insert data in local grapl via upload-*.py
+      - ${SQS_PORT}:${SQS_PORT}
     networks:
       default:
         aliases:


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/257

### What changes does this PR make to Grapl? Why?

Opens up ports required for SQS and Ratel interface to operate on local grapl

### How were these changes tested?

Ran `make up` locally to verify that:

* I was able to upload logs to local sqs using `upload-sysmon-logs.py`
* I was able to access and interact with the ratel interface on port 8000 (which uses port 8080 for running queries)
