### PR TITLE
Fix AWS's `analyzer-executor` by unrequiring `command` and removing SQS health check

### DIFF
--- a/pulumi/infra/analyzer_executor.py
+++ b/pulumi/infra/analyzer_executor.py
@@ -28,7 +28,6 @@ class AnalyzerExecutor(FargateService):
                 target="analyzer-executor-deploy",
                 context="../src",
             ),
-            command="/analyzer-executor",
             env={
                 **configurable_envvars("analyzer-executor", ["GRAPL_LOG_LEVEL"]),
                 "ANALYZER_MATCH_BUCKET": analyzers_bucket.bucket,
@@ -55,5 +54,4 @@ class AnalyzerExecutor(FargateService):
             model_plugins_bucket.grant_get_and_list_to(svc.task_role)
             output_emitter.grant_read_to(svc.task_role)
 
-        # TODO: CDK doesn't actually have this for some reason
         self.allow_egress_to_cache(cache)

--- a/pulumi/infra/fargate_service.py
+++ b/pulumi/infra/fargate_service.py
@@ -100,11 +100,14 @@ class _AWSFargateService(pulumi.ComponentResource):
         output_emitter: EventEmitter,
         network: Network,
         image: pulumi.Output[str],
-        command: str,
+        command: Optional[str],
         env: Mapping[str, Union[str, pulumi.Output[str]]],
         forwarder: MetricForwarder,
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
+        """
+        :param command: supply an override to the CMD defined in the Dockerfile.
+        """
 
         super().__init__("grapl:AWSFargateService", name, None, opts)
 
@@ -207,7 +210,6 @@ class _AWSFargateService(pulumi.ComponentResource):
                             # are named this. Perhaps due to CDK's
                             # QueueProcessingFargateService abstraction?
                             "name": "QueueProcessingContainer",
-                            "command": [command],
                             "image": inputs["image"],
                             "environment": _environment_from_map(
                                 {
@@ -228,6 +230,7 @@ class _AWSFargateService(pulumi.ComponentResource):
                                     "awslogs-group": inputs["log_group"],
                                 },
                             },
+                            **({"command": [command]} if command else {}),
                         },
                     ]
                 )
@@ -277,9 +280,9 @@ class FargateService(pulumi.ComponentResource):
         output_emitter: EventEmitter,
         network: Network,
         image: docker.DockerBuild,
-        command: str,
         env: Mapping[str, Union[str, pulumi.Output[str]]],
         forwarder: MetricForwarder,
+        command: Optional[str] = None,
         retry_image: Optional[docker.DockerBuild] = None,
         retry_command: Optional[str] = None,
         opts: Optional[pulumi.ResourceOptions] = None,

--- a/pulumi/infra/lambda_.py
+++ b/pulumi/infra/lambda_.py
@@ -182,9 +182,9 @@ class Lambda(pulumi.ComponentResource):
         # specify retention rules.
         self.log_group = aws.cloudwatch.LogGroup(
             f"{name}-log-group",
-            # Don't change - or rather, if you decide to, 
+            # Don't change - or rather, if you decide to,
             # follow these instructions:
-             #https://www.pulumi.com/docs/reference/pkg/aws/lambda/function/#cloudwatch-logging-and-permissions 
+            # https://www.pulumi.com/docs/reference/pkg/aws/lambda/function/#cloudwatch-logging-and-permissions
             name=f"/aws/lambda/{lambda_name}",
             retention_in_days=SERVICE_LOG_RETENTION_DAYS,
             opts=pulumi.ResourceOptions(parent=self),

--- a/pulumi/infra/lambda_.py
+++ b/pulumi/infra/lambda_.py
@@ -178,10 +178,13 @@ class Lambda(pulumi.ComponentResource):
             )
 
         # Lambda function output is automatically sent to log
-        # groups named like this; we create one explicitly so we can
+        # groups named like this; we denote this one explicitly so we can
         # specify retention rules.
         self.log_group = aws.cloudwatch.LogGroup(
             f"{name}-log-group",
+            # Don't change - or rather, if you decide to, 
+            # follow these instructions:
+             #https://www.pulumi.com/docs/reference/pkg/aws/lambda/function/#cloudwatch-logging-and-permissions 
             name=f"/aws/lambda/{lambda_name}",
             retention_in_days=SERVICE_LOG_RETENTION_DAYS,
             opts=pulumi.ResourceOptions(parent=self),


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/576

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Two things were broken with analyzer executor.
- `command` was wrong; just use the one defined in the dockerfile.
- there were permission issues with the SQS health check - that should not be needed anymore now that we have `depends_on` in docker-compose

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->
I got data all the way up to `engagement-creator` :) 

### How were these changes tested?
against aws in my sandbox + looking at logs and dashboards
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
