### PR TITLE
Use Docker mount cache for Rust builds

### DIFF
--- a/.buildkite/scripts/integration.sh
+++ b/.buildkite/scripts/integration.sh
@@ -2,10 +2,6 @@
 
 set -euo pipefail
 
-echo "unset RUSTC_WRAPPER" > rust_env.sh
-chmod 777 rust_env.sh
-
 export GRAPL_LOG_LEVEL=DEBUG
-export GRAPL_RUST_ENV_FILE=rust_env.sh
 
 make test-integration

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 -include .env
 TAG ?= latest
-CARGO_PROFILE ?= debug
+RUST_BUILD ?= debug
 UID = $(shell id -u)
 GID = $(shell id -g)
 DOCKER_BUILDX_BAKE_OPTS ?=
@@ -127,7 +127,7 @@ build: build-services ## Alias for `services` (default)
 
 .PHONY: build-release
 build-release: ## 'make build-services' with cargo --release
-	$(MAKE) CARGO_PROFILE=release build-services
+	$(MAKE) RUST_BUILD=release build-services
 
 .PHONY: build-all
 build-all: ## Build all targets (incl. services, tests, zip)

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -19,7 +19,7 @@ services:
       dockerfile: rust/Dockerfile
       target: sysmon-subgraph-generator-deploy
       args:
-        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
+        - RUST_BUILD=${RUST_BUILD:-debug}
 
   grapl-osquery-subgraph-generator:
     image: grapl/grapl-osquery-subgraph-generator:${TAG:-latest}
@@ -28,7 +28,7 @@ services:
       dockerfile: rust/Dockerfile
       target: osquery-subgraph-generator-deploy
       args:
-        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
+        - RUST_BUILD=${RUST_BUILD:-debug}
 
   grapl-node-identifier:
     image: grapl/grapl-node-identifier:${TAG:-latest}
@@ -37,7 +37,7 @@ services:
       dockerfile: rust/Dockerfile
       target: node-identifier-deploy
       args:
-        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
+        - RUST_BUILD=${RUST_BUILD:-debug}
 
   grapl-node-identifier-retry-handler:
     image: grapl/grapl-node-identifier-retry-handler:${TAG:-latest}
@@ -46,7 +46,7 @@ services:
       dockerfile: rust/Dockerfile
       target: node-identifier-retry-handler-deploy
       args:
-        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
+        - RUST_BUILD=${RUST_BUILD:-debug}
 
   grapl-graph-merger:
     image: grapl/grapl-graph-merger:${TAG:-latest}
@@ -55,7 +55,7 @@ services:
       dockerfile: rust/Dockerfile
       target: graph-merger-deploy
       args:
-        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
+        - RUST_BUILD=${RUST_BUILD:-debug}
 
   grapl-analyzer-dispatcher:
     image: grapl/grapl-analyzer-dispatcher:${TAG:-latest}
@@ -64,7 +64,7 @@ services:
       dockerfile: rust/Dockerfile
       target: analyzer-dispatcher-deploy
       args:
-        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
+        - RUST_BUILD=${RUST_BUILD:-debug}
 
   ########################################################################
   # Python Services

--- a/docker-compose.lambda-zips.rust.yml
+++ b/docker-compose.lambda-zips.rust.yml
@@ -9,7 +9,7 @@ services:
       dockerfile: rust/Dockerfile
       target: metric-forwarder-zip
       args:
-        - CARGO_PROFILE=${CARGO_PROFILE:-debug}
+        - RUST_BUILD=${RUST_BUILD:-debug}
     volumes:
       - ./src/js/grapl-cdk/zips:/tmp/zips
     user: ${UID}:${GID}

--- a/src/js/grapl-cdk/lib/services/analyzer_dispatcher.ts
+++ b/src/js/grapl-cdk/lib/services/analyzer_dispatcher.ts
@@ -65,7 +65,7 @@ export class AnalyzerDispatch extends cdk.NestedStack {
             serviceImage: ContainerImage.fromAsset(SRC_DIR, {
                 target: "analyzer-dispatcher-deploy",
                 buildArgs: {
-                    CARGO_PROFILE: "debug",
+                    RUST_BUILD: "debug",
                 },
                 file: RUST_DOCKERFILE,
             }),

--- a/src/js/grapl-cdk/lib/services/graph_merger.ts
+++ b/src/js/grapl-cdk/lib/services/graph_merger.ts
@@ -58,7 +58,7 @@ export class GraphMerger extends cdk.NestedStack {
             serviceImage: ContainerImage.fromAsset(SRC_DIR, {
                 target: "graph-merger-deploy",
                 buildArgs: {
-                    CARGO_PROFILE: "debug",
+                    RUST_BUILD: "debug",
                 },
                 file: RUST_DOCKERFILE,
             }),

--- a/src/js/grapl-cdk/lib/services/node_identifier.ts
+++ b/src/js/grapl-cdk/lib/services/node_identifier.ts
@@ -73,14 +73,14 @@ export class NodeIdentifier extends cdk.NestedStack {
             serviceImage: ContainerImage.fromAsset(SRC_DIR, {
                 target: "node-identifier-deploy",
                 buildArgs: {
-                    CARGO_PROFILE: "debug",
+                    RUST_BUILD: "debug",
                 },
                 file: RUST_DOCKERFILE,
             }),
             retryServiceImage: ContainerImage.fromAsset(SRC_DIR, {
                 target: "node-identifier-retry-handler-deploy",
                 buildArgs: {
-                    CARGO_PROFILE: "debug",
+                    RUST_BUILD: "debug",
                 },
                 file: RUST_DOCKERFILE,
             }),

--- a/src/js/grapl-cdk/lib/services/osquery_graph_generator.ts
+++ b/src/js/grapl-cdk/lib/services/osquery_graph_generator.ts
@@ -47,7 +47,7 @@ export class OSQueryGraphGenerator extends cdk.NestedStack {
             serviceImage: ContainerImage.fromAsset(SRC_DIR, {
                 target: "osquery-subgraph-generator-deploy",
                 buildArgs: {
-                    CARGO_PROFILE: "debug",
+                    RUST_BUILD: "debug",
                 },
                 file: RUST_DOCKERFILE,
             }),

--- a/src/js/grapl-cdk/lib/services/sysmon_graph_generator.ts
+++ b/src/js/grapl-cdk/lib/services/sysmon_graph_generator.ts
@@ -47,7 +47,7 @@ export class SysmonGraphGenerator extends cdk.NestedStack {
             serviceImage: ContainerImage.fromAsset(SRC_DIR, {
                 target: "sysmon-subgraph-generator-deploy",
                 buildArgs: {
-                    CARGO_PROFILE: "debug",
+                    RUST_BUILD: "debug",
                 },
                 file: RUST_DOCKERFILE,
             }),

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -1,22 +1,8 @@
-FROM rust:1-slim-buster AS build
+FROM rust:1-slim-buster AS base
 
-ARG CARGO_PROFILE=debug
+ARG RUST_BUILD=debug
 
 SHELL ["/bin/bash", "-c"]
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        wget \
-        zip \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /tmp
-
-RUN wget -q https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz && \
-    tar xvzf sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz && \
-    chmod +x sccache-v0.2.15-x86_64-unknown-linux-musl/sccache && \
-    cp sccache-v0.2.15-x86_64-unknown-linux-musl/sccache /usr/local/bin/sccache
-
-ENV RUSTC_WRAPPER=/usr/local/bin/sccache
 
 # Install rust toolchain before copying sources to avoid unecessarily
 # resinstalling on source file changes.
@@ -33,104 +19,131 @@ COPY rust rust
 
 WORKDIR /grapl/rust
 
-RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
+
+# build
+################################################################################
+FROM base AS build
+
+RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=secret,id=rust_env,dst=/grapl/env \
-    source /grapl/env; \
-    case "${CARGO_PROFILE}" in \
+    if [ -f /grapl/env ]; then source /grapl/env; fi && \
+    case "${RUST_BUILD}" in \
       debug) \
         cargo build ;; \
       release) \
         cargo build --release ;; \
       *) \
-        echo "ERROR: Unknown profile: ${CARGO_PROFILE}"; \
+        echo "ERROR:  Unknown RUST_BUILD option: ${RUST_BUILD}"; \
         exit 1 ;; \
     esac
 
+# Copy the build outputs to location that's not a cache mount.
+# TODO: switch to using --out-dir when stable: https://github.com/rust-lang/cargo/issues/6790
+RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
+    mkdir -p /dist && \
+    find "/grapl/rust/target/${RUST_BUILD}" -maxdepth 1 -type f -executable -exec cp {} /dist \;
 
+
+# build-test
+# This target is not merged with the `build` target because the actions to run
+# after cargo are different when building for tests and building the services, 
+# and we'd rather not save all of the Rust `target/` directory to Docker image
+# if we don't have to.
+################################################################################
+FROM base AS build-test
+
+RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=secret,id=rust_env,dst=/grapl/env \
+    if [ -f /grapl/env ]; then source /grapl/env; fi && \
+    case "${RUST_BUILD}" in \
+      test) \
+        cargo test --no-run ;; \
+      test-integration) \
+        cargo test --features node-identifier/integration,sqs-executor/integration --test "*" --no-run ;; \
+      *) \
+        echo "ERROR: Unknown RUST_BUILD option: ${RUST_BUILD}"; \
+        exit 1 ;; \
+    esac
+
+# Save the mount cache to the Docker image, as these files are needed for
+# running the integration tests in containers. 
+RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    cp -a /grapl/rust/target /tmp/target && \
+    cp -a /usr/local/cargo/registry /tmp/registry
+
+RUN mv /tmp/target /grapl/rust/target && \
+    mv /tmp/registry /usr/local/cargo/registry
 
 # metric-forwarder-zip
 ################################################################################
 FROM build AS metric-forwarder-zip
 
+RUN --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends \
+        zip
+
 RUN mkdir -p /grapl/zips; \
     grapl-zip() { \
       TMPDIR="$(mktemp -d)"; \
       cd "$TMPDIR"; \
-      cp "/grapl/rust/target/${CARGO_PROFILE}/${1}" bootstrap && \
+      cp "/dist/${1}" bootstrap && \
       zip --quiet -9 "/grapl/zips/${1}.zip" bootstrap; \
     }; \
     grapl-zip metric-forwarder
-
-
-# build test stages
-################################################################################
-FROM build AS build-test-unit
-
-RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
-    --mount=type=secret,id=rust_env,dst=/grapl/env \
-    source /grapl/env; \
-    cargo test --no-run
-
-
-FROM build AS build-test-integration
-
-RUN --mount=type=cache,mode=0777,target=/root/.cache/sccache \
-    --mount=type=secret,id=rust_env,dst=/grapl/env \
-    source /grapl/env; \
-    cargo test --features node-identifier/integration,sqs-executor/integration --test '*' --no-run
 
 
 # images for running services
 ################################################################################
 FROM debian:buster-slim AS rust-dist
 
-ARG CARGO_PROFILE=debug
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
-        netbase \
-    && rm -rf /var/lib/apt/lists/*
+        netbase
 
 USER nobody
 
 # analyzer-dispatcher
 FROM rust-dist AS analyzer-dispatcher-deploy
 
-COPY --from=build "/grapl/rust/target/${CARGO_PROFILE}/analyzer-dispatcher" /
+COPY --from=build /dist/analyzer-dispatcher /
 CMD ["/analyzer-dispatcher"]
 
 # generic-subgraph-generator
 FROM rust-dist AS generic-subgraph-generator-deploy
 
-COPY --from=build "/grapl/rust/target/${CARGO_PROFILE}/generic-subgraph-generator" /
+COPY --from=build /dist/generic-subgraph-generator /
 CMD ["/generic-subgraph-generator"]
 
 # graph-merger
 FROM rust-dist AS graph-merger-deploy
 
-COPY --from=build "/grapl/rust/target/${CARGO_PROFILE}/graph-merger" /
+COPY --from=build /dist/graph-merger /
 CMD ["/graph-merger"]
 
 # node-identifier
 FROM rust-dist AS node-identifier-deploy
 
-COPY --from=build "/grapl/rust/target/${CARGO_PROFILE}/node-identifier" /
+COPY --from=build /dist/node-identifier /
 CMD ["/node-identifier"]
 
 # node-identifier-retry-handler
 FROM rust-dist AS node-identifier-retry-handler-deploy
 
-COPY --from=build "/grapl/rust/target/${CARGO_PROFILE}/node-identifier-retry-handler" /
+COPY --from=build /dist/node-identifier-retry-handler /
 CMD ["/node-identifier-retry-handler"]
 
 # sysmon-subgraph-generator
 FROM rust-dist AS sysmon-subgraph-generator-deploy
 
-COPY --from=build "/grapl/rust/target/${CARGO_PROFILE}/sysmon-subgraph-generator" /
+COPY --from=build /dist/sysmon-subgraph-generator /
 CMD ["/sysmon-subgraph-generator"]
 
 # osquery-subgraph-generator
 FROM rust-dist AS osquery-subgraph-generator-deploy
 
-COPY --from=build "/grapl/rust/target/${CARGO_PROFILE}/osquery-subgraph-generator" /
+COPY --from=build /dist/osquery-subgraph-generator /
 CMD ["/osquery-subgraph-generator"]

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -8,9 +8,9 @@ services:
     build:
       context: ${PWD}/src
       dockerfile: rust/Dockerfile
-      target: build-test-integration
+      target: build-test
       args:
-        - CARGO_PROFILE=debug
+        - RUST_BUILD=test-integration
     command: cargo test --features node-identifier/integration --test '*'
     environment:
       - AWS_REGION
@@ -40,9 +40,9 @@ services:
     build:
       context: ${PWD}/src
       dockerfile: rust/Dockerfile
-      target: build-test-integration
+      target: build-test
       args:
-        - CARGO_PROFILE=debug
+        - RUST_BUILD=test-integration
     command: cargo test --features sqs-executor/integration --test '*'
     environment:
       - REDIS_ENDPOINT

--- a/test/docker-compose.unit-tests-rust.yml
+++ b/test/docker-compose.unit-tests-rust.yml
@@ -9,7 +9,7 @@ services:
     build:
       context: ${PWD}/src
       dockerfile: ./rust/Dockerfile
-      target: build-test-unit
+      target: build-test
       args:
-        - CARGO_PROFILE=debug
+        - RUST_BUILD=test
     command: cargo test


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This changes the Rust Dockerfile to better leverage cache mounts by using them for the following:

1. The Cargo `target` directory, instead of using sccache and its local directory
2. The Cargo local registry. This prevents from having to redownload Rust sources on subsequent builds.
3. The Apt local repository. This prevents from having to redownload OS packages on subsequent builds.

To make this work, we need to save the `target` and Cargo local registry directories in the final image used for Rust tests in containers, so we have steps to copy them to temp directory and move them back before finishing.

This speeds up Rust builds for both clean builds and subsequent builds with changes (measured on my local machine):
| | Main  | This PR |
| ------------- | ------------- | ------------- |
| Clean build | 6:52 | 5:46 |
| Subseq build | 3:47 | 1:25 |

### How were these changes tested?

`make test`
