### PR TITLE
Add route tables to Pulumi network subnets. Still doesn't work, but it's an improvement

### DIFF
--- a/pulumi/infra/network.py
+++ b/pulumi/infra/network.py
@@ -182,7 +182,7 @@ class Network(pulumi.ComponentResource):
                 tags={"Name": name},
                 opts=pulumi.ResourceOptions(parent=subnet),
             )
-    
+
             aws.ec2.RouteTableAssociation(
                 f"assoc-{subnet._name}",
                 subnet_id=subnet.id,

--- a/pulumi/infra/network.py
+++ b/pulumi/infra/network.py
@@ -115,6 +115,9 @@ class Network(pulumi.ComponentResource):
         self.internet_gateway = aws.ec2.InternetGateway(
             f"{name}-internet-gateway",
             vpc_id=self.vpc.id,
+            tags={
+                "Name": f"{DEPLOYMENT_NAME}-internet-gateway",
+            },
             opts=pulumi.ResourceOptions(parent=self),
         )
 
@@ -135,9 +138,56 @@ class Network(pulumi.ComponentResource):
             # This is id instead of allocation_id because of a bug
             # https://github.com/pulumi/pulumi-aws/issues/498
             allocation_id=self.eip.id,
+            tags={
+                "Name": f"{DEPLOYMENT_NAME}-nat-gateway",
+            },
             opts=pulumi.ResourceOptions(
                 parent=self, depends_on=[self.internet_gateway]
             ),
         )
+
+        for subnet in self.public_subnets:
+            name = f"route-for-{subnet._name}"
+            route_table = aws.ec2.RouteTable(
+                name,
+                vpc_id=self.vpc.id,
+                routes=[
+                    aws.ec2.RouteTableRouteArgs(
+                        cidr_block="0.0.0.0/0",
+                        gateway_id=self.internet_gateway.id,
+                    )
+                ],
+                tags={"Name": name},
+                opts=pulumi.ResourceOptions(parent=subnet),
+            )
+
+            aws.ec2.RouteTableAssociation(
+                f"assoc-{subnet._name}",
+                subnet_id=subnet.id,
+                route_table_id=route_table.id,
+                opts=pulumi.ResourceOptions(parent=subnet),
+            )
+
+        for subnet in self.private_subnets:
+            name = f"route-for-{subnet._name}"
+            route_table = aws.ec2.RouteTable(
+                name,
+                vpc_id=self.vpc.id,
+                routes=[
+                    aws.ec2.RouteTableRouteArgs(
+                        cidr_block="0.0.0.0/0",
+                        nat_gateway_id=self.nat_gateway.id,
+                    )
+                ],
+                tags={"Name": name},
+                opts=pulumi.ResourceOptions(parent=subnet),
+            )
+    
+            aws.ec2.RouteTableAssociation(
+                f"assoc-{subnet._name}",
+                subnet_id=subnet.id,
+                route_table_id=route_table.id,
+                opts=pulumi.ResourceOptions(parent=subnet),
+            )
 
         self.register_outputs({})


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/441

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Associate each subnet with a route table.
SSM still doesn't work, but this looks closer to correct than it was previously.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
pulumi up

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
