### PR TITLE
Pass missing TAG argument to provisioner build.

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -124,3 +124,5 @@ services:
     build:
       context: .
       dockerfile: ./src/python/provisioner/provisioner.Dockerfile
+      args:
+        - TAG=${TAG:-latest}

--- a/test/docker-compose.e2e-tests.yml
+++ b/test/docker-compose.e2e-tests.yml
@@ -9,6 +9,8 @@ services:
     build:
       context: .
       dockerfile: ./src/python/e2e-test-runner/e2e-test-runner.Dockerfile
+      args:
+        - TAG=${TAG:-latest}
     command: |
       /bin/bash -c "
           graplctl \


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/593

### What changes does this PR make to Grapl? Why?

This passes a missing TAG arg to the provisioner Docker build.

### How were these changes tested?

```
$ make clean
...
$ export TAG=asdf
$ make graplctl
...
$ make build-services
...
$ echo $?
0
```
