### PR TITLE
Use RolePolicies, rather than RolePolicyAttachments

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -153,10 +153,10 @@ def main() -> None:
         dgraph_cluster=dgraph_cluster,
     )
 
-    provisioner = Provisioner(
+    Provisioner(
         network=network,
         secret=secret,
-        dynamodb=dynamodb_tables,
+        db=dynamodb_tables,
         dgraph_cluster=dgraph_cluster,
     )
 

--- a/pulumi/infra/bucket.py
+++ b/pulumi/infra/bucket.py
@@ -68,7 +68,7 @@ class Bucket(aws.s3.Bucket):
                     }
                 )
             ),
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=role),
         )
 
     def grant_get_and_list_to(self, role: aws.iam.Role) -> None:
@@ -101,7 +101,7 @@ class Bucket(aws.s3.Bucket):
                     }
                 )
             ),
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=role),
         )
 
     def grant_get_to(self, role: aws.iam.Role) -> None:
@@ -123,7 +123,7 @@ class Bucket(aws.s3.Bucket):
                     }
                 )
             ),
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=role),
         )
 
     def grant_read_write_permissions_to(self, role: aws.iam.Role) -> None:
@@ -157,7 +157,7 @@ class Bucket(aws.s3.Bucket):
                     }
                 )
             ),
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=role),
         )
 
     def grant_delete_permissions_to(self, role: aws.iam.Role) -> None:
@@ -181,7 +181,7 @@ class Bucket(aws.s3.Bucket):
                     }
                 )
             ),
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=role),
         )
 
     def _upload_file_to_bucket(

--- a/pulumi/infra/dynamodb.py
+++ b/pulumi/infra/dynamodb.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence
 
 import pulumi_aws as aws
 from infra.config import DEPLOYMENT_NAME
@@ -37,70 +37,6 @@ class DynamoDBTable(aws.dynamodb.Table):
             range_key=range_key,
             billing_mode="PAY_PER_REQUEST",
             opts=opts,
-        )
-
-    def grant_read_permissions_to(self, role: aws.iam.Role) -> None:
-        """ Adds the ability to read from this table to the provided `Role`. """
-        aws.iam.RolePolicy(
-            f"{role._name}-reads-{self._name}",
-            role=role.name,
-            policy=self.arn.apply(
-                lambda table_arn: json.dumps(
-                    {
-                        "Version": "2012-10-17",
-                        "Statement": [
-                            {
-                                "Effect": "Allow",
-                                "Action": [
-                                    "dynamodb:BatchGetItem",
-                                    "dynamodb:GetRecords",
-                                    "dynamodb:GetShardIterator",
-                                    "dynamodb:Query",
-                                    "dynamodb:GetItem",
-                                    "dynamodb:Scan",
-                                ],
-                                "Resource": table_arn,
-                            }
-                        ],
-                    }
-                )
-            ),
-            opts=pulumi.ResourceOptions(parent=role),
-        )
-
-    def grant_read_write_permissions_to(self, role: aws.iam.Role) -> None:
-        """ Gives the provided `Role` the ability to read from and write to this table. """
-        aws.iam.RolePolicy(
-            f"{role._name}-reads-and-writes-{self._name}",
-            role=role.name,
-            policy=self.arn.apply(
-                lambda table_arn: json.dumps(
-                    {
-                        "Version": "2012-10-17",
-                        "Statement": [
-                            {
-                                "Effect": "Allow",
-                                "Action": [
-                                    # Read
-                                    "dynamodb:BatchGetItem",
-                                    "dynamodb:GetRecords",
-                                    "dynamodb:GetShardIterator",
-                                    "dynamodb:Query",
-                                    "dynamodb:GetItem",
-                                    "dynamodb:Scan",
-                                    # Write
-                                    "dynamodb:BatchWriteItem",
-                                    "dynamodb:PutItem",
-                                    "dynamodb:UpdateItem",
-                                    "dynamodb:DeleteItem",
-                                ],
-                                "Resource": table_arn,
-                            }
-                        ],
-                    }
-                )
-            ),
-            opts=pulumi.ResourceOptions(parent=role),
         )
 
 
@@ -209,3 +145,79 @@ class DynamoDB(pulumi.ComponentResource):
         )
 
         self.register_outputs({})
+
+
+def grant_read_write_on_tables(
+    role: aws.iam.Role, tables: Sequence[aws.dynamodb.Table]
+) -> None:
+    """Rather than granting permissions to each table individually, we
+    grant to multiple tables at once in order to keep overall Role sizes
+    down.
+    """
+    aws.iam.RolePolicy(
+        f"{role._name}-reads-and-writes-dynamodb-tables",
+        role=role.name,
+        policy=pulumi.Output.all(*[t.arn for t in tables]).apply(
+            lambda arns: json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                # Read
+                                "dynamodb:BatchGetItem",
+                                "dynamodb:GetRecords",
+                                "dynamodb:GetShardIterator",
+                                "dynamodb:Query",
+                                "dynamodb:GetItem",
+                                "dynamodb:Scan",
+                                # Write
+                                "dynamodb:BatchWriteItem",
+                                "dynamodb:PutItem",
+                                "dynamodb:UpdateItem",
+                                "dynamodb:DeleteItem",
+                            ],
+                            "Resource": [a for a in arns],
+                        }
+                    ],
+                }
+            )
+        ),
+        opts=pulumi.ResourceOptions(parent=role),
+    )
+
+
+def grant_read_on_tables(
+    role: aws.iam.Role, tables: Sequence[aws.dynamodb.Table]
+) -> None:
+    """Rather than granting permissions to each table individually, we
+    grant to multiple tables at once in order to keep overall Role sizes
+    down.
+    """
+    aws.iam.RolePolicy(
+        f"{role._name}-reads-dynamodb-tables",
+        role=role.name,
+        policy=pulumi.Output.all(*[t.arn for t in tables]).apply(
+            lambda arns: json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "dynamodb:BatchGetItem",
+                                "dynamodb:GetRecords",
+                                "dynamodb:GetShardIterator",
+                                "dynamodb:Query",
+                                "dynamodb:GetItem",
+                                "dynamodb:Scan",
+                            ],
+                            "Resource": [a for a in arns],
+                        }
+                    ],
+                }
+            )
+        ),
+        opts=pulumi.ResourceOptions(parent=role),
+    )

--- a/pulumi/infra/dynamodb.py
+++ b/pulumi/infra/dynamodb.py
@@ -65,7 +65,7 @@ class DynamoDBTable(aws.dynamodb.Table):
                     }
                 )
             ),
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=role),
         )
 
     def grant_read_write_permissions_to(self, role: aws.iam.Role) -> None:
@@ -100,7 +100,7 @@ class DynamoDBTable(aws.dynamodb.Table):
                     }
                 )
             ),
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=role),
         )
 
 

--- a/pulumi/infra/emitter.py
+++ b/pulumi/infra/emitter.py
@@ -100,7 +100,7 @@ class EventEmitter(pulumi.ComponentResource):
                     }
                 )
             ),
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=role),
         )
 
     def grant_read_to(self, role: aws.iam.Role) -> None:
@@ -121,5 +121,5 @@ class EventEmitter(pulumi.ComponentResource):
                     }
                 )
             ),
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=role),
         )

--- a/pulumi/infra/emitter.py
+++ b/pulumi/infra/emitter.py
@@ -4,7 +4,6 @@ from typing import Optional
 import pulumi_aws as aws
 from infra.bucket import Bucket
 from infra.config import DEPLOYMENT_NAME
-from infra.policies import attach_policy
 
 import pulumi
 
@@ -23,59 +22,6 @@ class EventEmitter(pulumi.ComponentResource):
         logical_bucket_name = f"{event_name}-bucket"
         self.bucket = Bucket(
             logical_bucket_name, sse=True, opts=pulumi.ResourceOptions(parent=self)
-        )
-
-        # TODO: Unclear if this should be attached to our Bucket
-        # abstraction or here. Will keep it here for the time being.
-        #
-        # One nice thing about keeping it here is that we aren't
-        # creating policies for buckets that won't need them.
-        self.bucket_object_read_policy = aws.iam.Policy(
-            f"read-objects-from-{logical_bucket_name}",
-            description=self.bucket.bucket.apply(
-                lambda n: f"Read *only* objects from {n} bucket"
-            ),
-            policy=self.bucket.arn.apply(
-                lambda bucket_arn: json.dumps(
-                    {
-                        "Version": "2012-10-17",
-                        "Statement": [
-                            {
-                                "Effect": "Allow",
-                                "Action": "s3:GetObject",
-                                "Resource": f"{bucket_arn}/*",
-                            }
-                        ],
-                    }
-                )
-            ),
-            opts=pulumi.ResourceOptions(parent=self),
-        )
-
-        self.bucket_write_policy = aws.iam.Policy(
-            f"write-objects-to-{logical_bucket_name}",
-            description=self.bucket.bucket.apply(
-                lambda n: f"Write objects to {n} bucket"
-            ),
-            policy=self.bucket.arn.apply(
-                lambda bucket_arn: json.dumps(
-                    {
-                        "Version": "2012-10-17",
-                        "Statement": [
-                            {
-                                "Effect": "Allow",
-                                "Action": [
-                                    "s3:Abort*",
-                                    "s3:DeleteObject*",
-                                    "s3:PutObject*",
-                                ],
-                                "Resource": [bucket_arn, f"{bucket_arn}/*"],
-                            }
-                        ],
-                    }
-                )
-            ),
-            opts=pulumi.ResourceOptions(parent=self),
         )
 
         physical_topic_name = f"{DEPLOYMENT_NAME}-{event_name}-topic"
@@ -133,7 +79,47 @@ class EventEmitter(pulumi.ComponentResource):
         self.register_outputs({})
 
     def grant_write_to(self, role: aws.iam.Role) -> None:
-        attach_policy(self.bucket_write_policy, role)
+        aws.iam.RolePolicy(
+            f"{role._name}-writes-objects-to-{self.bucket._name}",
+            role=role.name,
+            policy=self.bucket.arn.apply(
+                lambda bucket_arn: json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "s3:Abort*",
+                                    "s3:DeleteObject*",
+                                    "s3:PutObject*",
+                                ],
+                                "Resource": [bucket_arn, f"{bucket_arn}/*"],
+                            }
+                        ],
+                    }
+                )
+            ),
+            opts=pulumi.ResourceOptions(parent=self),
+        )
 
     def grant_read_to(self, role: aws.iam.Role) -> None:
-        attach_policy(self.bucket_object_read_policy, role)
+        aws.iam.RolePolicy(
+            f"{role._name}-reads-objects-from-{self.bucket._name}",
+            role=role.name,
+            policy=self.bucket.arn.apply(
+                lambda bucket_arn: json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": "s3:GetObject",
+                                "Resource": f"{bucket_arn}/*",
+                            }
+                        ],
+                    }
+                )
+            ),
+            opts=pulumi.ResourceOptions(parent=self),
+        )

--- a/pulumi/infra/engagement_creator.py
+++ b/pulumi/infra/engagement_creator.py
@@ -67,7 +67,7 @@ class EngagementCreator(Service):
             name=f"{DEPLOYMENT_NAME}-{name}-publishes-to-topic",
             role=self.role.name,
             policy=publish_to_topic_policy,
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=self.role),
         )
 
         for handler in self.handlers:

--- a/pulumi/infra/engagement_edge.py
+++ b/pulumi/infra/engagement_edge.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from infra import dynamodb
 from infra.bucket import Bucket
 from infra.config import GLOBAL_LAMBDA_ZIP_TAG, configurable_envvars
 from infra.dgraph_cluster import DgraphCluster
@@ -69,7 +70,7 @@ class EngagementEdge(pulumi.ComponentResource):
             notebook.grant_presigned_url_permissions_to(self.role)
 
         secret.grant_read_permissions_to(self.role)
-        db.user_auth_table.grant_read_permissions_to(self.role)
+        dynamodb.grant_read_on_tables(self.role, [db.user_auth_table])
         dgraph_cluster.allow_connections_from(self.function.security_group)
 
         self.register_outputs({})

--- a/pulumi/infra/engagement_notebook.py
+++ b/pulumi/infra/engagement_notebook.py
@@ -2,6 +2,7 @@ import json
 from typing import Optional
 
 import pulumi_aws as aws
+from infra import dynamodb
 from infra.bucket import Bucket
 from infra.config import DEPLOYMENT_NAME
 from infra.dgraph_cluster import DgraphCluster
@@ -63,8 +64,9 @@ class EngagementNotebook(pulumi.ComponentResource):
             opts=pulumi.ResourceOptions(parent=self),
         )
 
-        db.user_auth_table.grant_read_write_permissions_to(self.role)
-        db.schema_table.grant_read_write_permissions_to(self.role)
+        dynamodb.grant_read_write_on_tables(
+            self.role, [db.user_auth_table, db.schema_table]
+        )
         plugins_bucket.grant_read_permissions_to(self.role)
 
         self.notebook = aws.sagemaker.NotebookInstance(

--- a/pulumi/infra/engagement_notebook.py
+++ b/pulumi/infra/engagement_notebook.py
@@ -104,5 +104,5 @@ class EngagementNotebook(pulumi.ComponentResource):
                     }
                 )
             ),
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=role),
         )

--- a/pulumi/infra/metric_forwarder.py
+++ b/pulumi/infra/metric_forwarder.py
@@ -61,7 +61,7 @@ class MetricForwarder(pulumi.ComponentResource):
                     ],
                 }
             ),
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=self.role),
         )
 
         self.register_outputs({})

--- a/pulumi/infra/model_plugin_deployer.py
+++ b/pulumi/infra/model_plugin_deployer.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from infra import dynamodb
 from infra.bucket import Bucket
 from infra.config import GLOBAL_LAMBDA_ZIP_TAG, LOCAL_GRAPL, configurable_envvars
 from infra.dgraph_cluster import DgraphCluster
@@ -59,14 +60,8 @@ class ModelPluginDeployer(pulumi.ComponentResource):
 
         secret.grant_read_permissions_to(self.role)
 
-        # TODO: Consider moving these permission-granting functions
-        # into the dynamodb module (but still register them
-        # here... just want to centralize the logic).
-
-        # Read permissions for user auth DynamoDB table
-        db.user_auth_table.grant_read_permissions_to(self.role)
-
-        db.schema_table.grant_read_write_permissions_to(self.role)
+        dynamodb.grant_read_on_tables(self.role, [db.user_auth_table])
+        dynamodb.grant_read_write_on_tables(self.role, [db.schema_table])
 
         plugins_bucket.grant_read_write_permissions_to(self.role)
 

--- a/pulumi/infra/policies.py
+++ b/pulumi/infra/policies.py
@@ -128,7 +128,7 @@ def attach_policy(
     )
 
 
-def _attach_policy_to_ship_logs_to_cloudwatch(
+def attach_policy_to_ship_logs_to_cloudwatch(
     role: aws.iam.Role, log_group: aws.cloudwatch.LogGroup, opts: pulumi.ResourceOptions
 ) -> aws.iam.RolePolicyAttachment:
     # This seems like it's a strict subset of CLOUDWATCH_AGENT_SERVER_POLICY

--- a/pulumi/infra/provision_lambda.py
+++ b/pulumi/infra/provision_lambda.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from infra import dynamodb
 from infra.config import DEPLOYMENT_NAME, GLOBAL_LAMBDA_ZIP_TAG
 from infra.dgraph_cluster import DgraphCluster
 from infra.dynamodb import DynamoDB
@@ -15,7 +16,7 @@ class Provisioner(pulumi.ComponentResource):
         self,
         network: Network,
         secret: JWTSecret,
-        dynamodb: DynamoDB,
+        db: DynamoDB,
         dgraph_cluster: DgraphCluster,
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
@@ -50,7 +51,9 @@ class Provisioner(pulumi.ComponentResource):
         )
 
         secret.grant_read_permissions_to(self.role)
-        dynamodb.user_auth_table.grant_read_permissions_to(self.role)
+
+        dynamodb.grant_read_on_tables(self.role, [db.user_auth_table])
+
         dgraph_cluster.allow_connections_from(self.function.security_group)
 
         self.register_outputs({})

--- a/pulumi/infra/queue_driven_lambda.py
+++ b/pulumi/infra/queue_driven_lambda.py
@@ -55,7 +55,7 @@ class QueueDrivenLambda(pulumi.ComponentResource):
                     }
                 )
             ),
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=args.execution_role),
         )
 
         self.event_source_mapping = aws.lambda_.EventSourceMapping(

--- a/pulumi/infra/repository.py
+++ b/pulumi/infra/repository.py
@@ -5,7 +5,6 @@ from typing import Optional
 import pulumi_aws as aws
 import pulumi_docker as docker
 from infra.config import AWS_ACCOUNT_ID, DEPLOYMENT_NAME
-from infra.policies import attach_policy
 
 import pulumi
 
@@ -66,14 +65,25 @@ class Repository(pulumi.ComponentResource):
             opts=pulumi.ResourceOptions(parent=self, delete_before_replace=True),
         )
 
-        # This is the policy that would need to be attached to Fargate
-        # execution roles (for services that pull images from this
-        # repository, of course).
-        self.access_policy = aws.iam.Policy(
-            f"{image_name}-repository-access-policy",
-            description=self.repository.name.apply(
-                lambda n: f"Access images from {n} repository"
-            ),
+        self.register_outputs({})
+
+    @property
+    def registry_qualified_name(self) -> pulumi.Output[str]:
+        """
+        The fully-qualified image name for this repository, not including tags, e.g.,
+
+        <AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/<DEPLOYMENT_NAME>/<NAME>
+        """
+        return self.repository.repository_url  # type: ignore[no-any-return]
+
+    def grant_access_to(self, role: aws.iam.Role) -> None:
+        """This is the policy that would need to be attached to Fargate
+        execution roles (for services that pull images from this
+        repository, of course)."""
+
+        aws.iam.RolePolicy(
+            f"{role._name}-accesses-{self.repository._name}",
+            role=role.name,
             policy=self.repository.arn.apply(
                 lambda arn: json.dumps(
                     {
@@ -94,17 +104,3 @@ class Repository(pulumi.ComponentResource):
             ),
             opts=pulumi.ResourceOptions(parent=self.repository),
         )
-
-        self.register_outputs({})
-
-    @property
-    def registry_qualified_name(self) -> pulumi.Output[str]:
-        """
-        The fully-qualified image name for this repository, not including tags, e.g.,
-
-        <AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/<DEPLOYMENT_NAME>/<NAME>
-        """
-        return self.repository.repository_url  # type: ignore[no-any-return]
-
-    def grant_access_to(self, role: aws.iam.Role) -> None:
-        attach_policy(self.access_policy, role)

--- a/pulumi/infra/repository.py
+++ b/pulumi/infra/repository.py
@@ -102,5 +102,5 @@ class Repository(pulumi.ComponentResource):
                     }
                 )
             ),
-            opts=pulumi.ResourceOptions(parent=self.repository),
+            opts=pulumi.ResourceOptions(parent=role),
         )

--- a/pulumi/infra/secret.py
+++ b/pulumi/infra/secret.py
@@ -68,5 +68,5 @@ class JWTSecret(pulumi.ComponentResource):
                     }
                 )
             ),
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=role),
         )

--- a/pulumi/infra/service_queue.py
+++ b/pulumi/infra/service_queue.py
@@ -161,7 +161,7 @@ def _queue_consumption_policy(queue: aws.sqs.Queue, role: aws.iam.Role) -> None:
                 }
             )
         ),
-        opts=pulumi.ResourceOptions(parent=queue),
+        opts=pulumi.ResourceOptions(parent=role),
     )
 
 
@@ -187,5 +187,5 @@ def _queue_send_policy(queue: aws.sqs.Queue, role: aws.iam.Role) -> None:
                 }
             )
         ),
-        opts=pulumi.ResourceOptions(parent=queue),
+        opts=pulumi.ResourceOptions(parent=role),
     )

--- a/pulumi/infra/swarm.py
+++ b/pulumi/infra/swarm.py
@@ -143,7 +143,7 @@ class Swarm(pulumi.ComponentResource):
             role=self.role, policy=policies.CLOUDWATCH_AGENT_SERVER_POLICY
         )
         policies.attach_policy(role=self.role, policy=policies.SSM_POLICY)
-        policies._attach_policy_to_ship_logs_to_cloudwatch(
+        policies.attach_policy_to_ship_logs_to_cloudwatch(
             role=self.role, log_group=self.log_group, opts=child_opts
         )
 


### PR DESCRIPTION
You can only have so many IAM policies attached to any given role, which is now causing issues due to how we have been modeling our policies in a relatively granular way. Basically, we have too many policies to attach, and we're exceeding the limit.

Inline policies, using `RolePolicy`, don't have a numerical limit, which makes them a bit more flexible for our purposes. They do have overall size limits, though, which calls for a bit of rethinking. The main change made here in that regard is to grant permissions on multiple DynamoDB tables in a single policy, as opposed to a policy per table as we had been doing before. This gives us the most savings in the case of the node identifier service, which needs access to nine tables.