### PR TITLE
Rust integration test fixes

### DIFF
--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -70,7 +70,7 @@ RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
       test) \
         cargo test --no-run ;; \
       test-integration) \
-        cargo test --features node-identifier/integration,sqs-executor/integration --test "*" --no-run ;; \
+        cargo test --features node-identifier/integration,sqs-executor/integration,kafka-metrics-exporter/integration --test "*" --no-run ;; \
       *) \
         echo "ERROR: Unknown RUST_BUILD option: ${RUST_BUILD}"; \
         exit 1 ;; \

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -64,6 +64,8 @@ FROM base AS build-test
 
 ENV RUST_INTEGRATION_TEST_FEATURES="node-identifier/integration,sqs-executor/integration,kafka-metrics-exporter/integration"
 
+# At the end of the test run, save the mount cache to the Docker image, as
+# these files are needed for running the integration tests in containers. 
 RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=secret,id=rust_env,dst=/grapl/env \
@@ -76,17 +78,15 @@ RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
       *) \
         echo "ERROR: Unknown RUST_BUILD option: ${RUST_BUILD}"; \
         exit 1 ;; \
-    esac
-
-# Save the mount cache to the Docker image, as these files are needed for
-# running the integration tests in containers. 
-RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/registry \
+    esac && \
     cp -a /grapl/rust/target /tmp/target && \
     cp -a /usr/local/cargo/registry /tmp/registry
 
-RUN mv /tmp/target /grapl/rust/target && \
-    mv /tmp/registry /usr/local/cargo/registry
+# Move the files back to where they belong.
+# The mv command is apparently very slow here, cp and rm is much faster
+RUN cp -ar /tmp/target/. /grapl/rust/target/ && \
+    cp -ar /tmp/registry/. /usr/local/cargo/registry/ && \
+    rm -rf /tmp/{target,registry}
 
 CMD [ "bash", "-c", "cargo test --features \"${RUST_INTEGRATION_TEST_FEATURES}\" --test \"*\"" ]
 

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -70,7 +70,7 @@ RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
       test) \
         cargo test --no-run ;; \
       test-integration) \
-        cargo test --features node-identifier/integration,sqs-executor/integration,kafka-metrics-exporter/integration,graph-merger/integration --test "*" --no-run ;; \
+        cargo test --features node-identifier/integration,sqs-executor/integration,kafka-metrics-exporter/integration --test "*" --no-run ;; \
       *) \
         echo "ERROR: Unknown RUST_BUILD option: ${RUST_BUILD}"; \
         exit 1 ;; \

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -62,6 +62,8 @@ RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
 ################################################################################
 FROM base AS build-test
 
+ENV RUST_INTEGRATION_TEST_FEATURES="node-identifier/integration,sqs-executor/integration,kafka-metrics-exporter/integration"
+
 RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=secret,id=rust_env,dst=/grapl/env \
@@ -70,7 +72,7 @@ RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
       test) \
         cargo test --no-run ;; \
       test-integration) \
-        cargo test --features node-identifier/integration,sqs-executor/integration,kafka-metrics-exporter/integration --test "*" --no-run ;; \
+        cargo test --features "${RUST_INTEGRATION_TEST_FEATURES}" --test "*" --no-run ;; \
       *) \
         echo "ERROR: Unknown RUST_BUILD option: ${RUST_BUILD}"; \
         exit 1 ;; \
@@ -85,6 +87,8 @@ RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
 
 RUN mv /tmp/target /grapl/rust/target && \
     mv /tmp/registry /usr/local/cargo/registry
+
+CMD [ "bash", "-c", "cargo test --features \"${RUST_INTEGRATION_TEST_FEATURES}\" --test \"*\"" ]
 
 # metric-forwarder-zip
 ################################################################################

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -70,7 +70,7 @@ RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
       test) \
         cargo test --no-run ;; \
       test-integration) \
-        cargo test --features node-identifier/integration,sqs-executor/integration,kafka-metrics-exporter/integration --test "*" --no-run ;; \
+        cargo test --features node-identifier/integration,sqs-executor/integration,kafka-metrics-exporter/integration,graph-merger/integration --test "*" --no-run ;; \
       *) \
         echo "ERROR: Unknown RUST_BUILD option: ${RUST_BUILD}"; \
         exit 1 ;; \

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -4,6 +4,15 @@ ARG RUST_BUILD=debug
 
 SHELL ["/bin/bash", "-c"]
 
+# Necessary for rdkafka
+RUN --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
+        cmake \
+        libzstd-dev \
+        build-essential \
+        zlib1g-dev
+
 # Install rust toolchain before copying sources to avoid unecessarily
 # resinstalling on source file changes.
 WORKDIR /grapl
@@ -23,15 +32,6 @@ WORKDIR /grapl/rust
 # build
 ################################################################################
 FROM base AS build
-
-# Necessary for rdkafka
-RUN --mount=type=cache,target=/var/lib/apt/lists \
-    apt-get update && apt-get install -y --no-install-recommends \
-        python3 \
-        cmake \
-        libzstd-dev \
-        build-essential \
-        zlib1g-dev
 
 RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/registry \
@@ -61,15 +61,6 @@ RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
 # if we don't have to.
 ################################################################################
 FROM base AS build-test
-
-# Necessary for rdkafka
-RUN --mount=type=cache,target=/var/lib/apt/lists \
-    apt-get update && apt-get install -y --no-install-recommends \
-        python3 \
-        cmake \
-        libzstd-dev \
-        build-essential \
-        zlib1g-dev
 
 RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/registry \
@@ -101,12 +92,7 @@ FROM build AS metric-forwarder-zip
 
 RUN --mount=type=cache,target=/var/lib/apt/lists \
     apt-get update && apt-get install -y --no-install-recommends \
-        zip \
-        python3 \
-        cmake \
-        libzstd-dev \
-        build-essential \
-        zlib1g-dev
+        zip
 
 RUN mkdir -p /grapl/zips; \
     grapl-zip() { \

--- a/src/rust/graph-merger/tests/test_merging.rs
+++ b/src/rust/graph-merger/tests/test_merging.rs
@@ -145,9 +145,13 @@ pub mod test {
 
             std::thread::spawn(move || {
                 let rt = tokio::runtime::Runtime::new().expect("failed to init runtime");
+                let mg_alpha = grapl_config::mg_alphas()
+                    .pop()
+                    .expect("Dgraph Alpha not specified.");
+
                 rt.block_on(async {
-                    let dgraph_client = DgraphClient::new("http://127.0.0.1:9080")
-                        .expect("Failed to create dgraph client.");
+                    let dgraph_client =
+                        DgraphClient::new(mg_alpha).expect("Failed to create dgraph client.");
 
                     dgraph_client
                         .alter(dgraph_tonic::Operation {
@@ -174,10 +178,13 @@ pub mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_upsert_edge_and_retrieve() -> Result<(), Box<dyn std::error::Error>> {
         init_test_env();
+        let mg_alpha = grapl_config::mg_alphas()
+            .pop()
+            .expect("Dgraph Alpha not specified.");
+
         let mut identified_graph = IdentifiedGraph::new();
         let mut merged_graph = MergedGraph::new();
-        let dgraph_client =
-            DgraphClient::new("http://127.0.0.1:9080").expect("Failed to create dgraph client.");
+        let dgraph_client = DgraphClient::new(mg_alpha).expect("Failed to create dgraph client.");
         let dgraph_client = std::sync::Arc::new(dgraph_client);
         let mut properties = HashMap::new();
         properties.insert(
@@ -269,9 +276,11 @@ pub mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_upsert_idempotency() -> Result<(), Box<dyn std::error::Error>> {
         init_test_env();
+        let mg_alpha = grapl_config::mg_alphas()
+            .pop()
+            .expect("Dgraph Alpha not specified.");
 
-        let dgraph_client =
-            DgraphClient::new("http://127.0.0.1:9080").expect("Failed to create dgraph client.");
+        let dgraph_client = DgraphClient::new(mg_alpha).expect("Failed to create dgraph client.");
         let dgraph_client = std::sync::Arc::new(dgraph_client);
 
         let node_key = "test_upsert_idempotency-example-node-key";
@@ -348,9 +357,11 @@ pub mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_upsert_multifield() -> Result<(), Box<dyn std::error::Error>> {
         init_test_env();
+        let mg_alpha = grapl_config::mg_alphas()
+            .pop()
+            .expect("Dgraph Alpha not specified.");
 
-        let dgraph_client =
-            DgraphClient::new("http://127.0.0.1:9080").expect("Failed to create dgraph client.");
+        let dgraph_client = DgraphClient::new(mg_alpha).expect("Failed to create dgraph client.");
         let dgraph_client = std::sync::Arc::new(dgraph_client);
 
         let node_key = "test_upsert_multifield-example-node-key";

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -12,7 +12,7 @@ services:
       target: build-test
       args:
         - RUST_BUILD=test-integration
-    command: cargo test --features sqs-executor/integration,node-identifier/integration,kafka-metrics-exporter/integration --test '*'
+    command: cargo test --features sqs-executor/integration,node-identifier/integration,kafka-metrics-exporter/integration,graph-merger/integration --test '*'
     environment:
       - AWS_REGION
       - DEPLOYMENT_NAME

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -3,7 +3,8 @@ version: "3.8"
 # environment variable PWD is assumed to be grapl root directory
 
 services:
-  rust-node-identifier-integration-tests:
+
+  rust-integration-tests:
     image: grapl/rust-integration-tests:${TAG:-latest}
     build:
       context: ${PWD}/src
@@ -11,7 +12,7 @@ services:
       target: build-test
       args:
         - RUST_BUILD=test-integration
-    command: cargo test --features node-identifier/integration --test '*'
+    command: cargo test --features sqs-executor/integration,node-identifier/integration,kafka-metrics-exporter/integration --test '*'
     environment:
       - AWS_REGION
       - DEPLOYMENT_NAME
@@ -33,17 +34,6 @@ services:
       - NETWORK_CONNECTION_HISTORY_TABLE=${DEPLOYMENT_NAME}-network_connection_history_table
       - IP_CONNECTION_HISTORY_TABLE=${DEPLOYMENT_NAME}-ip_connection_history_table
       - ASSET_ID_MAPPINGS=${DEPLOYMENT_NAME}-asset_id_mappings
-
-  rust-sqs-executor-integration-tests:
-    image: grapl/rust-integration-tests:${TAG:-latest}
-    build:
-      context: ${PWD}/src
-      dockerfile: rust/Dockerfile
-      target: build-test
-      args:
-        - RUST_BUILD=test-integration
-    command: cargo test --features sqs-executor/integration --test '*'
-    environment:
       - REDIS_ENDPOINT
 
   grapl-analyzerlib-integration-tests:
@@ -103,16 +93,6 @@ services:
       - GRAPL_TEST_USER_NAME
       - IS_LOCAL=True
       - UX_BUCKET_URL="ux_bucket_url"
-
-  kafka-metrics-exporter-integration-tests:
-    image: grapl/kafka-metrics-exporter-test:${TAG:-latest}
-    build:
-      context: ${PWD}/src
-      dockerfile: rust/Dockerfile
-      target: build-test
-      args:
-        - RUST_BUILD=test-integration
-    command: cargo test --features kafka-metrics-exporter/integration --test '*'
 
   # TODO: Re-enable these tests after the following issues are resolved:
   # - https://github.com/grapl-security/issue-tracker/issues/385

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -12,7 +12,7 @@ services:
       target: build-test
       args:
         - RUST_BUILD=test-integration
-    command: cargo test --features sqs-executor/integration,node-identifier/integration,kafka-metrics-exporter/integration,graph-merger/integration --test '*'
+    command: cargo test --features sqs-executor/integration,node-identifier/integration,kafka-metrics-exporter/integration --test '*'
     environment:
       - AWS_REGION
       - DEPLOYMENT_NAME

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -12,7 +12,8 @@ services:
       target: build-test
       args:
         - RUST_BUILD=test-integration
-    command: cargo test --features sqs-executor/integration,node-identifier/integration,kafka-metrics-exporter/integration --test '*'
+    # Use the default command defined in the Dockerfile for running integration tests.
+    # command: <do not use>
     environment:
       - AWS_REGION
       - DEPLOYMENT_NAME


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/594

Unfiled (at the moment):
The Rust integration tests were split into multiple containers, which adds unnecessary complexity and brittleness. An example of how this can cause issues can be seen with the latest addition of the kafka-metrics-exporter, which was not being built in the Dockerfile.

### What changes does this PR make to Grapl? Why?

There are a number of small commits in this PR:
1. Consolidate a duplicate apt install line in the Rust Dockerfile
2. Add the kafka-metrics-exporter/integration feature to the cargo test build command.
3. Consolidate Rust integration tests to a single container.
4. ~Add the graph-merger integration tests~ Reverted, this apparently breaks other tests. I'll file a ticket for that.
5. Fix an issue in the graph-merger integration test where it was trying to connect to DGraph on local host.
6. Define CMD in the Dockerfile and use an environment variable to specify the integration test features only once.
7. Make the target directory copying more robust to destination directories existing or not. 

### How were these changes tested?

Running the integration tests locally and in CI.
