### PR TITLE
Set TAG env var to non-default value in CI pipeline 

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -1,6 +1,7 @@
 ---
 env:
   PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
+  TAG: ci-pipeline
 
 # TODO: Cache for JS, Rust deps
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -484,6 +484,7 @@ services:
         target: /home/grapl/pulumi-outputs
         read_only: false
     environment:
+      TAG:
       PULUMI_CONFIG_PASSPHRASE: local-grapl-passphrase
       # Other environment variables like MG_ALPHAS are passed in via
       # Pulumi.local-grapl.yaml

--- a/pulumi/README.md
+++ b/pulumi/README.md
@@ -95,7 +95,7 @@ This is the directory in which ZIP archives of our lambda functions
 are found. If overriding, an absolute path may be used. If a relative
 path is given, it must be relative to the `pulumi` directory.
 
-## GRAPL_LAMBDA_TAG
+## TAG
 
 Default Value: `latest`
 

--- a/pulumi/infra/config.py
+++ b/pulumi/infra/config.py
@@ -36,7 +36,7 @@ LOCAL_GRAPL = DEPLOYMENT_NAME == "local-grapl"
 # that includes the AWS account ID.
 AWS_ACCOUNT_ID = "000000000000" if LOCAL_GRAPL else aws.get_caller_identity().account_id
 
-GLOBAL_LAMBDA_ZIP_TAG = os.getenv("GRAPL_LAMBDA_TAG", "latest")
+GLOBAL_LAMBDA_ZIP_TAG = os.getenv("TAG", "latest")
 """Filename tag for all lambda function ZIP files.
 
 All our lambda function ZIP files currently have a name like:
@@ -45,7 +45,7 @@ All our lambda function ZIP files currently have a name like:
 
 Since all the lambdas share the same tag, we can specify this globally.
 
-Use the environment variable `GRAPL_LAMBDA_TAG` to specify a tag, or
+Use the environment variable `TAG` to specify a tag, or
 leave it unset to use the default value of `latest`.
 
 """


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/593

### What changes does this PR make to Grapl? Why?

This sets the `TAG` environment variable in CI to catch potential issues related to the above issue.

### How were these changes tested?

We'll test with CI, but need https://github.com/grapl-security/grapl/pull/957 to land before we can test this PR, which is why I'm keeping in draft mode for now.
