### PR TITLE
Added `quiet_docker_build_output` to pulumi

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -19,7 +19,7 @@ from infra.network import Network
 from infra.node_identifier import NodeIdentifier
 from infra.osquery_generator import OSQueryGenerator
 from infra.provision_lambda import Provisioner
-from infra.quiet_docker_build_spam import quiet_docker_output
+from infra.quiet_docker_build_output import quiet_docker_output
 from infra.secret import JWTSecret
 from infra.sysmon_generator import SysmonGenerator
 

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -19,6 +19,7 @@ from infra.network import Network
 from infra.node_identifier import NodeIdentifier
 from infra.osquery_generator import OSQueryGenerator
 from infra.provision_lambda import Provisioner
+from infra.quiet_docker_build_spam import quiet_docker_output
 from infra.secret import JWTSecret
 from infra.sysmon_generator import SysmonGenerator
 
@@ -41,6 +42,8 @@ def main() -> None:
         # Local Grapl, though.
         if not os.getenv("DOCKER_BUILDKIT"):
             raise KeyError("Please re-run with 'DOCKER_BUILDKIT=1'")
+
+    quiet_docker_output()
 
     # These tags will be added to all provisioned infrastructure
     # objects.

--- a/pulumi/infra/quiet_docker_build_output.py
+++ b/pulumi/infra/quiet_docker_build_output.py
@@ -15,8 +15,8 @@ import pulumi
 def quiet_docker_output() -> None:
     """
     Replace `pulumi.log.warn` with a function that quiets any `msg`
-    called from the module `pulumi_docker.docker`.
-    Disable behavior with QUIET_DOCKER_OUTPUT=0
+    called from the module `pulumi_docker`.
+    Disable behavior with VERBOSE_DOCKER_OUTPUT=1
     """
     skip_quiet = os.getenv("VERBOSE_DOCKER_OUTPUT", default=0)
     if skip_quiet:

--- a/pulumi/infra/quiet_docker_build_output.py
+++ b/pulumi/infra/quiet_docker_build_output.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 import inspect
 import os
-from typing import Any, List, Optional
-from unittest.mock import call, patch
+from typing import List, Optional
+from unittest.mock import patch
 
 import pulumi
 

--- a/pulumi/infra/quiet_docker_build_spam.py
+++ b/pulumi/infra/quiet_docker_build_spam.py
@@ -1,0 +1,53 @@
+"""
+Once `docker buildx build` truly supports a `--quiet`, we can remove all this.
+https://github.com/docker/buildx/issues/621
+"""
+from __future__ import annotations
+
+import inspect
+import os
+from typing import Any, List, Optional
+from unittest.mock import call, patch
+
+import pulumi
+
+
+def quiet_docker_output() -> None:
+    """
+    Replace `pulumi.log.warn` with a function that quiets any `msg`
+    called from the module `pulumi_docker.docker`.
+    Disable behavior with QUIET_DOCKER_OUTPUT=0
+    """
+    should_quiet = os.getenv("QUIET_DOCKER_OUTPUT", default=1)
+    if not should_quiet:
+        return
+
+    original_warn = pulumi.log.warn
+
+    def replacement_warn(
+        msg: str,
+        resource: Optional[pulumi.Resource] = None,
+        stream_id: Optional[int] = None,
+        ephemeral: Optional[bool] = None,
+    ) -> None:
+        # Same method signature as original_warn
+        callers = first_n_callers_in_stack(n=6)
+        if any(c == "pulumi_docker.docker" for c in callers):
+            msg = "<redacted Docker spew from `quiet_docker_output`>"
+        original_warn(
+            msg=msg, resource=resource, stream_id=stream_id, ephemeral=ephemeral
+        )
+
+    patcher = patch.object(pulumi.log, pulumi.log.warn.__name__).start()
+    patcher.side_effect = replacement_warn
+
+
+def first_n_callers_in_stack(n: int) -> List[str]:
+    """
+    Get the names of the modules in the current stack call context
+    """
+    caller_stacks = [inspect.stack()[i] for i in range(1, n)]
+    caller_module_names = [
+        inspect.getmodule(stack[0]).__name__ for stack in caller_stacks
+    ]
+    return caller_module_names


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None of ours, but necessary due to the lack of quiet in buildx: https://github.com/docker/buildx/issues/621

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Monkeypatch the pulumi logging system to throw away warnings from `pulumi_docker` modules.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
![image](https://user-images.githubusercontent.com/69007229/121727792-3c96e700-caa1-11eb-9532-dff5563760a3.png)


<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
