### PR TITLE
change Fargate service LogGroup removal policy to DESTROY

### DIFF
--- a/src/js/grapl-cdk/lib/fargate_service.ts
+++ b/src/js/grapl-cdk/lib/fargate_service.ts
@@ -100,10 +100,12 @@ export class FargateService {
 
         this.logGroups = {
             default: new logs.LogGroup(scope, "default", {
-                logGroupName: `grapl/${this.serviceName}/default`
+                logGroupName: `grapl/${this.serviceName}/default`,
+                removalPolicy: cdk.RemovalPolicy.DESTROY
             }),
             retry: new logs.LogGroup(scope, "retry", {
-                logGroupName: `grapl/${this.serviceName}/retry`
+                logGroupName: `grapl/${this.serviceName}/retry`,
+                removalPolicy: cdk.RemovalPolicy.DESTROY
             }),
         }
 


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/285

### What changes does this PR make to Grapl? Why?

This changes the LogGroup removal policy to DESTROY. By default the log groups persist after CloudFormation stack removal, which will cause a later deployment of the same name to fail.

Alternative to this solution, it seems we could check `fromLogGroupName` and use that if found before trying to create a new one, but I'm not sure we want these log groups around after removing a stack anyway.

### How were these changes tested?

I have the same code for this in a generator in external repo, where I tested this diff. With these changes the issue was resolved.