### PR TITLE
Tweak log dumping script to account for Lambda functions, Buildkite migration

### DIFF
--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -150,20 +150,12 @@ jobs:
           echo "unset RUSTC_WRAPPER" > rust_env.sh
           GRAPL_RUST_ENV_FILE=rust_env.sh GRAPL_LOG_LEVEL=DEBUG make test-integration
 
-      # NOTE: This requires >= py37
-      # Unlike the e2e tests, we don't dump the database contents; strictly logs.
-      - name: 'Collect integration test artifacts'
-        if: ${{ always() }}
-        run: |
-          python3 ./etc/ci_scripts/dump_artifacts.py --compose-project "grapl-integration_tests"
-
       - name: 'Upload integration test artifacts'
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: integration-test-artifacts
-          # this path is specified in dump_artifacts.py
-          path: /tmp/dumped_artifacts/
+          path: "artifacts_grapl-integration_tests_*"
           retention-days: 28
 
 
@@ -196,18 +188,10 @@ jobs:
           GRAPL_LOG_LEVEL=DEBUG DUMP_ARTIFACTS=True make test-e2e ||
           GRAPL_LOG_LEVEL=DEBUG DUMP_ARTIFACTS=True make test-e2e
 
-
-      # NOTE: This requires >= py37
-      - name: 'Collect e2e test artifacts'
-        if: ${{ always() }}
-        run: |
-          python3 ./etc/ci_scripts/dump_artifacts.py --compose-project "grapl-e2e_tests"
-
       - name: 'Upload e2e test artifacts'
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: e2e-artifacts
-          # this path is specified in dump_artifacts.py
-          path: /tmp/dumped_artifacts/
+          path: "artifacts_grapl-e2e_tests_*"
           retention-days: 28

--- a/.github/workflows/grapl-build.yml
+++ b/.github/workflows/grapl-build.yml
@@ -155,7 +155,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: integration-test-artifacts
-          path: "artifacts_grapl-integration_tests_*"
+          path: "test_artifacts"
           retention-days: 28
 
 
@@ -193,5 +193,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: e2e-artifacts
-          path: "artifacts_grapl-e2e_tests_*"
+          path: "test_artifacts"
           retention-days: 28

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 # Test outputs
 test/integration-outputs
 # Artifacts dumped from dump_artifacts.py script
-/artifacts_*_[0-9]*/
+/test_artifacts/
 
 # Environments
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 # Test outputs
 test/integration-outputs
+# Artifacts dumped from dump_artifacts.py script
+/artifacts_*_[0-9]*/
 
 # Environments
 .env

--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ clean-mount-cache: ## Prune all docker mount cache (used by sccache)
 
 .PHONY: clean-artifacts
 clean-artifacts: ## Remove all dumped artifacts from test runs (see dump_artifacts.py)
-	rm -Rf artifacts_*_[0-9]*
+	rm -Rf test_artifacts
 
 .PHONY: zip
 zip: build-lambdas ## Generate zips for deploying to AWS (src/js/grapl-cdk/zips/)

--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,7 @@ test-with-env: # (Do not include help text - not to be used directly)
 		fi
 		# Unset COMPOSE_FILE to help ensure it will be ignored with use of --file
 		unset COMPOSE_FILE
+		etc/ci_scripts/dump_artifacts.py --compose-project=${COMPOSE_PROJECT_NAME}
 		docker-compose --file docker-compose.yml stop;
 	}
 	# Ensure we call stop even after test failure, and return exit code from

--- a/Makefile
+++ b/Makefile
@@ -352,6 +352,10 @@ clean: ## Prune all docker build cache and remove Grapl containers and images
 clean-mount-cache: ## Prune all docker mount cache (used by sccache)
 	docker builder prune --filter type=exec.cachemount
 
+.PHONY: clean-artifacts
+clean-artifacts: ## Remove all dumped artifacts from test runs (see dump_artifacts.py)
+	rm -Rf artifacts_*_[0-9]*
+
 .PHONY: zip
 zip: build-lambdas ## Generate zips for deploying to AWS (src/js/grapl-cdk/zips/)
 	docker-compose $(EVERY_LAMBDA_COMPOSE_FILE) up

--- a/etc/ci_scripts/dump_artifacts.py
+++ b/etc/ci_scripts/dump_artifacts.py
@@ -108,6 +108,7 @@ def _dump_docker_log(container_name: str, dir: Path) -> None:
     run `docker logs` and dump to $DIR/$CONTAINER_NAME.log
     """
     destination = dir / f"{container_name}.log"
+    logging.info(f"Dumping logs for '{container_name}' container to '{destination}'")
     with open(destination, "wb") as out_stream:
         subprocess.run(
             f"docker logs --timestamps {container_name}",

--- a/etc/ci_scripts/dump_artifacts.py
+++ b/etc/ci_scripts/dump_artifacts.py
@@ -164,7 +164,7 @@ if __name__ == "__main__":
 
     cwd = os.getcwd()
     timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
-    artifacts_dir = Path(f"{cwd}/artifacts_{compose_project}_{timestamp}")
+    artifacts_dir = Path(f"{cwd}/test_artifacts/{compose_project}_{timestamp}")
     os.makedirs(artifacts_dir, exist_ok=False)
 
     dump_all_logs(compose_project=compose_project, artifacts_dir=artifacts_dir)

--- a/etc/ci_scripts/dump_artifacts.py
+++ b/etc/ci_scripts/dump_artifacts.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import logging
 import os
 import subprocess

--- a/etc/ci_scripts/dump_artifacts.py
+++ b/etc/ci_scripts/dump_artifacts.py
@@ -47,6 +47,61 @@ def _container_names_by_prefix(prefix: str) -> List[str]:
     return containers
 
 
+def _lambda_names() -> List[str]:
+    """
+    Return the names of the lambdas that are running in our Localstack instance.
+    """
+
+    # All Localstack lambda containers begin with this prefix; what
+    # remains is the actual lambda's name.
+    #
+    # We always use the us-east-1 region, and don't change the account
+    # ID from Localstack's default of 000000000000; if that ever
+    # changes, this prefix would need to be changed accordingly.
+    lambda_container_prefix="localstack_lambda_arn_aws_lambda_us-east-1_000000000000_function_"
+    containers=_container_names_by_prefix(lambda_container_prefix)
+
+    # Chop off the prefix to get just the names of the lambda functions
+    return [name.replace(lambda_container_prefix, "") for name in containers ]
+
+
+def _dump_lambda_log(lambda_name: str, dir: Path) -> None:
+    """Dump the Cloudwatch logs of the given lambda function from Localstack.
+
+    Requires the AWS CLI to be present, and assumes a running
+    Localstack instance is available at http://localhost:4566.
+
+    These same logs are also available in the Localstack container's
+    log output, but mixed in with the logs of every other lambda. By
+    using this function, we can isolate them.
+
+    Note, however, that these logs will be only what the lambda
+    function itself outputs during its execution. There will still be
+    important information in the Localstack logs concerning how the
+    functions are *invoked* that may be useful in debugging issues.
+
+    """
+    destination = dir / f"{lambda_name}_lambda.log"
+    logging.info(f"Dumping logs for '{lambda_name}' lambda function to '{destination}'")
+    with open(destination, "wb") as out_stream:
+        subprocess.run(
+            [
+                "aws",
+                "--endpoint-url=http://localhost:4566",
+                "logs",
+                "tail",
+                f"/aws/lambda/{lambda_name}"
+            ],
+            stdout=out_stream,
+            env={
+                "PATH": os.environ["PATH"],
+                # "test" is the value assumed by Localstack
+                "AWS_ACCESS_KEY_ID": "test",
+                "AWS_SECRET_ACCESS_KEY": "test"
+            }
+        )
+
+
 def _dump_docker_log(container_name: str, dir: Path) -> None:
     """
     run `docker logs` and dump to $DIR/$CONTAINER_NAME.log
@@ -73,6 +128,8 @@ def dump_all_logs(compose_project: str) -> None:
     os.makedirs(ARTIFACTS_PATH, exist_ok=True)
     for container in containers:
         _dump_docker_log(container_name=container, dir=ARTIFACTS_PATH)
+    for lambda_fn in _lambda_names():
+        _dump_lambda_log(lambda_fn, dir=ARTIFACTS_PATH)
 
 
 def dump_volume(compose_project: Optional[str], volume_name: str) -> None:

--- a/etc/ci_scripts/dump_artifacts.py
+++ b/etc/ci_scripts/dump_artifacts.py
@@ -26,12 +26,11 @@ def _name_of_all_containers(compose_project: str) -> List[str]:
             "--filter",
             f"name={compose_project}",
             "--format",
-            "table {{.Names}}",
+            "{{.Names}}",
         ],
         capture_output=True,
     )
     containers: List[str] = run_result.stdout.decode("utf-8").split("\n")
-    containers = containers[1:]  # remove the table column header
     containers = [c for c in containers if c]  # filter empty
     if not containers:
         raise ValueError(f"Couldn't find any containers for '{compose_project}'")


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

With the addition of lambda functions to our Local Grapl setup, we need to adjust how we're capturing logs to make it easier to debug issues. In particular, we must capture lambda output from the Localstack instance's Cloudwatch endpoint while it is still running.

Here, we modify the `dump_artifacts.py` script to take this into account. It dynamically determines which lambda functions are running (based on the containers that Localstack spins up for them) and runs the appropriate `aws` CLI command to dump the logs.

Also added in this PR is a change to dump artifacts into a timestamped directory, rather than always using `/tmp/dumped_artifacts`. This is particularly important for our coming Buildkite rollout, because a given runner may service multiple test runs over its lifetime. If we were to use a static global path like `/tmp/dumped_artifacts`, we would end up mixing outputs from different runs. This does mean that we dump artifacts into the repository root, but we also add `.gitignore` rules and Makefile cleanup targets, so the impact should be minimal.

Additional cleanups and simplifications were added as appropriate.

### How were these changes tested?

Run `make test-integration` or `make test-e2e` and observe the creation of `artifacts_<COMPOSE_PROJECT>_<YYYYMMDDHHMMSS>` directories.