### PR TITLE
Fix graplctl build order issue.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,17 +154,17 @@ build-test-typecheck:
 	docker buildx bake --file ./test/docker-compose.typecheck-tests.yml
 
 .PHONY: build-test-integration
-build-test-integration: graplctl modern-lambdas build-services
+build-test-integration: modern-lambdas build-services
 	$(WITH_LOCAL_GRAPL_ENV) \
 	$(DOCKER_BUILDX_BAKE) --file ./test/docker-compose.integration-tests.yml
 
 .PHONY: build-test-e2e
-build-test-e2e: graplctl modern-lambdas build-services
+build-test-e2e: modern-lambdas build-services
 	$(WITH_LOCAL_GRAPL_ENV) \
 	$(DOCKER_BUILDX_BAKE) --file ./test/docker-compose.e2e-tests.yml
 
 .PHONY: build-services
-build-services: ## Build Grapl services
+build-services: graplctl ## Build Grapl services
 	$(DOCKER_BUILDX_BAKE) --file docker-compose.build.yml
 
 .PHONY: build-lambdas


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/592

### What changes does this PR make to Grapl? Why?

This make the `build-services` Make target depend on the `graplctl` target.

### How were these changes tested?

I ran `make up` successfully.