### PR TITLE
Fix 'make down' by running with the various project names that we use

### DIFF
--- a/test/docker-compose-with-error.sh
+++ b/test/docker-compose-with-error.sh
@@ -1,60 +1,29 @@
 #!/bin/bash
 
 set -e
-trap compose_stop EXIT
-
-compose_stop() {
-    docker-compose ${FILE_ARGS} --project-name "$p" stop
-}
 
 usage() { 
-    echo 'Usage: $0 -p <project-name> -f docker-compose1.yml [SERVICES]' 1>&2
+    echo 'Usage: $0 [SERVICES]' 1>&2
     echo
-    echo 'This script calls into `docker-compose up` with the supplied arguments' 1>&2
-    echo 'and checks the exit code of each container upon exit. If any container' 1>&2
-    echo 'exit code is non-zero, this script will exit non-zero.' 1>&2
+    echo 'This script calls into `docker-compose up` and checks the exit code' 1>&2
+    echo 'of each container upon exit. If any container exit code is non-zero,' 1>&2
+    echo 'this script will exit non-zero.' 1>&2
     echo
-    echo 'Options:' 1>&2
-    echo '    -f	Path to compose file. Can be passed multiple times.' 1>&2
-    echo '    -p	Project name.' 1>&2
-    echo '    -t	Target (if you only want to execute one thing).' 1>&2
+    echo 'Use Compose environment variables, such as COMPOSE_FILE and COMPOSE_PROJECT_NAME,' 1>&2
+    echo 'for directing docker-compose.' 1>&2
     exit 1
 }
 
-while getopts "hf:p:t:" arg; do
-    case $arg in
-        f)
-            FILE_ARGS+="-f ${OPTARG} "
-            ;;
-        t)
-            TARGET_ARGS="${OPTARG} "
-            ;;
-        p)
-            p=${OPTARG}
-            ;;
-        h) # Show help
-            usage
-            ;;
-    esac
-done
-
-if [ -z "${FILE_ARGS}" ] || [ -z "${p}" ]; then
-    usage
-fi
-
-if [ -z "${TARGET_ARGS}" ]; then
-    TARGET_ARGS=""
-fi
-
-shift $(($OPTIND - 1))
+# We'll pass SERVICES to the end of docker-compose up to allow users to specify
+# specific services to run, instead of all of them, which is the default behavior.
 SERVICES="$@"
 
 # Execute the 'up'
-docker-compose ${FILE_ARGS} --project-name "$p" up --force-recreate ${SERVICES} ${TARGET_ARGS}
+docker-compose up --force-recreate ${SERVICES}
 
 # check for container exit codes other than 0
 EXIT_CODE=0
-ALL_TESTS=$(docker-compose ${FILE_ARGS} --project-name "$p" ps -q ${SERVICES})
+ALL_TESTS=$(docker-compose ps --quiet ${SERVICES})
 for test in $ALL_TESTS; do
     docker inspect -f "{{ .State.ExitCode }}" $test | grep -q ^0;
     if [ $? -ne 0 ]; then 
@@ -62,7 +31,5 @@ for test in $ALL_TESTS; do
         break
     fi
 done
-
-compose_stop
 
 exit $EXIT_CODE


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

In trying to clean a local environment by `make down`, docker-compose would fail in trying to remove the docker network. This would be due to the Grapl local environment still being up after tests were done running, so containers were still running that were using the network. 

```
Removing network grapl-network
ERROR: error while removing network: network grapl-network id 6b829bd70b1b4fd4ae89bb89c37219b38039f06b4e472be72f19e0e202bbd852 has active endpoints
make: *** [Makefile:285: down] Error 1
```

These changes do a few things:
1. Remove from the test wrapper the code that would stop test containers and move that functionality into the Makefile. We still have some functionality of that wrapper in a script, but it only checks the exit codes of containers now.
2. Set .ONESHELL in the Makefile, and shell opts to preserve Make behavior. This is required for the previous and should 
3. The `make down` target now calls down for each of the compose project names we use.

### How were these changes tested?

I ran `make test` and ensured they all worked locally. Also, I verified a test failure still surfaces to Make.