### PR TITLE
Rework an e2e assertion to account for multiple files

### DIFF
--- a/src/python/grapl_e2e_tests/tests.py
+++ b/src/python/grapl_e2e_tests/tests.py
@@ -177,14 +177,7 @@ def check_plugin_path_has_schemas_file(
     files: List[str],
 ) -> None:
     logging.info(f"files: {files}")
-    for filename in files:
-        if "schemas.py" in filename:
-            assert True, f"Found Schemas in plugin path"
-        else:
-            logging.error(
-                "Did not find schemas.py file. Please add this file and try again, thanks!"
-            )
-            assert False, f"Did not find schemas.py file in {files}"
+    assert "schemas.py" in files, f"Did not find schemas.py file in {files}"
 
 
 def get_plugin_list(model_plugin_client: ModelPluginDeployerClient) -> None:


### PR DESCRIPTION
Originally, the directory in question only had one file. Recently, a
`BUILD` file was added, which violated the assumptions of this
particular assertion. It has now been rewritten.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>