### PR TITLE
Remove circular dependency between Lambda and MetricForwarder

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -200,6 +200,7 @@ def main() -> None:
         ux_bucket=ux_bucket,
         db=dynamodb_tables,
         plugins_bucket=model_plugins_bucket,
+        forwarder=forwarder,
         dgraph_cluster=dgraph_cluster,
     )
 

--- a/pulumi/infra/api.py
+++ b/pulumi/infra/api.py
@@ -9,6 +9,7 @@ from infra.engagement_edge import EngagementEdge
 from infra.engagement_notebook import EngagementNotebook
 from infra.graphql import GraphQL
 from infra.lambda_ import Lambda
+from infra.metric_forwarder import MetricForwarder
 from infra.model_plugin_deployer import ModelPluginDeployer
 from infra.network import Network
 from infra.secret import JWTSecret
@@ -138,6 +139,7 @@ class Api(pulumi.ComponentResource):
         plugins_bucket: Bucket,
         db: DynamoDB,
         dgraph_cluster: DgraphCluster,
+        forwarder: MetricForwarder,
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
         name = "api-gateway"
@@ -202,6 +204,7 @@ class Api(pulumi.ComponentResource):
             network=network,
             secret=secret,
             ux_bucket=ux_bucket,
+            forwarder=forwarder,
         )
 
         # Sagemaker isn't currently supported in Localstack :/
@@ -223,6 +226,7 @@ class Api(pulumi.ComponentResource):
             ux_bucket=ux_bucket,
             db=db,
             notebook=self.notebook,
+            forwarder=forwarder,
             dgraph_cluster=dgraph_cluster,
             opts=pulumi.ResourceOptions(parent=self),
         )
@@ -236,6 +240,7 @@ class Api(pulumi.ComponentResource):
                 ux_bucket=ux_bucket,
                 plugins_bucket=plugins_bucket,
                 dgraph_cluster=dgraph_cluster,
+                forwarder=forwarder,
             )
 
             self.graphql_endpoint = GraphQL(
@@ -243,6 +248,7 @@ class Api(pulumi.ComponentResource):
                 secret=secret,
                 ux_bucket=ux_bucket,
                 dgraph_cluster=dgraph_cluster,
+                forwarder=forwarder,
             )
 
         self.proxies = [

--- a/pulumi/infra/engagement_edge.py
+++ b/pulumi/infra/engagement_edge.py
@@ -7,6 +7,7 @@ from infra.dgraph_cluster import DgraphCluster
 from infra.dynamodb import DynamoDB
 from infra.engagement_notebook import EngagementNotebook
 from infra.lambda_ import Lambda, LambdaExecutionRole, PythonLambdaArgs, code_path_for
+from infra.metric_forwarder import MetricForwarder
 from infra.network import Network
 from infra.secret import JWTSecret
 
@@ -22,6 +23,7 @@ class EngagementEdge(pulumi.ComponentResource):
         ux_bucket: Bucket,
         db: DynamoDB,
         dgraph_cluster: DgraphCluster,
+        forwarder: MetricForwarder,
         # This is optional ONLY because Localstack doesn't support
         # sagemaker :(
         notebook: Optional[EngagementNotebook] = None,
@@ -59,9 +61,10 @@ class EngagementEdge(pulumi.ComponentResource):
                 execution_role=self.role,
             ),
             network=network,
-            # TODO: Forwarder????
             opts=pulumi.ResourceOptions(parent=self),
         )
+
+        forwarder.subscribe_to_log_group(name, self.function.log_group)
 
         # TODO: Original infrastructure code allowed access to DGraph,
         # but it's not clear this is even necessary.

--- a/pulumi/infra/graphql.py
+++ b/pulumi/infra/graphql.py
@@ -19,7 +19,7 @@ class GraphQL(pulumi.ComponentResource):
         ux_bucket: Bucket,
         network: Network,
         dgraph_cluster: DgraphCluster,
-        forwarder: Optional[MetricForwarder] = None,
+        forwarder: MetricForwarder,
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
 
@@ -56,9 +56,10 @@ class GraphQL(pulumi.ComponentResource):
                 memory_size=128,
             ),
             network=network,
-            forwarder=forwarder,
             opts=pulumi.ResourceOptions(parent=self),
         )
+
+        forwarder.subscribe_to_log_group(name, self.function.log_group)
 
         secret.grant_read_permissions_to(self.role)
         dgraph_cluster.allow_connections_from(self.function.security_group)

--- a/pulumi/infra/lambda_.py
+++ b/pulumi/infra/lambda_.py
@@ -10,7 +10,6 @@ from infra.config import (
     LOCAL_GRAPL,
     SERVICE_LOG_RETENTION_DAYS,
 )
-from infra.metric_forwarder import MetricForwarder
 from infra.network import Network
 from typing_extensions import Literal
 
@@ -127,7 +126,6 @@ class Lambda(pulumi.ComponentResource):
         name: str,
         args: LambdaArgs,
         network: Network,
-        forwarder: Optional[MetricForwarder] = None,
         override_name: Optional[str] = None,
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
@@ -188,8 +186,5 @@ class Lambda(pulumi.ComponentResource):
             retention_in_days=SERVICE_LOG_RETENTION_DAYS,
             opts=pulumi.ResourceOptions(parent=self),
         )
-
-        if forwarder:
-            forwarder.subscribe_to_log_group(name, self.log_group)
 
         self.register_outputs({})

--- a/pulumi/infra/metric_forwarder.py
+++ b/pulumi/infra/metric_forwarder.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import pulumi_aws as aws
 from infra.config import GLOBAL_LAMBDA_ZIP_TAG, configurable_envvars
+from infra.lambda_ import Lambda, LambdaArgs, LambdaExecutionRole, code_path_for
 from infra.network import Network
 
 import pulumi
@@ -14,10 +15,6 @@ class MetricForwarder(pulumi.ComponentResource):
     ) -> None:
         name = "metric-forwarder"
         super().__init__("grapl:MetricForwarder", name, None, opts)
-
-        # Importing here avoids circular import hell between
-        # MetricForwarder and Lambda
-        from infra.lambda_ import Lambda, LambdaArgs, LambdaExecutionRole, code_path_for
 
         self.role = LambdaExecutionRole(
             name,

--- a/pulumi/infra/model_plugin_deployer.py
+++ b/pulumi/infra/model_plugin_deployer.py
@@ -22,7 +22,7 @@ class ModelPluginDeployer(pulumi.ComponentResource):
         ux_bucket: Bucket,
         plugins_bucket: Bucket,
         dgraph_cluster: DgraphCluster,
-        forwarder: Optional[MetricForwarder] = None,
+        forwarder: MetricForwarder,
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
 
@@ -54,9 +54,10 @@ class ModelPluginDeployer(pulumi.ComponentResource):
                 memory_size=256,
             ),
             network=network,
-            forwarder=forwarder,
             opts=pulumi.ResourceOptions(parent=self),
         )
+
+        forwarder.subscribe_to_log_group(name, self.function.log_group)
 
         secret.grant_read_permissions_to(self.role)
 

--- a/pulumi/infra/queue_driven_lambda.py
+++ b/pulumi/infra/queue_driven_lambda.py
@@ -18,7 +18,7 @@ class QueueDrivenLambda(pulumi.ComponentResource):
         queue: aws.sqs.Queue,
         args: LambdaArgs,
         network: Network,
-        forwarder: Optional[MetricForwarder] = None,
+        forwarder: MetricForwarder,
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
 
@@ -28,9 +28,10 @@ class QueueDrivenLambda(pulumi.ComponentResource):
             name,
             args=args,
             network=network,
-            forwarder=forwarder,
             opts=pulumi.ResourceOptions(parent=self),
         )
+
+        forwarder.subscribe_to_log_group(name, self.function.log_group)
 
         queue_policy.consumption_policy(queue, args.execution_role)
 

--- a/pulumi/infra/ux_router.py
+++ b/pulumi/infra/ux_router.py
@@ -16,7 +16,7 @@ class UxRouter(pulumi.ComponentResource):
         network: Network,
         secret: JWTSecret,
         ux_bucket: Bucket,
-        forwarder: Optional[MetricForwarder] = None,
+        forwarder: MetricForwarder,
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
 
@@ -42,9 +42,10 @@ class UxRouter(pulumi.ComponentResource):
             # TODO: I don't think we need a network, because I don't
             # think this needs access to anything in the VPC itself.
             network=network,
-            forwarder=forwarder,
             opts=pulumi.ResourceOptions(parent=self),
         )
+
+        forwarder.subscribe_to_log_group(name, self.function.log_group)
 
         ux_bucket.grant_read_permission_to(self.role)
         secret.grant_read_permissions_to(self.role)


### PR DESCRIPTION
Also removes the optionality of `MetricForwarder` everywhere, since
that was really an artifact of the process of getting things migrated
to Pulumi.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>