### PR TITLE
Add instructions, tooling to aid editor setup for Python code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ dist/
 /tags.lock
 /tags.temp
 .log
+pyrightconfig.json
 
 # Pants-related artifacts
 # https://www.pantsbuild.org/docs/gitignore

--- a/EDITOR_SETUP.md
+++ b/EDITOR_SETUP.md
@@ -146,15 +146,15 @@ As long as the `buf` binary is present in your `$PATH`, the [buf Visual Studio
 Code plugin][buf_vsc] will automatically lint your Protobuf files
 according to our configuration.
 
-[vsc]: https://code.visualstudio.com/
-[ra_vsc]: https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer
-[clippy]: https://github.com/rust-lang/rust-clippy
-[rustfmt]: https://github.com/rust-lang/rustfmt
 [buf]: https://buf.build
 [buf_release]: https://github.com/bufbuild/buf/releases
 [buf_vsc]: https://marketplace.visualstudio.com/items?itemName=bufbuild.vscode-buf
-[pyright-vsc]: https://marketplace.visualstudio.com/items?itemName=ms-pyright.pyright
-[pylance-vsc]: https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance
+[clippy]: https://github.com/rust-lang/rust-clippy
 [lsp-mode-emacs]: https://github.com/emacs-lsp/lsp-mode
 [lsp-pyright-emacs]: https://github.com/emacs-lsp/lsp-pyright
+[pylance-vsc]: https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance
 [pyright]: https://github.com/Microsoft/pyright
+[pyright-vsc]: https://marketplace.visualstudio.com/items?itemName=ms-pyright.pyright
+[ra_vsc]: https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer
+[rustfmt]: https://github.com/rust-lang/rustfmt
+[vsc]: https://code.visualstudio.com/

--- a/EDITOR_SETUP.md
+++ b/EDITOR_SETUP.md
@@ -54,6 +54,83 @@ the specific configurations are encapsulated into custom scripts that
 we also use in CI. By also using them in an editor, we can ensure a
 consistent experience for all uses of these tools.
 
+# Python Configuration
+
+Our Python monorepo relies heavily on the
+[Pants](https://pantsbuild.org) build system. The `pants` script is
+included in this repository (as is standard practice for Pants), so no
+additional tooling needs to be downloaded and installed for it.
+
+Pants knows all about how our Python code is structured, how it
+interrelates, and what code depends on it. However, we have a bit of
+work to do before that knowledge can be usefully exposed to our
+editors.
+
+## Common Setup for Pyright
+
+We have had good experience with [Pyright][pyright] for integrating
+our editors with our Python code. Plugins are available for a variety
+of editors, but some common setup must be done for each.
+
+First, you must set up an appropriate virtual environment for our
+3rd-party Python dependencies. Run the following command.
+
+```sh
+make populate-venv
+```
+Follow the instructions in the output of that command to activate the
+virtual environment.
+
+As our dependencies are updated, you can re-run this command to ensure
+your virtual environment is up-to-date.
+
+Next, you'll need to create a `pyrightconfig.json` file. Because of
+how our Python code is currently laid out, this can be a bit
+complex. Fortunately, this can be driven by the information from our
+Pants configuration file ([pants.toml](./pants.toml).
+
+To generate this file, run the following command (this requires that
+the virtual environment you created above is active):
+
+```sh
+build-support/editor_setup.py pyright generate
+```
+This will create a functional configuration for you. You may then modify it
+as you like.
+
+As we add to and modify our Python code (including its organization on
+disk), this `pyrightconfig.json` fill will need to be updated to
+reflect these changes. Automation saves the day once again,
+however. Running the following command will update only the parts of
+the configuration file that are impacted by our code layout:
+
+```sh
+build-support/editor_setup.py pyright update
+```
+Any customizations outside of that small amount of information will be
+preserved.
+
+(For further details, feel free to execute any of those
+`editor_setup.py` commands with the `--help` option.
+
+Once you have a configuration file in place, you can proceed on to
+editor-specific configuration in the sections below.
+
+### Visual Studio Code
+
+While you can use either the [Pyright][pyright-vsc] or
+[Pylance][pylance-vsc] plugins, Pylance is recommended, as it is based
+in part on Pyright, and is overall more advanced. These plugins will
+automatically configure themselves according to the
+`pyrightconfig.json` file we generated above.
+
+### Emacs
+
+Use [lsp-mode][lsp-mode-emacs] along with
+[lsp-pyright][lsp-pyright-emacs]. The necessary configuration will be
+picked up automatically from the `pyrightconfig.json` file we
+generated above.
+
 # Protobuf Configuration
 
 We use [buf][buf] to lint our Protobuf definitions. The tool can be
@@ -76,3 +153,8 @@ according to our configuration.
 [buf]: https://buf.build
 [buf_release]: https://github.com/bufbuild/buf/releases
 [buf_vsc]: https://marketplace.visualstudio.com/items?itemName=bufbuild.vscode-buf
+[pyright-vsc]: https://marketplace.visualstudio.com/items?itemName=ms-pyright.pyright
+[pylance-vsc]: https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance
+[lsp-mode-emacs]: https://github.com/emacs-lsp/lsp-mode
+[lsp-pyright-emacs]: https://github.com/emacs-lsp/lsp-pyright
+[pyright]: https://github.com/Microsoft/pyright

--- a/EDITOR_SETUP.md
+++ b/EDITOR_SETUP.md
@@ -15,13 +15,37 @@ If you have configuration instructions for an editor or IDE not
 covered here, please feel free to submit a
 [PR](https://github.com/grapl-security/grapl/pulls)!
 
-# Visual Studio Code
+# Rust Configuration
 
-[Link][vsc]
-
-## Rust Configuration
+## Visual Studio Code
 
 For Rust, the [Rust Analyzer Plugin][ra_vsc] is recommended.
+
+Add the following to your workspace settings (note that you will have
+to change all `/path/to/your/grapl/repo` paths as appropriate for your
+workstation):
+
+``` json
+"settings": {
+    "editor.formatOnSave": true,
+    "editor.formatOnPaste": true,
+    "[rust]": {
+        "editor.defaultFormatter": "matklad.rust-analyzer",
+    },
+    "rust-analyzer.linkedProjects": [
+        "src/rust/Cargo.toml"
+    ],
+    "rust-analyzer.checkOnSave.enable": true,
+    "rust-analyzer.checkOnSave.overrideCommand": [
+        "/path/to/your/grapl/repo/src/rust/bin/lint",
+        "json"
+    ],
+    "rust-analyzer.rustfmt.overrideCommand": [
+        "/path/to/your/grapl/repo/src/rust/bin/format",
+        "--editor"
+    ]
+}
+```
 
 Of particular note are the `checkOnSave` and `rustfmt` override
 commands. As with many Rust projects, we still use [rustfmt][rustfmt],
@@ -30,31 +54,7 @@ the specific configurations are encapsulated into custom scripts that
 we also use in CI. By also using them in an editor, we can ensure a
 consistent experience for all uses of these tools.
 
-Add the following to your workspace settings:
-
-``` json
-    "settings": {
-        "editor.formatOnSave": true,
-        "editor.formatOnPaste": true,
-        "[rust]": {
-            "editor.defaultFormatter": "matklad.rust-analyzer",
-        },
-        "rust-analyzer.linkedProjects": [
-            "src/rust/Cargo.toml"
-        ],
-        "rust-analyzer.checkOnSave.enable": true,
-        "rust-analyzer.checkOnSave.overrideCommand": [
-            "/path/to/your/grapl/repo/src/rust/bin/lint",
-            "json"
-        ],
-        "rust-analyzer.rustfmt.overrideCommand": [
-            "/path/to/your/grapl/repo/src/rust/bin/format",
-            "--editor"
-        ]
-    }
-```
-
-## Protobuf Configuration
+# Protobuf Configuration
 
 We use [buf][buf] to lint our Protobuf definitions. The tool can be
 downloaded from [the Github Releases page][buf_release], or by using
@@ -63,7 +63,9 @@ repository.
 
 The tool itself is configured via [buf.yaml](./buf.yaml).
 
-As long as the binary is present in your `$PATH`, the [buf Visual Studio
+## Visual Studio Code
+
+As long as the `buf` binary is present in your `$PATH`, the [buf Visual Studio
 Code plugin][buf_vsc] will automatically lint your Protobuf files
 according to our configuration.
 

--- a/Makefile
+++ b/Makefile
@@ -145,10 +145,14 @@ test-typecheck: build-test-typecheck ## Build and run typecheck tests (non-Pants
 test-typecheck-pulumi: ## Typecheck Pulumi Python code
 	./pants typecheck pulumi::
 
-# Right now, we're only typechecking Pulumi code with Pants until CM
-# fixes https://github.com/pantsbuild/pants/issues/11553
+.PHONY: test-typecheck-build-support
+test-typecheck-build-support: ## Typecheck build-support Python code
+	./pants typecheck build-support::
+
+# Right now, we're only typechecking a select portion of code with
+# Pants until CM fixes https://github.com/pantsbuild/pants/issues/11553
 .PHONY: test-typecheck-pants
-test-typecheck-pants: test-typecheck-pulumi ## Typecheck Python code with Pants
+test-typecheck-pants: test-typecheck-pulumi test-typecheck-build-support ## Typecheck Python code with Pants
 
 .PHONY: test-integration
 test-integration: export COMPOSE_IGNORE_ORPHANS=1
@@ -265,7 +269,7 @@ e2e-logs: ## All docker-compose logs
 
 .PHONY: help
 help: ## Print this help
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {gsub("\\\\n",sprintf("\n%22c",""), $$2);printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {gsub("\\\\n",sprintf("\n%22c",""), $$2);printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 .PHONY: docker-kill-all
 docker-kill-all:  # Kill all currently running Docker containers

--- a/build-support/BUILD
+++ b/build-support/BUILD
@@ -1,0 +1,1 @@
+python_library()

--- a/build-support/editor_setup.py
+++ b/build-support/editor_setup.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+
+"""Encapsulates logic for generating and updating editor
+configuration files to make it easy to work with Grapl code.
+
+Provided as a self-documenting Click app for discoverability and ease
+of maintenance.
+
+"""
+
+import json
+from typing import Dict, List, Union
+
+import click
+import toml
+from typing_extensions import TypedDict
+
+
+# NOTE: This is essentially to silence the typechecker (and help us
+# not shoot ourselves in the foot). It's not making any attempt to be
+# a complete and faithful typing of Pyright configuration documents;
+# it's just typing what we're currently using. Feel free to update
+# this as this code develops and matures.
+class PyrightConfig(TypedDict):
+    pythonVersion: str
+    pythonPlatform: str
+    venvPath: str
+    venv: str
+    verboseOutput: bool
+    reportMissingImports: bool
+    exclude: List[str]
+    executionEnvironments: List[Dict[str, Union[str, List[str]]]]
+
+
+BASE_PYRIGHTCONFIG: PyrightConfig = {
+    "pythonVersion": "3.7",
+    "pythonPlatform": "Linux",
+    "venvPath": "build-support",
+    "venv": "grapl-venv",
+    "verboseOutput": True,
+    "reportMissingImports": True,
+    "exclude": [
+        "src/js/**",
+        "src/rust/**",
+    ],
+    "executionEnvironments": [
+        {"root": "pulumi"},
+        {"root": "pants-plugins"},
+        # NOTE: We will augment this with the src/python root in the
+        # code below
+    ],
+}
+
+PANTS_TOML = "pants.toml"
+PYRIGHTCONFIG_JSON = "pyrightconfig.json"
+
+
+def src_python_execution_environment() -> Dict[str, Union[str, List[str]]]:
+    """Generate a pyright "executionEnvironments" entry for code in our
+    `src/python` directory.
+
+    Since this code is all interrelated, we need to provide the
+    appropriate "extraPaths" for Pyright to properly resolve imports,
+    types, etc. In general, this amounts to adding our Pants source
+    roots, with a few caveats:
+
+    1) not all the roots are required for Python code in that
+    directory
+
+    2) Our Pants configuration explicitly provides absolute paths, not
+    patterns that may be matched anywhere
+
+    As such, we first filter out what we don't need, and then
+    "relativize" the paths, since this is what Pyright need.
+
+    """
+    pants = toml.load(PANTS_TOML)
+    source_roots = pants["source"]["root_patterns"]
+
+    if any(not r.startswith("/") for r in source_roots):
+        raise click.ClickException(
+            "Expected all Pants source roots to be absolute, but at least one was not!"
+        )
+
+    # We don't care about these source roots for things that are in src/python
+    filtered = [
+        root
+        for root in source_roots
+        if root
+        not in (
+            "/3rdparty",
+            "/build-support",
+            "/pants-plugins",
+            "/pulumi",
+            "/src/js/grapl-cdk",
+            "/src/proto",
+        )
+    ]
+    relativized = [root.lstrip("/") for root in filtered]
+
+    return {"root": "src/python", "extraPaths": relativized}
+
+
+def write_or_echo(output: str, path: str, write_file: bool) -> None:
+    """ Consolidate logic for whether to write `output` to the file at `path`, or to send it to standard output instead."""
+    if write_file:
+        with click.open_file(path, "w") as f:
+            f.write(output)
+        click.echo(f"Wrote content to {path} file")
+    else:
+        click.echo(output)
+
+
+@click.command(name="generate")
+@click.option(
+    "--write-file/--no-write-file",
+    is_flag=True,
+    default=True,
+    show_default=True,
+    help="Controls whether or not to write the generated output to disk, or to standard output.",
+)
+def generate_pyrightconfig(write_file: bool) -> None:
+    """Generate a pyrightconfig.json file from pants.toml.
+
+    Do this if you have no existing pyrightconfig.json file that you
+    are using. If you already have one, on the other hand, please see
+    the `update` command instead.
+
+    """
+
+    pyrightconfig = BASE_PYRIGHTCONFIG
+    pyrightconfig["executionEnvironments"].append(src_python_execution_environment())
+    output = json.dumps(pyrightconfig, indent=4)
+
+    write_or_echo(output, PYRIGHTCONFIG_JSON, write_file)
+
+
+@click.command(name="update")
+@click.option(
+    "--write-file/--no-write-file",
+    is_flag=True,
+    default=True,
+    show_default=True,
+    help="Controls whether or not to write the generated output to disk, or to standard output.",
+)
+def update_pyrightconfig(write_file: bool) -> None:
+    """Update an existing pyrightconfig.json file.
+
+    In particular, the `extraPaths` entries for various
+    `executionEnvironments` must be kept in-sync with what we declare
+    in our pants.toml file.
+
+    Any other changes you may have made to your file will be
+    preserved.
+
+    """
+
+    with click.open_file(PYRIGHTCONFIG_JSON, "r") as f:
+        pyright = json.load(f)
+
+    execution_environments = pyright["executionEnvironments"]
+
+    # Preserve other environments; we're only concerned about the
+    # src/python one here
+    new_execution_environments = [
+        e for e in execution_environments if e["root"] != "src/python"
+    ]
+    new_execution_environments.append(src_python_execution_environment())
+    pyright.update({"executionEnvironments": new_execution_environments})
+
+    output = json.dumps(pyright, indent=4)
+    write_or_echo(output, PYRIGHTCONFIG_JSON, write_file)
+
+
+@click.group(name="pyright")
+def configure_pyright() -> None:
+    """ Set up Pyright for Python IDE integration. """
+
+
+configure_pyright.add_command(generate_pyrightconfig)
+configure_pyright.add_command(update_pyrightconfig)
+
+
+@click.group()
+def editor_setup() -> None:
+    """A utility for helping to configure IDEs and editors for working
+    with Grapl code."""
+
+
+editor_setup.add_command(configure_pyright)
+
+if __name__ == "__main__":
+    editor_setup()

--- a/pants.toml
+++ b/pants.toml
@@ -31,6 +31,7 @@ pants_ignore = [
 [source]
 root_patterns = [
   "/3rdparty",
+  "/build-support",
   "/pants-plugins",
   "/pulumi",
   "/src/js/grapl-cdk",


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/320

### What changes does this PR make to Grapl? Why?

Adds instructions on how to set up editors for efficiently working with our Python code. This includes some tooling to make it easier to keep this information up-to-date as we mature our use of Pants.

Read the individual commit messages for further details.

### How were these changes tested?

```sh
build-support/editor_setup.py pyright generate
```