### PR TITLE
Simplify the --against option for running Buf in CI

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -23,7 +23,7 @@ steps:
 
   - label: ":large_blue_square::face_with_symbols_on_mouth: Protobuf Breaking Changes"
     command:
-      - buf breaking --against="${BUILDKITE_REPO}.git" --verbose
+      - "buf breaking --against=https://github.com/grapl-security/grapl.git --verbose"
 
   - label: ":rust: rustfmt"
     command:


### PR DESCRIPTION
I'm not quite certain why the `BUILDKITE_REPO` variable now appears to
be different between our verify and merge pipelines, but it appears
that appending `.git` isn't really needed.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
