### PR TITLE
Put UX Router behind the API Gateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,6 +369,7 @@ zip-pants: ## Generate Lambda zip artifacts using pants
 	cp ./dist/src.python.engagement-creator/engagement-creator.zip ./src/js/grapl-cdk/zips/engagement-creator-$(TAG).zip
 	cp ./dist/src.python.grapl-dgraph-ttl/lambda.zip ./src/js/grapl-cdk/zips/dgraph-ttl-$(TAG).zip
 	cp ./dist/src.python.engagement_edge/engagement_edge.zip ./src/js/grapl-cdk/zips/engagement-edge-$(TAG).zip
+	cp ./dist/src.python.grapl-ux-router/grapl-ux-router.zip ./src/js/grapl-cdk/zips/ux-router-$(TAG).zip
 
 # This target is intended to help ease the transition to Pulumi, and
 # using lambdas in local Grapl testing deployments. Essentially, every

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -77,13 +77,6 @@ services:
       dockerfile: ./python/Dockerfile
       target: analyzer-executor-deploy
 
-  grapl-ux-router:
-    image: grapl/grapl-ux-router:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: ./python/Dockerfile
-      target: grapl-ux-router-deploy
-
   grapl-engagement-creator:
     image: grapl/grapl-engagement-creator:${TAG:-latest}
     build:

--- a/docker-compose.lambda-zips.python.yml
+++ b/docker-compose.lambda-zips.python.yml
@@ -15,17 +15,3 @@ services:
     environment:
       - TAG=${TAG:-latest}
     command: cp /home/grapl/lambda.zip model-plugin-deployer-${TAG:-latest}.zip
-
-  grapl-ux-router-zip:
-    image: grapl/grapl-ux-router-zip:${TAG:-latest}
-    build:
-      context: src
-      dockerfile: ./python/Dockerfile
-      target: ux-router-zip
-    volumes:
-      - ./src/js/grapl-cdk/zips:/grapl
-    user: ${UID}:${GID}
-    working_dir: /grapl
-    environment:
-      - TAG=${TAG:-latest}
-    command: cp /home/grapl/lambda.zip ux-router-${TAG:-latest}.zip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -327,29 +327,6 @@ services:
       redis:
         condition: service_healthy
 
-  grapl-ux-router:
-    image: grapl/grapl-ux-router:${TAG:-latest}
-    command: |
-      /bin/sh -c '
-        . venv/bin/activate &&
-        cd app &&
-        chalice local --no-autoreload --host=0.0.0.0 --port=${GRAPL_UX_ROUTER_PORT}
-      '
-    environment:
-      GRAPL_LOG_LEVEL: "DEBUG"
-      IS_LOCAL: "True"
-      UX_BUCKET_NAME: "${DEPLOYMENT_NAME}-engagement-ux-bucket"
-      <<: *aws-region
-      <<: *s3-env
-    depends_on:
-      grapl-engagement-view-uploader:
-        condition: service_completed_successfully
-    tty: true
-    networks:
-      default:
-        aliases:
-          - ${GRAPL_UX_ROUTER_HOST}
-
   grapl-model-plugin-deployer:
     image: grapl/grapl-model-plugin-deployer:${TAG:-latest}
     command: |
@@ -409,16 +386,12 @@ services:
       - GRAPL_GRAPHQL_PORT
       - GRAPL_MODEL_PLUGIN_DEPLOYER_HOST
       - GRAPL_MODEL_PLUGIN_DEPLOYER_PORT
-      - GRAPL_UX_ROUTER_HOST
-      - GRAPL_UX_ROUTER_PORT
       - LOCALSTACK_HOST
       - LOCALSTACK_PORT
     depends_on:
       grapl-model-plugin-deployer:
         condition: service_started
       grapl-graphql-endpoint:
-        condition: service_started
-      grapl-ux-router:
         condition: service_started
       grapl-pulumi:
         # We must wait until Pulumi has created the API gateway so we

--- a/etc/local_grapl/nginx_templates/default.conf.template
+++ b/etc/local_grapl/nginx_templates/default.conf.template
@@ -31,11 +31,11 @@ server {
   }
 
   location /static/ {
-    proxy_pass http://${GRAPL_UX_ROUTER_HOST}:${GRAPL_UX_ROUTER_PORT}$uri;
+    proxy_pass http://${LOCALSTACK_HOST}:${LOCALSTACK_PORT}/restapis/${API_GATEWAY_API_ID}/prod/_user_request_/static/;
   }
 
   location / {
-    proxy_pass http://${GRAPL_UX_ROUTER_HOST}:${GRAPL_UX_ROUTER_PORT}$uri;
+    proxy_pass http://${LOCALSTACK_HOST}:${LOCALSTACK_PORT}/restapis/${API_GATEWAY_API_ID}/prod/_user_request_/;
   }
 
 }

--- a/local-grapl.env
+++ b/local-grapl.env
@@ -29,7 +29,6 @@ GRAPL_GRAPHQL_PORT=5000
 GRAPL_HTTP_FRONTEND_PORT=3128
 GRAPL_MODEL_PLUGIN_DEPLOYER_PORT=8123
 GRAPL_NOTEBOOK_PORT=8888
-GRAPL_UX_ROUTER_PORT=8901
 
 # Redis default port
 REDIS_PORT=6379
@@ -64,7 +63,6 @@ S3_HOST=s3.${AWS_REGION}.amazonaws.com
 # locally, these host names should probably go away.
 GRAPL_MODEL_PLUGIN_DEPLOYER_HOST=model-plugin-deployer.grapl.test
 GRAPL_GRAPHQL_HOST=graphql.grapl.test
-GRAPL_UX_ROUTER_HOST=ux-router.grapl.test
 
 # Endpoints
 #

--- a/pants.toml
+++ b/pants.toml
@@ -53,7 +53,7 @@ root_patterns = [
   "/src/python/grapl-model-plugin-deployer/tests",
   "/src/python/grapl_provision",
   "/src/python/grapl-tests-common",
-  "/src/python/grapl-ux-router/src",
+  "/src/python/grapl-ux-router",
   "/src/python/provisioner/src",
   "/src/python/provisioner/tests",
   "/src/python/repl",

--- a/pulumi/infra/api.py
+++ b/pulumi/infra/api.py
@@ -9,6 +9,7 @@ from infra.engagement_notebook import EngagementNotebook
 from infra.lambda_ import Lambda
 from infra.network import Network
 from infra.secret import JWTSecret
+from infra.ux_router import UxRouter
 
 import pulumi
 
@@ -193,9 +194,11 @@ class Api(pulumi.ComponentResource):
         # way to do that would seem to be making this API own
         # instances of each of them.
 
-        # TODO: Add UX Router
-        # TODO: Add GraphQL endpoint
-        # TODO: Add Model Plugin Deployer
+        self.ux_router = UxRouter(
+            network=network,
+            secret=secret,
+            ux_bucket=ux_bucket,
+        )
 
         # Sagemaker isn't currently supported in Localstack :/
         self.notebook = (
@@ -219,6 +222,7 @@ class Api(pulumi.ComponentResource):
         )
 
         self.proxies = [
+            self._add_proxy_resource_integration(self.ux_router.function),
             self._add_proxy_resource_integration(
                 self.engagement_edge.function, path_part="auth"
             ),

--- a/pulumi/infra/ux_router.py
+++ b/pulumi/infra/ux_router.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+import pulumi_aws as aws
+from infra.bucket import Bucket
+from infra.config import GLOBAL_LAMBDA_ZIP_TAG
+from infra.lambda_ import Lambda, LambdaExecutionRole, PythonLambdaArgs, code_path_for
+from infra.metric_forwarder import MetricForwarder
+from infra.network import Network
+from infra.secret import JWTSecret
+
+import pulumi
+
+
+class UxRouter(pulumi.ComponentResource):
+    def __init__(
+        self,
+        network: Network,
+        secret: JWTSecret,
+        ux_bucket: Bucket,
+        forwarder: Optional[MetricForwarder] = None,
+        opts: Optional[pulumi.ResourceOptions] = None,
+    ) -> None:
+
+        name = "ux-router"
+        super().__init__("grapl:UXRouter", name, None, opts)
+
+        self.role = LambdaExecutionRole(name, opts=pulumi.ResourceOptions(parent=self))
+
+        self.function = Lambda(
+            name,
+            args=PythonLambdaArgs(
+                execution_role=self.role,
+                description=GLOBAL_LAMBDA_ZIP_TAG,
+                handler="lambdex_handler.handler",
+                code_path=code_path_for(name),
+                env={"GRAPL_LOG_LEVEL": "INFO", "UX_BUCKET_NAME": ux_bucket.bucket},
+                timeout=5,
+                memory_size=128,
+            ),
+            # TODO: I don't think we need a network, because I don't
+            # think this needs access to anything in the VPC itself.
+            network=network,
+            forwarder=forwarder,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        ux_bucket.grant_read_permissions_to(self.role)
+        secret.grant_read_permissions_to(self.role)
+
+        self.register_outputs({})

--- a/src/js/grapl-cdk/lib/ux_router.ts
+++ b/src/js/grapl-cdk/lib/ux_router.ts
@@ -29,7 +29,7 @@ export class UxRouter extends cdk.NestedStack {
 
         this.event_handler = new lambda.Function(this, "Handler", {
             runtime: lambda.Runtime.PYTHON_3_7,
-            handler: `src.grapl_ux_router.app`,
+            handler: `lambdex_handler.handler`,
             functionName: serviceName + "-Handler",
             code: lambda.Code.fromAsset(
                 `./zips/ux-router-${props.version}.zip`

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -256,29 +256,6 @@ RUN source venv/bin/activate && \
     cd grapl-ux-router && \
     pip install .
 
-# zip
-FROM grapl-ux-router-build AS ux-router-zip
-
-RUN ORIG_DIR=$(pwd); \
-    cd ~/venv/lib/python3.7/site-packages/ && \
-    zip -q9r -dg "${ORIG_DIR}/lambda.zip" ./ && \
-    cd ~/grapl-ux-router/src && \
-    find . -type f -name "*.py" -exec zip -g "${ORIG_DIR}/lambda.zip" "{}" \;
-
-# deploy
-FROM grapl-python-deploy AS grapl-ux-router-deploy
-
-COPY --chown=grapl --from=grapl-ux-router-build /home/grapl/venv venv
-
-RUN source venv/bin/activate && \
-    chalice new-project app/
-
-COPY --chown=grapl --from=grapl-ux-router-build /home/grapl/grapl-ux-router/src/grapl_ux_router.py app/app.py
-
-CMD source venv/bin/activate && \
-    cd app && \
-    chalice local --no-autoreload --host=0.0.0.0 --port=8901
-
 
 # dgraph-ttl
 ################################################################################

--- a/src/python/grapl-ux-router/BUILD
+++ b/src/python/grapl-ux-router/BUILD
@@ -1,0 +1,4 @@
+python_awslambda(
+    runtime="python3.7",
+    handler="src/grapl_ux_router.py:app"
+)

--- a/src/python/grapl-ux-router/src/grapl_ux_router.py
+++ b/src/python/grapl-ux-router/src/grapl_ux_router.py
@@ -12,16 +12,14 @@ import boto3
 from chalice import Chalice, Response
 from grapl_common.env_helpers import S3ResourceFactory
 
-try:
-    from src.lib.env_vars import GRAPL_LOG_LEVEL, IS_LOCAL, UX_BUCKET_NAME
-except:
-    from lib.env_vars import GRAPL_LOG_LEVEL, IS_LOCAL, UX_BUCKET_NAME
-
 if TYPE_CHECKING:
     from mypy_boto3_s3.service_resource import Bucket
 
     pass
 
+IS_LOCAL = bool(os.environ.get("IS_LOCAL", False))
+GRAPL_LOG_LEVEL = os.environ.get("GRAPL_LOG_LEVEL", "ERROR")
+UX_BUCKET_NAME = os.environ["UX_BUCKET_NAME"]
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(GRAPL_LOG_LEVEL)

--- a/src/python/grapl-ux-router/src/lib/BUILD
+++ b/src/python/grapl-ux-router/src/lib/BUILD
@@ -1,1 +1,0 @@
-python_library()

--- a/src/python/grapl-ux-router/src/lib/env_vars.py
+++ b/src/python/grapl-ux-router/src/lib/env_vars.py
@@ -1,5 +1,0 @@
-import os
-
-IS_LOCAL = bool(os.environ.get("IS_LOCAL", False))
-GRAPL_LOG_LEVEL = os.environ.get("GRAPL_LOG_LEVEL", "ERROR")
-UX_BUCKET_NAME = os.environ["UX_BUCKET_NAME"]


### PR DESCRIPTION
Additionally, build the ZIP with Pants, remove some Docker
infrastructure for building ux-router images, and also simplify the
ux-router code a bit (mainly by moving the content of `env_vars` into
the main module).

Signed-off-by: Christopher Maier <chris@graplsecurity.com>