### PR TITLE
Fix the shebang line in dump_artifacts to explicitly use Python 3

### DIFF
--- a/etc/ci_scripts/dump_artifacts.py
+++ b/etc/ci_scripts/dump_artifacts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import logging
 import os


### PR DESCRIPTION
Turns out this only reliably works in a virtualenv where `python` is
actually Python 3. Outside of that, the `python` binary is generally
of the 2.x flavor, which causes failures.

A thousand apologies.

![](https://media.giphy.com/media/RFDXes97gboYg/giphy.gif)

Signed-off-by: Christopher Maier <chris@graplsecurity.com>