### PR TITLE
Create lambda zip files in dist directory without "tags"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@ build-support/grapl-venv
 .pants.workdir.file_lock*
 .pids
 **/__pycache__
-src/aws-provision/zips
 src/rust/target/**
 .yarn
 test_artifacts/**

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ src/js/engagement_view/.yarn/install-state.gz
 
 # Distribution / packaging
 build/
-dist/
 *.zip
 
 # IDE files
@@ -49,6 +48,7 @@ pyrightconfig.json
 ########################################################################
 /.pants.d/
 /dist/
+!/dist/.gitkeep
 /.pids
 /.pants.workdir.file_lock*
 /.cache

--- a/Makefile
+++ b/Makefile
@@ -374,13 +374,6 @@ zip: build-lambdas ## Generate zips for deploying to AWS
 .PHONY: zip-pants
 zip-pants: ## Generate Lambda zip artifacts using pants
 	./pants filter --target-type=python_awslambda :: | xargs ./pants package
-	cp ./dist/src.python.provisioner.provisioner/lambda.zip ./src/aws-provision/zips/provisioner-$(TAG).zip
-	cp ./dist/src.python.engagement-creator/lambda.zip ./src/aws-provision/zips/engagement-creator-$(TAG).zip
-	cp ./dist/src.python.grapl-dgraph-ttl/lambda.zip ./src/aws-provision/zips/dgraph-ttl-$(TAG).zip
-	cp ./dist/src.python.engagement_edge/engagement_edge.zip ./src/aws-provision/zips/engagement-edge-$(TAG).zip
-	cp ./dist/src.python.grapl-ux-router/lambda.zip ./src/aws-provision/zips/ux-router-$(TAG).zip
-	cp ./dist/src.python.grapl-model-plugin-deployer/lambda.zip ./src/aws-provision/zips/model-plugin-deployer-$(TAG).zip
-	cp ./dist/src.python.e2e-test-runner.e2e_test_runner/lambda.zip ./src/aws-provision/zips/e2e-test-runner-$(TAG).zip
 
 # This target is intended to help ease the transition to Pulumi, and
 # using lambdas in local Grapl testing deployments. Essentially, every

--- a/docker-compose.lambda-zips.js.yml
+++ b/docker-compose.lambda-zips.js.yml
@@ -9,9 +9,7 @@ services:
       dockerfile: js/graphql_endpoint/Dockerfile
       target: graphql-endpoint-zip
     volumes:
-      - ./src/aws-provision/zips:/grapl
+      - ./dist:/grapl
     user: ${UID}:${GID}
     working_dir: /grapl
-    environment:
-      - TAG=${TAG:-latest}
-    command: cp /home/grapl/lambda.zip graphql-endpoint-${TAG:-latest}.zip
+    command: cp /home/grapl/lambda.zip graphql-endpoint-lambda.zip

--- a/docker-compose.lambda-zips.rust.yml
+++ b/docker-compose.lambda-zips.rust.yml
@@ -11,9 +11,7 @@ services:
       args:
         - RUST_BUILD=${RUST_BUILD:-debug}
     volumes:
-      - ./src/aws-provision/zips:/tmp/zips
+      - ./dist:/tmp/zips
     user: ${UID}:${GID}
     working_dir: /grapl/zips
-    environment:
-      - TAG=${TAG:-latest}
-    command: sh -c 'cp /grapl/zips/metric-forwarder.zip /tmp/zips/metric-forwarder-${TAG:-latest}.zip'
+    command: sh -c 'cp /grapl/zips/metric-forwarder.zip /tmp/zips/metric-forwarder-lambda.zip'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -476,8 +476,8 @@ services:
     network_mode: "service:localstack"
     volumes:
       - type: bind
-        source: ./src/aws-provision/zips
-        target: /home/grapl/src/aws-provision/zips
+        source: ./dist
+        target: /home/grapl/dist
         read_only: true
       - type: volume
         source: pulumi_outputs

--- a/pulumi/README.md
+++ b/pulumi/README.md
@@ -89,21 +89,11 @@ really stack-specific; they're more general.
 
 ## GRAPL_LAMBDA_ZIP_DIR
 
-Default Value: `../src/aws-provision/zips`
+Default Value: `../dist/`
 
 This is the directory in which ZIP archives of our lambda functions
 are found. If overriding, an absolute path may be used. If a relative
 path is given, it must be relative to the `pulumi` directory.
-
-## TAG
-
-Default Value: `latest`
-
-Currently, our lambda ZIP archives are named as
-`<LAMBDA_NAME>-<TAG>.zip`. Examples might be
-"engagement-creator-v0.0.1.zip" or
-"metric-forwarder-latest.zip". Importantly, all ZIP archives share the
-same value for `TAG`.
 
 [pulumi]: https://pulumi.com
 [ls]: https://localstack.cloud/

--- a/pulumi/infra/dgraph_ttl.py
+++ b/pulumi/infra/dgraph_ttl.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import pulumi_aws as aws
-from infra.config import GLOBAL_LAMBDA_ZIP_TAG, configurable_envvars
+from infra.config import configurable_envvars
 from infra.dgraph_cluster import DgraphCluster
 from infra.ec2 import Ec2Port
 from infra.lambda_ import Lambda, LambdaExecutionRole, PythonLambdaArgs, code_path_for
@@ -30,7 +30,6 @@ class DGraphTTL(pulumi.ComponentResource):
             f"{name}-Handler",
             args=PythonLambdaArgs(
                 execution_role=self.role,
-                description=GLOBAL_LAMBDA_ZIP_TAG,
                 handler="lambdex_handler.handler",
                 code_path=code_path_for(name),
                 env={

--- a/pulumi/infra/e2e_test_runner.py
+++ b/pulumi/infra/e2e_test_runner.py
@@ -2,7 +2,7 @@ from typing import Optional
 from urllib.parse import urlparse
 
 from infra.api import Api
-from infra.config import DEPLOYMENT_NAME, GLOBAL_LAMBDA_ZIP_TAG, GRAPL_TEST_USER_NAME
+from infra.config import DEPLOYMENT_NAME, GRAPL_TEST_USER_NAME
 from infra.dgraph_cluster import DgraphCluster
 from infra.network import Network
 from infra.secret import JWTSecret, TestUserPassword
@@ -38,7 +38,6 @@ class E2eTestRunner(pulumi.ComponentResource):
         self.function = Lambda(
             name,
             args=PythonLambdaArgs(
-                description=GLOBAL_LAMBDA_ZIP_TAG,
                 handler="lambdex_handler.handler",
                 code_path=code_path_for(name),
                 env={

--- a/pulumi/infra/engagement_creator.py
+++ b/pulumi/infra/engagement_creator.py
@@ -1,4 +1,4 @@
-from infra.config import GLOBAL_LAMBDA_ZIP_TAG, configurable_envvars
+from infra.config import configurable_envvars
 from infra.dgraph_cluster import DgraphCluster
 from infra.emitter import EventEmitter
 from infra.lambda_ import code_path_for
@@ -20,7 +20,6 @@ class EngagementCreator(Service):
         super().__init__(
             name,
             forwarder=forwarder,
-            lambda_description=GLOBAL_LAMBDA_ZIP_TAG,
             lambda_handler_fn="lambdex_handler.handler",
             lambda_code_path=code_path_for("engagement-creator"),
             network=network,

--- a/pulumi/infra/engagement_edge.py
+++ b/pulumi/infra/engagement_edge.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from infra import dynamodb
 from infra.bucket import Bucket
-from infra.config import GLOBAL_LAMBDA_ZIP_TAG, configurable_envvars
+from infra.config import configurable_envvars
 from infra.dgraph_cluster import DgraphCluster
 from infra.dynamodb import DynamoDB
 from infra.ec2 import Ec2Port
@@ -40,7 +40,6 @@ class EngagementEdge(pulumi.ComponentResource):
             name,
             args=PythonLambdaArgs(
                 handler="lambdex_handler.handler",
-                description=GLOBAL_LAMBDA_ZIP_TAG,
                 code_path=code_path_for(name),
                 env={
                     **configurable_envvars(name, ["GRAPL_LOG_LEVEL"]),

--- a/pulumi/infra/graphql.py
+++ b/pulumi/infra/graphql.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pulumi_aws as aws
 from infra import dynamodb
 from infra.bucket import Bucket
-from infra.config import GLOBAL_LAMBDA_ZIP_TAG, LOCAL_GRAPL
+from infra.config import LOCAL_GRAPL
 from infra.dgraph_cluster import DgraphCluster
 from infra.dynamodb import DynamoDB
 from infra.ec2 import Ec2Port
@@ -36,7 +36,6 @@ class GraphQL(pulumi.ComponentResource):
             name,
             args=LambdaArgs(
                 execution_role=self.role,
-                description=GLOBAL_LAMBDA_ZIP_TAG,
                 handler="server.handler",
                 runtime=aws.lambda_.Runtime.NODE_JS14D_X,
                 code_path=code_path_for(name),

--- a/pulumi/infra/lambda_.py
+++ b/pulumi/infra/lambda_.py
@@ -4,12 +4,7 @@ from dataclasses import dataclass, field
 from typing import Mapping, Optional, Union
 
 import pulumi_aws as aws
-from infra.config import (
-    DEPLOYMENT_NAME,
-    GLOBAL_LAMBDA_ZIP_TAG,
-    LOCAL_GRAPL,
-    SERVICE_LOG_RETENTION_DAYS,
-)
+from infra.config import DEPLOYMENT_NAME, LOCAL_GRAPL, SERVICE_LOG_RETENTION_DAYS
 from infra.network import Network
 from typing_extensions import Literal
 
@@ -19,16 +14,13 @@ import pulumi
 def code_path_for(lambda_fn: str) -> str:
     """Given the name of a lambda, return the local path of the ZIP archive for that lambda.
 
-    Looks in "<REPOSITORY_ROOT>/src/aws-provision/zips" currently, but
+    Looks in "<REPOSITORY_ROOT>/dist" currently, but
     this can be overridden by setting the `GRAPL_LAMBDA_ZIP_DIR`
     environment variable to an appropriate directory.
 
-    Uses the globally-defined "tag" (see `GLOBAL_LAMBDA_ZIP_TAG`) to
-    put together the appropriate file name.
-
     """
-    root_dir = os.getenv("GRAPL_LAMBDA_ZIP_DIR", "../src/aws-provision/zips")
-    return f"{root_dir}/{lambda_fn}-{GLOBAL_LAMBDA_ZIP_TAG}.zip"
+    root_dir = os.getenv("GRAPL_LAMBDA_ZIP_DIR", "../dist")
+    return f"{root_dir}/{lambda_fn}-lambda.zip"
 
 
 LambdaPackageType = Literal["Zip", "Image"]
@@ -53,9 +45,6 @@ class LambdaArgs:
     """ The path to a local file on disk that contains the code for this
     function."""
 
-    description: str
-    """ Textual description of what this function does. """
-
     runtime: aws.lambda_.Runtime
     """ The lambda runtime to use for this function. """
 
@@ -70,6 +59,9 @@ class LambdaArgs:
 
     env: Mapping[str, Union[str, pulumi.Output[str]]]
     """ Environment variables to set for each function invocation. """
+
+    description: Optional[str] = None
+    """ Textual description of what this function does. """
 
 
 @dataclass(frozen=True)

--- a/pulumi/infra/metric_forwarder.py
+++ b/pulumi/infra/metric_forwarder.py
@@ -2,7 +2,7 @@ import json
 from typing import Optional
 
 import pulumi_aws as aws
-from infra.config import GLOBAL_LAMBDA_ZIP_TAG, configurable_envvars
+from infra.config import configurable_envvars
 from infra.lambda_ import Lambda, LambdaArgs, LambdaExecutionRole, code_path_for
 from infra.network import Network
 
@@ -24,7 +24,6 @@ class MetricForwarder(pulumi.ComponentResource):
         self.function = Lambda(
             name,
             args=LambdaArgs(
-                description=GLOBAL_LAMBDA_ZIP_TAG,
                 execution_role=self.role,
                 runtime=aws.lambda_.Runtime.CUSTOM_AL2,
                 handler="metric-forwarder",

--- a/pulumi/infra/model_plugin_deployer.py
+++ b/pulumi/infra/model_plugin_deployer.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from infra import dynamodb
 from infra.bucket import Bucket
-from infra.config import GLOBAL_LAMBDA_ZIP_TAG, LOCAL_GRAPL, configurable_envvars
+from infra.config import LOCAL_GRAPL, configurable_envvars
 from infra.dgraph_cluster import DgraphCluster
 from infra.dynamodb import DynamoDB
 from infra.ec2 import Ec2Port
@@ -36,7 +36,6 @@ class ModelPluginDeployer(pulumi.ComponentResource):
             name,
             args=PythonLambdaArgs(
                 execution_role=self.role,
-                description=GLOBAL_LAMBDA_ZIP_TAG,
                 handler="lambdex_handler.handler",
                 code_path=code_path_for(name),
                 env={

--- a/pulumi/infra/provision_lambda.py
+++ b/pulumi/infra/provision_lambda.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from infra import dynamodb
-from infra.config import DEPLOYMENT_NAME, GLOBAL_LAMBDA_ZIP_TAG
+from infra.config import DEPLOYMENT_NAME
 from infra.dgraph_cluster import DgraphCluster
 from infra.dynamodb import DynamoDB
 from infra.lambda_ import Lambda, LambdaExecutionRole, PythonLambdaArgs, code_path_for
@@ -31,7 +31,6 @@ class Provisioner(pulumi.ComponentResource):
             name,
             args=PythonLambdaArgs(
                 handler="lambdex_handler.handler",
-                description=GLOBAL_LAMBDA_ZIP_TAG,
                 code_path=code_path_for(name),
                 env={
                     "GRAPL_LOG_LEVEL": "DEBUG",

--- a/pulumi/infra/service.py
+++ b/pulumi/infra/service.py
@@ -25,11 +25,11 @@ class Service(pulumi.ComponentResource):
         self,
         name: str,
         forwarder: MetricForwarder,
-        lambda_description: str,
         lambda_handler_fn: str,
         lambda_code_path: str,
         network: Network,
         env: Mapping[str, Union[str, pulumi.Output[str]]],
+        lambda_description: Optional[str] = None,
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
         super().__init__("grapl:Service", name, None, opts)

--- a/pulumi/infra/ux_router.py
+++ b/pulumi/infra/ux_router.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from infra.bucket import Bucket
-from infra.config import GLOBAL_LAMBDA_ZIP_TAG, configurable_envvars
+from infra.config import configurable_envvars
 from infra.ec2 import Ec2Port
 from infra.lambda_ import Lambda, LambdaExecutionRole, PythonLambdaArgs, code_path_for
 from infra.metric_forwarder import MetricForwarder
@@ -30,7 +30,6 @@ class UxRouter(pulumi.ComponentResource):
             name,
             args=PythonLambdaArgs(
                 execution_role=self.role,
-                description=GLOBAL_LAMBDA_ZIP_TAG,
                 handler="lambdex_handler.handler",
                 code_path=code_path_for(name),
                 env={

--- a/src/python/e2e-test-runner/e2e-test-runner.Dockerfile
+++ b/src/python/e2e-test-runner/e2e-test-runner.Dockerfile
@@ -7,5 +7,5 @@ FROM grapl/graplctl:$TAG AS e2e-tests
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends unzip
 USER grapl
-COPY --chown=grapl ./dist/src.python.e2e-test-runner.e2e_test_runner/lambda.zip lambda.zip
+COPY --chown=grapl ./dist/e2e-test-runner-lambda.zip lambda.zip
 RUN unzip lambda.zip

--- a/src/python/e2e-test-runner/e2e_test_runner/BUILD
+++ b/src/python/e2e-test-runner/e2e_test_runner/BUILD
@@ -4,6 +4,7 @@ python_library(
 
 python_awslambda(
     name="lambda",
+    output_path="e2e-test-runner-lambda.zip",
     runtime="python3.7",
     handler="./main.py:lambda_handler",
     dependencies=["./test_*.py", "./schemas.py"]

--- a/src/python/engagement-creator/BUILD
+++ b/src/python/engagement-creator/BUILD
@@ -2,6 +2,7 @@ python_library()
 
 python_awslambda(
     name="lambda",
+    output_path="engagement-creator-lambda.zip",
     runtime="python3.7",
     handler="engagement_creator.py:lambda_handler",
 )

--- a/src/python/engagement_edge/BUILD
+++ b/src/python/engagement_edge/BUILD
@@ -1,4 +1,5 @@
 python_awslambda(
+    output_path="engagement-edge-lambda.zip",
     runtime="python3.7",
     handler="engagement_edge/engagement_edge.py:app"
 )

--- a/src/python/grapl-dgraph-ttl/BUILD
+++ b/src/python/grapl-dgraph-ttl/BUILD
@@ -2,6 +2,7 @@ python_library()
 
 python_awslambda(
     name="lambda",
+    output_path="dgraph-ttl-lambda.zip",
     runtime="python3.7",
     handler="grapl_dgraph_ttl.py:prune_expired_subgraphs"
 )

--- a/src/python/grapl-model-plugin-deployer/BUILD
+++ b/src/python/grapl-model-plugin-deployer/BUILD
@@ -2,6 +2,7 @@ python_library()
 
 python_awslambda(
     name="lambda",
+    output_path="model-plugin-deployer-lambda.zip",
     runtime="python3.7",
     handler="grapl_model_plugin_deployer.py:app"
 )

--- a/src/python/grapl-ux-router/BUILD
+++ b/src/python/grapl-ux-router/BUILD
@@ -2,6 +2,7 @@ python_library()
 
 python_awslambda(
     name="lambda",
+    output_path="ux-router-lambda.zip",
     runtime="python3.7",
     handler="grapl_ux_router.py:app"
 )

--- a/src/python/provisioner/provisioner.Dockerfile
+++ b/src/python/provisioner/provisioner.Dockerfile
@@ -7,5 +7,5 @@ FROM grapl/graplctl:$TAG AS provisioner
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends unzip
 USER grapl
-COPY --chown=grapl ./dist/src.python.provisioner.provisioner/lambda.zip lambda.zip
+COPY --chown=grapl ./dist/provisioner-lambda.zip lambda.zip
 RUN unzip lambda.zip

--- a/src/python/provisioner/provisioner/BUILD
+++ b/src/python/provisioner/provisioner/BUILD
@@ -4,6 +4,7 @@ python_library(
 
 python_awslambda(
     name="lambda",
+    output_path="provisioner-lambda.zip",
     runtime="python3.7",
     handler="./app.py:provision",
 )


### PR DESCRIPTION
The idea of a "tag" doesn't make much sense when thinking about lambda
zip files, particularly in the near future when we'll have an artifact
repository for them. As such, we can remove this logic from our zip
file creation.

Additionally, zip files will not be created in
`src/aws-provision/zips` anymore, since they are artifacts and not
source code. Instead, they will be created in `dist`. Though this is
the default directory in which Pants creates its packages, we will
also use this for our Rust and Typescript-based lambdas.

Now, all lambda zip files will simply be named like
`<LAMBDA_NAME>-lambda.zip`.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
