### PR TITLE
Add VPC infrastructure to Pulumi, Localstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - IMAGE_NAME=localstack/localstack:0.12.8
       - EDGE_PORT=${LOCALSTACK_PORT}
       - HOSTNAME_EXTERNAL=${LOCALSTACK_HOST}
-      - SERVICES=dynamodb,events,iam,lambda,logs,s3,secretsmanager,sns,sqs
+      - SERVICES=dynamodb,ec2,events,iam,lambda,logs,s3,secretsmanager,sns,sqs
       - DEBUG=1
       - LS_LOG=debug
       - LAMBDA_EXECUTOR=docker

--- a/pulumi/Pulumi.local-grapl.yaml
+++ b/pulumi/Pulumi.local-grapl.yaml
@@ -5,6 +5,7 @@ config:
   - cloudwatchevents: http://localhost:4566
     cloudwatchlogs: http://localhost:4566
     dynamodb: http://localhost:4566
+    ec2: http://localhost:4566
     iam: http://localhost:4566
     lambda: http://localhost:4566
     s3: http://localhost:4566

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -5,6 +5,7 @@ from infra.config import DEPLOYMENT_NAME, LOCAL_GRAPL
 from infra.dgraph_ttl import DGraphTTL
 from infra.engagement_creator import EngagementCreator
 from infra.metric_forwarder import MetricForwarder
+from infra.network import Network
 from infra.secret import JWTSecret
 from infra.service_queue import ServiceQueue
 from infra.ux import EngagementUX
@@ -15,7 +16,9 @@ if __name__ == "__main__":
     # objects.
     register_auto_tags({"grapl deployment": DEPLOYMENT_NAME})
 
-    dgraph_ttl = DGraphTTL()
+    network = Network("grapl-network")
+
+    dgraph_ttl = DGraphTTL(network=network)
 
     secret = JWTSecret()
 
@@ -52,9 +55,11 @@ if __name__ == "__main__":
     for service in services:
         ServiceQueue(service)
 
-    forwarder = MetricForwarder()
+    forwarder = MetricForwarder(network=network)
 
-    ec = EngagementCreator(source_emitter=analyzer_matched, forwarder=forwarder)
+    ec = EngagementCreator(
+        source_emitter=analyzer_matched, network=network, forwarder=forwarder
+    )
 
     if LOCAL_GRAPL:
         from infra.local import user

--- a/pulumi/infra/dgraph_ttl.py
+++ b/pulumi/infra/dgraph_ttl.py
@@ -3,12 +3,15 @@ from typing import Optional
 import pulumi_aws as aws
 from infra.config import GLOBAL_LAMBDA_ZIP_TAG, mg_alphas
 from infra.lambda_ import Lambda, LambdaExecutionRole, PythonLambdaArgs, code_path_for
+from infra.network import Network
 
 import pulumi
 
 
 class DGraphTTL(pulumi.ComponentResource):
-    def __init__(self, opts: Optional[pulumi.ResourceOptions] = None) -> None:
+    def __init__(
+        self, network: Network, opts: Optional[pulumi.ResourceOptions] = None
+    ) -> None:
 
         name = "dgraph-ttl"
         super().__init__("grapl:DGraphTTL", name, None, opts)
@@ -34,6 +37,7 @@ class DGraphTTL(pulumi.ComponentResource):
                 memory_size=128,
                 timeout=600,
             ),
+            network=network,
             opts=pulumi.ResourceOptions(parent=self),
         )
 

--- a/pulumi/infra/engagement_creator.py
+++ b/pulumi/infra/engagement_creator.py
@@ -11,6 +11,7 @@ from infra.config import (
 from infra.emitter import EventEmitter
 from infra.lambda_ import code_path_for
 from infra.metric_forwarder import MetricForwarder
+from infra.network import Network
 from infra.service import Service
 
 import pulumi
@@ -18,7 +19,7 @@ import pulumi
 
 class EngagementCreator(Service):
     def __init__(
-        self, source_emitter: EventEmitter, forwarder: MetricForwarder
+        self, source_emitter: EventEmitter, network: Network, forwarder: MetricForwarder
     ) -> None:
 
         name = "engagement-creator"
@@ -28,6 +29,7 @@ class EngagementCreator(Service):
             lambda_description=GLOBAL_LAMBDA_ZIP_TAG,
             lambda_handler_fn="lambdex_handler.handler",
             lambda_code_path=code_path_for("engagement-creator"),
+            network=network,
             env={
                 "GRAPL_LOG_LEVEL": "INFO",
                 "MG_ALPHAS": mg_alphas(),

--- a/pulumi/infra/metric_forwarder.py
+++ b/pulumi/infra/metric_forwarder.py
@@ -3,13 +3,16 @@ from typing import Optional
 
 import pulumi_aws as aws
 from infra.config import GLOBAL_LAMBDA_ZIP_TAG
+from infra.network import Network
 
 import pulumi
 
 
 # TODO: will need VPC here
 class MetricForwarder(pulumi.ComponentResource):
-    def __init__(self, opts: Optional[pulumi.ResourceOptions] = None) -> None:
+    def __init__(
+        self, network: Network, opts: Optional[pulumi.ResourceOptions] = None
+    ) -> None:
         name = "metric-forwarder"
         super().__init__("grapl:MetricForwarder", name, None, opts)
 
@@ -35,6 +38,7 @@ class MetricForwarder(pulumi.ComponentResource):
                 memory_size=128,
                 timeout=45,
             ),
+            network=network,
             opts=pulumi.ResourceOptions(parent=self),
         )
 

--- a/pulumi/infra/network.py
+++ b/pulumi/infra/network.py
@@ -1,0 +1,138 @@
+import ipaddress
+import math
+from typing import Optional
+
+import pulumi_aws as aws
+
+import pulumi
+
+# TODO: Add policy requiring that each networking-related
+# infrastructure component have a "Name" (note capitalization) tag,
+# since this is how these objects get their names. Otherwise, they
+# have no name, which makes interaction via the AWS UI slightly more
+# awkward than it needs to be.
+#
+# Security groups don't seem to work this way, though. They get a name
+# independent of a Name tag (though the AWS UI shows both, somewhat
+# confusingly).
+
+
+class Network(pulumi.ComponentResource):
+    def __init__(
+        self,
+        name: str,
+        opts: Optional[pulumi.ResourceOptions] = None,
+    ) -> None:
+        super().__init__("grapl:Network", name, None, opts)
+
+        # From CDK's @aws-cdk/aws-ec2.Vpc Construct (which we used
+        # before):
+        #
+        # It will automatically divide the provided VPC CIDR range,
+        # and create public and private subnets per Availability
+        # Zone. Network routing for the public subnets will be
+        # configured to allow outbound access directly via an Internet
+        # Gateway. Network routing for the private subnets will be
+        # configured to allow outbound access via a set of resilient
+        # NAT Gateways (one per AZ).
+
+        # TODO: Is it worth setting up routing tables, network ACLs
+        # here, too? Currently, the default ones are all we need, but
+        # it could be useful in the future to have Pulumi be aware of
+        # them.
+
+        cidr_block = ipaddress.ip_network("10.0.0.0/16")
+
+        self.vpc = aws.ec2.Vpc(
+            f"{name}-vpc",
+            cidr_block=str(cidr_block),
+            enable_dns_hostnames=True,
+            enable_dns_support=True,
+            tags={"Name": name},
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        # We will create a public and a private subnet per
+        # availability zone for some number of zones. Our CDK code
+        # defaulted to 2 AZs, so that's what we'll do here.
+        azs = aws.get_availability_zones(state="available").names
+
+        # Split the block into two non-overlapping subnets; these will
+        # be further divided by availability zone
+        public, private = cidr_block.subnets()
+
+        # Always assume at least 2 availibity zones; no region has
+        # less. us-east-1 currently has the most AZs at 6.
+        #
+        # TODO: Consider parameterizing this value. This just happens
+        # to be what we ended up with from our CDK usage. Also
+        # consider implications of scaling up/down with the
+        # delete/recreate semantics of subnets (which can't overlap).
+        desired_az_spread = 2
+        num_azs = min(desired_az_spread, len(azs))
+        # 2 AZs => 2 subnets
+        # 3 AZs => 4 subnets (extra 1 doesn't actually get created)
+        # 4 AZs => 4 subnets
+        # 5 AZs => 8 subnets (extra 3 don't actually get created)
+        # etc.
+        prefixlen_diff = math.ceil(math.log(num_azs, 2))
+
+        self.public_subnets = [
+            aws.ec2.Subnet(
+                f"{name}-{az}-public-subnet",
+                vpc_id=self.vpc.id,
+                availability_zone=az,
+                cidr_block=str(subnet),
+                map_public_ip_on_launch=True,
+                tags={"Name": f"{name}-{az}-public-subnet"},
+                opts=pulumi.ResourceOptions(parent=self),
+            )
+            for az, subnet in zip(
+                azs[:num_azs], public.subnets(prefixlen_diff=prefixlen_diff)
+            )
+        ]
+
+        self.private_subnets = [
+            aws.ec2.Subnet(
+                f"{name}-{az}-private-subnet",
+                vpc_id=self.vpc.id,
+                availability_zone=az,
+                cidr_block=str(subnet),
+                map_public_ip_on_launch=False,
+                tags={"Name": f"{name}-{az}-private-subnet"},
+                opts=pulumi.ResourceOptions(parent=self),
+            )
+            for az, subnet in zip(
+                azs[:num_azs], private.subnets(prefixlen_diff=prefixlen_diff)
+            )
+        ]
+
+        self.internet_gateway = aws.ec2.InternetGateway(
+            f"{name}-internet-gateway",
+            vpc_id=self.vpc.id,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        self.eip = aws.ec2.Eip(
+            f"{name}-eip",
+            vpc=True,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        # TODO: Do we want to manage the NICs as well?
+
+        # Note that NAT gateways need to have an internet gateway
+        # attached to the VPC first... that's why we have a depends_on
+        # value set.
+        self.nat_gateway = aws.ec2.NatGateway(
+            f"{name}-nat-gateway",
+            subnet_id=self.public_subnets[0].id,
+            # This is id instead of allocation_id because of a bug
+            # https://github.com/pulumi/pulumi-aws/issues/498
+            allocation_id=self.eip.id,
+            opts=pulumi.ResourceOptions(
+                parent=self, depends_on=[self.internet_gateway]
+            ),
+        )
+
+        self.register_outputs({})

--- a/pulumi/infra/queue_driven_lambda.py
+++ b/pulumi/infra/queue_driven_lambda.py
@@ -4,6 +4,7 @@ from typing import Optional
 import pulumi_aws as aws
 from infra.lambda_ import Lambda, LambdaArgs
 from infra.metric_forwarder import MetricForwarder
+from infra.network import Network
 
 import pulumi
 
@@ -16,6 +17,7 @@ class QueueDrivenLambda(pulumi.ComponentResource):
         name: str,
         queue: aws.sqs.Queue,
         args: LambdaArgs,
+        network: Network,
         forwarder: Optional[MetricForwarder] = None,
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
@@ -25,6 +27,7 @@ class QueueDrivenLambda(pulumi.ComponentResource):
         self.function = Lambda(
             name,
             args=args,
+            network=network,
             forwarder=forwarder,
             opts=pulumi.ResourceOptions(parent=self),
         )

--- a/pulumi/infra/service.py
+++ b/pulumi/infra/service.py
@@ -3,6 +3,7 @@ from typing import Mapping, Optional, Union
 
 from infra.lambda_ import LambdaExecutionRole, PythonLambdaArgs
 from infra.metric_forwarder import MetricForwarder
+from infra.network import Network
 from infra.queue_driven_lambda import QueueDrivenLambda
 from infra.service_queue import ServiceQueue
 
@@ -18,6 +19,7 @@ class Service(pulumi.ComponentResource):
         lambda_description: str,
         lambda_handler_fn: str,
         lambda_code_path: str,
+        network: Network,
         env: Mapping[str, Union[str, pulumi.Output[str]]],
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
@@ -51,6 +53,7 @@ class Service(pulumi.ComponentResource):
             self.queue.queue,
             args=args,
             forwarder=forwarder,
+            network=network,
             opts=pulumi.ResourceOptions(parent=self),
         )
 
@@ -70,6 +73,7 @@ class Service(pulumi.ComponentResource):
                 },
             ),
             forwarder=forwarder,
+            network=network,
             opts=pulumi.ResourceOptions(parent=self),
         )
 


### PR DESCRIPTION
This replicates (to the best of my knowledge) the infrastructure that
was generated for us by CDK's VPC construct:

- One VPC
- 2 public subnets, 2 private subnets, one each in two separate
  availability zones
- 1 internet gateway
- 1 NAT gateway
- Each lambda function gets a dedicated Security Group, as well as
  access to both private subnets.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
