### PR TITLE
Adding missing GRAPL_SCHEMA_PROPERTIES_TABLE env var to graphql lambda.

### DIFF
--- a/pulumi/infra/graphql.py
+++ b/pulumi/infra/graphql.py
@@ -55,6 +55,7 @@ class GraphQL(pulumi.ComponentResource):
                     "UX_BUCKET_URL": pulumi.Output.concat(
                         "https://", ux_bucket.bucket_regional_domain_name
                     ),
+                    "GRAPL_SCHEMA_PROPERTIES_TABLE": db.schema_properties_table.name,
                 },
                 timeout=30,
                 memory_size=128,


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/578

### What changes does this PR make to Grapl? Why?

This sets GRAPL_SCHEMA_PROPERTIES_TABLE for the GraphQL Endpoint lambda, which is needed.

### How were these changes tested?

I updated a deployment with these changes and eye-balled the env var in the Lambda console was set with appropriate value. I was unable to use pulumi to update the deployment where https://github.com/grapl-security/issue-tracker/issues/578 was originally found, but I verified a similar fix applied manually resolved the issue.