### PR TITLE
Tighten up dependency order with bucket notifications

### DIFF
--- a/pulumi/infra/emitter.py
+++ b/pulumi/infra/emitter.py
@@ -81,7 +81,9 @@ class EventEmitter(pulumi.ComponentResource):
             # straddle CDK and Pulumi; it'll go away once we're
             # totally migrated.
             opts=import_aware_opts(
-                bucket_physical_name(logical_bucket_name), parent=self
+                bucket_physical_name(logical_bucket_name),
+                parent=self,
+                depends_on=[self.topic_policy_attachment],
             ),
         )
 


### PR DESCRIPTION
Apparently, a TopicPolicy must exist before a BucketNotification is
created. Since the Pulumi resource does not have a direct dependency,
we have to declare one manually using `depends_on`.

This has worked many times in the past; my (unproven) hypothesis is
that maybe something got tightened up in the underlying AWS
interaction library between Pulumi 2.x and 3.x.

Fixes https://github.com/grapl-security/issue-tracker/issues/449

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
