### PR TITLE
Fargate: Default services scale [1..4], retry services scale [0..4]. CDK only!

### DIFF
--- a/src/js/grapl-cdk/lib/fargate_service.ts
+++ b/src/js/grapl-cdk/lib/fargate_service.ts
@@ -68,7 +68,13 @@ interface DefaultAndRetry<T> {
     readonly retry: T;
 }
 
-function getAutoscalingProps({minTasks, maxTasks}: {minTasks: number, maxTasks: number}): Partial<QueueProcessingFargateServiceProps> {
+function getAutoscalingProps({
+    minTasks,
+    maxTasks,
+}: {
+    minTasks: number;
+    maxTasks: number;
+}): Partial<QueueProcessingFargateServiceProps> {
     return {
         // Fargate autoscaling groups can adjust their scaling based on any metric, like:
         // CPU usage, approximate queue messages, etc.
@@ -141,12 +147,18 @@ export class FargateService {
             }),
         };
 
-        const defaultAutoscaling = getAutoscalingProps({minTasks: 1, maxTasks: 4});
+        const defaultAutoscaling = getAutoscalingProps({
+            minTasks: 1,
+            maxTasks: 4,
+        });
 
         // Scaling to zero causes some latency issues. We've decided to enable
         // it for retry services. Basically a tradeoff between cost and how long it takes to process.
         // https://grapl-internal.slack.com/archives/C018YCSN0B0/p1620156010045800?thread_ts=1620154431.041100&cid=C018YCSN0B0
-        const retryAutoscaling = getAutoscalingProps({minTasks: 0, maxTasks: 4});
+        const retryAutoscaling = getAutoscalingProps({
+            minTasks: 0,
+            maxTasks: 4,
+        });
 
         // Create a load-balanced Fargate service and make it public
         this.service = new ecs_patterns.QueueProcessingFargateService(

--- a/src/js/grapl-cdk/lib/fargate_service.ts
+++ b/src/js/grapl-cdk/lib/fargate_service.ts
@@ -62,7 +62,7 @@ export interface FargateServiceProps {
     metric_forwarder?: Service;
 }
 
-interface DeafultAndRetry<T> {
+interface DefaultAndRetry<T> {
     readonly default: T;
     readonly retry: T;
 }
@@ -72,7 +72,7 @@ export class FargateService {
     readonly serviceName: string;
     readonly service: ecs_patterns.QueueProcessingFargateService;
     readonly retryService: ecs_patterns.QueueProcessingFargateService;
-    readonly logGroups: DeafultAndRetry<logs.LogGroup>;
+    readonly logGroups: DefaultAndRetry<logs.LogGroup>;
 
     constructor(
         scope: cdk.Construct,
@@ -117,6 +117,16 @@ export class FargateService {
             }),
         };
 
+        const autoscalingProps = {
+            // Fargate autoscaling groups can adjust their scaling based on any metric, like:
+            // CPU usage, approximate queue messages, etc.
+            // The QueueProcessingFargateService pattern does it based on both of those metrics!
+            // https://github.com/aws/aws-cdk/blob/7966f8d48c4bff26beb22856d289f9d0c7e7081d/packages/%40aws-cdk/aws-ecs-patterns/lib/base/queue-processing-service-base.ts#L331
+            minScalingCapacity: 0, // CURRENTLY BROKEN https://github.com/aws/aws-cdk/issues/14336
+            maxScalingCapacity: 5,
+            // Potential optimization would be to calibrate `scalingSteps`, but default seems okay for now.
+        };
+
         // Create a load-balanced Fargate service and make it public
         this.service = new ecs_patterns.QueueProcessingFargateService(
             scope,
@@ -138,11 +148,11 @@ export class FargateService {
                 queue: queues.queue,
                 cpu: 256,
                 memoryLimitMiB: 512,
-                desiredTaskCount: 1,
                 logDriver: new AwsLogDriver({
                     streamPrefix: "logs",
                     logGroup: this.logGroups.default,
                 }),
+                ...autoscalingProps,
             }
         );
 
@@ -166,11 +176,11 @@ export class FargateService {
                 queue: queues.retryQueue,
                 cpu: 256,
                 memoryLimitMiB: 512,
-                desiredTaskCount: 1,
                 logDriver: new AwsLogDriver({
                     streamPrefix: "logs",
                     logGroup: this.logGroups.retry,
                 }),
+                ...autoscalingProps,
             }
         );
 

--- a/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
+++ b/src/js/grapl-cdk/lib/grapl-cdk-stack.ts
@@ -1,5 +1,6 @@
 import * as apigateway from "@aws-cdk/aws-apigateway";
 import * as cdk from "@aws-cdk/core";
+import * as cxapi from "@aws-cdk/cx-api";
 import * as ec2 from "@aws-cdk/aws-ec2";
 import * as s3 from "@aws-cdk/aws-s3";
 import * as secretsmanager from "@aws-cdk/aws-secretsmanager";
@@ -65,6 +66,12 @@ export class GraplCdkStack extends cdk.Stack {
 
     constructor(scope: cdk.Construct, id: string, props: GraplStackProps) {
         super(scope, id, props);
+
+        const setFeatureFlags = () => {
+            // ECS "Default Desired Count" is deprecated in favor of minScalingCapacity maxScalingCapacity
+            this.node.setContext(cxapi.ECS_REMOVE_DEFAULT_DESIRED_COUNT, true);
+        };
+        setFeatureFlags();
 
         this.deploymentName = props.stackName;
         const deployment_name = this.deploymentName.toLowerCase();

--- a/src/js/grapl-cdk/lib/pipeline_dashboard.ts
+++ b/src/js/grapl-cdk/lib/pipeline_dashboard.ts
@@ -39,7 +39,7 @@ function fargateInvocationsWidget(
     isRetry?: boolean
 ): cloudwatch.GraphWidget {
     const titleSuffix = isRetry ? " (retry)" : "";
-    const handler = isRetry ? service.service : service.retryService;
+    const handler = isRetry ? service.retryService : service.service;
 
     return new cloudwatch.GraphWidget({
         title: `Invoke ${service.serviceName}${titleSuffix}`,


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/401

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Remove `defaultCapacity` in favor of `min/maxScalingCapacity`, and flip on some sort of feature flag surrounding that
- will port to Pulumi once cm done with main fargate pulumi stuff

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Tested behavior in AWS, it works :) 

![image](https://user-images.githubusercontent.com/69007229/117257533-db745780-ae00-11eb-840d-529927ceda35.png)
![image](https://user-images.githubusercontent.com/69007229/117257569-e3cc9280-ae00-11eb-9484-6bff676bc51c.png)


<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
