### PR TITLE
add provisioning back to docs, fix dockerfiles for aws deployments

### DIFF
--- a/docs/setup/aws.md
+++ b/docs/setup/aws.md
@@ -144,6 +144,10 @@ see the available options by running:
 bin/graplctl aws deploy --help
 ```
 
+### Provision Grapl
+
+After we deploy to AWS successfully, we need to provision Grapl by running `./bin/graplctl aws provision` which will invoke the provisioner lambda.
+
 ## DGraph operations
 
 You can manage the DGraph cluster with the docker swarm tooling by

--- a/src/js/engagement_view/Dockerfile
+++ b/src/js/engagement_view/Dockerfile
@@ -8,6 +8,7 @@ COPY js/engagement_view/package.json package.json
 COPY js/engagement_view/yarn.lock yarn.lock
 COPY js/engagement_view/.yarnrc.yml .yarnrc.yml
 COPY js/engagement_view/.yarn/releases .yarn/releases
+COPY js/engagement_view/.yarn/cache .yarn/cache
 
 RUN yarn set version berry
 RUN yarn install

--- a/src/js/engagement_view/Dockerfile
+++ b/src/js/engagement_view/Dockerfile
@@ -8,7 +8,6 @@ COPY js/engagement_view/package.json package.json
 COPY js/engagement_view/yarn.lock yarn.lock
 COPY js/engagement_view/.yarnrc.yml .yarnrc.yml
 COPY js/engagement_view/.yarn/releases .yarn/releases
-COPY js/engagement_view/.yarn/cache .yarn/cache
 
 RUN yarn set version berry
 RUN yarn install

--- a/src/js/graphql_endpoint/Dockerfile
+++ b/src/js/graphql_endpoint/Dockerfile
@@ -33,6 +33,7 @@ COPY --chown=grapl js/graphql_endpoint/server.ts server.ts
 
 # This compiles the typescript and spits out the built js files to `lambda/ts_compiled'
 RUN npx tsc
+RUN cp -r ./node_modules/ ./ts_compiled/
 
 WORKDIR /home/grapl
 


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

- Add AWS provision command to AWS documentation 

- Resolve newly introduced bugs with dockerfiles that were preventing successful deployments for `graphqlEndpoint` because we weren't including `node_modules` so we weren't able to use dependencies

### How were these changes tested?
Docs: N/A
Package Manager: Locally & AWS  off a different branch ( did not test this branch in AWS, but tested these changes in a different branch - wanted to add them here in case someone else runs into these issues before the PR fixing them goes up )
