### PR TITLE
Refactor bucket abstraction in Pulumi

### DIFF
--- a/pulumi/infra/emitter.py
+++ b/pulumi/infra/emitter.py
@@ -20,7 +20,9 @@ class EventEmitter(pulumi.ComponentResource):
         super().__init__("grapl:EventEmitter", event_name, None, opts)
 
         logical_bucket_name = f"{event_name}-bucket"
-        self.bucket = Bucket(logical_bucket_name, sse=True, parent=self)
+        self.bucket = Bucket(
+            logical_bucket_name, sse=True, opts=pulumi.ResourceOptions(parent=self)
+        )
 
         region = aws.get_region().name
         physical_topic_name = f"{DEPLOYMENT_NAME}-{event_name}-topic"

--- a/pulumi/infra/ux.py
+++ b/pulumi/infra/ux.py
@@ -18,7 +18,7 @@ class EngagementUX(pulumi.ComponentResource):
             website_args=aws.s3.BucketWebsiteArgs(
                 index_document="index.html",
             ),
-            parent=self,
+            opts=pulumi.ResourceOptions(parent=self),
         )
 
         self.register_outputs({})


### PR DESCRIPTION
Uses more conventional `pulumi.ResourceOptions` arguments, rather than
simply providing a parent resource explicitly.

Also adds several permission-granting methods that will come in handy
as we move more infrastructure over to Pulumi.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>