### PR TITLE
Remove no-longer-existing file from `EVERY_COMPOSE_FILE` in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ export EVERY_COMPOSE_FILE=--file docker-compose.yml \
 	--file ./test/docker-compose.integration-tests.yml \
 	--file ./test/docker-compose.e2e-tests.yml \
 	--file ./test/docker-compose.typecheck-tests.yml \
-	--file ./test/docker-compose.test-utils.yml \
 	${EVERY_LAMBDA_COMPOSE_FILE}
 
 DOCKER_BUILDX_BAKE := docker buildx bake $(DOCKER_BUILDX_BAKE_OPTS)


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

The Makefile was referencing a file that no longer exists. This removes that reference.

### How were these changes tested?

I'll rely on CI tests.