### PR TITLE
Remove import_aware_opts abstraction

### DIFF
--- a/pulumi/Pulumi.local-grapl.yaml
+++ b/pulumi/Pulumi.local-grapl.yaml
@@ -19,4 +19,3 @@ config:
   aws:skipCredentialsValidation: "true"
   aws:skipRequestingAccountId: "true"
   grapl:MG_ALPHAS: dgraph.grapl.test:9080
-  grapl:import_from_existing: "False"

--- a/pulumi/README.md
+++ b/pulumi/README.md
@@ -51,7 +51,6 @@ set `PULUMI_CONFIG_PASSPHRASE` accordingly.
 ```
 pulumi stack init <NAME>
 pulumi config set aws:region us-east-1
-pulumi config set grapl:import_from_existing False
 ```
 
 Then, you should set your `AWS_PROFILE` in your environment, and then
@@ -59,40 +58,6 @@ run `aws sso login`.
 
 Now, when you run `pulumi up`, you will be provisioning infrastructure
 in your AWS account.
-
-# Migrating from CDK
-
-To help evaluate the faithfulness of this Pulumi port of our CDK
-logic, we can run Pulumi against an existing CDK-generated Grapl
-deployment in a kind of "import mode". This tells our Pulumi code to
-adopt existing AWS resources into its stack state, rather than
-creating them new. After the resources have been imported, we can
-manage them completely through Pulumi.
-
-If we are in "import mode", if our Pulumi code differs in any way from
-the resources we are trying to import, Pulumi will tell us. We can
-then inspect the difference and modify our Pulumi code appropriately.
-
-If we are *not* in "import mode", then Pulumi will attempt to create
-new resources, regardless of what exists in AWS. This is what you want
-if you are creating fresh infrastructure, or interacting with
-Localstack.
-
-You *must* set this value in configuration explicitly, or the Pulumi
-run *will* fail.
-
-To enable import mode:
-```sh
-pulumi config set grapl:import_from_existing True
-```
-
-To disable import mode:
-```sh
-pulumi config set grapl:import_from_existing False
-```
-
-Once we have fully migrated away from CDK, we can remove this
-configuration option and the code that supports it.
 
 ## CDK and Pulumi Configuration Caveat
 

--- a/pulumi/infra/config.py
+++ b/pulumi/infra/config.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Any, Mapping, Sequence
+from typing import Mapping, Sequence
 
 import pulumi_aws as aws
 from typing_extensions import Final
@@ -101,35 +101,3 @@ def configurable_envvars(service_name: str, vars: Sequence[str]) -> Mapping[str,
     splicing into other environment maps for configuring services.
     """
     return {v: configurable_envvar(service_name, v) for v in vars}
-
-
-# Yes I hate the 'Any' type just as much as you do, but there's
-# apparently not a way to type kwargs right now.
-def import_aware_opts(resource_id: str, **kwargs: Any) -> pulumi.ResourceOptions:
-    """Pass the resource ID that corresponds to a particular resource
-    when you're importing from existing infrastructure, as well as any
-    other kwargs that `pulumi.ResourceOptions` would accept.
-
-    If the Pulumi stack is currently configured to import (rather than
-    create), the appropriate configuration will be injected into the
-    `ResourceOptions` that is returned.
-
-    Otherwise, a `ResourceOptions` constructed from the given kwargs
-    will be returned.
-
-    This should be used to generate `ResourceOptions` for *all* resources!
-
-    To enable importing, rather than creating, set the following
-    config for the stack:
-
-        pulumi config set grapl:import_from_existing True
-
-    """
-
-    import_from_existing = pulumi.Config().require_bool("import_from_existing")
-
-    given_opts = pulumi.ResourceOptions(**kwargs)
-    import_opts = pulumi.ResourceOptions(
-        import_=resource_id if import_from_existing else None
-    )
-    return pulumi.ResourceOptions.merge(given_opts, import_opts)

--- a/pulumi/infra/emitter.py
+++ b/pulumi/infra/emitter.py
@@ -2,8 +2,8 @@ import json
 from typing import Optional
 
 import pulumi_aws as aws
-from infra.bucket import Bucket, bucket_physical_name
-from infra.config import AWS_ACCOUNT_ID, DEPLOYMENT_NAME, import_aware_opts
+from infra.bucket import Bucket
+from infra.config import DEPLOYMENT_NAME
 from infra.policies import attach_policy
 
 import pulumi
@@ -78,15 +78,11 @@ class EventEmitter(pulumi.ComponentResource):
             opts=pulumi.ResourceOptions(parent=self),
         )
 
-        region = aws.get_region().name
         physical_topic_name = f"{DEPLOYMENT_NAME}-{event_name}-topic"
-        topic_lookup_arn = (
-            f"arn:aws:sns:{region}:{AWS_ACCOUNT_ID}:{physical_topic_name}"
-        )
         self.topic = aws.sns.Topic(
             f"{event_name}-topic",
             name=physical_topic_name,
-            opts=import_aware_opts(topic_lookup_arn, parent=self),
+            opts=pulumi.ResourceOptions(parent=self),
         )
 
         # This is a resource-based policy to allow our bucket to
@@ -116,7 +112,7 @@ class EventEmitter(pulumi.ComponentResource):
                     }
                 )
             ),
-            opts=import_aware_opts(topic_lookup_arn, parent=self),
+            opts=pulumi.ResourceOptions(parent=self),
         )
 
         self.bucket_notification = aws.s3.BucketNotification(
@@ -128,14 +124,7 @@ class EventEmitter(pulumi.ComponentResource):
                     events=["s3:ObjectCreated:*"],
                 )
             ],
-            # Ideally, I'd like to use `self.bucket.id` for this, but
-            # that isn't going to be available from the Pulumi
-            # resource at planning time, which is when we'd need this
-            # string.  However, we're only going to need this while we
-            # straddle CDK and Pulumi; it'll go away once we're
-            # totally migrated.
-            opts=import_aware_opts(
-                bucket_physical_name(logical_bucket_name),
+            opts=pulumi.ResourceOptions(
                 parent=self,
                 depends_on=[self.topic_policy_attachment],
             ),

--- a/pulumi/infra/engagement_creator.py
+++ b/pulumi/infra/engagement_creator.py
@@ -1,13 +1,7 @@
 import json
 
 import pulumi_aws as aws
-from infra.config import (
-    AWS_ACCOUNT_ID,
-    DEPLOYMENT_NAME,
-    GLOBAL_LAMBDA_ZIP_TAG,
-    configurable_envvars,
-    import_aware_opts,
-)
+from infra.config import DEPLOYMENT_NAME, GLOBAL_LAMBDA_ZIP_TAG, configurable_envvars
 from infra.dgraph_cluster import DgraphCluster
 from infra.emitter import EventEmitter
 from infra.lambda_ import code_path_for
@@ -44,15 +38,11 @@ class EngagementCreator(Service):
         self.queue.subscribe_to_emitter(input_emitter)
         input_emitter.grant_read_to(self.role)
 
-        region = aws.get_region().name
         physical_topic_name = f"{DEPLOYMENT_NAME}-engagements-created-topic"
-        topic_lookup_arn = (
-            f"arn:aws:sns:{region}:{AWS_ACCOUNT_ID}:{physical_topic_name}"
-        )
         self.created_topic = aws.sns.Topic(
             "engagements-created-topic",
             name=physical_topic_name,
-            opts=import_aware_opts(topic_lookup_arn, parent=self),
+            opts=pulumi.ResourceOptions(parent=self),
         )
 
         publish_to_topic_policy = self.created_topic.arn.apply(

--- a/pulumi/infra/lambda_.py
+++ b/pulumi/infra/lambda_.py
@@ -9,7 +9,6 @@ from infra.config import (
     GLOBAL_LAMBDA_ZIP_TAG,
     LOCAL_GRAPL,
     SERVICE_LOG_RETENTION_DAYS,
-    import_aware_opts,
 )
 from infra.metric_forwarder import MetricForwarder
 from infra.network import Network
@@ -162,7 +161,7 @@ class Lambda(pulumi.ComponentResource):
                 security_group_ids=[self.security_group.id],
                 subnet_ids=[net.id for net in network.private_subnets],
             ),
-            opts=import_aware_opts(lambda_name, parent=self),
+            opts=pulumi.ResourceOptions(parent=self),
         )
 
         if not LOCAL_GRAPL:
@@ -177,7 +176,7 @@ class Lambda(pulumi.ComponentResource):
                 function_name=self.function.arn,
                 function_version=self.function.version,
                 name="live",
-                opts=import_aware_opts(f"{lambda_name}/live", parent=self),
+                opts=pulumi.ResourceOptions(parent=self),
             )
 
         # Lambda function output is automatically sent to log


### PR DESCRIPTION
Now that we're basically done with the CDK-to-Pulumi migration, this
is no longer needed.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
