### PR TITLE
KEEP_TEST_ENV=1 to keep environment after running a test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,12 @@ test-e2e: build-test-e2e modern-lambdas ## Build and run e2e tests
 .PHONY: test-with-env
 test-with-env: # (Do not include help text - not to be used directly)
 	stopGrapl() {
+		# skip if KEEP_TEST_ENV is set
+		if [[ -z "${KEEP_TEST_ENV}" ]]; then
+			echo "Tearing down test environment"
+		else
+			echo "Keeping test environment" && return 0
+		fi
 		# Unset COMPOSE_FILE to help ensure it will be ignored with use of --file
 		unset COMPOSE_FILE
 		docker-compose --file docker-compose.yml stop;


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
its hack week

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
KEEP_TEST_ENV=1 make test-e2e
will preserve the test environment
this is *super useful* for, say, manually logging in to engagement-UX afterwards and wanting to see how it renders the data (events.xml) 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
locally, with and without KEEP_TEST_ENV

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
