### PR TITLE
link the local setup docs to the correct url

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,4 +160,4 @@ querying capabilities.
 ## Setup
 Grapl can run locally on your computer, or you can deploy to AWS.
 
-https://grapl.readthedocs.io/en/latest/setup/local.html
+https://grapl.readthedocs.io/en/main/setup/local.html


### PR DESCRIPTION
The URL for documentation for local setup is outdated. This PR updates the link in the README.