### PR TITLE
Change Sysmon generator event handler to only take a Vec of events only

### DIFF
--- a/src/rust/generators/sysmon-subgraph-generator/benches/generator_bench.rs
+++ b/src/rust/generators/sysmon-subgraph-generator/benches/generator_bench.rs
@@ -50,7 +50,6 @@ fn bench_sysmon_generator_1000_events(c: &mut Criterion) {
             .decode(test_data_bytes)
             .expect("Unable to parse sysmon sample data into sysmon events.")
             .into_iter()
-            .filter(|item| item.is_ok())
             .take(1_000)
             .collect()
     });

--- a/src/rust/generators/sysmon-subgraph-generator/src/serialization.rs
+++ b/src/rust/generators/sysmon-subgraph-generator/src/serialization.rs
@@ -33,43 +33,59 @@ impl CheckedError for SysmonDecoderError {
 #[derive(Debug, Clone, Default)]
 pub struct SysmonDecoder;
 
-impl PayloadDecoder<Vec<Result<Event, SysmonDecoderError>>> for SysmonDecoder {
+impl PayloadDecoder<Vec<Event>> for SysmonDecoder {
     type DecoderError = SysmonDecoderError;
 
-    fn decode(
-        &mut self,
-        body: Vec<u8>,
-    ) -> Result<Vec<Result<Event, Self::DecoderError>>, Self::DecoderError> {
+    fn decode(&mut self, body: Vec<u8>) -> Result<Vec<Event>, Self::DecoderError> {
         let decompressed = grapl_service::decoder::decompress::maybe_decompress(body.as_slice())?;
+
+        let mut first_deserialization_error: Option<SysmonDecoderError> = None;
 
         /*
            This iterator is taking a set of bytes of the logs, splitting the logs on newlines,
-           converting the byte sequences to utf-8 strings, and then filtering on the following criteria:
-               1. The line isn't empty
-               2. The line is not `\n` (to prevent issues with multiple newline sequences)
-               3. The line contains event with ID 1, 3, or 11
-
-           The event ids 1, 3, and 11 correspond to Process Creation, Network Connection, and File Creation
-           in that order.
+           converting the byte sequences to utf-8 strings, and then filtering on supported event
+           types: Process Creation, Network Connection, and File Creation.
 
            https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#events
         */
-        let events: Vec<Result<Event, Self::DecoderError>> = decompressed
+        let events: Vec<_> = decompressed
             .split(|byte| *byte == b'\n')
             .map(String::from_utf8_lossy)
             .map(|s| s.to_string())
-            .filter(|event| {
-                (!event.is_empty() && event != "\n")
-                    && (event.contains("EventID>1<")
-                        || event.contains("EventID>3<")
-                        || event.contains("EventID>11<"))
+            .filter_map(|event_str| {
+                let parsed_event = Event::from_str(&event_str);
+                match parsed_event {
+                    Ok(event) => Some(event),
+                    Err(error) => {
+                        tracing::error!(
+                            message = "Unable to deserialize Sysmon event",
+                            error =? error,
+                            event_str =% event_str
+                        );
+
+                        if first_deserialization_error.is_none() {
+                            first_deserialization_error =
+                                Some(SysmonDecoderError::DeserializeError(error.to_string()))
+                        }
+                        None
+                    }
+                }
             })
-            .map(|event| {
-                Event::from_str(&event)
-                    .map_err(|e| SysmonDecoderError::DeserializeError(e.to_string()))
+            .filter(|event| {
+                event.is_process_create()
+                    || event.is_file_create()
+                    || event.is_inbound_network()
+                    || event.is_outbound_network()
             })
             .collect();
 
-        Ok(events)
+        // This is a bit awkward at the moment, due to interfaces to the sqs-executor. If some of
+        // our events successfully parsed then we want to continue and send those to the event
+        // handler. Only if all parsing has failed and we have no events do we want to return an
+        // error here.
+        match first_deserialization_error {
+            Some(error) if events.is_empty() => Err(error),
+            _ => Ok(events),
+        }
     }
 }


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

Change Sysmon generator event handler to only take a Vec of events only, instead of Vec<Result<Event, Error>>.

Also, change the Sysmon parser to filter for supported events after parsing. This should help ensure we don't filter events that we shouldn't be.

### How were these changes tested?

I'm relying on CI tests.
