### PR TITLE
Typecheck more code with pants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,7 @@ test-typecheck-pants: ## Typecheck Python code with Pants
 	./pants typecheck \
 	pulumi:: \
 	build-support:: \
+	src/python/engagement_edge:: \
 	src/python/grapl-common::
 
 .PHONY: test-integration

--- a/Makefile
+++ b/Makefile
@@ -218,18 +218,14 @@ test-typecheck: export COMPOSE_FILE := ./test/docker-compose.typecheck-tests.yml
 test-typecheck: build-test-typecheck ## Build and run typecheck tests (non-Pants)
 	test/docker-compose-with-error.sh
 
-.PHONY: test-typecheck-pulumi
-test-typecheck-pulumi: ## Typecheck Pulumi Python code
-	./pants typecheck pulumi::
-
-.PHONY: test-typecheck-build-support
-test-typecheck-build-support: ## Typecheck build-support Python code
-	./pants typecheck build-support::
-
 # Right now, we're only typechecking a select portion of code with
-# Pants until CM fixes https://github.com/pantsbuild/pants/issues/11553
+# Pants until grapl-analyzerlib can be typed with MyPy; see
+# https://github.com/pantsbuild/pants/issues/11553
 .PHONY: test-typecheck-pants
-test-typecheck-pants: test-typecheck-pulumi test-typecheck-build-support ## Typecheck Python code with Pants
+test-typecheck-pants: ## Typecheck Python code with Pants
+	./pants typecheck \
+	pulumi:: \
+	build-support::
 
 .PHONY: test-integration
 test-integration: export COMPOSE_PROJECT_NAME := $(COMPOSE_PROJECT_INTEGRATION_TESTS)

--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,8 @@ test-typecheck: build-test-typecheck ## Build and run typecheck tests (non-Pants
 test-typecheck-pants: ## Typecheck Python code with Pants
 	./pants typecheck \
 	pulumi:: \
-	build-support::
+	build-support:: \
+	src/python/grapl-common::
 
 .PHONY: test-integration
 test-integration: export COMPOSE_PROJECT_NAME := $(COMPOSE_PROJECT_INTEGRATION_TESTS)

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -102,14 +102,6 @@ RUN source venv/bin/activate && \
     pip install . && \
     python setup.py sdist bdist_wheel
 
-# test
-FROM grapl-common-build AS grapl-common-test
-
-## Install test requirements
-COPY --chown=grapl --from=python-test-deps /home/grapl/python_test_deps python_test_deps
-RUN python_test_deps/install_requirements.sh
-
-
 # grapl_analyzerlib
 ################################################################################
 

--- a/src/python/engagement_edge/requirements.txt
+++ b/src/python/engagement_edge/requirements.txt
@@ -1,5 +1,4 @@
 pydgraph==20.7.0
 boto3
 pyjwt==2.0.*
-grapl_analyzerlib
 chalice==1.22.4

--- a/src/python/mypy.ini
+++ b/src/python/mypy.ini
@@ -3,3 +3,6 @@
 warn_return_any = True
 warn_unused_configs = True
 disallow_untyped_defs = True
+
+[mypy-boto3]
+ignore_missing_imports = True

--- a/test/docker-compose.typecheck-tests.yml
+++ b/test/docker-compose.typecheck-tests.yml
@@ -92,20 +92,6 @@ services:
         mypy .
         "
 
-  typecheck-engagement-edge:
-    image: grapl/grapl-engagement-edge-test:${TAG:-latest}
-    build:
-      context: ${PWD}/src
-      dockerfile: ./python/Dockerfile
-      target: engagement-edge-test
-    command: |
-      /bin/bash -c "
-        source venv/bin/activate &&
-        touch venv/lib/python3.7/site-packages/chalice/py.typed &&
-        cd engagement_edge &&
-        mypy .
-        "
-
   typecheck-grapl-analyzerlib:
     image: grapl/grapl-analyzerlib-test:${TAG:-latest}
     build:

--- a/test/docker-compose.typecheck-tests.yml
+++ b/test/docker-compose.typecheck-tests.yml
@@ -7,6 +7,14 @@ services:
   #
   # Python services
   #
+  # All of these either are, or depend on, grapl-analyzerlib, which
+  # must be typechecked with PyType at the moment. Due to a bug in how
+  # Pants invokes MyPy, it will attempt to typecheck grapl-analyzerlib
+  # even when only being instructed to typecheck something that
+  # depends on it.
+  #
+  # Until we can type grapl-analyzerlib with MyPy, we'll need to
+  # typecheck these libraries here.
 
   typecheck-analyzer-executor:
     image: grapl/analyzer-executor-test:${TAG:-latest}

--- a/test/docker-compose.typecheck-tests.yml
+++ b/test/docker-compose.typecheck-tests.yml
@@ -21,20 +21,6 @@ services:
         mypy analyzer_executor/**/*.py
         "
 
-  typecheck-grapl-common:
-    image: grapl/grapl-grapl-common-test:${TAG:-latest}
-    build:
-      context: ${PWD}/src
-      dockerfile: ./python/Dockerfile
-      target: grapl-common-test
-    command: |
-      /bin/bash -c "
-        source venv/bin/activate &&
-        cd grapl-common &&
-        pip install '.[typecheck]' &&
-        mypy .
-        "
-  
   typecheck-grapl-tests-common:
     image: grapl/grapl-tests-common-python-build:${TAG:-latest}
     build:


### PR DESCRIPTION
Typecheck grapl-common and engagement-edge using Pants, removing the components of the Docker build setup that were handling that.

While there are additional projects that we can typecheck with Pants, they are things that are not currently typechecked, and thus have some type failures. Those can follow later.

This is in support of removing all the extra code in place that Pants can handle now.