### PR TITLE
e2e (or rather, test-with-env) exit codes seem to work now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,6 @@ test-e2e: build-test-e2e ## Build and run e2e tests
 .PHONY: test-with-env
 test-with-env: # (Do not include help text - not to be used directly)
 	stopGrapl() {
-		EXIT_CODE=$$?
 		# skip if KEEP_TEST_ENV is set
 		if [[ -z "${KEEP_TEST_ENV}" ]]; then
 			echo "Tearing down test environment"
@@ -258,7 +257,6 @@ test-with-env: # (Do not include help text - not to be used directly)
 		unset COMPOSE_FILE
 		etc/ci_scripts/dump_artifacts.py --compose-project=${COMPOSE_PROJECT_NAME}
 		docker-compose --file docker-compose.yml stop;
-		exit $$EXIT_CODE
 	}
 	# Ensure we call stop even after test failure, and return exit code from
 	# the test, not the stop command.

--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,7 @@ test-e2e: build-test-e2e ## Build and run e2e tests
 .PHONY: test-with-env
 test-with-env: # (Do not include help text - not to be used directly)
 	stopGrapl() {
+		EXIT_CODE=$$?
 		# skip if KEEP_TEST_ENV is set
 		if [[ -z "${KEEP_TEST_ENV}" ]]; then
 			echo "Tearing down test environment"
@@ -257,6 +258,7 @@ test-with-env: # (Do not include help text - not to be used directly)
 		unset COMPOSE_FILE
 		etc/ci_scripts/dump_artifacts.py --compose-project=${COMPOSE_PROJECT_NAME}
 		docker-compose --file docker-compose.yml stop;
+		exit $$EXIT_CODE
 	}
 	# Ensure we call stop even after test failure, and return exit code from
 	# the test, not the stop command.

--- a/test/docker-compose-with-error.sh
+++ b/test/docker-compose-with-error.sh
@@ -5,7 +5,7 @@
 # which services to run, instead of all of them, which is the default behavior.
 TARGETS="${TARGETS}"
 
-set -e
+set -eu
 
 usage() {
     echo "Usage: [TARGETS=\"service1 service2\"] $0" 1>&2
@@ -26,10 +26,13 @@ docker-compose up --force-recreate ${TARGETS}
 EXIT_CODE=0
 ALL_TESTS=$(docker-compose ps --quiet ${TARGETS})
 for test in $ALL_TESTS; do
-    if ! docker inspect -f "{{ .State.ExitCode }}" "${test}" | grep -q ^0; then
-        EXIT_CODE=$?
+    test_exit_code_str=$(docker inspect -f "{{ .State.ExitCode }}" "${test}")
+    test_exit_code=$(($test_exit_code_str+0))  # cast to int
+    if [[ ${test_exit_code} -ne 0 ]]; then
+        EXIT_CODE=$test_exit_code
         break
     fi
 done
 
+echo "docker-compose-with-error: exit code $EXIT_CODE"
 exit $EXIT_CODE

--- a/test/docker-compose-with-error.sh
+++ b/test/docker-compose-with-error.sh
@@ -26,8 +26,7 @@ docker-compose up --force-recreate ${TARGETS}
 EXIT_CODE=0
 ALL_TESTS=$(docker-compose ps --quiet ${TARGETS})
 for test in $ALL_TESTS; do
-    test_exit_code_str=$(docker inspect -f "{{ .State.ExitCode }}" "${test}")
-    test_exit_code=$(($test_exit_code_str + 0)) # cast to int
+    test_exit_code=$(docker inspect -f "{{ .State.ExitCode }}" "${test}")
     if [[ ${test_exit_code} -ne 0 ]]; then
         EXIT_CODE=$test_exit_code
         break

--- a/test/docker-compose-with-error.sh
+++ b/test/docker-compose-with-error.sh
@@ -27,7 +27,7 @@ EXIT_CODE=0
 ALL_TESTS=$(docker-compose ps --quiet ${TARGETS})
 for test in $ALL_TESTS; do
     test_exit_code_str=$(docker inspect -f "{{ .State.ExitCode }}" "${test}")
-    test_exit_code=$(($test_exit_code_str+0))  # cast to int
+    test_exit_code=$(($test_exit_code_str + 0)) # cast to int
     if [[ ${test_exit_code} -ne 0 ]]; then
         EXIT_CODE=$test_exit_code
         break


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
Sorta has to do with https://github.com/grapl-security/grapl/pull/934.

Jesse discovered that despite e2e failing, our CI reports success.
Heads up: I think this PR *will* fail e2e in CI; we need to land #934, #935 in some order

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- More robust propagation of exit codes from docker -> docker-compose-with-error -> makefile

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
- introduce an `exit(42)` into e2e lambda; it fails.
- undo it; it succeeds.
- this was not the case before this change.
- (also, i tested it with https://github.com/grapl-security/grapl/pull/935 )

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
