### PR TITLE
Add instructions for activating our virtulenv with direnv

### DIFF
--- a/build-support/manage_virtualenv.sh
+++ b/build-support/manage_virtualenv.sh
@@ -67,6 +67,11 @@ function exit_message() {
     log "Please run the following to activate it:"
     log
     log "source ${virtualenv}/bin/activate"
+    log
+    log "Alternatively, if using 'direnv', add the following 2 lines to an '.envrc' file in the repository root:"
+    log
+    log "export VIRTUAL_ENV=build-support/grapl-venv"
+    log "PATH_add \${VIRTUAL_ENV}/bin"
 }
 
 function usage() {


### PR DESCRIPTION
### How were these changes tested?

```sh
build-support/manage_virtualenv.sh populate
# follow new direnv-specific instructions that are output
direnv allow
which python # should be a path in our virtualenv
```