### PR TITLE
Rust dockerfile fixes

### DIFF
--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir -p /grapl/zips; \
     grapl-zip() { \
       TMPDIR="$(mktemp -d)"; \
       cd "$TMPDIR"; \
-      cp "/grapl/rust/target/${TARGET}/${CARGO_PROFILE}/${1}" bootstrap && \
+      cp "/grapl/rust/target/${CARGO_PROFILE}/${1}" bootstrap && \
       zip --quiet -9 "/grapl/zips/${1}.zip" bootstrap; \
     }; \
     grapl-zip metric-forwarder

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1-slim-buster AS base
+FROM rust:1-slim-buster AS build
 
 ARG CARGO_PROFILE=debug
 
@@ -33,14 +33,6 @@ COPY proto proto
 COPY rust rust
 
 WORKDIR /grapl/rust
-
-
-# build
-#
-# the `base` stage isn't used by the build system, but let's 
-# make `base` and `build` in case it becomes convenient.
-################################################################################
-FROM base AS build
 
 RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
     --mount=type=secret,id=rust_env,dst=/grapl/env \


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/374

### What changes does this PR make to Grapl? Why?

1. This removes a gratuitous build stage we had in the Rust Dockerfile.
2. We had a bogus expansion of `TARGET` in the Rust Dockerfile, which is no longer used. This apparently was harmless, as the path resovles the same, but still doesn't make sense to be there.

### How were these changes tested?

I verified the Rust builds with Docker still work by running `make test-unit-rust`. I'll rely on CI tests for the rest.