### PR TITLE
Engagement UX: login card is now in a popover (floats on screen)

### DIFF
--- a/src/js/engagement_view/src/components/reusableComponents/notifications/Notifications.tsx
+++ b/src/js/engagement_view/src/components/reusableComponents/notifications/Notifications.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import Popover from '@material-ui/core/Popover';
 import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';
 import CardActions from '@material-ui/core/CardActions';
@@ -15,6 +16,17 @@ export default function LoginNotification() {
     const classes = useStyles();
 
     return (
+    <Popover 
+        open={true}
+        anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+        }}
+        transformOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+        }}
+        >
         <Card variant="outlined" className={classes.root}>
             <CardActionArea>
                 <CardContent>
@@ -37,5 +49,6 @@ export default function LoginNotification() {
                 > Login </Button>
             </CardActions>
         </Card>
+    </Popover>
     );
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
none

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
![image](https://user-images.githubusercontent.com/69007229/114671441-f7c91c80-9cb8-11eb-8513-d8b554e2db11.png)

the login thing on the right side used to push the 3 buttons to the left; now, it's inside a Popover element, so it behaves as expected.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
browser
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
