### PR TITLE
Remove an incorrect entry from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ export EVERY_COMPOSE_FILE=--file docker-compose.yml \
 	--file ./test/docker-compose.integration-tests.yml \
 	--file ./test/docker-compose.e2e-tests.yml \
 	--file ./test/docker-compose.typecheck-tests.yml \
-	--file ./test/docker-compose.formatter.yml \
 	${EVERY_LAMBDA_COMPOSE_FILE}
 
 DOCKER_BUILDX_BAKE := docker buildx bake $(DOCKER_BUILDX_BAKE_OPTS)


### PR DESCRIPTION
This poorly named variable should not contain that docker-compose file (which, also, is not in test/)