### PR TITLE
Minor change to hypothesis tests - stop generating 3-char strings and assuming len > 3

### DIFF
--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/test_utils/strategies/misc.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/test_utils/strategies/misc.py
@@ -9,9 +9,9 @@ T = TypeVar("T", bound=str)
 
 @st.composite
 def text_dgraph_compat(
-    draw: Callable[[st.SearchStrategy[str]], str], max_size: int = 128
+    draw: Callable[[st.SearchStrategy[str]], str], max_size: int = 64
 ) -> str:
-    base_text = draw(st.text(min_size=3, max_size=max_size))
+    base_text = draw(st.text(min_size=4, max_size=max_size))
     # Don't fuck with newlines due to a dgraph bug
     # https://github.com/dgraph-io/dgraph/issues/4694
     assume(len(base_text) > 3)


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://grapl-internal.slack.com/archives/C0176MS6LBY/p1617301403291500
`hypothesis.errors.FailedHealthCheck: Data generation is extremely slow: Only produced 4 valid examples in 1.01 seconds (7 invalid ones and 0 exceeded maximum size). Try decreasing size of the data you're generating (with e.g.max_size or max_leaves parameters).`

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Stop assuming len > 3, when we're generating len-3 strings

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
it's all about tests

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
