### PR TITLE
Update Rust toolchain to 1.51 and latest nightly that supports rustfmt.

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -9,4 +9,4 @@ reorder_modules = true
 group_imports = "StdExternalCrate"
 imports_indent = "Visual"
 imports_layout = "Vertical"
-merge_imports = true
+imports_granularity = "Crate"

--- a/src/rust/bin/format
+++ b/src/rust/bin/format
@@ -14,7 +14,7 @@ set -euo pipefail
 # Note that you will need your Rustup profile set to something higher
 # than "minimal" (e.g., "default"), since `rustup` isn't included in
 # "minimal".
-export RUSTUP_TOOLCHAIN="nightly-2021-01-20"
+export RUSTUP_TOOLCHAIN="nightly-2021-03-25"
 
 # Default to checking formatting in the absence of any options.
 mode="check"

--- a/src/rust/generators/sysmon-subgraph-generator/src/generator.rs
+++ b/src/rust/generators/sysmon-subgraph-generator/src/generator.rs
@@ -26,8 +26,6 @@ pub enum SysmonGeneratorError {
     TimeError(#[from] chrono::ParseError),
     #[error("Unsupported event type")]
     UnsupportedEventType(String),
-    #[error("Generator failed")]
-    Unexpected,
 }
 
 impl CheckedError for SysmonGeneratorError {
@@ -37,7 +35,6 @@ impl CheckedError for SysmonGeneratorError {
             Self::NegativeEventTime(_) => Recoverable::Persistent,
             Self::TimeError(_) => Recoverable::Persistent,
             Self::UnsupportedEventType(_) => Recoverable::Persistent,
-            Self::Unexpected => Recoverable::Transient,
         }
     }
 }

--- a/src/rust/rust-toolchain
+++ b/src/rust/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.49.0"
+channel = "1.51.0"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This change does the following, which should cover the bases for our Rust chores:
1. This updates the Rust stable to 1.51
2. Updates rustfmt to latest nightly version that supports it, which is `2021-03-25` at time of writing: https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
3. Fix for warning seen on new rustfmt: 
`Warning: the 'merge_imports' option is deprecated. Use 'imports_granularity=Crate' instead`
4. Fix for new build error:
```
error: variant is never constructed: `Unexpected`
  --> generators/sysmon-subgraph-generator/src/generator.rs:30:5
   |
30 |     Unexpected,
   |     ^^^^^^^^^^
   |
   = note: `-D dead-code` implied by `-D warnings`
```
5. I ran `cd src/rust; bin/format --update` (no changes).
6. For each rustfmt unstable option we use, I checked to see if they'd become stable. None have.

### How were these changes tested?

I ran `make test-unit-rust` and will rely on CI tests for the rest.