### PR TITLE
Switch analyzer_dispatcher permissions method

### DIFF
--- a/pulumi/infra/analyzer_dispatcher.py
+++ b/pulumi/infra/analyzer_dispatcher.py
@@ -42,7 +42,7 @@ class AnalyzerDispatcher(FargateService):
             network=network,
         )
 
-        analyzers_bucket.grant_read_permissions_to(self.default_service.task_role)
-        analyzers_bucket.grant_read_permissions_to(self.retry_service.task_role)
+        analyzers_bucket.grant_get_and_list_to(self.default_service.task_role)
+        analyzers_bucket.grant_get_and_list_to(self.retry_service.task_role)
 
         self.allow_egress_to_cache(cache)


### PR DESCRIPTION
`grant_get_and_list_to` provides the same permissions as
`grant_read_permissions_to` at the moment, but the latter will
ultimately just end up granting `s3:GetObject`. The analyzer-dispatcher
appears to legitimately need both `s3:GetObject` and `s3:ListBucket`,
however, so this change makes things more accurate and obvious.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
