### PR TITLE
Remove s3:AbortMultipartUpload permissions

### DIFF
--- a/pulumi/infra/bucket.py
+++ b/pulumi/infra/bucket.py
@@ -196,7 +196,6 @@ class Bucket(aws.s3.Bucket):
                                     "s3:PutObjectTagging",
                                     "s3:PutObjectVersionAcl",
                                     "s3:PutObjectVersionTagging",
-                                    "s3:AbortMultipartUpload",
                                 ],
                                 "Resource": [bucket_arn, f"{bucket_arn}/*"],
                             },

--- a/pulumi/infra/emitter.py
+++ b/pulumi/infra/emitter.py
@@ -90,7 +90,6 @@ class EventEmitter(pulumi.ComponentResource):
                             {
                                 "Effect": "Allow",
                                 "Action": [
-                                    "s3:AbortMultipartUpload",
                                     "s3:DeleteObject",
                                     "s3:DeleteObjectTagging",
                                     "s3:DeleteObjectVersion",


### PR DESCRIPTION
We don't do anything with multipart uploads.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
