### PR TITLE
mark the expected data in dgraph test as pytest.xfail

### DIFF
--- a/src/python/e2e-test-runner/e2e_test_runner/test_main.py
+++ b/src/python/e2e-test-runner/e2e_test_runner/test_main.py
@@ -29,6 +29,8 @@ class TestException(Exception):
 
 @pytest.mark.integration_test
 class TestEndToEnd(TestCase):
+
+    @pytest.mark.xfail  # TODO: remove once graphql endpoint HTTP 413 resolved
     def test_expected_data_in_dgraph(self) -> None:
         # There is some unidentified, nondeterministic failure with e2e.
         # We fall into one of three buckets:

--- a/src/python/e2e-test-runner/e2e_test_runner/test_main.py
+++ b/src/python/e2e-test-runner/e2e_test_runner/test_main.py
@@ -29,7 +29,6 @@ class TestException(Exception):
 
 @pytest.mark.integration_test
 class TestEndToEnd(TestCase):
-
     @pytest.mark.xfail  # TODO: remove once graphql endpoint HTTP 413 resolved
     def test_expected_data_in_dgraph(self) -> None:
         # There is some unidentified, nondeterministic failure with e2e.


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/576
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
marks the `test_expected_data_in_dgraph` test with `@pytest.mark.xfail` s.t. the test suite passes in AWS
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
`graplctl aws test`
logs from e2e-test-runner lambda:
```
START RequestId: 48c00858-0d12-4322-a6d2-c1f9d2a1da90 Version: $LATEST
--
============================= test session starts ==============================
platform linux -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /var/task
collected 8 items
e2e_test_runner/test_main.py [DEBUG]	2021-06-18T19:47:07.565Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	created EngagementEdgeClient for endpoint https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth
.[DEBUG]	2021-06-18T19:47:09.741Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	created EngagementEdgeClient for endpoint https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth
.[DEBUG]	2021-06-18T19:47:09.861Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	created EngagementEdgeClient for endpoint https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth
[DEBUG]	2021-06-18T19:47:09.861Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieving jwt cookie
[DEBUG]	2021-06-18T19:47:10.523Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieving jgrillo-sandbox-TestUserPassword
[DEBUG]	2021-06-18T19:47:10.685Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	logging in with user jgrillo-sandbox-grapl-test-user at https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth/login
[DEBUG]	2021-06-18T19:47:13.791Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieved jwt cookie
.[DEBUG]	2021-06-18T19:47:13.793Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	created EngagementEdgeClient for endpoint https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth
[DEBUG]	2021-06-18T19:47:13.793Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieving jwt cookie
[DEBUG]	2021-06-18T19:47:13.825Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieving jgrillo-sandbox-TestUserPassword
[DEBUG]	2021-06-18T19:47:14.005Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	logging in with user jgrillo-sandbox-grapl-test-user at https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth/login
[DEBUG]	2021-06-18T19:47:16.937Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieved jwt cookie
x[DEBUG]	2021-06-18T19:47:19.977Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	created EngagementEdgeClient for endpoint https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth
[DEBUG]	2021-06-18T19:47:19.977Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieving jwt cookie
[DEBUG]	2021-06-18T19:47:19.985Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieving jgrillo-sandbox-TestUserPassword
[DEBUG]	2021-06-18T19:47:20.167Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	logging in with user jgrillo-sandbox-grapl-test-user at https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth/login
[DEBUG]	2021-06-18T19:47:23.060Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieved jwt cookie
x[DEBUG]	2021-06-18T19:52:23.970Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	created EngagementEdgeClient for endpoint https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth
[DEBUG]	2021-06-18T19:52:23.971Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieving jwt cookie
[DEBUG]	2021-06-18T19:52:23.975Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieving jgrillo-sandbox-TestUserPassword
[DEBUG]	2021-06-18T19:52:24.151Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	logging in with user jgrillo-sandbox-grapl-test-user at https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth/login
[DEBUG]	2021-06-18T19:52:27.061Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieved jwt cookie
[DEBUG]	2021-06-18T19:52:27.061Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	created EngagementEdgeClient for endpoint https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth
.[DEBUG]	2021-06-18T19:52:27.549Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	created EngagementEdgeClient for endpoint https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth
[DEBUG]	2021-06-18T19:52:27.549Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieving jwt cookie
[DEBUG]	2021-06-18T19:52:27.569Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieving jgrillo-sandbox-TestUserPassword
[DEBUG]	2021-06-18T19:52:27.715Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	logging in with user jgrillo-sandbox-grapl-test-user at https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth/login
[DEBUG]	2021-06-18T19:52:30.742Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieved jwt cookie
x[DEBUG]	2021-06-18T19:52:31.049Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	created EngagementEdgeClient for endpoint https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth
[DEBUG]	2021-06-18T19:52:31.049Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieving jwt cookie
[DEBUG]	2021-06-18T19:52:31.090Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieving jgrillo-sandbox-TestUserPassword
[DEBUG]	2021-06-18T19:52:31.270Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	logging in with user jgrillo-sandbox-grapl-test-user at https://m4h6fr431j.execute-api.us-east-1.amazonaws.com:443/prod/auth/login
[DEBUG]	2021-06-18T19:52:34.301Z	48c00858-0d12-4322-a6d2-c1f9d2a1da90	retrieved jwt cookie
.
=============================== warnings summary ===============================
e2e_test_runner/test_main.py:30
/var/task/e2e_test_runner/test_main.py:30: PytestUnknownMarkWarning: Unknown pytest.mark.integration_test - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
@pytest.mark.integration_test
e2e_test_runner/test_main.py:26
/var/task/e2e_test_runner/test_main.py:26: PytestCollectionWarning: cannot collect test class 'TestException' because it has a __init__ constructor (from: e2e_test_runner/test_main.py)
class TestException(Exception):
.deps/pytest-6.2.4-py3-none-any.whl/_pytest/cacheprovider.py:428
/var/task/.deps/pytest-6.2.4-py3-none-any.whl/_pytest/cacheprovider.py:428: PytestCacheWarning: could not create cache path /var/task/.pytest_cache/v/cache/nodeids
config.cache.set("cache/nodeids", sorted(self.cached_nodeids))
.deps/pytest-6.2.4-py3-none-any.whl/_pytest/stepwise.py:49
/var/task/.deps/pytest-6.2.4-py3-none-any.whl/_pytest/stepwise.py:49: PytestCacheWarning: could not create cache path /var/task/.pytest_cache/v/cache/stepwise
session.config.cache.set(STEPWISE_CACHE_DIR, [])
-- Docs: https://docs.pytest.org/en/stable/warnings.html
============= 5 passed, 3 xfailed, 4 warnings in 330.92s (0:05:30) =============
END RequestId: 48c00858-0d12-4322-a6d2-c1f9d2a1da90
REPORT RequestId: 48c00858-0d12-4322-a6d2-c1f9d2a1da90	Duration: 332573.03 ms	Billed Duration: 332574 ms	Memory Size: 256 MB	Max Memory Used: 126 MB	Init Duration: 1378.72 ms
RequestId: 48c00858-0d12-4322-a6d2-c1f9d2a1da90 Error: Runtime exited without providing a reasonRuntime.ExitError


```
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
