### PR TITLE
Use 443 outbound by default on all Lambda Services, Fargate Services

### DIFF
--- a/pulumi/infra/analyzer_dispatcher.py
+++ b/pulumi/infra/analyzer_dispatcher.py
@@ -39,7 +39,7 @@ class AnalyzerDispatcher(FargateService):
             network=network,
         )
 
-        analyzers_bucket.grant_get_and_list_to(self.default_service.task_role)
-        analyzers_bucket.grant_get_and_list_to(self.retry_service.task_role)
+        for svc in self.services:
+            analyzers_bucket.grant_get_and_list_to(svc.task_role)
 
         self.allow_egress_to_cache(cache)

--- a/pulumi/infra/analyzer_executor.py
+++ b/pulumi/infra/analyzer_executor.py
@@ -49,14 +49,11 @@ class AnalyzerExecutor(FargateService):
             network=network,
         )
 
-        dgraph_cluster.allow_connections_from(self.default_service.security_group)
-        dgraph_cluster.allow_connections_from(self.retry_service.security_group)
-
-        # TODO: These permissions are not granted to the retry
-        # service; that appears to be a bug
-        analyzers_bucket.grant_get_and_list_to(self.default_service.task_role)
-        model_plugins_bucket.grant_get_and_list_to(self.default_service.task_role)
-        output_emitter.grant_read_to(self.default_service.task_role)
+        for svc in self.services:
+            dgraph_cluster.allow_connections_from(svc.security_group)
+            analyzers_bucket.grant_get_and_list_to(svc.task_role)
+            model_plugins_bucket.grant_get_and_list_to(svc.task_role)
+            output_emitter.grant_read_to(svc.task_role)
 
         # TODO: CDK doesn't actually have this for some reason
         self.allow_egress_to_cache(cache)

--- a/pulumi/infra/ec2.py
+++ b/pulumi/infra/ec2.py
@@ -40,7 +40,7 @@ class Ec2Port:
 
     def allow_outbound_any_ip(self, sg: aws.ec2.SecurityGroup) -> None:
         aws.ec2.SecurityGroupRule(
-            f"outbound-any-ip-egress-{self}",
+            f"outbound-any-ip-egress-{self}-to-{sg._name}",
             type="egress",
             security_group_id=sg.id,
             from_port=self.port,

--- a/pulumi/infra/ec2.py
+++ b/pulumi/infra/ec2.py
@@ -51,4 +51,4 @@ class Ec2Port:
         )
 
     def __str__(self) -> str:
-        return f"Ec2Port({self.protocol}:{self.port})"
+        return f"{self.protocol}:{self.port}"

--- a/pulumi/infra/fargate_service.py
+++ b/pulumi/infra/fargate_service.py
@@ -1,5 +1,5 @@
 import json
-from typing import Iterator, Mapping, Optional, Sequence, Tuple, Union
+from typing import Mapping, Optional, Sequence, Tuple, Union
 
 import pulumi_aws as aws
 import pulumi_docker as docker

--- a/pulumi/infra/node_identifier.py
+++ b/pulumi/infra/node_identifier.py
@@ -57,25 +57,22 @@ class NodeIdentifier(FargateService):
             network=network,
         )
 
-        # Note that these permissions are only granted to the
-        # default service's task role, *not* the retry service.
-        # (This is probably a mistake).
-        #
         # Also, these are the same tables that were passed to the
         # service via environment variables above.
-        dynamodb.grant_read_write_on_tables(
-            self.default_service.task_role,
-            [
-                db.static_mapping_table,
-                db.dynamic_session_table,
-                db.process_history_table,
-                db.file_history_table,
-                db.inbound_connection_history_table,
-                db.outbound_connection_history_table,
-                db.network_connection_history_table,
-                db.ip_connection_history_table,
-                db.asset_id_mappings,
-            ],
-        )
+        for svc in self.services:
+            dynamodb.grant_read_write_on_tables(
+                svc.task_role,
+                [
+                    db.static_mapping_table,
+                    db.dynamic_session_table,
+                    db.process_history_table,
+                    db.file_history_table,
+                    db.inbound_connection_history_table,
+                    db.outbound_connection_history_table,
+                    db.network_connection_history_table,
+                    db.ip_connection_history_table,
+                    db.asset_id_mappings,
+                ],
+            )
 
         self.allow_egress_to_cache(cache)

--- a/pulumi/infra/service.py
+++ b/pulumi/infra/service.py
@@ -1,5 +1,4 @@
 import dataclasses
-from abc import ABC
 from typing import Mapping, Optional, Sequence, Union
 
 from infra.ec2 import Ec2Port
@@ -12,7 +11,7 @@ from infra.service_queue import ServiceQueue
 import pulumi
 
 
-class Service(pulumi.ComponentResource, ABC):
+class Service(pulumi.ComponentResource):
     def __init__(
         self,
         name: str,


### PR DESCRIPTION

<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
none, general pulumi infra

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
443 outbound is enabled by default for lambda and fargate services.
also, I fixed a few "oh this is enabled for Default but not Retry" bugs.

### How were these changes tested?
pulumi up --preview

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
