### PR TITLE
Make `TARGETS=` universal to any docker-compose-with-error.sh consumer; add documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ help: ## Print this help
 	@printf -- '\n'
 	@printf -- '${FMT_BOLD}Useful environment variables (with examples):${FMT_END}\n'
 	@printf -- '  ${FMT_PURPLE}TARGETS${FMT_END}="typecheck-analyzer-executor typecheck-grapl-common" make test-typecheck\n'
-	@printf -- '    to specify "only run a subset of tests/services".\n'
+	@printf -- '    to only run a subset of test targets.\n'
 	@printf -- '\n'
 	@printf -- '  ${FMT_PURPLE}KEEP_TEST_ENV=1${FMT_END} make test-integration\n'
 	@printf -- '    to keep the test environment around after a test suite.\n'
@@ -105,6 +105,8 @@ help: ## Print this help
 	@printf -- '  ${FMT_PURPLE}DEBUG_SERVICES${FMT_END}="graphql_endpoint grapl_e2e_tests" make test-e2e\n'
 	@printf -- '    to launch the VSCode Debugger (see ${VSC_DEBUGGER_DOCS_LINK}).\n'
 	@printf -- '\n'
+	@printf -- '  ${FMT_BOLD}FUN FACT${FMT_END}: You can also specify these as postfix, like:\n'
+	@printf -- '    make test-something KEEP_TEST_ENV=1\n'
 	@printf '\n'
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make ${FMT_BLUE}<target>${FMT_END}\n"} \
 		 /^[a-zA-Z0-9_-]+:.*?##/ { printf "  ${FMT_BLUE}%-46s${FMT_END} %s\n", $$1, $$2 } \

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,10 @@ SHELL := bash
 # way.
 WITH_LOCAL_GRAPL_ENV := set -o allexport; . ./local-grapl.env; set +o allexport;
 
-FORMATTING_BEGIN_BLUE = \033[36m
-FORMATTING_END = \033[0m
+FMT_BLUE = \033[36m
+FMT_PURPLE = \033[35m
+FMT_BOLD = \033[1m
+FMT_END = \033[0m
 
 .PHONY: help
 help: ## Print this help
@@ -91,7 +93,14 @@ help: ## Print this help
 	@printf -- '                /      \__, //_/    \__,_// .___//_/    \n'
 	@printf -- '             (≡)      /____/             /_/            \n'
 	@printf -- '\n'
-	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make ${FORMATTING_BEGIN_BLUE}<target>${FORMATTING_END}\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  ${FORMATTING_BEGIN_BLUE}%-46s${FORMATTING_END} %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make ${FMT_BLUE}<target>${FMT_END}\n"} \
+		 /^[a-zA-Z0-9_-]+:.*?##/ { printf "  ${FMT_BLUE}%-46s${FMT_END} %s\n", $$1, $$2 } \
+		 /^##@/ { printf "\n${FMT_BOLD}%s${FMT_END}\n", substr($$0, 5) } ' \
+		 $(MAKEFILE_LIST)
+	@printf '\n'
+	@printf -- '${FMT_BOLD}Useful environment variables:${FMT_END}\n'
+	@printf -- '  ${FMT_PURPLE}TARGETS="typecheck-analyzer-executor typecheck-grapl-common"${FMT_END} make test-typecheck\n'
+	@printf '\n'
 
 ##@ Build
 
@@ -182,7 +191,7 @@ test-unit-js: build-test-unit-js ## Build and run unit tests - JavaScript only
 test-typecheck: export COMPOSE_PROJECT_NAME := grapl-typecheck_tests
 test-typecheck: export COMPOSE_FILE := ./test/docker-compose.typecheck-tests.yml
 test-typecheck: build-test-typecheck ## Build and run typecheck tests (non-Pants)
-	test/docker-compose-with-error.sh "$(TARGET)"
+	test/docker-compose-with-error.sh
 
 .PHONY: test-typecheck-pulumi
 test-typecheck-pulumi: ## Typecheck Pulumi Python code
@@ -225,7 +234,7 @@ test-with-env: # (Do not include help text - not to be used directly)
 	# Bring up the Grapl environment and detach
 	$(MAKE) up-detach
 	# Run tests and check exit codes from each test container
-	test/docker-compose-with-error.sh $(TARGET)
+	test/docker-compose-with-error.sh
 
 ##@ Lint
 

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,8 @@ FMT_BLUE = \033[36m
 FMT_PURPLE = \033[35m
 FMT_BOLD = \033[1m
 FMT_END = \033[0m
+VSC_DEBUGGER_DOCS_LINK = https://grapl.readthedocs.io/en/latest/debugging/vscode_debugger.html
+
 
 .PHONY: help
 help: ## Print this help
@@ -93,14 +95,23 @@ help: ## Print this help
 	@printf -- '                /      \__, //_/    \__,_// .___//_/    \n'
 	@printf -- '             (≡)      /____/             /_/            \n'
 	@printf -- '\n'
+	@printf -- '${FMT_BOLD}Useful environment variables (with examples):${FMT_END}\n'
+	@printf -- '  ${FMT_PURPLE}TARGETS${FMT_END}="typecheck-analyzer-executor typecheck-grapl-common" make test-typecheck\n'
+	@printf -- '    to specify "only run a subset of tests/services".\n'
+	@printf -- '\n'
+	@printf -- '  ${FMT_PURPLE}KEEP_TEST_ENV=1${FMT_END} make test-integration\n'
+	@printf -- '    to keep the test environment around after a test suite.\n'
+	@printf -- '\n'
+	@printf -- '  ${FMT_PURPLE}DEBUG_SERVICES${FMT_END}="graphql_endpoint grapl_e2e_tests" make test-e2e\n'
+	@printf -- '    to launch the VSCode Debugger (see ${VSC_DEBUGGER_DOCS_LINK}).\n'
+	@printf -- '\n'
+	@printf '\n'
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make ${FMT_BLUE}<target>${FMT_END}\n"} \
 		 /^[a-zA-Z0-9_-]+:.*?##/ { printf "  ${FMT_BLUE}%-46s${FMT_END} %s\n", $$1, $$2 } \
 		 /^##@/ { printf "\n${FMT_BOLD}%s${FMT_END}\n", substr($$0, 5) } ' \
 		 $(MAKEFILE_LIST)
 	@printf '\n'
-	@printf -- '${FMT_BOLD}Useful environment variables:${FMT_END}\n'
-	@printf -- '  ${FMT_PURPLE}TARGETS="typecheck-analyzer-executor typecheck-grapl-common"${FMT_END} make test-typecheck\n'
-	@printf '\n'
+
 
 ##@ Build
 

--- a/test/docker-compose-with-error.sh
+++ b/test/docker-compose-with-error.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+# You can pass TARGETS to this script to specify
+# which services to run, instead of all of them, which is the default behavior.
+TARGETS="${TARGETS}"
+
 set -e
 
 usage() { 
-    echo 'Usage: $0 [SERVICES]' 1>&2
+    echo 'Usage: [TARGETS="service1 service2"] $0' 1>&2
     echo
     echo 'This script calls into `docker-compose up` and checks the exit code' 1>&2
     echo 'of each container upon exit. If any container exit code is non-zero,' 1>&2
@@ -14,16 +18,12 @@ usage() {
     exit 1
 }
 
-# We'll pass SERVICES to the end of docker-compose up to allow users to specify
-# specific services to run, instead of all of them, which is the default behavior.
-SERVICES="$@"
-
 # Execute the 'up'
-docker-compose up --force-recreate ${SERVICES}
+docker-compose up --force-recreate ${TARGETS}
 
 # check for container exit codes other than 0
 EXIT_CODE=0
-ALL_TESTS=$(docker-compose ps --quiet ${SERVICES})
+ALL_TESTS=$(docker-compose ps --quiet ${TARGETS})
 for test in $ALL_TESTS; do
     docker inspect -f "{{ .State.ExitCode }}" $test | grep -q ^0;
     if [ $? -ne 0 ]; then 


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Users can now specify `TARGETS="service1 service2" make test-something` in order to only run a subset of tests.
- Add documentation:
![image](https://user-images.githubusercontent.com/69007229/115298651-95d24200-a112-11eb-9e09-d0e799f76fc7.png)


<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Ran on my machine with
no TARGETS specified
TARGETS=something real
TARGETS=something fake

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
