### PR TITLE
Remove MinIO in favor of Localstack's S3 implementation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,24 +85,6 @@ services:
         aliases:
           - ${REDIS_HOST}
 
-  # While localstack does offer S3 capabilities, it's not actually
-  # MinIO, which is a very full-featured and faithful S3 clone. We
-  # have noticed test failures when we use localstack's s3, so we will
-  # continue to use MinIO.
-  s3:
-    image: minio/minio
-    command: server /data
-    environment:
-      - MINIO_ACCESS_KEY=${S3_ACCESS_KEY_ID}
-      - MINIO_REGION_NAME=${AWS_REGION}
-      - MINIO_SECRET_KEY=${S3_ACCESS_KEY_SECRET}
-    ports:
-      - 127.0.0.1:${S3_PORT_EXTERNAL}:${S3_PORT_INTERNAL}
-    networks:
-      default:
-        aliases:
-          - ${S3_HOST}
-
   localstack:
     image: localstack/localstack:0.12.6
     ports:
@@ -112,7 +94,7 @@ services:
     environment:
       - IMAGE_NAME=localstack/localstack:0.12.6
       - EDGE_PORT=${LOCALSTACK_PORT}
-      - SERVICES=dynamodb,sqs,secretsmanager
+      - SERVICES=dynamodb,s3,secretsmanager,sqs
       - DEBUG=${DEBUG- }
       - DATA_DIR=${DATA_DIR- }
     volumes:
@@ -153,7 +135,6 @@ services:
       - grapl-provision
       - localstack
       - redis
-      - s3
 
   grapl-osquery-subgraph-generator:
     image: grapl/grapl-osquery-subgraph-generator:${TAG:-latest}
@@ -176,7 +157,6 @@ services:
       - grapl-provision
       - localstack
       - redis
-      - s3
 
   grapl-node-identifier:
     image: grapl/grapl-node-identifier:${TAG:-latest}
@@ -200,7 +180,6 @@ services:
       - grapl-provision
       - localstack
       - redis
-      - s3
 
   grapl-node-identifier-retry-handler:
     image: grapl/grapl-node-identifier-retry-handler:${TAG:-latest}
@@ -224,7 +203,6 @@ services:
       - grapl-provision
       - localstack
       - redis
-      - s3
 
   grapl-graph-merger:
     image: grapl/grapl-graph-merger:${TAG:-latest}
@@ -250,7 +228,6 @@ services:
       - grapl-provision
       - localstack
       - redis
-      - s3
 
   grapl-analyzer-dispatcher:
     image: grapl/grapl-analyzer-dispatcher:${TAG:-latest}
@@ -271,7 +248,6 @@ services:
     tty: false
     depends_on:
       - localstack
-      - s3
 
   ########################################################################
   # Python Services
@@ -303,7 +279,6 @@ services:
       - dgraph
       - localstack
       - redis
-      - s3
 
   grapl-ux-router:
     image: grapl/grapl-ux-router:${TAG:-latest}
@@ -343,7 +318,6 @@ services:
     depends_on:
       - dgraph
       - localstack
-      - s3
 
   # TODO: really, this service should be grapl-auth
   grapl-engagement-edge:
@@ -398,7 +372,6 @@ services:
     depends_on:
       - dgraph
       - localstack
-      - s3
     networks:
       default:
         aliases:
@@ -459,7 +432,6 @@ services:
       <<: *s3-env
     depends_on:
       - grapl-provision
-      - s3
 
   grapl-graphql-endpoint:
     image: grapl/grapl-graphql-endpoint:${TAG:-latest}
@@ -502,15 +474,10 @@ services:
     image: grapl/grapl-local-pulumi:${TAG:-latest}
     command: |
       /bin/bash -c "
-         wait-for-it ${S3_HOST}:${S3_PORT_INTERNAL} --timeout=60 &&
          wait-for-it ${LOCALSTACK_HOST}:${LOCALSTACK_PORT} --timeout=60 &&
          sleep 10 &&
          pulumi login --local &&
          pulumi stack init local-grapl --non-interactive &&
-         # See pulumi/README.md fro why we do these configuration overrides
-         pulumi config set aws:accessKey ${FAKE_AWS_ACCESS_KEY_ID} --plaintext &&
-         pulumi config set aws:secretKey ${FAKE_AWS_SECRET_ACCESS_KEY} --plaintext &&
-         pulumi config set --path 'aws:endpoints[0].s3' ${S3_ENDPOINT} &&
          pulumi up --yes --skip-preview --stack=local-grapl &&
          # NOTE: This is running in localstack's network namespace, so
          # we will need to wait on localstack, NOT grapl-pulumi.
@@ -526,7 +493,6 @@ services:
       PULUMI_CONFIG_PASSPHRASE: local-grapl-passphrase
     depends_on:
       - localstack
-      - s3
 
   grapl-provision:
     image: grapl/grapl-provision:${TAG:-latest}

--- a/docs/analyzers/deploying.md
+++ b/docs/analyzers/deploying.md
@@ -10,12 +10,12 @@ Analyzers should be deployed with a key of the form:
 
 If you're uploading to a local Grapl,
 ```bash
-AWS_ACCESS_KEY_ID="THIS_IS_A_FAKE_AWS_ACCESS_KEY_ID" \
-AWS_SECRET_ACCESS_KEY="THIS_IS_A_FAKE_AWS_SECRET_ACCESS_KEY"
+AWS_ACCESS_KEY_ID="test" \
+AWS_SECRET_ACCESS_KEY="test"
 aws s3 cp \
 <path to analyzer> \
 s3://local-grapl-analyzers-bucket/analyzers/<analyzer_name>/main.py \
---endpoint-url=http://localhost:9000
+--endpoint-url=http://localhost:4566
 ```
 
 Otherwise, for an AWS deployed Grapl,

--- a/etc/local_grapl/bin/upload-osquery-logs.py
+++ b/etc/local_grapl/bin/upload-osquery-logs.py
@@ -51,12 +51,12 @@ def setup_env(deployment_name: str):
     if deployment_name == "local-grapl":
         kvs = [
             ("AWS_REGION", "us-east-1"),
-            ("S3_ENDPOINT", "http://localhost:9000"),
-            ("S3_ACCESS_KEY_ID", "THIS_IS_A_FAKE_AWS_ACCESS_KEY_ID"),
-            ("S3_ACCESS_KEY_SECRET", "THIS_IS_A_FAKE_AWS_SECRET_ACCESS_KEY"),
+            ("S3_ENDPOINT", "http://localhost:4566"),
+            ("S3_ACCESS_KEY_ID", "test"),
+            ("S3_ACCESS_KEY_SECRET", "test"),
             ("SQS_ENDPOINT", "http://localhost:4566"),
-            ("SQS_ACCESS_KEY_ID", "THIS_IS_A_FAKE_AWS_ACCESS_KEY_ID"),
-            ("SQS_ACCESS_KEY_SECRET", "THIS_IS_A_FAKE_AWS_SECRET_ACCESS_KEY"),
+            ("SQS_ACCESS_KEY_ID", "test"),
+            ("SQS_ACCESS_KEY_SECRET", "test"),
         ]
         for (k, v) in kvs:
             # fun fact: os.putenv is bad and this is preferred

--- a/etc/local_grapl/bin/upload-sysmon-logs.py
+++ b/etc/local_grapl/bin/upload-sysmon-logs.py
@@ -51,12 +51,12 @@ def setup_env(deployment_name: str):
     if deployment_name == "local-grapl":
         kvs = [
             ("AWS_REGION", "us-east-1"),
-            ("S3_ENDPOINT", "http://localhost:9000"),
-            ("S3_ACCESS_KEY_ID", "THIS_IS_A_FAKE_AWS_ACCESS_KEY_ID"),
-            ("S3_ACCESS_KEY_SECRET", "THIS_IS_A_FAKE_AWS_SECRET_ACCESS_KEY"),
+            ("S3_ENDPOINT", "http://localhost:4566"),
+            ("S3_ACCESS_KEY_ID", "test"),
+            ("S3_ACCESS_KEY_SECRET", "test"),
             ("SQS_ENDPOINT", "http://localhost:4566"),
-            ("SQS_ACCESS_KEY_ID", "THIS_IS_A_FAKE_AWS_ACCESS_KEY_ID"),
-            ("SQS_ACCESS_KEY_SECRET", "THIS_IS_A_FAKE_AWS_SECRET_ACCESS_KEY"),
+            ("SQS_ACCESS_KEY_ID", "test"),
+            ("SQS_ACCESS_KEY_SECRET", "test"),
         ]
         for (k, v) in kvs:
             # fun fact: os.putenv is bad and this is preferred

--- a/etc/local_grapl/bin/upload_analyzer_local.sh
+++ b/etc/local_grapl/bin/upload_analyzer_local.sh
@@ -14,11 +14,11 @@ local_grapl_dir="${analyzer_upload_script_path}/../"
 # we should pull this functionality into something like graplctl
 # with a more formalized way of pointing to a specific Grapl
 # instance.
-export AWS_ACCESS_KEY_ID="THIS_IS_A_FAKE_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="THIS_IS_A_FAKE_AWS_SECRET_ACCESS_KEY"
+export AWS_ACCESS_KEY_ID="test"
+export AWS_SECRET_ACCESS_KEY="test"
 
 deployment_name="local-grapl"
-local_s3_endpoint="http://localhost:9000"
+local_s3_endpoint="http://localhost:4566"
 region="us-east-1"
 
 aws s3 cp \

--- a/local-grapl.env
+++ b/local-grapl.env
@@ -1,3 +1,4 @@
+# -*- mode: sh -*-
 # Environment file used by our Docker Compose local environment /
 # integration / end-to-end testing setup.
 

--- a/local-grapl.env
+++ b/local-grapl.env
@@ -34,18 +34,6 @@ GRAPL_UX_ROUTER_PORT=8901
 # Redis default port
 REDIS_PORT=6379
 
-# MinIO default port.
-#
-# While localstack does have an S3 implementation, we've noted some
-# test failures using it. Until we fully understand the nature of that
-# failure, we will continue using MinIO as our S3 substitute.
-#
-# NOTE: If you change this value, please edit the scripts in
-# etc/local_grapl/bin/ as well. This is only until we can deal with
-# those scripts in a better, more formalized way.
-S3_PORT_INTERNAL=9000 # default value
-S3_PORT_EXTERNAL=${S3_PORT_INTERNAL}
-
 # Localstack Secretsmanager
 SECRETSMANAGER_PORT=${LOCALSTACK_PORT}
 
@@ -93,7 +81,6 @@ GRAPL_UX_ROUTER_HOST=ux-router.grapl.test
 ########################################################################
 
 REDIS_ENDPOINT=http://${REDIS_HOST}:${REDIS_PORT}
-S3_ENDPOINT=http://${S3_HOST}:${S3_PORT_INTERNAL}
 
 # The remaining endpoints are all just aliases for our unified
 # Localstack service
@@ -101,19 +88,17 @@ LOCALSTACK_ENDPOINT=http://${LOCALSTACK_HOST}:${LOCALSTACK_PORT}
 DYNAMODB_ENDPOINT=${LOCALSTACK_ENDPOINT}
 SQS_ENDPOINT=${LOCALSTACK_ENDPOINT}
 SECRETSMANAGER_ENDPOINT=${LOCALSTACK_ENDPOINT}
+S3_ENDPOINT=${LOCALSTACK_ENDPOINT}
 
 # Credentials
 ########################################################################
-# NOTE: If you change these values, please edit
-# etc/local_grapl/bin/upload_analyzer_local.sh and
-# upload-sysmon-logs.py as well. This is only until we can deal with
-# those scripts in a better, more formalized way.
+# NOTE: These are the default values assumed by Localstack
 #
 # NOTE: If you change these values, please edit the scripts in
 # etc/local_grapl/bin/ as well. This is only until we can deal with
 # those scripts in a better, more formalized way.
-FAKE_AWS_ACCESS_KEY_ID="THIS_IS_A_FAKE_AWS_ACCESS_KEY_ID"
-FAKE_AWS_SECRET_ACCESS_KEY="THIS_IS_A_FAKE_AWS_SECRET_ACCESS_KEY"
+FAKE_AWS_ACCESS_KEY_ID="test"
+FAKE_AWS_SECRET_ACCESS_KEY="test"
 
 DYNAMODB_ACCESS_KEY_ID="${FAKE_AWS_ACCESS_KEY_ID}"
 DYNAMODB_ACCESS_KEY_SECRET="${FAKE_AWS_SECRET_ACCESS_KEY}"

--- a/pulumi/README.md
+++ b/pulumi/README.md
@@ -12,25 +12,6 @@ and then `pulumi up` against the `local-grapl` stack and deploy to
 your Localstack instance. When working purely on infrastructure, this
 can be a way to iterate quickly.
 
-In our integration and testing environments, we also use Localstack,
-but inside a Docker Compose network, and also currently with
-[MinIO][minio] as our S3 service. This requires changing the S3
-endpoint, as well as the fake AWS credentials we use for
-Pulumi. However, this modification is handled within the
-`docker-compose.yml` file, so it is mentioned here for informational
-purposes only.
-
-(We use MinIO currently because we have some test code that does not
-appear to like Localstack's S3 implementation for an as-yet-unknown
-reason. Additionally, we have had trouble configuring Localstack to
-proxy MinIO as its S3 endpoint. As a result, we need to communicate
-directly with MinIO on its own endpoint. Additionally, MinIO requires
-a secret key of at least 8 characters, so we can't use localstack's
-default value of `test`. Since we don't want the hassle of trying to
-provide multiple sets of credentials to Pulumi, we just set an new set
-across all our services in our Docker Compose environment. In the
-future, we hope to be able to simplify this setup.)
-
 # Getting Started
 
 We're using the Python SDK for Pulumi. As such, we'll need to have

--- a/pulumi/infra/ux.py
+++ b/pulumi/infra/ux.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import pulumi_aws as aws
 from infra import util
-from infra.util import DEPLOYMENT_NAME, IS_LOCAL
+from infra.util import DEPLOYMENT_NAME
 
 import pulumi
 
@@ -13,20 +13,11 @@ class EngagementUX(pulumi.ComponentResource):
     def __init__(self, opts: Optional[pulumi.ResourceOptions] = None) -> None:
         super().__init__("grapl:EngagementUX", DEPLOYMENT_NAME, None, opts)
 
-        # It appears that the website configuration is not available
-        # in MinIO, which we currently use for s3 in local grapl. When
-        # interacting with local grapl, we'll just leave it out.
-        website_args = (
-            aws.s3.BucketWebsiteArgs(
-                index_document="index.html",
-            )
-            if not IS_LOCAL
-            else None
-        )
-
         self.bucket = util.grapl_bucket(
             "engagement-ux-bucket",
-            website_args=website_args,
+            website_args=aws.s3.BucketWebsiteArgs(
+                index_document="index.html",
+            ),
             parent=self,
         )
 

--- a/pulumi/infra/ux.py
+++ b/pulumi/infra/ux.py
@@ -11,7 +11,7 @@ class EngagementUX(pulumi.ComponentResource):
     """ Represents the web GUI for Grapl."""
 
     def __init__(self, opts: Optional[pulumi.ResourceOptions] = None) -> None:
-        super().__init__("grapl:UI", DEPLOYMENT_NAME, None, opts)
+        super().__init__("grapl:EngagementUX", DEPLOYMENT_NAME, None, opts)
 
         # It appears that the website configuration is not available
         # in MinIO, which we currently use for s3 in local grapl. When

--- a/src/js/engagement_view/upload_localhost.sh
+++ b/src/js/engagement_view/upload_localhost.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 cd ./build/ || exit
 
-export AWS_ACCESS_KEY_ID="THIS_IS_A_FAKE_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="THIS_IS_A_FAKE_AWS_SECRET_ACCESS_KEY"
+export AWS_ACCESS_KEY_ID="test"
+export AWS_SECRET_ACCESS_KEY="test"
 
 aws s3 sync . s3://local-grapl-engagement-ux-bucket/ \
-    --endpoint-url=http://localhost:9000 \
+    --endpoint-url=http://localhost:4566 \
     --region=us-east-1

--- a/src/python/grapl-ux-router/src/grapl_ux_router.py
+++ b/src/python/grapl-ux-router/src/grapl_ux_router.py
@@ -275,18 +275,18 @@ if IS_LOCAL:
         LOGGER.info(f'static_js_resource {app.current_request.context["path"]}')
         if app.current_request.method == "OPTIONS":
             return respond(None, {})
-        return _route_to_resource(app.current_request.context["path"])
+        return _route_to_resource(app.current_request.context["path"].lstrip("/"))
 
     @app.route("/static/css/{proxy+}", methods=["OPTIONS", "GET"])
     def static_css_resource_root_nop_route() -> Response:
         LOGGER.info(f'static_css_resource {app.current_request.context["path"]}')
         if app.current_request.method == "OPTIONS":
             return respond(None, {})
-        return _route_to_resource(app.current_request.context["path"])
+        return _route_to_resource(app.current_request.context["path"].lstrip("/"))
 
     @app.route("/static/media/{proxy+}", methods=["OPTIONS", "GET"])
     def static_media_resource_root_nop_route() -> Response:
         LOGGER.info(f'static_media_resource {app.current_request.context["path"]}')
         if app.current_request.method == "OPTIONS":
             return respond(None, {})
-        return _route_to_resource(app.current_request.context["path"])
+        return _route_to_resource(app.current_request.context["path"].lstrip("/"))


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

In order to more closely mimic AWS in our testing environments, we need a way to implement our bucket notifications to SNS topics. As long as we are using MinIO, we can't do that.

This PR replaces MinIO with Localstack's built-in S3 implementation, which should allow this. This removes testing infrastructure, and also allows us to start removing a bunch of special-casing in our code, starting with the website bucket configuration logic in our Pulumi code, as well as modifying certain Pulumi stack configuration values.

One interesting aspect of this was that we needed to strip the leading `/` from the S3 object keys (derived from URL paths) in our `grapl-ux-router` code. Apparently, MinIO was able to deal with finding an object named "/static/js/2.642cd0fc.chunk.js", whereas Localstack is more strict and wants this to be simply "static/js/2.642cd0fc.chunk.js" (this appears to be more proper anyway). The only code changed here was explicitly "local only"

### How were these changes tested?

``` sh
make test-integration
make test-e2e
```