### PR TITLE
Don't bother saving RolePolicy instances as attributes

### DIFF
--- a/pulumi/infra/fargate_service.py
+++ b/pulumi/infra/fargate_service.py
@@ -136,7 +136,7 @@ class _AWSFargateService(pulumi.ComponentResource):
             opts=pulumi.ResourceOptions(parent=self),
         )
 
-        self.execution_role_writes_logs = aws.iam.RolePolicy(
+        aws.iam.RolePolicy(
             f"{name}-write-log-events",
             role=self.execution_role.name,
             policy=self.log_group.arn.apply(

--- a/pulumi/infra/metric_forwarder.py
+++ b/pulumi/infra/metric_forwarder.py
@@ -46,7 +46,7 @@ class MetricForwarder(pulumi.ComponentResource):
         )
 
         # This allows us to write our metrics to cloudwatch
-        self.cloudwatch_policy = aws.iam.RolePolicy(
+        aws.iam.RolePolicy(
             f"{name}-writes-to-cloudwatch",
             role=self.role.name,
             policy=json.dumps(


### PR DESCRIPTION
They don't need to be reused or referenced, and none of the other
RolePolicy instances are saved either.

This is just for consistency.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
