### PR TITLE
Switch back to official Localstack container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,14 +93,15 @@ services:
           - ${REDIS_HOST}
 
   localstack:
-    # This is our own version until a PR is merged upstream
-    image: graplsec/localstack:chalice-compatible
+    # TODO: 0.12.11 is the one we want once it's released; until then
+    # we need an unreleased fix for lambda invocation
+    image: localstack/localstack:latest
     ports:
       # We'll expose localstack's edge port for ease of use with
       # things like the AWS CLI, Pulumi, etc.
       - 127.0.0.1:${LOCALSTACK_PORT}:${LOCALSTACK_PORT}
     environment:
-      - IMAGE_NAME=graplsec/localstack:chalice-compatible
+      - IMAGE_NAME=localstack/localstack:latest
       - EDGE_PORT=${LOCALSTACK_PORT}
       - HOSTNAME_EXTERNAL=${LOCALSTACK_HOST}
       - SERVICES=apigateway,dynamodb,ec2,events,iam,lambda,logs,s3,secretsmanager,sns,sqs


### PR DESCRIPTION
Previously, we were using an internally-built Localstack container
with a patch for calling our Chalice lambdas. Since then, the real fix
has landed in the main Localstack repository (possibly addressing some
additional lambda invocation related behavior that we also need, which
was not addressed in our custom container).

For now, these fixes are only available on the `latest` containers,
but in the interest of getting back on the official codebase, we'll
use this until Localstack 0.12.11 is formally released.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>