### PR TITLE
Fix import issue in Sysmon crate where the project couldn't be built from its directory.

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -3372,7 +3372,6 @@ dependencies = [
  "failure",
  "serde",
  "serde-xml-rs",
- "serde_derive",
  "uuid",
 ]
 

--- a/src/rust/sysmon/Cargo.toml
+++ b/src/rust/sysmon/Cargo.toml
@@ -12,8 +12,7 @@ readme = "README.md"
 [dependencies]
 failure = "0.1"
 serde-xml-rs = "0.4"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 derive_is_enum_variant = "0.1"
 anyhow = "1"
 chrono = "0.4"

--- a/src/rust/sysmon/src/lib.rs
+++ b/src/rust/sysmon/src/lib.rs
@@ -3,7 +3,6 @@ extern crate chrono;
 #[macro_use]
 extern crate derive_is_enum_variant;
 extern crate serde;
-extern crate serde_derive;
 extern crate serde_xml_rs;
 extern crate uuid;
 


### PR DESCRIPTION
### Which issue does this PR correspond to?

(Unfiled) Building the sysmon crate alone in its directory didn't work, though the sysmon generator was able to build it.

### What changes does this PR make to Grapl? Why?

This changes the sysmon crate to impors serde the same way the sysmon generator does.

### How were these changes tested?

Successfully building the crate from the sysmon directory.
