### PR TITLE
fix the graphql endpoint client

### DIFF
--- a/src/python/e2e-test-runner/e2e_test_runner/test_main.py
+++ b/src/python/e2e-test-runner/e2e_test_runner/test_main.py
@@ -23,10 +23,6 @@ LENS_NAME = "DESKTOP-FVSHABR"
 GqlLensDict = Dict[str, Any]
 
 
-class TestException(Exception):
-    pass
-
-
 @pytest.mark.integration_test
 class TestEndToEnd(TestCase):
     def test_expected_data_in_dgraph(self) -> None:

--- a/src/python/grapl-tests-common/grapl_tests_common/clients/graphql_endpoint_client.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/clients/graphql_endpoint_client.py
@@ -27,7 +27,7 @@ class GraphqlEndpointClient:
     ) -> Dict[str, Any]:
         resp = requests.post(
             f"{self.endpoint}/graphql",
-            params={"query": query, "variables": json.dumps(variables or {})},
+            json={"query": query, "variables": json.dumps(variables or {})},
             cookies={"grapl_jwt": self.jwt},
         )
         if resp.status_code != HTTPStatus.OK:

--- a/src/python/grapl-tests-common/grapl_tests_common/setup_tests.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/setup_tests.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
-import logging
 import sys
 from os import environ
-from sys import stdout
 from typing import List
 
 import pytest
 import requests
+from grapl_common.grapl_logger import get_module_grapl_logger
 from grapl_tests_common.dump_dynamodb import dump_dynamodb
 
 # Toggle if you want to dump databases, logs, etc.
 DUMP_ARTIFACTS = bool(environ.get("DUMP_ARTIFACTS", False))
 
-logging.basicConfig(stream=stdout, level=logging.INFO)
+LOGGER = get_module_grapl_logger()
 
 
 def _after_tests() -> None:
@@ -26,7 +25,7 @@ def _after_tests() -> None:
     if DUMP_ARTIFACTS:
         dgraph_host = environ["DGRAPH_HOST"]
         dgraph_alpha = environ["DGRAPH_ALPHA_HTTP_EXTERNAL_PUBLIC_PORT"]
-        logging.info("Executing post-test database dumps")
+        LOGGER.info("Executing post-test database dumps")
         export_request = requests.get(
             f"http://{dgraph_host}:{dgraph_alpha}/admin/export"
         )
@@ -35,11 +34,13 @@ def _after_tests() -> None:
 
 
 def exec_pytest() -> None:
+    LOGGER.info("running tests...")
     pytest_args: List[str] = []
     if environ.get("PYTEST_EXPRESSION"):
         pytest_args.extend(("-k", environ["PYTEST_EXPRESSION"]))
 
     result = pytest.main(["--capture=no", *pytest_args])  # disable stdout capture
+    LOGGER.info(f"tests completed with status code: {result}")
     _after_tests()
 
     sys.exit(result)


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/576
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
This PR fixes the graphql endpoint test client. Previously it was packing queries into URL parameters, now it's sending them as a request body.
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
`graplctl aws test`:

```
START RequestId: 0a8c3312-8640-408a-b763-36d3b03a32e8 Version: $LATEST
--
============================= test session starts ==============================
platform linux -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /var/task
collected 8 items
e2e_test_runner/test_main.py [DEBUG]	2021-06-21T20:10:29.625Z	0a8c3312-8640-408a-b763-36d3b03a32e8	created EngagementEdgeClient for endpoint https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth
.[DEBUG]	2021-06-21T20:10:31.770Z	0a8c3312-8640-408a-b763-36d3b03a32e8	created EngagementEdgeClient for endpoint https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth
.[DEBUG]	2021-06-21T20:10:31.904Z	0a8c3312-8640-408a-b763-36d3b03a32e8	created EngagementEdgeClient for endpoint https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth
[DEBUG]	2021-06-21T20:10:31.922Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieving jwt cookie
[DEBUG]	2021-06-21T20:10:32.563Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieving jgrillo-sandbox-TestUserPassword
[DEBUG]	2021-06-21T20:10:32.746Z	0a8c3312-8640-408a-b763-36d3b03a32e8	logging in with user jgrillo-sandbox-grapl-test-user at https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth/login
[DEBUG]	2021-06-21T20:10:35.938Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieved jwt cookie
.[DEBUG]	2021-06-21T20:10:35.940Z	0a8c3312-8640-408a-b763-36d3b03a32e8	created EngagementEdgeClient for endpoint https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth
[DEBUG]	2021-06-21T20:10:35.942Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieving jwt cookie
[DEBUG]	2021-06-21T20:10:35.946Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieving jgrillo-sandbox-TestUserPassword
[DEBUG]	2021-06-21T20:10:36.123Z	0a8c3312-8640-408a-b763-36d3b03a32e8	logging in with user jgrillo-sandbox-grapl-test-user at https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth/login
[DEBUG]	2021-06-21T20:10:38.988Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieved jwt cookie
x[DEBUG]	2021-06-21T20:10:42.493Z	0a8c3312-8640-408a-b763-36d3b03a32e8	created EngagementEdgeClient for endpoint https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth
[DEBUG]	2021-06-21T20:10:42.493Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieving jwt cookie
[DEBUG]	2021-06-21T20:10:42.505Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieving jgrillo-sandbox-TestUserPassword
[DEBUG]	2021-06-21T20:10:42.703Z	0a8c3312-8640-408a-b763-36d3b03a32e8	logging in with user jgrillo-sandbox-grapl-test-user at https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth/login
[DEBUG]	2021-06-21T20:10:45.465Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieved jwt cookie
.[DEBUG]	2021-06-21T20:10:51.184Z	0a8c3312-8640-408a-b763-36d3b03a32e8	created EngagementEdgeClient for endpoint https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth
[DEBUG]	2021-06-21T20:10:51.184Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieving jwt cookie
[DEBUG]	2021-06-21T20:10:51.204Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieving jgrillo-sandbox-TestUserPassword
[DEBUG]	2021-06-21T20:10:51.382Z	0a8c3312-8640-408a-b763-36d3b03a32e8	logging in with user jgrillo-sandbox-grapl-test-user at https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth/login
[DEBUG]	2021-06-21T20:10:54.243Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieved jwt cookie
[DEBUG]	2021-06-21T20:10:54.244Z	0a8c3312-8640-408a-b763-36d3b03a32e8	created EngagementEdgeClient for endpoint https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth
.[DEBUG]	2021-06-21T20:10:54.744Z	0a8c3312-8640-408a-b763-36d3b03a32e8	created EngagementEdgeClient for endpoint https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth
[DEBUG]	2021-06-21T20:10:54.762Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieving jwt cookie
[DEBUG]	2021-06-21T20:10:54.766Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieving jgrillo-sandbox-TestUserPassword
[DEBUG]	2021-06-21T20:10:54.964Z	0a8c3312-8640-408a-b763-36d3b03a32e8	logging in with user jgrillo-sandbox-grapl-test-user at https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth/login
[DEBUG]	2021-06-21T20:10:57.925Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieved jwt cookie
x[DEBUG]	2021-06-21T20:10:58.223Z	0a8c3312-8640-408a-b763-36d3b03a32e8	created EngagementEdgeClient for endpoint https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth
[DEBUG]	2021-06-21T20:10:58.224Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieving jwt cookie
[DEBUG]	2021-06-21T20:10:58.244Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieving jgrillo-sandbox-TestUserPassword
[DEBUG]	2021-06-21T20:10:58.424Z	0a8c3312-8640-408a-b763-36d3b03a32e8	logging in with user jgrillo-sandbox-grapl-test-user at https://e65twth5q4.execute-api.us-east-1.amazonaws.com:443/prod/auth/login
[DEBUG]	2021-06-21T20:11:01.404Z	0a8c3312-8640-408a-b763-36d3b03a32e8	retrieved jwt cookie
.
=============================== warnings summary ===============================
e2e_test_runner/test_main.py:30
/var/task/e2e_test_runner/test_main.py:30: PytestUnknownMarkWarning: Unknown pytest.mark.integration_test - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
@pytest.mark.integration_test
e2e_test_runner/test_main.py:26
/var/task/e2e_test_runner/test_main.py:26: PytestCollectionWarning: cannot collect test class 'TestException' because it has a __init__ constructor (from: e2e_test_runner/test_main.py)
class TestException(Exception):
.deps/pytest-6.2.4-py3-none-any.whl/_pytest/cacheprovider.py:428
/var/task/.deps/pytest-6.2.4-py3-none-any.whl/_pytest/cacheprovider.py:428: PytestCacheWarning: could not create cache path /var/task/.pytest_cache/v/cache/nodeids
config.cache.set("cache/nodeids", sorted(self.cached_nodeids))
.deps/pytest-6.2.4-py3-none-any.whl/_pytest/stepwise.py:49
/var/task/.deps/pytest-6.2.4-py3-none-any.whl/_pytest/stepwise.py:49: PytestCacheWarning: could not create cache path /var/task/.pytest_cache/v/cache/stepwise
session.config.cache.set(STEPWISE_CACHE_DIR, [])
-- Docs: https://docs.pytest.org/en/stable/warnings.html
================== 6 passed, 2 xfailed, 4 warnings in 35.94s ===================
END RequestId: 0a8c3312-8640-408a-b763-36d3b03a32e8
REPORT RequestId: 0a8c3312-8640-408a-b763-36d3b03a32e8	Duration: 37596.48 ms	Billed Duration: 37597 ms	Memory Size: 256 MB	Max Memory Used: 125 MB	Init Duration: 1259.21 ms
RequestId: 0a8c3312-8640-408a-b763-36d3b03a32e8 Error: Runtime exited without providing a reasonRuntime.ExitError
```
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
