### PR TITLE
Better waiting for disk metrics in graplctl

### DIFF
--- a/src/python/grapl-common/grapl_common/retry.py
+++ b/src/python/grapl-common/grapl_common/retry.py
@@ -1,6 +1,6 @@
 import time
 from functools import wraps
-from typing import Callable, Type, TypeVar
+from typing import Any, Callable, Type, TypeVar, cast
 
 F = TypeVar("F", bound=Callable)
 
@@ -34,7 +34,7 @@ def retry(
 
     def deco_retry(f: F) -> F:
         @wraps(f)
-        def f_retry(*args, **kwargs):
+        def f_retry(*args: Any, **kwargs: Any) -> Any:
             mtries, mdelay = tries, delay
             while mtries > 1:
                 try:
@@ -52,6 +52,6 @@ def retry(
 
             return f(*args, **kwargs)
 
-        return f_retry  # true decorator
+        return cast(F, f_retry)  # true decorator
 
     return deco_retry

--- a/src/python/grapl-tests-common/grapl_tests_common/wait.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/wait.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, Mapping, Optional, Sequence
 import botocore
 from grapl_analyzerlib.grapl_client import GraphClient
 from grapl_analyzerlib.nodes.base import BaseQuery, BaseView
-from grapl_analyzerlib.retry import retry
+from grapl_common.retry import retry
 from typing_extensions import Protocol
 
 

--- a/src/python/graplctl/graplctl/cli.py
+++ b/src/python/graplctl/graplctl/cli.py
@@ -61,7 +61,7 @@ def main(
     grapl_version: str,
     aws_profile: str,
 ) -> None:
-    session = boto3.Session(profile_name=aws_profile)
+    session = boto3.session.Session(profile_name=aws_profile)
     ctx.obj = State(
         grapl_region,
         grapl_deployment_name,

--- a/src/python/graplctl/tests/shared.py
+++ b/src/python/graplctl/tests/shared.py
@@ -54,7 +54,9 @@ class BotoSessionMock:
 @contextmanager
 def patch_boto3_session() -> Iterator[BotoSessionMock]:
     with patch.object(
-        cli.boto3.session, cli.boto3.session.Session.__name__, spec_set=cli.boto3.session.Session
+        cli.boto3.session,
+        cli.boto3.session.Session.__name__,
+        spec_set=cli.boto3.session.Session,
     ) as p_session_cls:
         session = Mock(name="Session instance")
         p_session_cls.return_value = session

--- a/src/python/graplctl/tests/shared.py
+++ b/src/python/graplctl/tests/shared.py
@@ -54,7 +54,7 @@ class BotoSessionMock:
 @contextmanager
 def patch_boto3_session() -> Iterator[BotoSessionMock]:
     with patch.object(
-        cli.boto3, cli.boto3.Session.__name__, spec_set=cli.boto3.Session
+        cli.boto3.session, cli.boto3.session.Session.__name__, spec_set=cli.boto3.session.Session
     ) as p_session_cls:
         session = Mock(name="Session instance")
         p_session_cls.return_value = session


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
There's a step where we try to create Cloudwatch alarms based off EC2 metrics.
Previously we waited a straight 5 minutes.
Now, we check for valid state every 30 seconds, up to 5 minutes.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
against aws

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
