### PR TITLE
E2e tests: our 'correct' answer was wrong, it's actually 5

### DIFF
--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -16,7 +16,7 @@ class TestEndToEnd(TestCase):
         # We fall into one of three buckets:
         # - No lens
         # - Lens with 3 scope
-        # - Lens with 4 scope 
+        # - Lens with 4 scope
         # - Lens with 5 scope (correct)
 
         query = LensQuery().with_lens_name(LENS_NAME)

--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -16,7 +16,8 @@ class TestEndToEnd(TestCase):
         # We fall into one of three buckets:
         # - No lens
         # - Lens with 3 scope
-        # - Lens with 4 scope (correct)
+        # - Lens with 4 scope 
+        # - Lens with 5 scope (correct)
 
         query = LensQuery().with_lens_name(LENS_NAME)
         lens: LensView = wait_for_one(WaitForQuery(query), timeout_secs=120)
@@ -25,13 +26,14 @@ class TestEndToEnd(TestCase):
         # lens scope is not atomic
         def condition() -> bool:
             length = len(lens.get_scope())
-            logging.info(f"Expected 3-4 nodes in scope, currently is {length}")
+            logging.info(f"Expected 3-5 nodes in scope, currently is {length}")
 
-            # The correct answer for this is 4.
-            # We are temp 'allowing' 3 because it means the pipeline is, _mostly_, working.
+            # The correct answer for this is 5.
+            # We are temp 'allowing' below that because it means the pipeline is, _mostly_, working.
             return length in (
                 3,
                 4,
+                5,
             )
 
         wait_for_one(WaitForCondition(condition), timeout_secs=240)


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Make e2e tests allow any answer from 3 to 5.
It is now too performant and actually shows us that 5 is possible and probably the right answer.

Yes i considered using range([start, end)) but whatever

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
CI

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
