### PR TITLE
Internal 258 nginx port

### DIFF
--- a/etc/local_grapl/nginx_templates/default.conf.template
+++ b/etc/local_grapl/nginx_templates/default.conf.template
@@ -11,11 +11,11 @@ server {
   listen 3128;
 
   location /auth/ {
-    proxy_pass http://${GRAPL_AUTH_HOST}:${GRAPL_AUTH_HOST}$uri;
+    proxy_pass http://${GRAPL_AUTH_HOST}:${GRAPL_AUTH_PORT}$uri;
   }
 
   location /prod/auth/ {
-    proxy_pass http://${GRAPL_AUTH_HOST}:${GRAPL_AUTH_HOST}$uri;
+    proxy_pass http://${GRAPL_AUTH_HOST}:${GRAPL_AUTH_PORT}$uri;
   }
 
   location /graphQlEndpoint/ {


### PR DESCRIPTION
### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/258

### What changes does this PR make to Grapl? Why?
Fixes a host being passed in where a port is expected

### How were these changes tested?
I was able to log in locally, thus demonstrating the fix.