### PR TITLE
Bump up Localstack startup period; write docker ps results

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,9 +125,14 @@ services:
           export AWS_SECRET_ACCESS_KEY=${FAKE_AWS_SECRET_ACCESS_KEY} &&
           aws --endpoint-url=http://${LOCALSTACK_HOST}:${LOCALSTACK_PORT} s3 ls
         '
+      # Probe failure during this period will not be counted towards the maximum number of retries
+      start_period: 30s
+      # Health check is executed every `interval` seconds.
       interval: 5s
+      # If a single run of the check takes longer than `timeout` seconds then the check is considered to have failed.
       timeout: 10s
-      start_period: 10s
+      # It takes `retries` consecutive failures of the health check for the container to be considered unhealthy.
+      retries: 3
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
     networks:

--- a/etc/ci_scripts/dump_artifacts.py
+++ b/etc/ci_scripts/dump_artifacts.py
@@ -117,6 +117,19 @@ def _dump_docker_log(container_name: str, dir: Path) -> None:
             shell=True,
         )
 
+def dump_docker_ps(dir: Path) -> None:
+    """
+    run `docker ps` and dump to $DIR/docker_ps.log
+    """
+    destination = dir / "docker_ps.log"
+    logging.info(f"Dumping 'docker ps' to '{destination}'")
+    with open(destination, "wb") as out_stream:
+        subprocess.run(
+            f"docker ps",
+            stdout=out_stream,
+            stderr=subprocess.DEVNULL,
+            shell=True,
+        )
 
 def dump_all_logs(compose_project: str, artifacts_dir: Path) -> None:
     containers = _container_names_by_prefix(compose_project)
@@ -168,6 +181,7 @@ if __name__ == "__main__":
     artifacts_dir = Path(f"{cwd}/test_artifacts/{compose_project}_{timestamp}")
     os.makedirs(artifacts_dir, exist_ok=False)
 
+    dump_docker_ps(artifacts_dir)
     dump_all_logs(compose_project=compose_project, artifacts_dir=artifacts_dir)
     dump_volume(compose_project=compose_project, volume_name="dgraph_export", artifacts_dir=artifacts_dir)
     # dynamodb dump is done in the e2e binary, which is outside compose - hence, no compose project.

--- a/etc/ci_scripts/dump_artifacts.py
+++ b/etc/ci_scripts/dump_artifacts.py
@@ -113,7 +113,7 @@ def _dump_docker_log(container_name: str, dir: Path) -> None:
         subprocess.run(
             f"docker logs --timestamps {container_name}",
             stdout=out_stream,
-            stderr=subprocess.DEVNULL,
+            stderr=out_stream,
             shell=True,
         )
 
@@ -127,7 +127,7 @@ def dump_docker_ps(dir: Path) -> None:
         subprocess.run(
             f"docker ps",
             stdout=out_stream,
-            stderr=subprocess.DEVNULL,
+            stderr=out_stream,
             shell=True,
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/420

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Increase localstack startup period before it starts failing healthcheck
- while debugging the above issue I had to make an assumption about the identity of a contianer hash; to avoid that in the future we're writing `docker ps` to the artifacts.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
throw it on CI and see what happens

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
