### PR TITLE
Shush a harmless warning for 'coroutine was never awaited' in analyzer-executor

### DIFF
--- a/src/python/analyzer_executor/tests/test_sqs_timeout_manager.py
+++ b/src/python/analyzer_executor/tests/test_sqs_timeout_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import asyncio
 import unittest
 from dataclasses import dataclass
@@ -47,14 +48,18 @@ class TestSqsTimeoutManager(unittest.TestCase):
 
         _quiet_never_awaited_error(f)
 
+
 def _quiet_never_awaited_error(f: SqsTimeoutManagerFixture) -> None:
     """
     Some tests that consume SqsTimeoutManagerFixture never await. That's OK.
     Solves "coroutine was never awaited"
     """
+
     async def cancel_it() -> None:
         asyncio.create_task(f.timeout_manager.coroutine).cancel()
+
     asyncio.run(cancel_it())
+
 
 class SqsTimeoutManagerFixture:
     def __init__(self) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/268

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Basically, we have this fixture that - by default - creates an instance of a coroutine (but doesn't run it).
Pytest helpfully lets you know when you've done this, as it usually implies a programming error.
However, in this case, it's a red herring.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
make test-unit-python

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
