### PR TITLE
Remove s3:ListBucket from Bucket#get_read_permissions_to

### DIFF
--- a/pulumi/infra/bucket.py
+++ b/pulumi/infra/bucket.py
@@ -43,8 +43,8 @@ class Bucket(aws.s3.Bucket):
             opts=opts,
         )
 
-    def grant_read_permissions_to(self, role: aws.iam.Role) -> None:
-        """ Adds the ability to read from this bucket to the provided `Role`. """
+    def grant_read_permission_to(self, role: aws.iam.Role) -> None:
+        """ Adds the ability to read objects from this bucket to the provided `Role`. """
         aws.iam.RolePolicy(
             f"{role._name}-reads-{self._name}",
             role=role.name,
@@ -57,12 +57,7 @@ class Bucket(aws.s3.Bucket):
                                 "Effect": "Allow",
                                 "Action": "s3:GetObject",
                                 "Resource": f"{bucket_arn}/*",
-                            },
-                            {
-                                "Effect": "Allow",
-                                "Action": "s3:ListBucket",
-                                "Resource": bucket_arn,
-                            },
+                            }
                         ],
                     }
                 )

--- a/pulumi/infra/dgraph_cluster.py
+++ b/pulumi/infra/dgraph_cluster.py
@@ -51,7 +51,7 @@ class DgraphCluster(pulumi.ComponentResource):
             logical_bucket_name="dgraph-config-bucket",
             opts=child_opts,
         )
-        self.dgraph_config_bucket.grant_read_permissions_to(self.swarm.role)
+        self.dgraph_config_bucket.grant_read_permission_to(self.swarm.role)
         self.dgraph_config_bucket.upload_to_bucket(DGRAPH_CONFIG_DIR)
 
         self.register_outputs({})

--- a/pulumi/infra/swarm.py
+++ b/pulumi/infra/swarm.py
@@ -145,7 +145,7 @@ class Swarm(pulumi.ComponentResource):
             logical_bucket_name="swarm-config-bucket",
             opts=child_opts,
         )
-        self.swarm_config_bucket.grant_read_permissions_to(self.role)
+        self.swarm_config_bucket.grant_read_permission_to(self.role)
         self.swarm_config_bucket.upload_to_bucket(SWARM_INIT_DIR)
 
         self.register_outputs({})

--- a/pulumi/infra/ux_router.py
+++ b/pulumi/infra/ux_router.py
@@ -46,7 +46,7 @@ class UxRouter(pulumi.ComponentResource):
             opts=pulumi.ResourceOptions(parent=self),
         )
 
-        ux_bucket.grant_read_permissions_to(self.role)
+        ux_bucket.grant_read_permission_to(self.role)
         secret.grant_read_permissions_to(self.role)
 
         self.register_outputs({})


### PR DESCRIPTION
The only remaining consumers of this function appear to only need the
ability to retrieve objects from a bucket, not list their contents.

This affects the dgraph and swarm config buckets, and the ux bucket.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>