### PR TITLE
Put forwarder-related infrastructure into MetricForwarder class

### DIFF
--- a/pulumi/infra/metric_forwarder.py
+++ b/pulumi/infra/metric_forwarder.py
@@ -8,7 +8,6 @@ from infra.network import Network
 import pulumi
 
 
-# TODO: will need VPC here
 class MetricForwarder(pulumi.ComponentResource):
     def __init__(
         self, network: Network, opts: Optional[pulumi.ResourceOptions] = None


### PR DESCRIPTION
Doesn't change any functionality, but prepares for when we add Fargate services, which will need the same metric forwarding.