### PR TITLE
Remove s3:DeleteObject* permissions from EventEmitter

### DIFF
--- a/pulumi/infra/emitter.py
+++ b/pulumi/infra/emitter.py
@@ -90,10 +90,6 @@ class EventEmitter(pulumi.ComponentResource):
                             {
                                 "Effect": "Allow",
                                 "Action": [
-                                    "s3:DeleteObject",
-                                    "s3:DeleteObjectTagging",
-                                    "s3:DeleteObjectVersion",
-                                    "s3:DeleteObjectVersionTagging",
                                     "s3:PutObject",
                                     "s3:PutObjectAcl",
                                     "s3:PutObjectLegalHold",


### PR DESCRIPTION
No service that adds objects to an EventEmitter ever needs to
delete any object.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>