### PR TITLE
Pin zstd at 1.4.9.1

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -20,7 +20,7 @@ pytest
 requests
 redis
 typing_extensions
-zstd
+zstd==1.4.9.1
 
 # This was introduced when we updated to Pants 2.4.0; lambdex (which
 # we use to generate AWS lambda zip files) has requirements that

--- a/src/python/grapl-tests-common/setup.py
+++ b/src/python/grapl-tests-common/setup.py
@@ -42,7 +42,7 @@ setup(
     install_requires=[
         "requests",
         "typing_extensions",
-        "zstd",
+        "zstd==1.4.9.1",
     ],
     # We'll probably have some dataclasses in here in the future
     python_requires=">=3.6",


### PR DESCRIPTION
We've noticed some issues with later releases that appear to result
from problems building with native dependencies. Until we sort that
out, we'll pin to the last known good version (which is already in our
constraints.txt file)

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
