### PR TITLE
Remove Docker version update in CI script. Add note for future use.

### DIFF
--- a/etc/ci_scripts/install_requirements.sh
+++ b/etc/ci_scripts/install_requirements.sh
@@ -1,8 +1,13 @@
+# This is a placeholder for installing or updating dependencies in our CI
+# (GitHub) runners when needed. A list of software versions installed on our
+# runners can be found at
+# https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md.
+#
+# This was used in the past to recent versions of software, without having to
+# wait for GitHub to update the runners.
+#
+# As we use this script for updating software versions (not installing software
+# in the first place), we should make note of the version we require and create
+# a housekeeping issue for future cleanup to follow up once the CI runners
+# incluse the version(s) we require.
 
-# update docker
-docker --version
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
-sudo apt-get update
-sudo apt install docker-ce docker-ce-cli containerd.io
-docker --version


### PR DESCRIPTION
### Which issue does this PR correspond to?

NA

### What changes does this PR make to Grapl? Why?

This removes the Docker version update in that we were doing in CI, as it's no longer needed.

In addition, add notes about how adding software version updates should be tracked with housecleaning tickets, so that we can come back and remove in the future as the versions installed on the runners cover those we require.

### How were these changes tested?

Change to CI script only, will rely on CI tests.
