### PR TITLE
Sqs executor error helpers

### DIFF
--- a/src/rust/sqs-executor/src/errors.rs
+++ b/src/rust/sqs-executor/src/errors.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub enum Recoverable {
     Transient,
     Persistent,
@@ -8,6 +8,14 @@ pub enum Recoverable {
 
 pub trait CheckedError: std::error::Error {
     fn error_type(&self) -> Recoverable;
+
+    fn is_transient(&self) -> bool {
+        self.error_type() == Recoverable::Transient
+    }
+
+    fn is_persistent(&self) -> bool {
+        self.error_type() == Recoverable::Persistent
+    }
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
### Which issue does this PR correspond to?

- https://github.com/grapl-security/issue-tracker/issues/271
- https://github.com/grapl-security/issue-tracker/issues/265

### What changes does this PR make to Grapl? Why?

In fixing 271, we provide two ways for users to check the type. They could use helper functions we've added to the type, or they can now check for equality now that `Eq` and `PartialEq` are derived for the type enum.

In order to resolve 265, we first needed to resolve 271. The fix is a little awkward, which is its own issue being tracked at https://github.com/grapl-security/issue-tracker/issues/269. The fix is for the generator to prefer to return a `Recoverable::Transient` error over a `Recoverable::Persistent` error.

### How were these changes tested?

I only ran the local tests.