### PR TITLE
Introduce a 'make up-detach' for integration tests (particularly, for Cloudtrail e2e to consume)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ up-detach: build-services ## Docker-compose up + detach and return control to tt
 	docker-compose \
 		-p $(PROJECT_NAME) \
 		-f docker-compose.yml \
-		up --detach
+		up --detach --force-recreate
 
 .PHONY: down
 down: ## docker-compose down - both stops and removes the containers

--- a/Makefile
+++ b/Makefile
@@ -144,10 +144,7 @@ test-typecheck: build-test-typecheck ## Build and run typecheck tests
 test-integration: export COMPOSE_IGNORE_ORPHANS=1
 test-integration: build-test-integration ## Build and run integration tests
 	$(WITH_LOCAL_GRAPL_ENV) \
-	docker-compose \
-		--file docker-compose.yml \
-		--project-name "grapl-integration_tests" \
-		up --force-recreate -d && \
+	$(MAKE) up-detach PROJECT_NAME="grapl-integration_tests" && \
 	test/docker-compose-with-error.sh \
 		-f ./test/docker-compose.integration-tests.yml \
 		-p "grapl-integration_tests"
@@ -156,10 +153,7 @@ test-integration: build-test-integration ## Build and run integration tests
 test-e2e: export COMPOSE_IGNORE_ORPHANS=1
 test-e2e: build-test-e2e ## Build and run e2e tests
 	$(WITH_LOCAL_GRAPL_ENV) \
-	docker-compose \
-		--file docker-compose.yml \
-		--project-name "grapl-e2e_tests" \
-		up --force-recreate -d && \
+	$(MAKE) up-detach PROJECT_NAME="grapl-e2e_tests" && \
 	test/docker-compose-with-error.sh \
 		-f ./test/docker-compose.e2e-tests.yml \
 		-p "grapl-e2e_tests"
@@ -229,6 +223,16 @@ push: ## Push Grapl containers to Docker Hub
 up: build-services ## Build Grapl services and launch docker-compose up
 	$(WITH_LOCAL_GRAPL_ENV) \
 	docker-compose -f docker-compose.yml up
+
+.PHONY: up-detach
+up-detach: build-services ## Docker-compose up + detach and return control to tty
+	# Primarily used for bringing up an environment for integration testing.
+	# Usage: `make up-detach PROJECT_NAME=asdf`
+	$(WITH_LOCAL_GRAPL_ENV) \
+	docker-compose \
+		-p $(PROJECT_NAME) \
+		-f docker-compose.yml \
+		up --detach
 
 .PHONY: down
 down: ## docker-compose down - both stops and removes the containers


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/235

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Add a new mechanism to the makefile that makes spinning up integration tests easier

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
locally
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
