### PR TITLE
Add DGraph TTL service to Pulumi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,7 @@ zip-pants: ## Generate Lambda zip artifacts using pants
 	./pants filter --filter-target-type=python_awslambda :: | xargs ./pants package
 	cp ./dist/src.python.provisioner.src/lambda.zip ./src/js/grapl-cdk/zips/provisioner-$(TAG).zip
 	cp ./dist/src.python.engagement-creator/engagement-creator.zip ./src/js/grapl-cdk/zips/engagement-creator-$(TAG).zip
+	cp ./dist/src.python.grapl-dgraph-ttl/lambda.zip ./src/js/grapl-cdk/zips/dgraph-ttl-$(TAG).zip
 
 # This target is intended to help ease the transition to Pulumi, and
 # using lambdas in local Grapl testing deployments. Essentially, every

--- a/docker-compose.lambda-zips.python.yml
+++ b/docker-compose.lambda-zips.python.yml
@@ -2,20 +2,6 @@ version: "3.8"
 
 services:
 
-  grapl-dgraph-ttl-zip:
-    image: grapl/grapl-dgraph-ttl-zip:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: ./python/Dockerfile
-      target: dgraph-ttl-zip
-    volumes:
-      - ./src/js/grapl-cdk/zips:/grapl
-    user: ${UID}:${GID}
-    working_dir: /grapl
-    environment:
-      - TAG=${TAG:-latest}
-    command: cp /home/grapl/lambda.zip dgraph-ttl-${TAG:-latest}.zip
-
   grapl-engagement-edge-zip:
     image: grapl/grapl-engagement-edge-zip:${TAG:-latest}
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - IMAGE_NAME=localstack/localstack:0.12.8
       - EDGE_PORT=${LOCALSTACK_PORT}
       - HOSTNAME_EXTERNAL=${LOCALSTACK_HOST}
-      - SERVICES=dynamodb,iam,lambda,logs,s3,secretsmanager,sns,sqs
+      - SERVICES=dynamodb,events,iam,lambda,logs,s3,secretsmanager,sns,sqs
       - DEBUG=1
       - LS_LOG=debug
       - LAMBDA_EXECUTOR=docker
@@ -367,19 +367,6 @@ services:
       default:
         aliases:
           - ${GRAPL_MODEL_PLUGIN_DEPLOYER_HOST}
-
-  grapl-dgraph-ttl:
-    image: grapl/grapl-dgraph-ttl:${TAG:-latest}
-    command: /bin/sh -c '. venv/bin/activate && cd /home/grapl/app && chalice local --no-autoreload --host=0.0.0.0 --port=${GRAPL_DGRAPH_TTL_PORT}'
-    environment:
-      <<: *dgraph-env
-      GRAPL_DGRAPH_TTL_S: "${GRAPL_DGRAPH_TTL_S:-31536000}"
-      GRAPL_TTL_DELETE_BATCH_SIZE: "${GRAPL_TTL_DELETE_BATCH_SIZE:-10}"
-      IS_LOCAL: "True"
-      <<: *log-level
-    tty: true
-    depends_on:
-      - dgraph
 
   ########################################################################
   # Web Services

--- a/pulumi/Pulumi.local-grapl.yaml
+++ b/pulumi/Pulumi.local-grapl.yaml
@@ -2,7 +2,8 @@ encryptionsalt: v1:KRH5XXw/Vv4=:v1:Mi1EOttYFIuFy8Zl:u/QoTfZuh9c5m6Jyw2L3mAKC+VNs
 config:
   aws:accessKey: test
   aws:endpoints:
-  - cloudwatchlogs: http://localhost:4566
+  - cloudwatchevents: http://localhost:4566
+    cloudwatchlogs: http://localhost:4566
     dynamodb: http://localhost:4566
     iam: http://localhost:4566
     lambda: http://localhost:4566

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -2,6 +2,7 @@ from infra import dynamodb, emitter
 from infra.autotag import register_auto_tags
 from infra.bucket import Bucket
 from infra.config import DEPLOYMENT_NAME, LOCAL_GRAPL
+from infra.dgraph_ttl import DGraphTTL
 from infra.engagement_creator import EngagementCreator
 from infra.metric_forwarder import MetricForwarder
 from infra.secret import JWTSecret
@@ -13,6 +14,8 @@ if __name__ == "__main__":
     # These tags will be added to all provisioned infrastructure
     # objects.
     register_auto_tags({"grapl deployment": DEPLOYMENT_NAME})
+
+    dgraph_ttl = DGraphTTL()
 
     secret = JWTSecret()
 

--- a/pulumi/infra/dgraph_ttl.py
+++ b/pulumi/infra/dgraph_ttl.py
@@ -1,0 +1,55 @@
+from typing import Optional
+
+import pulumi_aws as aws
+from infra.config import GLOBAL_LAMBDA_ZIP_TAG, mg_alphas
+from infra.lambda_ import Lambda, LambdaExecutionRole, PythonLambdaArgs, code_path_for
+
+import pulumi
+
+
+class DGraphTTL(pulumi.ComponentResource):
+    def __init__(self, opts: Optional[pulumi.ResourceOptions] = None) -> None:
+
+        name = "dgraph-ttl"
+        super().__init__("grapl:DGraphTTL", name, None, opts)
+
+        self.role = LambdaExecutionRole(
+            name,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        self.function = Lambda(
+            f"{name}-Handler",
+            args=PythonLambdaArgs(
+                execution_role=self.role,
+                description=GLOBAL_LAMBDA_ZIP_TAG,
+                handler="lambdex_handler.handler",
+                code_path=code_path_for(name),
+                env={
+                    "GRAPL_LOG_LEVEL": "INFO",
+                    "MG_ALPHAS": mg_alphas(),
+                    "GRAPL_DGRAPH_TTL_S": str(60 * 60 * 24 * 31),  # 1 month
+                    "GRAPL_TTL_DELETE_BATCH_SIZE": "1000",
+                },
+                memory_size=128,
+                timeout=600,
+            ),
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        # TODO: Need to allow connections to DGraph from this lambda
+
+        self.scheduling_rule = aws.cloudwatch.EventRule(
+            f"{name}-hourly-trigger",
+            schedule_expression="rate(1 hour)",
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        self.target = aws.cloudwatch.EventTarget(
+            f"{name}-invocation-target",
+            arn=self.function.function.arn,
+            rule=self.scheduling_rule.name,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        self.register_outputs({})

--- a/src/js/grapl-cdk/lib/services/dgraph_ttl.ts
+++ b/src/js/grapl-cdk/lib/services/dgraph_ttl.ts
@@ -27,7 +27,7 @@ export class DGraphTtl extends cdk.NestedStack {
 
         const event_handler = new lambda.Function(this, 'Handler', {
             runtime: lambda.Runtime.PYTHON_3_7,
-            handler: 'app.prune_expired_subgraphs',
+            handler: 'lambdex_handler.handler',
             functionName: serviceName + '-Handler',
             code: lambda.Code.fromAsset(
                 `./zips/dgraph-ttl-${props.version}.zip`

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -317,15 +317,6 @@ COPY --chown=grapl --from=grapl-analyzerlib-build /home/grapl/venv venv
 RUN source venv/bin/activate && \
     pip install -r dgraph-ttl/requirements.txt
 
-# zip
-FROM dgraph-ttl-build AS dgraph-ttl-zip
-
-RUN LAMBDA_DIR=$(pwd); \
-    cd ~/venv/lib/python3.7/site-packages && \
-    zip -q9r -dg "${LAMBDA_DIR}/lambda.zip" ./ && \
-    cd ~/dgraph-ttl && \
-    zip -g "${LAMBDA_DIR}/lambda.zip" app.py
-
 # deploy
 FROM grapl-python-deploy AS dgraph-ttl-deploy
 

--- a/src/python/grapl-dgraph-ttl/BUILD
+++ b/src/python/grapl-dgraph-ttl/BUILD
@@ -1,1 +1,7 @@
 python_library()
+
+python_awslambda(
+    name="lambda",
+    runtime="python3.7",
+    handler="grapl_dgraph_ttl.py:prune_expired_subgraphs"
+)

--- a/src/python/grapl-dgraph-ttl/grapl_dgraph_ttl.py
+++ b/src/python/grapl-dgraph-ttl/grapl_dgraph_ttl.py
@@ -6,7 +6,6 @@ from typing import Dict, Iterable, Iterator, List, Optional, Tuple, Union
 from chalice import Chalice
 from grapl_analyzerlib.grapl_client import GraphClient
 
-IS_LOCAL = bool(os.environ.get("IS_LOCAL", False))
 GRAPL_DGRAPH_TTL_S = int(os.environ.get("GRAPL_DGRAPH_TTL_S", "-1"))
 GRAPL_LOG_LEVEL = os.environ.get("GRAPL_LOG_LEVEL", "ERROR")
 GRAPL_TTL_DELETE_BATCH_SIZE = int(os.environ.get("GRAPL_TTL_DELETE_BATCH_SIZE", "1000"))
@@ -145,11 +144,3 @@ def prune_expired_subgraphs(event, lambda_context) -> None:
         app.log.info(f"Pruned {node_count} nodes and {edge_count} edges")
     else:
         app.log.warn("GRAPL_DGRAPH_TTL_S is not set, exiting.")
-
-
-if IS_LOCAL:
-    import time
-
-    while 1:
-        time.sleep(60)
-        prune_expired_subgraphs(None, None)


### PR DESCRIPTION
This also entails:
- Building the lambda ZIP using Pants
- Changing the handler name in our CDK code accordingly
- Renaming app.py to grapl_dgraph_ttl.py for use with Pants
  We've got another `app.py` module elsewhere at the same level, so
  that ends up clashing in Pants' dependency resolution logic.
- Removing old ZIP-building services and Docker containers
- Removing the standalone "local" DGraph TTL service from Local Grapl
- Removing the `IS_LOCAL` logic from the service

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
