### PR TITLE
Bucket read/write policy doesn't need s3:GetBucket* at all

### DIFF
--- a/pulumi/infra/bucket.py
+++ b/pulumi/infra/bucket.py
@@ -151,20 +151,6 @@ class Bucket(aws.s3.Bucket):
                                 # enumerate the *specific*
                                 # actions that are needed.
                                 "Action": [
-                                    "s3:GetBucketAcl",
-                                    "s3:GetBucketCORS",
-                                    "s3:GetBucketLocation",
-                                    "s3:GetBucketLogging",
-                                    "s3:GetBucketNotification",
-                                    "s3:GetBucketObjectLockConfiguration",
-                                    "s3:GetBucketOwnershipControls",
-                                    "s3:GetBucketPolicy",
-                                    "s3:GetBucketPolicyStatus",
-                                    "s3:GetBucketPublicAccessBlock",
-                                    "s3:GetBucketRequestPayment",
-                                    "s3:GetBucketTagging",
-                                    "s3:GetBucketVersioning",
-                                    "s3:GetBucketWebsite",
                                     "s3:GetObject",
                                     "s3:GetObjectAcl",
                                     "s3:GetObjectLegalHold",


### PR DESCRIPTION
None of these GetBucket* permissions appear applicable to anything we
do.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
