### PR TITLE
Add login instructions to aws deployment

### DIFF
--- a/docs/setup/aws.md
+++ b/docs/setup/aws.md
@@ -190,7 +190,10 @@ bin/graplctl aws deploy --help
 
 ### Provision Grapl
 
-After we deploy to AWS successfully, we need to provision Grapl by running `./bin/graplctl aws provision` which will invoke the provisioner lambda.
+After we deploy to AWS successfully, we need to provision Grapl by running 
+```./bin/graplctl aws provision
+```
+which will invoke the provisioner lambda.
 
 ## DGraph operations
 
@@ -241,4 +244,6 @@ append a `/index.html` to the URL in that file.
 
 To login to Grapl, your username should will be your deployment name followed by -grapl-test-user. For example, if your deployment was named test-deployment, your username would be test-deployment-grapl-test-user. 
 
-To generate a password for grapl, navigate to Secrets Manager in the AWS console, click on your deployment and scroll down until you see "". Click the "" button which is the password you'll use for your Grapl deployment. 
+To retrieve the password for your grapl deployment, navigate to "AWS Secrets Manager" and click on "Secrets". 
+
+Click on the "Secret name" url that represents your deployment name followed by -TestUserPassword . Clicking that link will bring you to the "secret details" screen. Scroll down to the section labeled"Secret Value" and click "Retrieve Secret Value" button. The password for your deployment will appear under "PlainText"

--- a/docs/setup/aws.md
+++ b/docs/setup/aws.md
@@ -236,3 +236,9 @@ deployment by looking at the Cloudwatch Dashboard named
 
 You can find the base url in `src/js/grapl-cdk/cdk-output.json`; just
 append a `/index.html` to the URL in that file.
+
+### Logging In To Grapl
+
+To login to Grapl, your username should will be your deployment name followed by -grapl-test-user. For example, if your deployment was named test-deployment, your username would be test-deployment-grapl-test-user. 
+
+To generate a password for grapl, navigate to Secrets Manager in the AWS console, click on your deployment and scroll down until you see "". Click the "" button which is the password you'll use for your Grapl deployment. 

--- a/src/js/graphql_endpoint/Dockerfile
+++ b/src/js/graphql_endpoint/Dockerfile
@@ -33,7 +33,6 @@ COPY --chown=grapl js/graphql_endpoint/server.ts server.ts
 
 # This compiles the typescript and spits out the built js files to `lambda/ts_compiled'
 RUN npx tsc
-RUN cp -r ./node_modules/ ./ts_compiled/
 
 WORKDIR /home/grapl
 


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

Add instructions for generating password for grapl in AWS.

Remove line in graphql dockerfile per Max - this is not necessary (was introduced in https://github.com/grapl-security/grapl/pull/710) earlier today.

### How were these changes tested?
N/A - Documentation Changes
