### PR TITLE
Beginning some work to allow Pulumi Dgraph to be provisioned by graplctl (but doesn't work all the way yet)

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -8,6 +8,7 @@ from infra.dgraph_ttl import DGraphTTL
 from infra.engagement_creator import EngagementCreator
 from infra.metric_forwarder import MetricForwarder
 from infra.network import Network
+from infra.provision_lambda import Provisioner
 from infra.secret import JWTSecret
 from infra.service_queue import ServiceQueue
 
@@ -72,6 +73,13 @@ def main() -> None:
         source_emitter=analyzer_matched,
         network=network,
         forwarder=forwarder,
+        dgraph_cluster=dgraph_cluster,
+    )
+
+    provisioner = Provisioner(
+        network=network,
+        secret=secret,
+        dynamodb=dynamodb_tables,
         dgraph_cluster=dgraph_cluster,
     )
 

--- a/pulumi/infra/lambda_.py
+++ b/pulumi/infra/lambda_.py
@@ -129,6 +129,7 @@ class Lambda(pulumi.ComponentResource):
         args: LambdaArgs,
         network: Network,
         forwarder: Optional[MetricForwarder] = None,
+        override_name: Optional[str] = None,
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
         super().__init__("grapl:Lambda", name, None, opts)
@@ -146,7 +147,7 @@ class Lambda(pulumi.ComponentResource):
         lambda_name = f"{DEPLOYMENT_NAME}-{name}"
         self.function = aws.lambda_.Function(
             f"{name}-lambda",
-            name=name,
+            name=override_name or name,
             description=args.description,
             runtime=args.runtime,
             package_type=args.package_type,

--- a/pulumi/infra/network.py
+++ b/pulumi/infra/network.py
@@ -43,14 +43,13 @@ class Network(pulumi.ComponentResource):
         # them.
 
         cidr_block = ipaddress.ip_network("10.0.0.0/16")
-        name_for_graplctl = f"{DEPLOYMENT_NAME}-grapl-vpc"
 
         self.vpc = aws.ec2.Vpc(
             f"{name}-vpc",
             cidr_block=str(cidr_block),
             enable_dns_hostnames=True,
             enable_dns_support=True,
-            tags={"name": name_for_graplctl},
+            tags={"Name": name},
             opts=pulumi.ResourceOptions(parent=self),
         )
 

--- a/pulumi/infra/provision_lambda.py
+++ b/pulumi/infra/provision_lambda.py
@@ -34,9 +34,9 @@ class Provisioner(pulumi.ComponentResource):
                 description=GLOBAL_LAMBDA_ZIP_TAG,
                 code_path=code_path_for(name),
                 env={
+                    # TODO: this is mostly copy pasted, figure out what we actually need
                     "GRAPL_LOG_LEVEL": "DEBUG",
                     "DEPLOYMENT_NAME": pulumi.get_stack(),
-                    # TODO: Not clear that this is even used.
                     "MG_ALPHAS": dgraph_cluster.alpha_host_port(),
                     "GRAPL_TEST_USER_NAME": f"{DEPLOYMENT_NAME}-grapl-test-user",
                 },
@@ -52,5 +52,6 @@ class Provisioner(pulumi.ComponentResource):
 
         secret.grant_read_permissions_to(self.role)
         dynamodb.user_auth_table.grant_read_permissions_to(self.role)
+        dgraph_cluster.allow_connections_from(self.function.security_group)
 
         self.register_outputs({})

--- a/pulumi/infra/provision_lambda.py
+++ b/pulumi/infra/provision_lambda.py
@@ -37,7 +37,7 @@ class Provisioner(pulumi.ComponentResource):
                     # TODO: this is mostly copy pasted, figure out what we actually need
                     "GRAPL_LOG_LEVEL": "DEBUG",
                     "DEPLOYMENT_NAME": pulumi.get_stack(),
-                    "MG_ALPHAS": dgraph_cluster.alpha_host_port(),
+                    "MG_ALPHAS": dgraph_cluster.alpha_host_port,
                     "GRAPL_TEST_USER_NAME": f"{DEPLOYMENT_NAME}-grapl-test-user",
                 },
                 timeout=600,

--- a/pulumi/infra/provision_lambda.py
+++ b/pulumi/infra/provision_lambda.py
@@ -1,0 +1,59 @@
+from typing import Optional
+
+from infra.bucket import Bucket
+from infra.config import DEPLOYMENT_NAME, GLOBAL_LAMBDA_ZIP_TAG, mg_alphas
+from infra.dynamodb import DynamoDB
+from infra.engagement_notebook import EngagementNotebook
+from infra.lambda_ import Lambda, LambdaExecutionRole, PythonLambdaArgs, code_path_for
+from infra.network import Network
+from infra.secret import JWTSecret
+
+import pulumi
+
+
+class Provisioner(pulumi.ComponentResource):
+    def __init__(
+        self,
+        network: Network,
+        secret: JWTSecret,
+        db: DynamoDB,
+        opts: Optional[pulumi.ResourceOptions] = None,
+    ) -> None:
+
+        name = "provisioner"
+        super().__init__("grapl:Provisioner", name, None, opts)
+
+        self.role = LambdaExecutionRole(name, opts=pulumi.ResourceOptions(parent=self))
+
+        self.function = Lambda(
+            name,
+            args=PythonLambdaArgs(
+                handler="lambdex_handler.handler",
+                description=GLOBAL_LAMBDA_ZIP_TAG,
+                code_path=code_path_for(name),
+                env={
+                    "GRAPL_LOG_LEVEL": "DEBUG",
+                    "DEPLOYMENT_NAME": pulumi.get_stack(),
+                    # TODO: Not clear that this is even used.
+                    "MG_ALPHAS": mg_alphas(),
+                    "GRAPL_TEST_USER_NAME": f"{DEPLOYMENT_NAME}-grapl-test-user",
+                },
+                timeout=600,
+                memory_size=256,
+                execution_role=self.role,
+            ),
+            network=network,
+            # TODO: Forwarder????
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        # TODO: Original infrastructure code allowed access to DGraph,
+        # but it's not clear this is even necessary.
+
+        if notebook:
+            notebook.grant_presigned_url_permissions_to(self.role)
+
+        secret.grant_read_permissions_to(self.role)
+        db.user_auth_table.grant_read_permissions_to(self.role)
+
+        self.register_outputs({})

--- a/pulumi/infra/provision_lambda.py
+++ b/pulumi/infra/provision_lambda.py
@@ -22,7 +22,7 @@ class Provisioner(pulumi.ComponentResource):
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
 
-        name = f"provisioner"
+        name = "provisioner"
         super().__init__("grapl:Provisioner", name, None, opts)
 
         self.role = LambdaExecutionRole(name, opts=pulumi.ResourceOptions(parent=self))
@@ -36,7 +36,7 @@ class Provisioner(pulumi.ComponentResource):
                 env={
                     # TODO: this is mostly copy pasted, figure out what we actually need
                     "GRAPL_LOG_LEVEL": "DEBUG",
-                    "DEPLOYMENT_NAME": pulumi.get_stack(),
+                    "DEPLOYMENT_NAME": DEPLOYMENT_NAME,
                     "MG_ALPHAS": dgraph_cluster.alpha_host_port,
                     "GRAPL_TEST_USER_NAME": f"{DEPLOYMENT_NAME}-grapl-test-user",
                 },
@@ -45,8 +45,9 @@ class Provisioner(pulumi.ComponentResource):
                 execution_role=self.role,
             ),
             network=network,
+            # graplctl currently expects a very specific function name.
+            # in the future we should just have it pull from pulumi outputs.
             override_name=f"{DEPLOYMENT_NAME}-Provisioner-Handler",
-            # TODO: Forwarder????
             opts=pulumi.ResourceOptions(parent=self),
         )
 

--- a/pulumi/infra/provision_lambda.py
+++ b/pulumi/infra/provision_lambda.py
@@ -22,7 +22,7 @@ class Provisioner(pulumi.ComponentResource):
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
 
-        name = "provisioner"
+        name = f"provisioner"
         super().__init__("grapl:Provisioner", name, None, opts)
 
         self.role = LambdaExecutionRole(name, opts=pulumi.ResourceOptions(parent=self))
@@ -45,11 +45,12 @@ class Provisioner(pulumi.ComponentResource):
                 execution_role=self.role,
             ),
             network=network,
+            override_name=f"{DEPLOYMENT_NAME}-Provisioner-Handler",
             # TODO: Forwarder????
             opts=pulumi.ResourceOptions(parent=self),
         )
 
         secret.grant_read_permissions_to(self.role)
-        db.user_auth_table.grant_read_permissions_to(self.role)
+        dynamodb.user_auth_table.grant_read_permissions_to(self.role)
 
         self.register_outputs({})

--- a/pulumi/infra/swarm.py
+++ b/pulumi/infra/swarm.py
@@ -106,7 +106,7 @@ class Swarm(pulumi.ComponentResource):
             f"{name}-sec-group",
             description=f"Docker Swarm security group",
             vpc_id=vpc.id,
-            tags={"swarm-sec-group-for-deployment": f"{DEPLOYMENT_NAME}"},
+            tags={"swarm-sec-group-for-deployment": "{DEPLOYMENT_NAME}"},
             opts=child_opts,
         )
 

--- a/pulumi/infra/swarm.py
+++ b/pulumi/infra/swarm.py
@@ -106,7 +106,7 @@ class Swarm(pulumi.ComponentResource):
             f"{name}-sec-group",
             description=f"Docker Swarm security group",
             vpc_id=vpc.id,
-            tags={"swarm-sec-group-for-deployment": "{DEPLOYMENT_NAME}"},
+            tags={"swarm-sec-group-for-deployment": DEPLOYMENT_NAME},
             opts=child_opts,
         )
 

--- a/pulumi/infra/swarm.py
+++ b/pulumi/infra/swarm.py
@@ -39,16 +39,14 @@ class Ec2Port:
             self=True,
         )
         return (ingress, egress)
-    
-    def allow_outbound_any_ip(
-        self
-    ) -> aws.ec2.SecurityGroupEgressArgs:
-            return aws.ec2.SecurityGroupEgressArgs(
-                from_port=self.port,
-                to_port=self.port,
-                protocol=self.protocol,
-                cidr_blocks=[TRAFFIC_FROM_ANYWHERE_CIDR],
-            )
+
+    def allow_outbound_any_ip(self) -> aws.ec2.SecurityGroupEgressArgs:
+        return aws.ec2.SecurityGroupEgressArgs(
+            from_port=self.port,
+            to_port=self.port,
+            protocol=self.protocol,
+            cidr_blocks=[TRAFFIC_FROM_ANYWHERE_CIDR],
+        )
 
     def __str__(self) -> str:
         return f"Ec2Port({self.protocol}:{self.port})"
@@ -107,8 +105,6 @@ class Swarm(pulumi.ComponentResource):
         self.security_group = aws.ec2.SecurityGroup(
             f"{name}-sec-group",
             description=f"Docker Swarm security group",
-            ingress=ingress_rules,
-            egress=egress_rules,
             vpc_id=vpc.id,
             tags={"swarm-sec-group-for-deployment": f"{DEPLOYMENT_NAME}"},
             opts=child_opts,

--- a/pulumi/infra/swarm.py
+++ b/pulumi/infra/swarm.py
@@ -15,6 +15,8 @@ from pulumi.resource import ResourceOptions
 # These are COPYd in from Dockerfile.pulumi
 SWARM_INIT_DIR = Path("../src/js/grapl-cdk/swarm").resolve()
 
+TRAFFIC_FROM_ANYWHERE_CIDR = "0.0.0.0/0"
+
 
 @dataclass
 class Ec2Port:
@@ -89,13 +91,13 @@ class Swarm(pulumi.ComponentResource):
                 from_port=443,
                 to_port=443,
                 protocol="tcp",
-                self=True,
+                cidr_blocks=[TRAFFIC_FROM_ANYWHERE_CIDR],
             ),
             aws.ec2.SecurityGroupEgressArgs(
                 from_port=80,
                 to_port=80,
                 protocol="tcp",
-                self=True,
+                cidr_blocks=[TRAFFIC_FROM_ANYWHERE_CIDR],
             ),
         ] + [egress for _, egress in internal_rules]
 
@@ -105,6 +107,7 @@ class Swarm(pulumi.ComponentResource):
             ingress=ingress_rules,
             egress=egress_rules,
             vpc_id=vpc.id,
+            tags={"swarm-sec-group-for-deployment": f"{DEPLOYMENT_NAME}"},
             opts=child_opts,
         )
 

--- a/src/python/grapl-common/grapl_common/grapl_logger.py
+++ b/src/python/grapl-common/grapl_common/grapl_logger.py
@@ -4,7 +4,9 @@ import os
 import sys
 
 
-def get_module_grapl_logger(default_log_level: str = "ERROR") -> logging.Logger:
+def get_module_grapl_logger(
+    default_log_level: str = "ERROR", log_to_stdout: bool = False
+) -> logging.Logger:
     """
     Callers should put
     LOGGER = get_module_grapl_logger()
@@ -15,6 +17,10 @@ def get_module_grapl_logger(default_log_level: str = "ERROR") -> logging.Logger:
     assert caller_module
     logger = logging.getLogger(caller_module.__name__)
     logger.setLevel(os.getenv("GRAPL_LOG_LEVEL", default_log_level))
-    # While a lot of our code defines this, I believe it just doubles our log output
-    # logger.addHandler(logging.StreamHandler(stream=sys.stdout))
+
+    # While a lot of our code defines this, it's possible it just doubles our log output
+    # However, it makes sense for stuff like graplctl that don't currently
+    # create log files
+    if log_to_stdout:
+        logger.addHandler(logging.StreamHandler(stream=sys.stdout))
     return logger

--- a/src/python/grapl-common/grapl_common/utils/benchmark.py
+++ b/src/python/grapl-common/grapl_common/utils/benchmark.py
@@ -1,0 +1,25 @@
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from typing import Iterator, Optional
+
+
+class BenchmarkResult:
+    result: Optional[timedelta]
+
+    def __init__(self) -> None:
+        self.result = None
+
+    def __str__(self) -> str:
+        assert self.result, "You can't consume BenchmarkResult until after the context."
+        return f"{int(self.result.total_seconds())} seconds"
+
+
+@contextmanager
+def benchmark_ctx() -> Iterator[BenchmarkResult]:
+    will_contain_result = BenchmarkResult()
+    start = datetime.utcnow()
+    yield will_contain_result
+    end = datetime.utcnow()
+
+    result = end - start
+    will_contain_result.result = result

--- a/src/python/graplctl/graplctl/dgraph/lib.py
+++ b/src/python/graplctl/graplctl/dgraph/lib.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple
 
 from botocore.client import ClientError
 from click import progressbar
+from grapl_common.grapl_logger import get_module_grapl_logger
 
 if TYPE_CHECKING:
     from mypy_boto3_cloudwatch.client import CloudWatchClient
@@ -19,9 +20,7 @@ if TYPE_CHECKING:
 import graplctl.swarm.lib as docker_swarm_ops
 from graplctl.common import Ec2Instance, State, Tag, get_command_results, ticker
 
-LOGGER = logging.getLogger(__name__)
-LOGGER.setLevel(os.getenv("GRAPL_LOG_LEVEL", "INFO"))
-LOGGER.addHandler(logging.StreamHandler(stream=sys.stdout))
+LOGGER = get_module_grapl_logger(log_to_stdout=True)
 
 CW_NAMESPACE = "CWAgent"
 CW_DISK_USAGE_METRIC_NAME = "disk_used_percent"


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/441

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Introduce better abstractions to Ec2Port
- Introduce the Provisioner lambda into pulumi
- add a benchmark utility
- Pulumi Dgraph adds a few new tags
- graplctl consumes these new tags

Provision still doesn't work, but we're getting closer. It gets stuck on SSM - I suspect the cluster isn't allowing 443 correctly or something. This has blocked me for daaaaays

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Against AWS

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
