### PR TITLE
Added a graphql endpoint test to e2e tests, just so we have *some* coverage on it

### DIFF
--- a/src/python/engagement_edge/tests/test_engagement_edge.py
+++ b/src/python/engagement_edge/tests/test_engagement_edge.py
@@ -16,7 +16,7 @@ JWT_SECRET.secret = "hey im a fake secret"
 @pytest.mark.integration_test
 class TestEngagementEdgeClient(unittest.TestCase):
     def test_get_notebook_link(self) -> None:
-        client = EngagementEdgeClient(use_docker_links=True)
+        client = EngagementEdgeClient()
         jwt = client.get_jwt()
         notebook_url = client.get_notebook(jwt=jwt)
         assert "localhost:8888" in notebook_url

--- a/src/python/grapl-tests-common/grapl_tests_common/clients/engagement_edge_client.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/clients/engagement_edge_client.py
@@ -15,8 +15,8 @@ class EngagementEdgeException(Exception):
 
 
 class EngagementEdgeClient:
-    def __init__(self, use_docker_links: bool = False) -> None:
-        hostname = os.environ["GRAPL_AUTH_HOST"] if use_docker_links else "localhost"
+    def __init__(self) -> None:
+        hostname = os.environ["GRAPL_AUTH_HOST"]
         self.endpoint = f"http://{hostname}:{os.environ['GRAPL_AUTH_PORT']}"
 
     def get_jwt(self) -> str:

--- a/src/python/grapl-tests-common/grapl_tests_common/clients/graphql_endpoint_client.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/clients/graphql_endpoint_client.py
@@ -1,4 +1,5 @@
 import os
+
 import requests
 
 

--- a/src/python/grapl-tests-common/grapl_tests_common/clients/graphql_endpoint_client.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/clients/graphql_endpoint_client.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, Dict
 
 import requests
 
@@ -10,7 +11,7 @@ class GraphqlEndpointClient:
         self.endpoint = f"http://{hostname}:{port}"
         self.jwt = jwt
 
-    def query(self, query: str) -> None:
+    def query(self, query: str) -> Dict[str, Any]:
         resp = requests.post(
             f"{self.endpoint}/graphQlEndpoint/graphql",
             params={"query": query},

--- a/src/python/grapl-tests-common/grapl_tests_common/clients/graphql_endpoint_client.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/clients/graphql_endpoint_client.py
@@ -1,0 +1,18 @@
+import os
+import requests
+
+
+class GraphqlEndpointClient:
+    def __init__(self, jwt: str) -> None:
+        hostname = "grapl-graphql-endpoint"
+        port = os.environ["GRAPL_GRAPHQL_PORT"]
+        self.endpoint = f"http://{hostname}:{port}"
+        self.jwt = jwt
+
+    def query(self, query: str) -> None:
+        resp = requests.post(
+            f"{self.endpoint}/graphQlEndpoint/graphql",
+            params={"query": query},
+            cookies={"grapl_jwt": self.jwt},
+        )
+        return resp.json()["data"]

--- a/src/python/grapl-tests-common/grapl_tests_common/clients/graphql_endpoint_client.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/clients/graphql_endpoint_client.py
@@ -1,12 +1,12 @@
 import os
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 import requests
 
 
 class GraphqlEndpointClient:
     def __init__(self, jwt: str) -> None:
-        hostname = "grapl-graphql-endpoint"
+        hostname = os.environ["GRAPL_GRAPHQL_HOST"]
         port = os.environ["GRAPL_GRAPHQL_PORT"]
         self.endpoint = f"http://{hostname}:{port}"
         self.jwt = jwt
@@ -17,4 +17,4 @@ class GraphqlEndpointClient:
             params={"query": query},
             cookies={"grapl_jwt": self.jwt},
         )
-        return resp.json()["data"]
+        return cast(Dict[str, Any], resp.json()["data"])

--- a/src/python/grapl-tests-common/grapl_tests_common/setup.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/setup.py
@@ -1,23 +1,17 @@
 from __future__ import annotations
 
 import logging
-import subprocess
 import sys
 from os import environ
 from sys import stdout
-from typing import TYPE_CHECKING, Any, NamedTuple, Sequence
+from typing import TYPE_CHECKING, Sequence
 
 import boto3  # type: ignore
 import pytest
 import requests
 from grapl_common.env_helpers import S3ClientFactory, SQSClientFactory
 from grapl_tests_common.dump_dynamodb import dump_dynamodb
-from grapl_tests_common.sleep import verbose_sleep
-from grapl_tests_common.types import (
-    AnalyzerUpload,
-    S3ServiceResource,
-    SqsServiceResource,
-)
+from grapl_tests_common.types import AnalyzerUpload, S3ServiceResource
 from grapl_tests_common.upload_test_data import UploadTestData
 from grapl_tests_common.wait import WaitForS3Bucket, WaitForSqsQueue, wait_for
 
@@ -72,8 +66,6 @@ def setup(
     analyzers: Sequence[AnalyzerUpload],
     test_data: Sequence[UploadTestData],
 ) -> None:
-    verbose_sleep(10, "awaiting local aws")
-
     s3_client = _create_s3_client()
     sqs_client = _create_sqs_client()
 

--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -11,8 +11,6 @@ from grapl_tests_common.wait import WaitForCondition, WaitForQuery, wait_for_one
 
 LENS_NAME = "DESKTOP-FVSHABR"
 
-GqlLensDict = Dict[str, Any]
-
 
 @pytest.mark.integration_test
 class TestEndToEnd(TestCase):

--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -11,6 +11,8 @@ from grapl_tests_common.wait import WaitForCondition, WaitForQuery, wait_for_one
 
 LENS_NAME = "DESKTOP-FVSHABR"
 
+GqlLensDict = Dict[str, Any]
+
 
 @pytest.mark.integration_test
 class TestEndToEnd(TestCase):

--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -1,12 +1,17 @@
 import logging
+from typing import Any, Dict, List
 from unittest import TestCase
 
 import pytest
 from grapl_analyzerlib.nodes.lens import LensQuery, LensView
 from grapl_analyzerlib.retry import retry
+from grapl_tests_common.clients.engagement_edge_client import EngagementEdgeClient
+from grapl_tests_common.clients.graphql_endpoint_client import GraphqlEndpointClient
 from grapl_tests_common.wait import WaitForCondition, WaitForQuery, wait_for_one
 
 LENS_NAME = "DESKTOP-FVSHABR"
+
+GqlLensDict = Dict[str, Any]
 
 
 @pytest.mark.integration_test
@@ -37,3 +42,24 @@ class TestEndToEnd(TestCase):
             )
 
         wait_for_one(WaitForCondition(condition), timeout_secs=240)
+
+        # At this point, the lens should be available in Graphql
+        gql_lenses = _query_graphql_endpoint_for_lenses()
+        return gql_lenses[0]["lens_name"] == LENS_NAME
+
+
+def _query_graphql_endpoint_for_lenses() -> List[GqlLensDict]:
+    query = """
+        {
+            lenses(first: 100, offset: 0) {
+                uid,
+                node_key,
+                lens_name,
+                score, 
+                lens_type,
+            }
+        }
+    """
+    gql_client = GraphqlEndpointClient(jwt=EngagementEdgeClient().get_jwt())
+    resp = gql_client.query(query)
+    return resp["lenses"]

--- a/test/docker-compose.e2e-tests.yml
+++ b/test/docker-compose.e2e-tests.yml
@@ -28,6 +28,8 @@ services:
       - DYNAMODB_ACCESS_KEY_ID
       - DYNAMODB_ACCESS_KEY_SECRET
       - DYNAMODB_ENDPOINT
+      - GRAPL_AUTH_HOST
+      - GRAPL_AUTH_PORT
       - GRAPL_LOG_LEVEL
       - IS_LOCAL=True
       - MG_ALPHAS

--- a/test/docker-compose.e2e-tests.yml
+++ b/test/docker-compose.e2e-tests.yml
@@ -30,6 +30,8 @@ services:
       - DYNAMODB_ENDPOINT
       - GRAPL_AUTH_HOST
       - GRAPL_AUTH_PORT
+      - GRAPL_GRAPHQL_HOST
+      - GRAPL_GRAPHQL_PORT
       - GRAPL_LOG_LEVEL
       - IS_LOCAL=True
       - MG_ALPHAS


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None yet.

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Add a rudimentary GraphqlEndpointClient to grapl-tests-common
- Add a rudimentary test that, yes, it loads lenses okay
- Remove some `use_docker_links=` stuff that's no longer applicable

I would like to have integration tests on it within the graphql endpoint source tree, but right now, this is a low-effort/high-ROI addition that ensures the endpoint hasn't broken.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
its all tests dude!!!

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
