### PR TITLE
Rust sqs-executor cache changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
       DEAD_LETTER_QUEUE_URL: "${SQS_ENDPOINT}/queue/${DEPLOYMENT_NAME}-sysmon-generator-dead-letter-queue"
       DEST_BUCKET_NAME: "${DEPLOYMENT_NAME}-unid-subgraphs-generated-bucket"
       DEST_QUEUE_URL: "${SQS_ENDPOINT}/queue/${DEPLOYMENT_NAME}-node-identifier-queue"
-      EVENT_CACHE_CLUSTER_ADDRESS: "${REDIS_HOST}:${REDIS_PORT}"
+      REDIS_ENDPOINT: "${REDIS_ENDPOINT}"
       IS_LOCAL: "True"
       <<: *log-level
       RETRY_QUEUE_URL: "${SQS_ENDPOINT}/000000000000/${DEPLOYMENT_NAME}-sysmon-generator-retry-queue"
@@ -147,7 +147,7 @@ services:
       DEAD_LETTER_QUEUE_URL: "${SQS_ENDPOINT}/queue/${DEPLOYMENT_NAME}-osquery-generator-dead-letter-queue"
       DEST_BUCKET_NAME: "${DEPLOYMENT_NAME}-unid-subgraphs-generated-bucket"
       DEST_QUEUE_URL: "${SQS_ENDPOINT}/queue/${DEPLOYMENT_NAME}-node-identifier-queue"
-      EVENT_CACHE_CLUSTER_ADDRESS: "${REDIS_HOST}:${REDIS_PORT}"
+      REDIS_ENDPOINT: "${REDIS_ENDPOINT}"
       IS_LOCAL: "True"
       <<: *log-level
       RETRY_QUEUE_URL: "${SQS_ENDPOINT}/queue/${DEPLOYMENT_NAME}-osquery-generator-retry-queue"
@@ -169,7 +169,7 @@ services:
       DEST_QUEUE_URL: "${SQS_ENDPOINT}/queue/${DEPLOYMENT_NAME}-graph-merger-queue"
       <<: *dynamodb-env
       <<: *dynamodb-mapping-tables
-      EVENT_CACHE_CLUSTER_ADDRESS: "${REDIS_HOST}:${REDIS_PORT}"
+      REDIS_ENDPOINT: "${REDIS_ENDPOINT}"
       IS_LOCAL: "true"
       <<: *log-level
       RETRY_QUEUE_URL: "${SQS_ENDPOINT}/queue/${DEPLOYMENT_NAME}-node-identifier-retry-queue"
@@ -192,7 +192,7 @@ services:
       DEST_QUEUE_URL: "${SQS_ENDPOINT}/queue/${DEPLOYMENT_NAME}-graph-merger-queue"
       <<: *dynamodb-env
       <<: *dynamodb-mapping-tables
-      EVENT_CACHE_CLUSTER_ADDRESS: "${REDIS_HOST}:${REDIS_PORT}"
+      REDIS_ENDPOINT: "${REDIS_ENDPOINT}"
       IS_LOCAL: "True"
       <<: *log-level
       RETRY_QUEUE_URL: "${SQS_ENDPOINT}/queue/${DEPLOYMENT_NAME}-node-identifier-dead-letter-queue"
@@ -215,7 +215,7 @@ services:
       DEST_QUEUE_URL: "${SQS_ENDPOINT}/queue/${DEPLOYMENT_NAME}-analyzer-dispatcher-queue"
       <<: *dgraph-env
       <<: *dynamodb-env
-      EVENT_CACHE_CLUSTER_ADDRESS: "${REDIS_HOST}:${REDIS_PORT}"
+      REDIS_ENDPOINT: "${REDIS_ENDPOINT}"
       GRAPL_SCHEMA_TABLE: "${DEPLOYMENT_NAME}-grapl_schema_table"
       IS_LOCAL: "True"
       <<: *log-level

--- a/local-grapl.env
+++ b/local-grapl.env
@@ -85,7 +85,7 @@ GRAPL_UX_ROUTER_HOST=ux-router.grapl.test
 # only for usage within the Docker Compose network.
 ########################################################################
 
-REDIS_ENDPOINT=http://${REDIS_HOST}:${REDIS_PORT}
+REDIS_ENDPOINT=redis://${REDIS_HOST}:${REDIS_PORT}
 
 # The remaining endpoints are all just aliases for our unified
 # Localstack service

--- a/src/js/grapl-cdk/lib/services/analyzer_dispatcher.ts
+++ b/src/js/grapl-cdk/lib/services/analyzer_dispatcher.ts
@@ -53,7 +53,7 @@ export class AnalyzerDispatch extends cdk.NestedStack {
             environment: {
                 ANALYZER_BUCKET: deployment_name + "-analyzers-bucket",
                 RUST_LOG: props.logLevels.analyzerDispatcherLogLevel,
-                EVENT_CACHE_CLUSTER_ADDRESS: dispatch_event_cache.address,
+                REDIS_ENDPOINT: dispatch_event_cache.address,
                 DISPATCHED_ANALYZER_BUCKET: props.writesTo.bucketName,
                 SUBGRAPH_MERGED_BUCKET: subgraphs_merged.bucket.bucketName,
             },

--- a/src/js/grapl-cdk/lib/services/graph_merger.ts
+++ b/src/js/grapl-cdk/lib/services/graph_merger.ts
@@ -41,7 +41,7 @@ export class GraphMerger extends cdk.NestedStack {
         this.service = new FargateService(this, service_name, {
             deploymentName: props.deploymentName,
             environment: {
-                EVENT_CACHE_CLUSTER_ADDRESS: event_cache.address,
+                REDIS_ENDPOINT: event_cache.address,
                 DEPLOYMENT_NAME: deployment_name,
                 RUST_LOG: props.logLevels.graphMergerLogLevel,
                 SUBGRAPH_MERGED_BUCKET: props.writesTo.bucketName,

--- a/src/js/grapl-cdk/lib/services/node_identifier.ts
+++ b/src/js/grapl-cdk/lib/services/node_identifier.ts
@@ -45,7 +45,7 @@ export class NodeIdentifier extends cdk.NestedStack {
             deploymentName: props.deploymentName,
             environment: {
                 RUST_LOG: props.logLevels.nodeIdentifierLogLevel,
-                EVENT_CACHE_CLUSTER_ADDRESS: event_cache.address,
+                REDIS_ENDPOINT: event_cache.address,
                 RETRY_IDENTITY_CACHE_ADDR:
                 event_cache.cluster.attrRedisEndpointAddress,
                 RETRY_IDENTITY_CACHE_PORT:

--- a/src/js/grapl-cdk/lib/services/osquery_graph_generator.ts
+++ b/src/js/grapl-cdk/lib/services/osquery_graph_generator.ts
@@ -37,7 +37,7 @@ export class OSQueryGraphGenerator extends cdk.NestedStack {
             environment: {
                 DEPLOYMENT_NAME: deployment_name,
                 RUST_LOG: props.logLevels.osquerySubgraphGeneratorLogLevel,
-                EVENT_CACHE_CLUSTER_ADDRESS: event_cache.address,
+                REDIS_ENDPOINT: event_cache.address,
             },
             vpc: props.vpc,
             eventEmitter: osquery_log,

--- a/src/js/grapl-cdk/lib/services/sysmon_graph_generator.ts
+++ b/src/js/grapl-cdk/lib/services/sysmon_graph_generator.ts
@@ -37,7 +37,7 @@ export class SysmonGraphGenerator extends cdk.NestedStack {
             environment: {
                 DEPLOYMENT_NAME: deployment_name,
                 RUST_LOG: props.logLevels.sysmonSubgraphGeneratorLogLevel,
-                EVENT_CACHE_CLUSTER_ADDRESS: event_cache.address,
+                REDIS_ENDPOINT: event_cache.address,
             },
             vpc: props.vpc,
             eventEmitter: sysmon_log,

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -91,6 +91,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "698b65a961a9d730fb45b6b0327e20207810c9f61ee421b082b27ba003f49e2b"
 
 [[package]]
+name = "arc-swap"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
+
+[[package]]
 name = "async-stream"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +396,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4369b5e4c0cddf64ad8981c0111e7df4f7078f4d6ba98fb31f2e17c4c57b7e"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-util",
+ "memchr",
+ "pin-project-lite 0.2.6",
+ "tokio 1.2.0",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,17 +555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
 dependencies = [
  "sct",
-]
-
-[[package]]
-name = "darkredis"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd75df5d84e3d811c34e3bded9546a6a5eff77196cfd968a01b136235308e14a"
-dependencies = [
- "futures 0.3.13",
- "quick-error",
- "tokio 1.2.0",
 ]
 
 [[package]]
@@ -2195,12 +2203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
-
-[[package]]
 name = "quickcheck"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,6 +2480,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "redis"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8f8d059ead7805e171fc22de8348a3d611c0f985aaa4f5cf6c0dfc7645407"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes 1.0.1",
+ "combine",
+ "dtoa",
+ "futures 0.3.13",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite 0.2.6",
+ "sha1",
+ "tokio 1.2.0",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -2956,16 +2980,17 @@ dependencies = [
  "async-trait",
  "aws_lambda_events 0.3.1",
  "chrono",
- "darkredis",
  "futures 0.3.13",
  "futures-util",
  "grapl-observe",
  "grapl-utils",
  "hex",
+ "itertools 0.10.0",
  "lazy_static",
  "lru",
  "num_cpus",
  "prost 0.7.0",
+ "redis",
  "rusoto_core",
  "rusoto_s3",
  "rusoto_sqs",

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -78,7 +78,7 @@ FROM build AS build-test-integration
 RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
     --mount=type=secret,id=rust_env,dst=/grapl/env \
     source /grapl/env; \
-    cargo test --manifest-path node-identifier/Cargo.toml --features integration --no-run
+    cargo test --features node-identifier/integration,sqs-executor/integration --test '*' --no-run
 
 
 # images for running services

--- a/src/rust/generators/generic-subgraph-generator/src/generator.rs
+++ b/src/rust/generators/generic-subgraph-generator/src/generator.rs
@@ -2,8 +2,7 @@ use std::convert::TryFrom;
 
 use async_trait::async_trait;
 use grapl_graph_descriptions::graph_description::*;
-use sqs_executor::{cache::{Cache,
-                           CacheResponse},
+use sqs_executor::{cache::Cache,
                    errors::{CheckedError,
                             Recoverable},
                    event_handler::{CompletedEvents,
@@ -84,13 +83,11 @@ where
         let mut final_subgraph = GraphDescription::new();
         let mut failed: Option<eyre::Report> = None;
 
+        // Skip events we've successfully processed and stored in the event cache.
+        let events = self.cache.filter_cached(events).await;
+
         for event in events {
             let identity = event.clone();
-
-            if let Ok(CacheResponse::Hit) = self.cache.get(identity.clone()).await {
-                // If this was a hit, skip over the event because we've already processed it
-                continue;
-            }
 
             let subgraph = match GraphDescription::try_from(event) {
                 Ok(subgraph) => subgraph,

--- a/src/rust/generators/generic-subgraph-generator/src/generator.rs
+++ b/src/rust/generators/generic-subgraph-generator/src/generator.rs
@@ -84,7 +84,7 @@ where
         let mut failed: Option<eyre::Report> = None;
 
         // Skip events we've successfully processed and stored in the event cache.
-        let events = self.cache.filter_cached(events).await;
+        let events = self.cache.filter_cached(&events).await;
 
         for event in events {
             let identity = event.clone();

--- a/src/rust/generators/sysmon-subgraph-generator/src/generator.rs
+++ b/src/rust/generators/sysmon-subgraph-generator/src/generator.rs
@@ -66,7 +66,7 @@ where
         let mut final_subgraph = GraphDescription::new();
 
         // Skip events we've successfully processed and stored in the event cache.
-        let events = self.cache.filter_cached(events).await;
+        let events = self.cache.filter_cached(&events).await;
 
         for event in events {
             let event = match Event::from_str(&event) {

--- a/src/rust/graph-merger/src/main.rs
+++ b/src/rust/graph-merger/src/main.rs
@@ -51,7 +51,6 @@ use serde::{Deserialize,
             Serialize};
 use serde_json::Value;
 use sqs_executor::{cache::{Cache,
-                           CacheResponse,
                            Cacheable},
                    errors::{CheckedError,
                             Recoverable},

--- a/src/rust/graph-merger/src/service.rs
+++ b/src/rust/graph-merger/src/service.rs
@@ -42,7 +42,6 @@ use serde::{Deserialize,
             Serialize};
 use serde_json::Value;
 use sqs_executor::{cache::{Cache,
-                           CacheResponse,
                            Cacheable},
                    errors::{CheckedError,
                             Recoverable},

--- a/src/rust/grapl-config/src/lib.rs
+++ b/src/rust/grapl-config/src/lib.rs
@@ -51,8 +51,7 @@ pub fn is_local() -> bool {
 }
 
 pub async fn event_cache(env: &ServiceEnv) -> RedisCache {
-    let cache_address =
-        std::env::var("EVENT_CACHE_CLUSTER_ADDRESS").expect("EVENT_CACHE_CLUSTER_ADDRESS");
+    let cache_address = std::env::var("REDIS_ENDPOINT").expect("REDIS_ENDPOINT");
     let lru_cache_size = std::env::var("LRU_CACHE_SIZE")
         .unwrap_or(String::from("1000000"))
         .parse::<usize>()

--- a/src/rust/grapl-config/src/lib.rs
+++ b/src/rust/grapl-config/src/lib.rs
@@ -53,7 +53,12 @@ pub fn is_local() -> bool {
 pub async fn event_cache(env: &ServiceEnv) -> RedisCache {
     let cache_address =
         std::env::var("EVENT_CACHE_CLUSTER_ADDRESS").expect("EVENT_CACHE_CLUSTER_ADDRESS");
-    RedisCache::new(
+    let lru_cache_size = std::env::var("LRU_CACHE_SIZE")
+        .unwrap_or(String::from("1000000"))
+        .parse::<usize>()
+        .unwrap_or(1_000_000);
+    RedisCache::with_lru_capacity(
+        lru_cache_size,
         cache_address.to_owned(),
         MetricReporter::<Stdout>::new(&env.service_name),
     )

--- a/src/rust/node-identifier/src/lib.rs
+++ b/src/rust/node-identifier/src/lib.rs
@@ -32,7 +32,6 @@ use sqs_executor::{cache::{Cache,
                    event_handler::{CompletedEvents,
                                    EventHandler},
                    event_retriever::S3PayloadRetriever,
-                   event_status::EventStatus,
                    make_ten,
                    s3_event_emitter::S3ToSqsEventNotifier,
                    time_based_key_fn};
@@ -115,7 +114,7 @@ where
     async fn handle_event(
         &mut self,
         unid_subgraph: GraphDescription,
-        completed: &mut CompletedEvents,
+        _completed: &mut CompletedEvents,
     ) -> Result<Self::OutputEvent, Result<(Self::OutputEvent, Self::Error), Self::Error>> {
         let mut attribution_failure = None;
 
@@ -150,21 +149,11 @@ where
         for (old_node_key, old_node) in output_subgraph.nodes.iter() {
             let node = old_node.clone();
 
-            // match self.cache.get(old_node_key.clone()).await {
-            //     Ok(CacheResponse::Hit) => {
-            //         info!("Got cache hit for old_node_key, skipping node.");
-            //         continue;
-            //     }
-            //     Err(e) => warn!("Failed to retrieve from cache: {:?}", e),
-            //     _ => (),
-            // };
-
             let node = match self.attribute_node_key(&node).await {
                 Ok(node) => node,
                 Err(e) => {
                     warn!("Failed to attribute node_key with: {}", e);
                     dead_node_ids.insert(node.clone_node_key());
-                    // completed.add_identity(node.clone_node_key(), EventStatus::Failure);
 
                     attribution_failure = Some(e);
                     continue;
@@ -238,14 +227,8 @@ where
             return Ok(IdentifiedGraph::new());
         }
 
-        let identities: Vec<_> = unid_id_map.keys().collect();
-
-        identities
-            .iter()
-            .for_each(|identity| completed.add_identity(identity.clone(), EventStatus::Success));
-
         if !dead_node_ids.is_empty() || attribution_failure.is_some() {
-            info!("Partial Success, identified {} nodes", identities.len());
+            info!("Partial Success, identified {} nodes", identified_graph.nodes.len());
             Err(Ok(
                 (identified_graph, NodeIdentifierError::Unexpected), // todo: Use a real error here
             ))

--- a/src/rust/sqs-executor/Cargo.toml
+++ b/src/rust/sqs-executor/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+integration = []
+
 [dependencies]
 grapl-observe = { path = "../grapl-observe" }
 grapl-utils = { path = "../grapl-utils" }

--- a/src/rust/sqs-executor/Cargo.toml
+++ b/src/rust/sqs-executor/Cargo.toml
@@ -16,6 +16,8 @@ rusoto_sqs = {version = "0.46", default_features = false, features=["rustls"]}
 
 tokio = { version = "1", features = ["io-util", "sync", "rt", "macros", "time", "rt-multi-thread"] }
 
+redis = { version = "0.20", features = ["tokio-comp", "connection-manager"] }
+
 serde = "1.0"
 serde_json = "1.0"
 prost = "0.7"
@@ -27,7 +29,6 @@ futures-util = "0.3.8"
 uuid = {version = "0.8.1", features=["v4"]}
 lazy_static = "1.4"
 futures = "0.3.8"
-darkredis = "0.8.0"
 num_cpus = "1.13.0"
 hex = "0.4.2"
 tap = "1.0.0"
@@ -35,3 +36,4 @@ chrono = "0.4.19"
 aws_lambda_events = "0.3.1"
 stopwatch = "0.0.7"
 lru = "0.6"
+itertools = "0.10"

--- a/src/rust/sqs-executor/src/cache.rs
+++ b/src/rust/sqs-executor/src/cache.rs
@@ -23,33 +23,36 @@ where
     }
 }
 
-
 #[async_trait]
 pub trait Cache: Clone {
     type CacheErrorT: CheckedError + Send + Sync + 'static;
 
-    async fn exists<CA: Cacheable + Send + Sync + Clone + 'static>(
-        &mut self,
-        cacheable: CA,
-    ) -> bool {
+    async fn all_exist<CA>(&mut self, cacheables: &[CA]) -> bool
+    where
+        CA: Cacheable + Send + Sync + Clone + 'static,
+    {
         // If cacheable doesn't return from filter_cached then
         // we know it exists in the cache
-        self.filter_cached(vec![cacheable]).await.is_empty()
+        self.filter_cached(cacheables).await.is_empty()
     }
 
-    async fn store(&mut self, identity: Vec<u8>) -> Result<(), Self::CacheErrorT>;
+    async fn store<CA>(&mut self, cacheable: CA) -> Result<(), Self::CacheErrorT>
+    where
+        CA: Cacheable + Send + Sync + Clone + 'static;
 
-    async fn store_all(&mut self, identities: Vec<Vec<u8>>) -> Result<(), Self::CacheErrorT> {
-        for identity in identities.into_iter() {
-            self.store(identity).await?;
+    async fn store_all<CA>(&mut self, cacheables: &[CA]) -> Result<(), Self::CacheErrorT>
+    where
+        CA: Cacheable + Send + Sync + Clone + 'static,
+    {
+        for cacheable in cacheables.into_iter() {
+            self.store(cacheable.identity()).await?;
         }
         Ok(())
     }
 
-    async fn filter_cached<CA: Cacheable + Send + Sync + Clone + 'static>(
-        &mut self,
-        cacheables: Vec<CA>,
-    ) -> Vec<CA>;
+    async fn filter_cached<CA>(&mut self, cacheables: &[CA]) -> Vec<CA>
+    where
+        CA: Cacheable + Send + Sync + Clone + 'static;
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -71,22 +74,25 @@ pub struct NopCache {}
 impl Cache for NopCache {
     type CacheErrorT = NopCacheError;
 
-    async fn exists<CA: Cacheable + Send + Sync + Clone + 'static>(
-        &mut self,
-        _cacheable: CA,
-    ) -> bool {
+    async fn all_exist<CA>(&mut self, _cacheables: &[CA]) -> bool
+    where
+        CA: Cacheable + Send + Sync + Clone + 'static,
+    {
         false
     }
 
-    async fn store(&mut self, _identity: Vec<u8>) -> Result<(), Self::CacheErrorT> {
+    async fn store<CA>(&mut self, _identity: CA) -> Result<(), Self::CacheErrorT>
+    where
+        CA: Cacheable + Send + Sync + Clone + 'static,
+    {
         tracing::debug!("nopcache.store operation");
         Ok(())
     }
 
-    async fn filter_cached<CA: Cacheable + Send + Sync + Clone + 'static>(
-        &mut self,
-        cacheables: Vec<CA>,
-    ) -> Vec<CA> {
-        cacheables
+    async fn filter_cached<CA>(&mut self, cacheables: &[CA]) -> Vec<CA>
+    where
+        CA: Cacheable + Send + Sync + Clone + 'static,
+    {
+        cacheables.to_vec()
     }
 }

--- a/src/rust/sqs-executor/src/cache.rs
+++ b/src/rust/sqs-executor/src/cache.rs
@@ -23,32 +23,18 @@ where
     }
 }
 
-#[derive(Eq, PartialEq, Clone)]
-pub enum CacheResponse {
-    Hit,
-    Miss,
-}
 
 #[async_trait]
 pub trait Cache: Clone {
     type CacheErrorT: CheckedError + Send + Sync + 'static;
 
-    async fn get<CA: Cacheable + Send + Sync + Clone + 'static>(
+    async fn exists<CA: Cacheable + Send + Sync + Clone + 'static>(
         &mut self,
         cacheable: CA,
-    ) -> Result<CacheResponse, Self::CacheErrorT>;
-
-    async fn get_all<CA: Cacheable + Send + Sync + Clone + 'static>(
-        &mut self,
-        cacheables: Vec<CA>,
-    ) -> Result<Vec<(CA, CacheResponse)>, Self::CacheErrorT> {
-        let mut results = Vec::with_capacity(cacheables.len());
-
-        for cacheable in cacheables {
-            results.push((cacheable.clone(), self.get(cacheable).await?));
-        }
-
-        Ok(results)
+    ) -> bool {
+        // If cacheable doesn't return from filter_cached then
+        // we know it exists in the cache
+        self.filter_cached(vec![cacheable]).await.is_empty()
     }
 
     async fn store(&mut self, identity: Vec<u8>) -> Result<(), Self::CacheErrorT>;
@@ -59,6 +45,11 @@ pub trait Cache: Clone {
         }
         Ok(())
     }
+
+    async fn filter_cached<CA: Cacheable + Send + Sync + Clone + 'static>(
+        &mut self,
+        cacheables: Vec<CA>,
+    ) -> Vec<CA>;
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -80,16 +71,22 @@ pub struct NopCache {}
 impl Cache for NopCache {
     type CacheErrorT = NopCacheError;
 
-    async fn get<CA: Cacheable + Send + Sync + Clone + 'static>(
+    async fn exists<CA: Cacheable + Send + Sync + Clone + 'static>(
         &mut self,
         _cacheable: CA,
-    ) -> Result<CacheResponse, Self::CacheErrorT> {
-        tracing::debug!("nopcache.get operation");
-        Ok(CacheResponse::Miss)
+    ) -> bool {
+        false
     }
 
     async fn store(&mut self, _identity: Vec<u8>) -> Result<(), Self::CacheErrorT> {
         tracing::debug!("nopcache.store operation");
         Ok(())
+    }
+
+    async fn filter_cached<CA: Cacheable + Send + Sync + Clone + 'static>(
+        &mut self,
+        cacheables: Vec<CA>,
+    ) -> Vec<CA> {
+        cacheables
     }
 }

--- a/src/rust/sqs-executor/src/lib.rs
+++ b/src/rust/sqs-executor/src/lib.rs
@@ -92,7 +92,7 @@ where
         }
     }
 
-    cache.store_all(to_cache).await.unwrap_or_else(|e| {
+    cache.store_all(&to_cache).await.unwrap_or_else(|e| {
         error!(
             error = e.to_string().as_str(),
             "Failed to store_all in cache"
@@ -175,7 +175,7 @@ async fn process_message<
     );
     let _enter = inner_loop_span.enter();
 
-    if cache.exists(message_id.as_bytes().to_owned()).await {
+    if cache.all_exist(&[message_id.to_owned()]).await {
         info!(
             message_id = message_id,
             "Message has already been processed",

--- a/src/rust/sqs-executor/src/lib.rs
+++ b/src/rust/sqs-executor/src/lib.rs
@@ -26,8 +26,7 @@ use tracing::{debug,
               error,
               info};
 
-use crate::{cache::{Cache,
-                    CacheResponse},
+use crate::{cache::Cache,
             completion_event_serializer::CompletionEventSerializer,
             errors::{CheckedError,
                      Recoverable},
@@ -176,7 +175,7 @@ async fn process_message<
     );
     let _enter = inner_loop_span.enter();
 
-    if let Ok(CacheResponse::Hit) = cache.get(message_id.as_bytes().to_owned()).await {
+    if cache.exists(message_id.as_bytes().to_owned()).await {
         info!(
             message_id = message_id,
             "Message has already been processed",

--- a/src/rust/sqs-executor/src/redis_cache.rs
+++ b/src/rust/sqs-executor/src/redis_cache.rs
@@ -1,20 +1,19 @@
 use std::{io::Stdout,
-          time::{Duration,
-                 Instant}};
+          time::Duration};
 
 use async_trait::async_trait;
-use darkredis::{ConnectionPool,
-                Error as RedisError,
-                MSetBuilder};
 use grapl_observe::{metric_reporter::{tag,
                                       MetricReporter},
                     timers::TimedFutureExt};
 use grapl_utils::future_ext::GraplFutureExt;
+use itertools::{Either,
+                Itertools};
 use lazy_static::lazy_static;
+use redis::{AsyncCommands,
+            RedisError};
 use tokio::time::error::Elapsed;
 
 use crate::{cache::{Cache,
-                    CacheResponse,
                     Cacheable},
             errors::{CheckedError,
                      Recoverable}};
@@ -22,8 +21,6 @@ use crate::{cache::{Cache,
 lazy_static! {
     /// Timeout for requests to Redis
     static ref REDIS_REQUEST_TIMEOUT: Duration = Duration::from_millis(300);
-    /// Expiration value for set Redis keys (after 30 minutes, the key is unset)
-    static ref REDIS_SET_EXPIRATION: Duration = Duration::from_secs(30 * 60); // 30 minutes
 }
 
 /// Value we set in Redis to represent a "set" key
@@ -44,18 +41,15 @@ pub enum RedisCacheError {
 impl CheckedError for RedisCacheError {
     fn error_type(&self) -> Recoverable {
         match self {
-            RedisCacheError::RedisError(RedisError::EmptySlice) => Recoverable::Persistent,
             _ => Recoverable::Transient,
         }
     }
 }
 
-// todo: We should add a circuit breaker to this and not hit the backing redis-store if it closes
-
 #[derive(Clone)]
 pub struct RedisCache {
     address: String,
-    connection_pool: ConnectionPool,
+    connection_manager: redis::aio::ConnectionManager,
     metric_reporter: MetricReporter<Stdout>,
     lru_cache: Arc<Mutex<lru::LruCache<Vec<u8>, ()>>>,
 }
@@ -65,145 +59,104 @@ impl RedisCache {
         address: String,
         metric_reporter: MetricReporter<Stdout>,
     ) -> Result<Self, RedisError> {
-        let connection_pool =
-            ConnectionPool::create(address.clone(), None, num_cpus::get() * 10).await?;
+        RedisCache::with_lru_capacity(100_000, address, metric_reporter).await
+    }
+
+    pub async fn with_lru_capacity(
+        cap: usize,
+        address: String,
+        metric_reporter: MetricReporter<Stdout>,
+    ) -> Result<Self, RedisError> {
+        let client = redis::Client::open(address.clone())?;
+        let connection_manager = client.get_tokio_connection_manager().await?;
 
         Ok(Self {
-            connection_pool,
             address,
+            connection_manager,
             metric_reporter,
-            lru_cache: Arc::new(Mutex::new(lru::LruCache::new(100_000))),
+            lru_cache: Arc::new(Mutex::new(lru::LruCache::new(cap))),
         })
     }
 }
 
 impl RedisCache {
-    #[tracing::instrument(skip(self, cacheable))]
-    async fn _get<CA>(&mut self, cacheable: CA) -> Result<CacheResponse, RedisCacheError>
+    async fn _filter_cached<CA>(&mut self, cacheables: Vec<CA>) -> Vec<CA>
     where
         CA: Cacheable + Send + Sync + Clone + 'static,
     {
-        self._get_all(vec![cacheable]).await.map(|mut results| {
-            results
-                .pop()
-                .map(|(_, response)| response)
-                .unwrap_or(CacheResponse::Miss)
-        })
-    }
+        let get_identities = |cacheables: &Vec<CA>| -> Vec<Vec<u8>> {
+            cacheables.into_iter().map(|c| c.identity()).collect()
+        };
 
-    async fn _get_all<CA>(
-        &mut self,
-        cacheables: Vec<CA>,
-    ) -> Result<Vec<(CA, CacheResponse)>, RedisCacheError>
-    where
-        CA: Cacheable + Send + Sync + Clone + 'static,
-    {
-        let cacheable_responses: Vec<(CA, Option<CacheResponse>)> = {
+        // Check LRU
+        let (lru_hits, lru_misses): (Vec<CA>, Vec<CA>) = {
             let mut lru_cache = self.lru_cache.lock().unwrap();
 
             cacheables
                 .into_iter()
-                .map(|cacheable| {
-                    // if this hits, it's a Some(CacheResponse::Hit)
-                    // otherwise, we use None to signify that we should check in with redis
-                    let identity_bytes = cacheable.identity();
-                    let lru_cache_response =
-                        lru_cache.get(&identity_bytes).map(|_| CacheResponse::Hit);
-
-                    (cacheable, lru_cache_response)
-                })
-                .collect()
+                .partition(|c| lru_cache.get(&c.identity()).is_some())
         };
 
-        // if the LRU cache satisfied all our needs, we should return early
-        let are_all_keys_handled = cacheable_responses
-            .iter()
-            .all(|(_, response)| response.is_some());
-
-        if are_all_keys_handled {
-            return Ok(cacheable_responses
-                .into_iter()
-                .filter_map(|(cacheable, response)| response.map(|response| (cacheable, response)))
-                .collect());
+        if !lru_hits.is_empty() {
+            info!(
+                "Event cache hits from LRU cache: {:?}",
+                get_identities(&lru_hits)
+            );
         }
 
-        // fetch the responses from redis and convert them into CacheResponses
-        // this Vec<_> should be equal in size to the number of entries in cacheable_responses with
-        // 'response' set to None
-        let mut unknown_cacheable_responses: VecDeque<CacheResponse> = {
-            // this vec will be len() > 0 since we would've returned earlier otherwise
-            let unknown_cacheables: Vec<_> = cacheable_responses
-                .iter()
-                .filter(|(_, response)| response.is_none())
-                .map(|(cacheable, _)| cacheable.identity())
-                .collect();
-
-            let client_pool = self.connection_pool.clone();
-            let mut client = client_pool.get().await;
-
-            client
-                .mget(&unknown_cacheables)
-                .timeout(REDIS_REQUEST_TIMEOUT.clone())
-                .await??
-                .into_iter()
-                .map(|mget_response: Option<_>| match mget_response {
-                    Some(_) => CacheResponse::Hit,
-                    None => CacheResponse::Miss,
-                })
-                .collect()
-        };
-
-        // convert original cacheable_responses into a complete set of CacheResponses
-        let complete_cacheable_responses: Vec<_> = cacheable_responses
-            .into_iter()
-            .map(|(cacheable, response)| {
-                let actual_response = match response {
-                    Some(cache_response) => cache_response,
-                    None => unknown_cacheable_responses.pop_front().unwrap_or_else(|| {
-                        error!("Missing cacheable response from redis fetch.");
-                        CacheResponse::Miss
-                    }),
-                };
-
-                (cacheable, actual_response)
-            })
-            .collect();
-
-        if !unknown_cacheable_responses.is_empty() {
-            error!("Redis returned more cache responses than expected.");
+        // If we have misses from the LRU cache, we check Redis.
+        // If lru_misses is empty we can return with empty vector
+        if lru_misses.is_empty() {
+            return lru_misses;
         }
 
-        Ok(complete_cacheable_responses)
+        // Check Redis for misses from the LRU cache
+        let lru_miss_ids = get_identities(&lru_misses);
+        let redis_result: Result<Vec<Option<u8>>, RedisError> =
+            self.connection_manager.get(lru_miss_ids).await;
+
+        match redis_result {
+            Ok(responses) => {
+                let (redis_hits, redis_misses): (Vec<CA>, Vec<CA>) = lru_misses
+                    .into_iter()
+                    .zip(responses.into_iter())
+                    .partition_map(|(c, r)| match r {
+                        Some(_) => Either::Left(c),
+                        None => Either::Right(c),
+                    });
+
+                if !redis_hits.is_empty() {
+                    info!(
+                        "Event cache hits from Redis: {:?}",
+                        get_identities(&redis_hits)
+                    );
+                }
+
+                // If we have entries in redis_hits here it means they weren't found
+                // in the LRU cache. So we'll put them back in LRU cache since they
+                // were some of the latest seen
+                {
+                    let mut lru_cache = self.lru_cache.lock().unwrap();
+                    for cacheable in &redis_hits {
+                        // We don't care if identity already exists, so we discard the Option returned from put.
+                        lru_cache.put(cacheable.identity(), LRU_SET_VALUE);
+                    }
+                }
+
+                // Return Redis cache missis, which should also be LRU cache misses
+                redis_misses
+            }
+            Err(e) => {
+                error!("{:?}", e);
+                // If Redis fails, we'll settle for returning LRU cache misses
+                lru_misses
+            }
+        }
     }
 
     #[tracing::instrument(skip(self, identity))]
     async fn _store(&mut self, identity: Vec<u8>) -> Result<(), RedisCacheError> {
-        // put the key into the cache
-        // if it was already in the cache, a Some will return and we know we can return Ok
-        if self
-            .lru_cache
-            .lock()
-            .unwrap()
-            .put(identity.clone(), LRU_SET_VALUE)
-            .is_some()
-        {
-            return Ok(());
-        }
-
-        let identity = hex::encode(identity);
-
-        let mut client = self.connection_pool.get().await;
-
-        client
-            .set_and_expire_seconds(
-                &identity,
-                REDIS_SET_VALUE,
-                (*REDIS_SET_EXPIRATION).as_secs() as u32,
-            )
-            .timeout(REDIS_REQUEST_TIMEOUT.clone())
-            .await??;
-
-        Ok(())
+        self._store_all(vec![identity]).await
     }
 
     #[tracing::instrument(skip(self, identities))]
@@ -212,60 +165,27 @@ impl RedisCache {
             return Ok(());
         }
 
-        let identities_to_check: Vec<_> = {
+        // Attempt to store all identities in LRU and Redis caches
+
+        // LRU PUT
+        {
             let mut lru_cache = self.lru_cache.lock().unwrap();
-
-            // for each of the identities:
-            //      1. update the lru cache status
-            //      2. if key is new (is_none()), collect into a Vec
-            identities
-                .into_iter()
-                .filter(|identity| lru_cache.put(identity.clone(), LRU_SET_VALUE).is_none())
-                .collect()
-        };
-
-        if identities_to_check.is_empty() {
-            return Ok(());
+            for identity in &identities {
+                // We don't care if identity already exists, so we discard the Option returned from put.
+                lru_cache.put(identity.clone(), LRU_SET_VALUE);
+            }
         }
 
-        let client_pool = self.connection_pool.clone();
-        let task_start = Instant::now();
-
-        tokio::spawn(async move {
-            let mut client = client_pool.get().await;
-            let mut mset_builder = MSetBuilder::new();
-
-            for identity in &identities_to_check {
-                mset_builder = mset_builder.set(identity, REDIS_SET_VALUE);
-            }
-
-            match client.mset(mset_builder).await {
-                Ok(_) => Ok(()),
-                Err(e) => {
-                    let elapsed = task_start.elapsed();
-
-                    if elapsed >= *REDIS_REQUEST_TIMEOUT {
-                        let elapsed_ms = elapsed.as_millis() as u64;
-                        error!(
-                            error = e.to_string().as_str(),
-                            elapsed_ms = elapsed_ms,
-                            "redis mset failed outside of ttl"
-                        );
-                        Ok(())
-                    } else {
-                        Err(e)
-                    }
-                }
-            }
-        })
-        .timeout(REDIS_REQUEST_TIMEOUT.clone())
-        .await???;
-        /*
-           Three question marks for the following reasons:
-           1. Result from timeout
-           2. Result from JoinHandle (from tokio::spawn)
-           3. Result from `async { ... }` region (we return Ok(()) or Err(..))
-        */
+        // Redis SET
+        let kv_pairs: Vec<(Vec<u8>, &[u8; 1])> = identities
+            .clone()
+            .into_iter()
+            .map(|k| (k, REDIS_SET_VALUE))
+            .collect();
+        self.connection_manager
+            .set_multiple(&kv_pairs)
+            .timeout(REDIS_REQUEST_TIMEOUT.clone())
+            .await??;
 
         Ok(())
     }
@@ -274,88 +194,35 @@ impl RedisCache {
 use std::sync::{Arc,
                 Mutex};
 
-use prost::alloc::collections::VecDeque;
-use tracing::error;
+use tracing::{error,
+              info};
 
 #[async_trait]
 impl Cache for RedisCache {
     type CacheErrorT = RedisCacheError;
 
     #[tracing::instrument(skip(self, cacheable))]
-    async fn get<CA>(&mut self, cacheable: CA) -> Result<CacheResponse, Self::CacheErrorT>
-    where
-        CA: Cacheable + Send + Sync + Clone + 'static,
-    {
-        let span = tracing::span!(
-            tracing::Level::TRACE,
-            "redis_cache.get",
-            address=?self.address,
-        );
-        let _enter = span.enter();
-        let (res, ms) = self._get(cacheable).timed().await;
-
-        // todo: Refactor metrics into their own structure
-        match res {
-            Ok(CacheResponse::Hit) => {
-                tracing::debug!("redis cache hit");
-                self.metric_reporter
-                    .histogram(
-                        "redis_cache.get.ms",
-                        ms as f64,
-                        &[tag("success", true), tag("hit", true)],
-                    )
-                    .unwrap_or_else(|e| error!("failed to report redis_cache.get.ms: {:?}", e));
-                self.metric_reporter
-                    .counter(
-                        "redis_cache.get.count",
-                        1f64,
-                        0.10,
-                        &[tag("success", true), tag("hit", true)],
-                    )
-                    .unwrap_or_else(|e| error!("failed to report redis_cache.get.count: {:?}", e));
-            }
-            Ok(CacheResponse::Miss) => {
-                self.metric_reporter
-                    .counter(
-                        "redis_cache.get.count",
-                        1f64,
-                        0.10,
-                        &[tag("success", true), tag("hit", false)],
-                    )
-                    .unwrap_or_else(|e| error!("failed to report redis_cache.get.count: {:?}", e));
-            }
-            _ => (),
-        }
-
-        res
-    }
-
-    #[tracing::instrument(skip(self, cacheables))]
-    async fn get_all<CA>(
+    async fn exists<CA: Cacheable + Send + Sync + Clone + 'static>(
         &mut self,
-        cacheables: Vec<CA>,
-    ) -> Result<Vec<(CA, CacheResponse)>, Self::CacheErrorT>
-    where
-        CA: Cacheable + Send + Sync + Clone + 'static,
-    {
+        cacheable: CA,
+    ) -> bool {
         let span = tracing::span!(
-            tracing::Level::TRACE,
-            "redis_cache.get_all",
+            tracing::Level::DEBUG,
+            "redis_cache.exists",
             address = self.address.as_str(),
-            cacheables_len = cacheables.len(),
         );
-        let _enter = span.enter();
 
-        let (res, ms) = self._get_all(cacheables).timed().await;
+        let _enter = span.enter();
+        // Here we call filtered_cached to reuse the code for checking LRU and Redis caches
+        // If the response is empty then we know the entry is in the cache and we return true
+        let (res, ms) = self._filter_cached(vec![cacheable]).timed().await;
 
         self.metric_reporter
-            .histogram(
-                "redis_cache.get_all.ms",
-                ms as f64,
-                &[tag("success", res.is_ok())],
-            )
-            .unwrap_or_else(|e| error!("failed to report redis_cache.get_all.ms: {:?}", e));
-        res
+            .histogram("redis_cache.exists.ms", ms as f64, &[tag("success", true)])
+            .unwrap_or_else(|e| error!("failed to report redis_cache.exists.ms: {:?}", e));
+
+        // If the response is empty then we know the entry is in the cache and we return true
+        res.is_empty()
     }
 
     #[tracing::instrument(skip(self, identity))]
@@ -395,6 +262,32 @@ impl Cache for RedisCache {
                 &[tag("success", res.is_ok())],
             )
             .unwrap_or_else(|e| error!("failed to report redis_cache.put_all.ms: {:?}", e));
+        res
+    }
+
+    #[tracing::instrument(skip(self, cacheables))]
+    async fn filter_cached<CA>(&mut self, cacheables: Vec<CA>) -> Vec<CA>
+    where
+        CA: Cacheable + Send + Sync + Clone + 'static,
+    {
+        let span = tracing::span!(
+            tracing::Level::TRACE,
+            "redis_cache.filter_cached",
+            address = self.address.as_str(),
+            cacheables_len = cacheables.len(),
+        );
+        let _enter = span.enter();
+
+        let (res, ms) = self._filter_cached(cacheables).timed().await;
+
+        self.metric_reporter
+            .histogram(
+                "redis_cache.filter_cached.ms",
+                ms as f64,
+                &[tag("success", true)],
+            )
+            .unwrap_or_else(|e| error!("failed to report redis_cache.filter_cached.ms: {:?}", e));
+
         res
     }
 }

--- a/src/rust/sqs-executor/tests/redis_cache.rs
+++ b/src/rust/sqs-executor/tests/redis_cache.rs
@@ -1,0 +1,40 @@
+#![cfg(feature = "integration")]
+
+use grapl_observe::metric_reporter::MetricReporter;
+use sqs_executor::cache::Cache;
+
+#[tokio::test]
+async fn redis_cache() {
+    const LRU_SIZE: usize = 5;
+    const TOTAL_SIZE: usize = 10;
+
+    // Create a set of cacheables that we'll store in the cache
+    let all_cacheables: Vec<String> = (0..TOTAL_SIZE)
+        .map(|i| format!("sqs-executor::tests::redis_cache-{}", i))
+        .collect();
+    let all_cacheables = all_cacheables.as_slice();
+    let (stored, not_stored) = all_cacheables.split_at(LRU_SIZE);
+
+    let redis_endpoint = std::env::var("REDIS_ENDPOINT").expect("REDIS_ENDPOINT");
+
+    let mut cache = sqs_executor::redis_cache::RedisCache::with_lru_capacity(
+        LRU_SIZE,
+        redis_endpoint,
+        MetricReporter::<std::io::Stdout>::new("redis_cache"),
+    )
+    .await
+    .expect("redis client");
+
+    cache.store_all(stored).await.unwrap();
+
+    // When calling `filter_cached` on what we've stored, we expect an empty response.
+    assert_eq!(cache.filter_cached(stored).await, Vec::new() as Vec<String>);
+    assert_eq!(cache.filter_cached(not_stored).await, not_stored);
+    assert_eq!(cache.filter_cached(all_cacheables).await, not_stored);
+
+    assert!(cache.all_exist(stored).await);
+    assert!(!cache.all_exist(not_stored).await);
+    assert!(!cache.all_exist(all_cacheables).await);
+
+    assert!(!cache.all_exist(&["non-existent-key"]).await);
+}

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -4,16 +4,15 @@ version: "3.8"
 
 services:
 
-  grapl-rust-node-identifier-integration-tests:
-    image: grapl/grapl-node-identifier-test:${TAG:-latest}
+  rust-node-identifier-integration-tests:
+    image: grapl/rust-integration-tests:${TAG:-latest}
     build:
       context: ${PWD}/src
       dockerfile: rust/Dockerfile
       target: build-test-integration
       args:
         - CARGO_PROFILE=debug
-    command: bash -c "
-      cargo test --manifest-path node-identifier/Cargo.toml --features integration"
+    command: cargo test --features node-identifier/integration --test '*'
     environment:
       - AWS_REGION
       - GRAPL_LOG_LEVEL=${GRAPL_LOG_LEVEL:-INFO}
@@ -36,6 +35,18 @@ services:
       - DYNAMODB_ENDPOINT
       - DYNAMODB_ACCESS_KEY_ID
       - DYNAMODB_ACCESS_KEY_SECRET
+
+  rust-sqs-executor-integration-tests:
+    image: grapl/rust-integration-tests:${TAG:-latest}
+    build:
+      context: ${PWD}/src
+      dockerfile: rust/Dockerfile
+      target: build-test-integration
+      args:
+        - CARGO_PROFILE=debug
+    command: cargo test --features sqs-executor/integration --test '*'
+    environment:
+      - REDIS_ENDPOINT=redis://${REDIS_HOST}:${REDIS_PORT}
 
   grapl-analyzerlib-integration-tests:
     image: grapl/grapl-analyzerlib-test:${TAG:-latest}

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -46,7 +46,7 @@ services:
         - CARGO_PROFILE=debug
     command: cargo test --features sqs-executor/integration --test '*'
     environment:
-      - REDIS_ENDPOINT=redis://${REDIS_HOST}:${REDIS_PORT}
+      - REDIS_ENDPOINT
 
   grapl-analyzerlib-integration-tests:
     image: grapl/grapl-analyzerlib-test:${TAG:-latest}


### PR DESCRIPTION
### Which issue does this PR correspond to?

This all started to resolve the following, but a number of other enhancements were made along the way:
- https://github.com/grapl-security/issue-tracker/issues/344

### What changes does this PR make to Grapl? Why?

This PR not only swaps darkredis for redis-rs in the sqs-executor, it makes significant changes to the cache API:
- Remove the `get` public methods and `CacheResponse` and replace with a new method `filter_cached`. The `get` methods weren't actually "gets", and we aren't really storing values for keys. Users of the `get` methods, like generators, would partition the keys that weren't in the cache and continue to process those. Instead of requiring users to do this parsing, we now provide `filter_cached`.
- Add an `all_exists` method to the cache API, another helper that some users were previously using the `get` methods.
- The cache API now prefers slices over Vecs
- An integration test! For the changes in this PR, that is.

### How were these changes tested?

I included an integration test that intends to cover the changes made.
