### PR TITLE
Dgraph in Pulumi: IAM fixes so it actually deploys. + Graplctl SSM sane-ification

### DIFF
--- a/pulumi/infra/bucket.py
+++ b/pulumi/infra/bucket.py
@@ -72,6 +72,7 @@ class Bucket(aws.s3.Bucket):
         We may be able to use this for other permissions, but this was
         a specific structure ported over from our CDK code.
 
+        NOTE: For SSM RunRemoteScript commands, use buckets with this grant.
         """
         aws.iam.RolePolicy(
             f"{role._name}-get-and-list-{self._name}",

--- a/pulumi/infra/dgraph_cluster.py
+++ b/pulumi/infra/dgraph_cluster.py
@@ -51,7 +51,7 @@ class DgraphCluster(pulumi.ComponentResource):
             logical_bucket_name="dgraph-config-bucket",
             opts=child_opts,
         )
-        self.dgraph_config_bucket.grant_read_permission_to(self.swarm.role)
+        self.dgraph_config_bucket.grant_get_and_list_to(self.swarm.role)
         self.dgraph_config_bucket.upload_to_bucket(DGRAPH_CONFIG_DIR)
 
         self.register_outputs({})

--- a/pulumi/infra/swarm.py
+++ b/pulumi/infra/swarm.py
@@ -145,7 +145,7 @@ class Swarm(pulumi.ComponentResource):
             logical_bucket_name="swarm-config-bucket",
             opts=child_opts,
         )
-        self.swarm_config_bucket.grant_read_permission_to(self.role)
+        self.swarm_config_bucket.grant_get_and_list_to(self.role)
         self.swarm_config_bucket.upload_to_bucket(SWARM_INIT_DIR)
 
         self.register_outputs({})


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/441

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Graplctl now retries when it encounters InvalidPluginName; this was stolen from jgrillo's ec2 PR (and pulled out to a function).
- When we use a bucket as source for an SSM command, we need to grant different perms to it.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
make graplctl && graplctl dgraph create -t i3.large

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
