### PR TITLE
Graplctl has some idempotency checks, and prevents uploading to un-provisioned grapl

### DIFF
--- a/src/python/graphql_endpoint_tests/test_schema_dynamodb.py
+++ b/src/python/graphql_endpoint_tests/test_schema_dynamodb.py
@@ -13,6 +13,7 @@ from grapl_analyzerlib.node_types import PropPrimitive
 from grapl_analyzerlib.provision import provision_common
 from grapl_common.env_helpers import DynamoDBResourceFactory
 from grapl_common.grapl_logger import get_module_grapl_logger
+from grapl_common.resources import known_dynamodb_tables
 
 LOGGER = get_module_grapl_logger()
 
@@ -23,8 +24,8 @@ class TestSchemaStoredInDynamodb(TestCase):
         self,
     ) -> None:
         resource = DynamoDBResourceFactory(boto3).from_env()
-        schema_props_table = resource.Table(
-            f"{os.environ['DEPLOYMENT_NAME']}-grapl_schema_properties_table"
+        schema_props_table = known_dynamodb_tables.schema_properties_table(
+            dynamodb=resource
         )
 
         asset_type = cast(

--- a/src/python/graphql_endpoint_tests/test_schema_dynamodb.py
+++ b/src/python/graphql_endpoint_tests/test_schema_dynamodb.py
@@ -3,7 +3,6 @@ Schema generation happens at the provision stage, which doesn't really have an
 associated test suite yet. So, for the time being, just gonna shoehorn it
 into graphql endpoint tests (which are *consumers* of the dynamodb node schemas)
 """
-import os
 from typing import cast
 from unittest import TestCase
 

--- a/src/python/grapl-common/grapl_common/resources/BUILD
+++ b/src/python/grapl-common/grapl_common/resources/BUILD
@@ -1,0 +1,1 @@
+python_library()

--- a/src/python/grapl-common/grapl_common/resources/known_dynamodb_tables.py
+++ b/src/python/grapl-common/grapl_common/resources/known_dynamodb_tables.py
@@ -4,26 +4,41 @@ some instances (especially graplctl) still need the old string-formatting way.
 """
 
 from __future__ import annotations
-import os
-from typing import Optional, TYPE_CHECKING
 
+import os
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
-    from mypy_boto3_dynamodb.service_resource import Table
     from mypy_boto3_dynamodb import DynamoDBServiceResource
+    from mypy_boto3_dynamodb.service_resource import Table
 
-def _get_table(dynamodb: DynamoDBServiceResource,
+
+def _get_table(
+    dynamodb: DynamoDBServiceResource,
     suffix: str,
-    deployment_name: Optional[str] = None
+    deployment_name: Optional[str] = None,
 ) -> Table:
-    deployment_name = deployment_name or os.environ['DEPLOYMENT_NAME']
+    deployment_name = deployment_name or os.environ["DEPLOYMENT_NAME"]
     return dynamodb.Table(f"{deployment_name}{suffix}")
 
-def schema_table(dynamodb: DynamoDBServiceResource, deployment_name: Optional[str] = None) -> Table:
+
+def schema_table(
+    dynamodb: DynamoDBServiceResource, deployment_name: Optional[str] = None
+) -> Table:
     return _get_table(dynamodb, "-grapl_schema_table", deployment_name=deployment_name)
 
-def schema_properties_table(dynamodb: DynamoDBServiceResource, deployment_name: Optional[str] = None) -> Table:
-    return _get_table(dynamodb, "-grapl_schema_properties_table", deployment_name=deployment_name)
 
-def session_table(dynamodb: DynamoDBServiceResource, deployment_name: Optional[str] = None) -> Table:
-    return _get_table(dynamodb, "-dynamic_session_table", deployment_name=deployment_name)
+def schema_properties_table(
+    dynamodb: DynamoDBServiceResource, deployment_name: Optional[str] = None
+) -> Table:
+    return _get_table(
+        dynamodb, "-grapl_schema_properties_table", deployment_name=deployment_name
+    )
+
+
+def session_table(
+    dynamodb: DynamoDBServiceResource, deployment_name: Optional[str] = None
+) -> Table:
+    return _get_table(
+        dynamodb, "-dynamic_session_table", deployment_name=deployment_name
+    )

--- a/src/python/grapl-common/grapl_common/resources/known_dynamodb_tables.py
+++ b/src/python/grapl-common/grapl_common/resources/known_dynamodb_tables.py
@@ -1,0 +1,29 @@
+"""
+In general, we'll want to depend on table names injected with `os.environ`; but
+some instances (especially graplctl) still need the old string-formatting way.
+"""
+
+from __future__ import annotations
+import os
+from typing import Optional, TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from mypy_boto3_dynamodb.service_resource import Table
+    from mypy_boto3_dynamodb import DynamoDBServiceResource
+
+def _get_table(dynamodb: DynamoDBServiceResource,
+    suffix: str,
+    deployment_name: Optional[str] = None
+) -> Table:
+    deployment_name = deployment_name or os.environ['DEPLOYMENT_NAME']
+    return dynamodb.Table(f"{deployment_name}{suffix}")
+
+def schema_table(dynamodb: DynamoDBServiceResource, deployment_name: Optional[str] = None) -> Table:
+    return _get_table(dynamodb, "-grapl_schema_table", deployment_name=deployment_name)
+
+def schema_properties_table(dynamodb: DynamoDBServiceResource, deployment_name: Optional[str] = None) -> Table:
+    return _get_table(dynamodb, "-grapl_schema_properties_table", deployment_name=deployment_name)
+
+def session_table(dynamodb: DynamoDBServiceResource, deployment_name: Optional[str] = None) -> Table:
+    return _get_table(dynamodb, "-dynamic_session_table", deployment_name=deployment_name)

--- a/src/python/grapl-tests-common/grapl_tests_common/dump_dynamodb.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/dump_dynamodb.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from pprint import pformat as pretty_format
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 import boto3
 from grapl_common.env_helpers import DynamoDBResourceFactory
 
 if TYPE_CHECKING:
-    from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource
+    from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource, Table
 
 DOCKER_VOLUME = Path("/mnt/dynamodb_dump")
 
@@ -31,12 +31,12 @@ def dump_dynamodb() -> None:
             f.write(table_dump)
 
 
-def _dump_dynamodb_table(table: Any) -> Optional[str]:
+def _dump_dynamodb_table(table: Table) -> Optional[str]:
     """
     Outputs a nicely-formatted Python list of all the items in the table.
     (you may need a `from decimal import Decimal` to interact with it, though.)
     """
-    if not table.item_count:
-        return None
     items = table.scan()["Items"]
+    if not items:
+        return None
     return pretty_format(items)

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/provision/provision_common.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/provision/provision_common.py
@@ -18,7 +18,6 @@ from grapl_analyzerlib.nodes.base import BaseSchema
 import pydgraph
 
 if TYPE_CHECKING:
-    from mypy_boto3_dynamodb import DynamoDBServiceResource
     from mypy_boto3_dynamodb.service_resource import Table
 
 

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/provision/provision_common.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/provision/provision_common.py
@@ -10,6 +10,7 @@ from grapl_analyzerlib.node_types import PropType
 from grapl_analyzerlib.provision.meta_into import meta_into_predicate
 from grapl_analyzerlib.provision.queries import query_dgraph_type
 
+from grapl_common.resources import known_dynamodb_tables
 from grapl_common.grapl_logger import get_module_grapl_logger
 from grapl_analyzerlib.grapl_client import GraphClient
 from grapl_analyzerlib.schema import Schema
@@ -42,16 +43,9 @@ SchemaPropertyDict = Dict[str, Any]
 SchemaDict = Dict[str, Any]
 
 
-def get_schema_table(dynamodb: DynamoDBServiceResource, deployment_name: str) -> Table:
-    table = dynamodb.Table(f"{deployment_name}-grapl_schema_table")
-    return table
-
-
-def get_schema_properties_table(
-    dynamodb: DynamoDBServiceResource, deployment_name: str
-) -> Table:
-    table = dynamodb.Table(f"{deployment_name}-grapl_schema_properties_table")
-    return table
+# just some aliases
+get_schema_table = known_dynamodb_tables.schema_table
+get_schema_properties_table = known_dynamodb_tables.schema_properties_table
 
 
 def store_schema_properties(table: Table, schema: Schema) -> None:

--- a/src/python/graplctl/graplctl/aws/commands.py
+++ b/src/python/graplctl/graplctl/aws/commands.py
@@ -27,6 +27,7 @@ def aws(
 @pass_graplctl_state
 def provision(graplctl_state: State) -> None:
     """provision the grapl deployment"""
+    # TODO: Add a check that dgraph has been created
     assert not idempotency_checks.is_grapl_provisioned(
         dynamodb=graplctl_state.dynamodb,
         deployment_name=graplctl_state.grapl_deployment_name,

--- a/src/python/graplctl/graplctl/aws/lib.py
+++ b/src/python/graplctl/graplctl/aws/lib.py
@@ -1,20 +1,14 @@
 import base64
-import logging
-import os
-import sys
 from typing import cast
 
 from botocore.response import StreamingBody
+from grapl_common.grapl_logger import get_module_grapl_logger
+from grapl_common.resources import known_dynamodb_tables
 from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource, Table
 from mypy_boto3_lambda import LambdaClient
 from mypy_boto3_lambda.type_defs import InvocationResponseTypeDef
 
-LOGGER = logging.getLogger(__name__)
-LOGGER.setLevel(os.getenv("GRAPL_LOG_LEVEL", "INFO"))
-LOGGER.addHandler(logging.StreamHandler(stream=sys.stdout))
-
-EDGE_UX_DIRECTORY = "/edge_ux_post_replace"
-CDK_OUT_FILENAME = "cdk-output.json"
+LOGGER = get_module_grapl_logger(log_to_stdout=True)
 
 
 def _extract_invocation_response_error_payload(
@@ -91,10 +85,10 @@ def run_e2e_tests(lambda_: LambdaClient, deployment_name: str) -> None:
 
 
 def wipe_dynamodb(dynamodb: DynamoDBServiceResource, deployment_name: str) -> None:
-    session_table = dynamodb.Table(f"{deployment_name}-dynamic_session_table")
-    schema_table = dynamodb.Table(f"{deployment_name}-grapl_schema_table")
-    schema_properties_table = dynamodb.Table(
-        f"{deployment_name}-grapl_schema_properties_table"
+    session_table = known_dynamodb_tables.session_table(dynamodb, deployment_name)
+    schema_table = known_dynamodb_tables.schema_table(dynamodb, deployment_name)
+    schema_properties_table = known_dynamodb_tables.schema_properties_table(
+        dynamodb, deployment_name
     )
     for table in (session_table, schema_table, schema_properties_table):
         LOGGER.info(f"Wiping {table}")

--- a/src/python/graplctl/graplctl/common.py
+++ b/src/python/graplctl/graplctl/common.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 import dataclasses
-import logging
-import os
-import sys
 import time
 from typing import TYPE_CHECKING, Dict, Iterator, List, Tuple
 
 import click
+from grapl_common.grapl_logger import get_module_grapl_logger
 
 if TYPE_CHECKING:
     import mypy_boto3_ec2.service_resource as ec2_resources
@@ -23,9 +21,7 @@ if TYPE_CHECKING:
     from mypy_boto3_ssm.client import SSMClient
     from mypy_boto3_ssm.type_defs import GetCommandInvocationResultTypeDef
 
-LOGGER = logging.getLogger(__name__)
-LOGGER.setLevel(os.getenv("GRAPL_LOG_LEVEL", "INFO"))
-LOGGER.addHandler(logging.StreamHandler(stream=sys.stdout))
+LOGGER = get_module_grapl_logger(log_to_stdout=True)
 
 IN_PROGRESS_STATUSES = {
     "Pending",

--- a/src/python/graplctl/graplctl/idempotency_checks.py
+++ b/src/python/graplctl/graplctl/idempotency_checks.py
@@ -1,0 +1,17 @@
+from grapl_common.grapl_logger import get_module_grapl_logger
+from grapl_common.resources import known_dynamodb_tables
+from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource
+
+LOGGER = get_module_grapl_logger(log_to_stdout=True)
+
+
+def is_grapl_provisioned(
+    dynamodb: DynamoDBServiceResource,
+    deployment_name: str,
+) -> bool:
+    """
+    We are doing a very simple check - "is there >0 things in schema_properties_table?"
+    to infer whether any provisioning has taken place.
+    """
+    table = known_dynamodb_tables.schema_table(dynamodb, deployment_name)
+    return table.item_count > 0

--- a/src/python/graplctl/graplctl/idempotency_checks.py
+++ b/src/python/graplctl/graplctl/idempotency_checks.py
@@ -1,6 +1,6 @@
 from grapl_common.grapl_logger import get_module_grapl_logger
 from grapl_common.resources import known_dynamodb_tables
-from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource
+from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource, Table
 
 LOGGER = get_module_grapl_logger(log_to_stdout=True)
 
@@ -14,4 +14,15 @@ def is_grapl_provisioned(
     to infer whether any provisioning has taken place.
     """
     table = known_dynamodb_tables.schema_table(dynamodb, deployment_name)
-    return table.item_count > 0
+    return not _table_is_empty(table)
+
+
+def _table_is_empty(table: Table) -> bool:
+    """
+    fun fact: some_table.item_count? It's only updated every 6 hours.
+    you have to do a scan.
+    """
+    items = table.scan()["Items"]
+    if items:
+        return False  # Something's in there!
+    return True

--- a/src/python/graplctl/graplctl/upload/commands.py
+++ b/src/python/graplctl/graplctl/upload/commands.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import click
 from grapl_tests_common.upload_logs import upload_osquery_logs, upload_sysmon_logs
+from graplctl import idempotency_checks
 from graplctl.common import State, pass_graplctl_state
 from graplctl.upload.lib import upload_analyzer
 
@@ -19,7 +20,10 @@ def upload(
     """commands like "upload analyzer" or "upload sysmon logs" """
     # TODO: Disallow any uploads until we've confirmed we've provisioned
     # https://github.com/grapl-security/issue-tracker/issues/340
-    pass
+    assert idempotency_checks.is_grapl_provisioned(
+        dynamodb=graplctl_state.dynamodb,
+        deployment_name=graplctl_state.grapl_deployment_name,
+    ), "You can't upload anything to grapl until it's provisioned."
 
 
 @upload.command()

--- a/src/python/graplctl/tests/shared.py
+++ b/src/python/graplctl/tests/shared.py
@@ -33,9 +33,13 @@ class BotoSessionMock:
             return self.clients[service_name]
 
         self.session.client.side_effect = _memoize_client
+        self.session.resource.side_effect = _memoize_client
 
     def client(self, client_name: str) -> Mock:
         return cast(Mock, self.session.client(client_name))
+
+    def resource(self, client_name: str) -> Mock:
+        return self.client(client_name)
 
     def return_fake_queues(self) -> None:
         sqs_client = self.client("sqs")


### PR DESCRIPTION
### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/340

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Unify all the places where we do Python string-formatting to figure out dynamodb's table names (primarily, just graplctl)
- Add some "assert grapl is provisioned" or "assert grapl is not provisioned yet" checks throughout graplctl

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
make graplctl
graplctl upload sysmon --logfile ./etc/sample_data/min_eventlog.xml
(this passed my 'is-provisioned' check)

did a `graplctl aws provision`
it failed with the assertion error

did a `graplctl aws wipe-state`
succeeded

did ^ again
failed, assertion error

did sysmon upload again
failed, assertion error


<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
