### PR TITLE
Fix engagement creator Lambda handler in CDK

### DIFF
--- a/docker-compose.lambda-zips.python.yml
+++ b/docker-compose.lambda-zips.python.yml
@@ -16,20 +16,6 @@ services:
       - TAG=${TAG:-latest}
     command: cp /home/grapl/lambda.zip dgraph-ttl-${TAG:-latest}.zip
 
-  grapl-engagement-creator-zip:
-    image: grapl/grapl-engagement-creator-zip:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: ./python/Dockerfile
-      target: engagement-creator-zip
-    volumes:
-      - ./src/js/grapl-cdk/zips:/grapl
-    user: ${UID}:${GID}
-    working_dir: /grapl
-    environment:
-      - TAG=${TAG:-latest}
-    command: cp /home/grapl/lambda.zip engagement-creator-${TAG:-latest}.zip
-
   grapl-engagement-edge-zip:
     image: grapl/grapl-engagement-edge-zip:${TAG:-latest}
     build:

--- a/src/js/grapl-cdk/lib/services/engagement_creator.ts
+++ b/src/js/grapl-cdk/lib/services/engagement_creator.ts
@@ -39,6 +39,8 @@ export class EngagementCreator extends cdk.NestedStack {
             reads_from: analyzer_matched_sugraphs.bucket,
             subscribes_to: analyzer_matched_sugraphs.topic,
             opt: {
+                // This is the entrypoint of a Pants-generated Lambda ZIP
+                py_entrypoint: "lambdex_handler.handler",
                 runtime: lambda.Runtime.PYTHON_3_7,
             },
             version: props.version,

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -187,15 +187,6 @@ RUN source venv/bin/activate && \
     cd engagement-creator && \
     pip install .
 
-# zip
-FROM engagement-creator-build AS engagement-creator-zip
-
-RUN LAMBDA_DIR=$(pwd); \
-    cd ~/venv/lib/python3.7/site-packages/ && \
-    zip -q9r -dg "${LAMBDA_DIR}/lambda.zip" ./ && \
-    cd ~/engagement-creator/src && \
-    find . -type f -name "*.py" -exec zip -g "${LAMBDA_DIR}/lambda.zip" "{}" \;
-
 # deploy
 FROM grapl-python-deploy AS engagement-creator-deploy
 


### PR DESCRIPTION
Back when we started generating the ZIP file for this service with Pants, I neglected to update CDK to take the new handler into account. This fixes that, and also removes the old container-based ZIP file build (which didn't use Pants).
