### PR TITLE
Revert 70ba3533ee422166edcf2c556f15404a59039024

### DIFF
--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -43,7 +43,6 @@ WORKDIR /grapl/rust
 FROM base AS build
 
 RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
-    --mount=type=cache,mode=0777,target=/usr/local/cargo/registry \
     --mount=type=secret,id=rust_env,dst=/grapl/env \
     source /grapl/env; \
     case "${CARGO_PROFILE}" in \
@@ -77,7 +76,6 @@ RUN mkdir -p /grapl/zips; \
 FROM build AS build-test-unit
 
 RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
-    --mount=type=cache,mode=0777,target=/usr/local/cargo/registry \
     --mount=type=secret,id=rust_env,dst=/grapl/env \
     source /grapl/env; \
     cargo test --no-run
@@ -86,7 +84,6 @@ RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
 FROM build AS build-test-integration
 
 RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
-    --mount=type=cache,mode=0777,target=/usr/local/cargo/registry \
     --mount=type=secret,id=rust_env,dst=/grapl/env \
     source /grapl/env; \
     cargo test --manifest-path node-identifier/Cargo.toml --features integration --no-run


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/355

### What changes does this PR make to Grapl? Why?

This removes the Cargo local registry from the docker build cache mount, which was originally put in place to help prevent from redownloading dependencies when iterating on Rust sources. However, this had the side-effect of https://github.com/grapl-security/issue-tracker/issues/355 because the Rust `target` directory was no longer available to the running containers, so cargo couldn't verify the test builds were up to date. Because it can't verify, it rebuilds. Not worth.

### How were these changes tested?

I ran `make test-unit-rust` and `make test-integration` locally and noticed the Rust test code is not recompiling at runtime. Also, I see similar for the GitHub actions from the PR as it is now: https://github.com/grapl-security/grapl/runs/2179081186?check_suite_focus=true and https://github.com/grapl-security/grapl/runs/2179081025?check_suite_focus=true.