### PR TITLE
WIP/Broken: Allow fargate services to scale to zero

### DIFF
--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -1,5 +1,6 @@
 import * as apigateway from "@aws-cdk/aws-apigateway";
 import * as cdk from "@aws-cdk/core";
+import * as cxapi from "@aws-cdk/cx-api";
 import * as ec2 from "@aws-cdk/aws-ec2";
 import * as s3 from "@aws-cdk/aws-s3";
 import * as secretsmanager from "@aws-cdk/aws-secretsmanager";
@@ -65,6 +66,12 @@ export class GraplCdkStack extends cdk.Stack {
 
     constructor(scope: cdk.Construct, id: string, props: GraplStackProps) {
         super(scope, id, props);
+
+        const setFeatureFlags = () => {
+            // ECS "Default Desired Count" is deprecated in favor of minScalingCapacity maxScalingCapacity
+            this.node.setContext(cxapi.ECS_REMOVE_DEFAULT_DESIRED_COUNT, true);
+        };
+        setFeatureFlags();
 
         this.deploymentName = props.stackName;
         const deployment_name = this.deploymentName.toLowerCase();


### PR DESCRIPTION


<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/401

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Remove `defaultCapacity` in favor of `min/maxScalingCapacity`, and flip on some sort of feature flag surrounding that

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
dude CDK didn't test their stuff!!! 

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
