### PR TITLE
Add vendoring to Cargo config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ __pycache__/
 .pytype/
 
 # Rust outputs
-target/
+src/rust/target/
 
 # Node packages
 node_modules/

--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -2,6 +2,7 @@
 **/node_modules
 
 rust/target
+# We intentionally do no include rust/vendor so Docker will pick it up if it exists
 
 js/grapl-cdk/zips
 js/grapl-cdk/cdk.out

--- a/src/rust/.cargo/config.toml
+++ b/src/rust/.cargo/config.toml
@@ -2,3 +2,9 @@
 rustflags = [
     "--deny=warnings",
 ]
+
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -43,7 +43,6 @@ WORKDIR /grapl/rust
 FROM base AS build
 
 RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
-    --mount=type=cache,mode=0777,target=/usr/local/cargo/registry \
     --mount=type=secret,id=rust_env,dst=/grapl/env \
     source /grapl/env; \
     case "${CARGO_PROFILE}" in \
@@ -77,7 +76,6 @@ RUN mkdir -p /grapl/zips; \
 FROM build AS build-test-unit
 
 RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
-    --mount=type=cache,mode=0777,target=/usr/local/cargo/registry \
     --mount=type=secret,id=rust_env,dst=/grapl/env \
     source /grapl/env; \
     cargo test --no-run
@@ -86,7 +84,6 @@ RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
 FROM build AS build-test-integration
 
 RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
-    --mount=type=cache,mode=0777,target=/usr/local/cargo/registry \
     --mount=type=secret,id=rust_env,dst=/grapl/env \
     source /grapl/env; \
     cargo test --manifest-path node-identifier/Cargo.toml --features integration --no-run

--- a/src/rust/vendor/.gitignore
+++ b/src/rust/vendor/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/355

### What changes does this PR make to Grapl? Why?

This adds vendoring to the Rust Cargo config and no longer adds the local Cargo registry to the Docker build cache.

This preserves the local developer experience of not having to redownload the dependency sources for each iteration during development. If the `vendor` directory exists locally, as it would in local Rust development, it'll be included in the initial Dockerfile COPY. Cargo will still download as needed if the directory doesn't exist locally.

### How were these changes tested?

I ran `make test-unit-rust` and `make test-integration` and verified we're not redownloading and rebuilding test dependencies. Also, I simulated the dev iteration by changing the sources and verified the dependency sources are not being redownloaded.