### PR TITLE
Remove `allow_comment_ignores` from buf.yaml

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -11,10 +11,6 @@ lint:
     # We have vendored some of the Google protobuf definitions; we
     # don't need to lint them, and will be able to remove them soon.
     - google
-  # TODO: Only allowing this temporarily for Edge#edgeName; remove at
-  # earliest possible convenience, since this allows for uncontrolled
-  # ignoring of arbitrary lints.
-  allow_comment_ignores: true
 breaking:
   # https://docs.buf.build/breaking-configuration
   use:


### PR DESCRIPTION
The `Edge#edgeName` field was renamed in #561 so we no longer need to
ignore any lints.

See https://github.com/grapl-security/issue-tracker/issues/237

Signed-off-by: Christopher Maier <chris@graplsecurity.com>