### PR TITLE
Make down again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,9 +303,9 @@ up-detach: build-services ## Bring up local Grapl and detach to return control t
 .PHONY: down
 down: ## docker-compose down - both stops and removes the containers
 	$(WITH_LOCAL_GRAPL_ENV)
-	docker-compose down --timeout=0
-	docker-compose --project-name $(COMPOSE_PROJECT_INTEGRATION_TESTS) down --timeout=0
-	docker-compose --project-name $(COMPOSE_PROJECT_E2E_TESTS) down --timeout=0
+	docker-compose $(EVERY_COMPOSE_FILE) down --timeout=0
+	docker-compose $(EVERY_COMPOSE_FILE) --project-name $(COMPOSE_PROJECT_INTEGRATION_TESTS) down --timeout=0
+	docker-compose $(EVERY_COMPOSE_FILE) --project-name $(COMPOSE_PROJECT_E2E_TESTS) down --timeout=0
 
 .PHONY: stop
 stop: ## docker-compose stop - stops (but preserves) the containers

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ ifneq ($(GRAPL_RUST_ENV_FILE),)
 DOCKER_BUILDX_BAKE_OPTS += --set *.secrets=id=rust_env,src="$(GRAPL_RUST_ENV_FILE)"
 endif
 COMPOSE_IGNORE_ORPHANS=1
+COMPOSE_PROJECT_NAME ?= grapl
 export
 
 export EVERY_LAMBDA_COMPOSE_FILE=--file docker-compose.lambda-zips.js.yml \


### PR DESCRIPTION
### Which issue does this PR correspond to?

None filed (yet?), but I noticed https://github.com/grapl-security/grapl/pull/692 doesn't quite achieve what it was meant to. The test containers, although stopped, will still exist after running make down. This is apparently due to not passing each compose file used for each project.

### What changes does this PR make to Grapl? Why?

For running docker-compose down, run by passing `EVERY_COMPOSE_FILE` to help ensure all containers are covered.

Additionally, this explicitly sets a default value for `COMPOSE_PROJECT_NAME` to `grapl`, which should be the same as what we currently expect. docker-compose will use the directory name that holds the compose file, which is still "grapl" in most cases, but not for those under `test/`. This helps ensure all container names created by us will be prefixed with "grapl", which makes cleanup easier.

### How were these changes tested?

I ran `make test-e2e` locally then `make down` and checked the list of containers that still exist with `docker container ls --all`. I did similar after running `make up-detach` to ensure `make down` will still remove grapl containers that are still running.
