### PR TITLE
Tear down test docker environment upon finishing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ test-with-env: # (Do not include help text - not to be used directly)
 		# Unset COMPOSE_FILE to help ensure it will be ignored with use of --file
 		unset COMPOSE_FILE
 		etc/ci_scripts/dump_artifacts.py --compose-project=${COMPOSE_PROJECT_NAME}
-		docker-compose --file docker-compose.yml stop;
+		$(MAKE) down
 	}
 	# Ensure we call stop even after test failure, and return exit code from
 	# the test, not the stop command.

--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ up-detach: build-services ## Bring up local Grapl and detach to return control t
 	unset COMPOSE_FILE
 	docker-compose \
 		--file docker-compose.yml \
-		up --detach --force-recreate
+		up --detach --force-recreate --always-recreate-deps
 
 .PHONY: down
 down: ## docker-compose down - both stops and removes the containers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,12 +88,6 @@ services:
 
   kafka-broker:
     image: confluentinc/cp-kafka:6.2.0
-    command: |
-      sh -c "
-        # Same hack we use to disable persistence in the Redis container
-        rm -rf /var/lib/kafka/data/* &&
-        /etc/confluent/docker/run
-      "
     depends_on:
       zookeeper:
         condition: service_healthy

--- a/test/docker-compose-with-error.sh
+++ b/test/docker-compose-with-error.sh
@@ -20,7 +20,7 @@ usage() {
 }
 
 # Execute the 'up'
-docker-compose up --force-recreate ${TARGETS}
+docker-compose up --force-recreate --always-recreate-deps ${TARGETS}
 
 # check for container exit codes other than 0
 EXIT_CODE=0


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/591

### What changes does this PR make to Grapl? Why?

This does a few things:
1. reverts the "hack" from https://github.com/grapl-security/grapl/pull/949 (but keeps the formatting change from it).
2. adds `--always-recreate-deps` when we call `docker-compose up` with `--force-recreate`. This isn't strictly necessary to fix https://github.com/grapl-security/issue-tracker/issues/591, but it seems like what we'd want.
3. Instead of calling `docker-compose stop` on test cleanup, we call `make down`.

### How were these changes tested?

I re-ran the issue repro steps locally with great success.