### PR TITLE
Docker ps --all when dumping artifacts

### DIFF
--- a/etc/ci_scripts/dump_artifacts.py
+++ b/etc/ci_scripts/dump_artifacts.py
@@ -138,7 +138,8 @@ def dump_docker_ps(dir: Path) -> None:
     logging.debug(f"Dumping 'docker ps' to '{destination}'")
     with open(destination, "wb") as out_stream:
         subprocess.run(
-            f"docker ps",
+            # --all includes containers that have already exited
+            f"docker ps --all",
             stdout=out_stream,
             stderr=out_stream,
             shell=True,


### PR DESCRIPTION
the `docker ps` log is useful for when the log says "container <hex> exited" but you don't know which container that represents.

--all includes exited containers; this was an oversight on my part, I meant to include it.