### PR TITLE
EventEmitter write policy only needs s3:PutObject

### DIFF
--- a/pulumi/infra/emitter.py
+++ b/pulumi/infra/emitter.py
@@ -95,12 +95,6 @@ class EventEmitter(pulumi.ComponentResource):
                                     "s3:DeleteObjectVersion",
                                     "s3:DeleteObjectVersionTagging",
                                     "s3:PutObject",
-                                    "s3:PutObjectAcl",
-                                    "s3:PutObjectLegalHold",
-                                    "s3:PutObjectRetention",
-                                    "s3:PutObjectTagging",
-                                    "s3:PutObjectVersionAcl",
-                                    "s3:PutObjectVersionTagging",
                                 ],
                                 "Resource": f"{bucket_arn}/*",
                             }


### PR DESCRIPTION
I don't see any evidence of manipulating ACLs, tags, or anything else.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
