### PR TITLE
Remove "grapl-" prefix from Docker services, container names

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -12,8 +12,8 @@ services:
   # Rust Services
   ########################################################################
 
-  grapl-sysmon-subgraph-generator:
-    image: grapl/grapl-sysmon-subgraph-generator:${TAG:-latest}
+  sysmon-subgraph-generator:
+    image: grapl/sysmon-subgraph-generator:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -21,8 +21,8 @@ services:
       args:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
-  grapl-osquery-subgraph-generator:
-    image: grapl/grapl-osquery-subgraph-generator:${TAG:-latest}
+  osquery-subgraph-generator:
+    image: grapl/osquery-subgraph-generator:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -30,8 +30,8 @@ services:
       args:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
-  grapl-node-identifier:
-    image: grapl/grapl-node-identifier:${TAG:-latest}
+  node-identifier:
+    image: grapl/node-identifier:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -39,8 +39,8 @@ services:
       args:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
-  grapl-node-identifier-retry-handler:
-    image: grapl/grapl-node-identifier-retry-handler:${TAG:-latest}
+  node-identifier-retry-handler:
+    image: grapl/node-identifier-retry-handler:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -48,8 +48,8 @@ services:
       args:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
-  grapl-graph-merger:
-    image: grapl/grapl-graph-merger:${TAG:-latest}
+  graph-merger:
+    image: grapl/graph-merger:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -57,8 +57,8 @@ services:
       args:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
-  grapl-analyzer-dispatcher:
-    image: grapl/grapl-analyzer-dispatcher:${TAG:-latest}
+  analyzer-dispatcher:
+    image: grapl/analyzer-dispatcher:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -70,15 +70,15 @@ services:
   # Python Services
   ########################################################################
 
-  grapl-analyzer-executor:
-    image: grapl/grapl-analyzer-executor:${TAG:-latest}
+  analyzer-executor:
+    image: grapl/analyzer-executor:${TAG:-latest}
     build:
       context: src
       dockerfile: ./python/Dockerfile
       target: analyzer-executor-deploy
 
-  grapl-model-plugin-deployer:
-    image: grapl/grapl-model-plugin-deployer:${TAG:-latest}
+  model-plugin-deployer:
+    image: grapl/model-plugin-deployer:${TAG:-latest}
     build:
       context: src
       dockerfile: ./python/Dockerfile
@@ -88,22 +88,22 @@ services:
   # Web Services
   ########################################################################
 
-  grapl-engagement-view-uploader:
-    image: grapl/grapl-engagement-view:${TAG:-latest}
+  engagement-view-uploader:
+    image: grapl/engagement-view:${TAG:-latest}
     build:
       context: src
       dockerfile: js/engagement_view/Dockerfile
       target: engagement-view-local-deploy
 
-  grapl-graphql-endpoint:
-    image: grapl/grapl-graphql-endpoint:${TAG:-latest}
+  graphql-endpoint:
+    image: grapl/graphql-endpoint:${TAG:-latest}
     build:
       context: src
       dockerfile: js/graphql_endpoint/Dockerfile
       target: graphql-endpoint-deploy
 
-  grapl-notebook:
-    image: grapl/grapl-notebook:${TAG:-latest}
+  notebook:
+    image: grapl/notebook:${TAG:-latest}
     build:
       context: src
       dockerfile: ./python/Dockerfile
@@ -113,8 +113,8 @@ services:
   # Utility Services
   ########################################################################
 
-  grapl-pulumi:
-    image: grapl/grapl-local-pulumi:${TAG:-latest}
+  pulumi:
+    image: grapl/local-pulumi:${TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.pulumi

--- a/docker-compose.lambda-zips.js.yml
+++ b/docker-compose.lambda-zips.js.yml
@@ -2,8 +2,8 @@ version: "3.8"
 
 services:
 
-  grapl-graphql-endpoint-zip:
-    image: grapl/grapl-graphql-endpoint-zip:${TAG:-latest}
+  graphql-endpoint-zip:
+    image: grapl/graphql-endpoint-zip:${TAG:-latest}
     build:
       context: src
       dockerfile: js/graphql_endpoint/Dockerfile

--- a/docker-compose.lambda-zips.rust.yml
+++ b/docker-compose.lambda-zips.rust.yml
@@ -2,8 +2,8 @@ version: "3.8"
 
 services:
 
-  grapl-metric-forwarder-zip:
-    image: grapl/rust-zip:${TAG:-latest}
+  metric-forwarder-zip:
+    image: grapl/metric-forwarder-zip:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,8 +171,8 @@ services:
   ########################################################################
 
 
-  grapl-sysmon-subgraph-generator:
-    image: grapl/grapl-sysmon-subgraph-generator:${TAG:-latest}
+  sysmon-subgraph-generator:
+    image: grapl/sysmon-subgraph-generator:${TAG:-latest}
     tty: false
     environment:
       <<: *aws-env
@@ -191,8 +191,8 @@ services:
       redis:
         condition: service_healthy
 
-  grapl-osquery-subgraph-generator:
-    image: grapl/grapl-osquery-subgraph-generator:${TAG:-latest}
+  osquery-subgraph-generator:
+    image: grapl/osquery-subgraph-generator:${TAG:-latest}
     tty: false
     environment:
       <<: *aws-env
@@ -212,8 +212,8 @@ services:
       redis:
         condition: service_healthy
 
-  grapl-node-identifier:
-    image: grapl/grapl-node-identifier:${TAG:-latest}
+  node-identifier:
+    image: grapl/node-identifier:${TAG:-latest}
     environment:
       <<: *aws-env
       DEAD_LETTER_QUEUE_URL: "${GRAPL_AWS_ENDPOINT}/queue/${DEPLOYMENT_NAME}-node-identifier-dead-letter-queue"
@@ -233,8 +233,8 @@ services:
       redis:
         condition: service_healthy
 
-  grapl-node-identifier-retry-handler:
-    image: grapl/grapl-node-identifier-retry-handler:${TAG:-latest}
+  node-identifier-retry-handler:
+    image: grapl/node-identifier-retry-handler:${TAG:-latest}
     environment:
       <<: *aws-env
       DEAD_LETTER_QUEUE_URL: "${GRAPL_AWS_ENDPOINT}/queue/${DEPLOYMENT_NAME}-node-identifier-dead-letter-queue"
@@ -254,8 +254,8 @@ services:
       redis:
         condition: service_healthy
 
-  grapl-graph-merger:
-    image: grapl/grapl-graph-merger:${TAG:-latest}
+  graph-merger:
+    image: grapl/graph-merger:${TAG:-latest}
     environment:
       <<: *aws-env
       DEAD_LETTER_QUEUE_URL: "${GRAPL_AWS_ENDPOINT}/queue/${DEPLOYMENT_NAME}-graph-merger-dead-letter-queue"
@@ -278,8 +278,8 @@ services:
       redis:
         condition: service_healthy
 
-  grapl-analyzer-dispatcher:
-    image: grapl/grapl-analyzer-dispatcher:${TAG:-latest}
+  analyzer-dispatcher:
+    image: grapl/analyzer-dispatcher:${TAG:-latest}
     environment:
       ANALYZER_BUCKET: "${DEPLOYMENT_NAME}-analyzers-bucket"
       <<: *aws-env
@@ -298,8 +298,8 @@ services:
   # Python Services
   ########################################################################
 
-  grapl-analyzer-executor:
-    image: grapl/grapl-analyzer-executor:${TAG:-latest}
+  analyzer-executor:
+    image: grapl/analyzer-executor:${TAG:-latest}
     environment:
       <<: *aws-env
       DEPLOYMENT_NAME: ${DEPLOYMENT_NAME}
@@ -328,8 +328,8 @@ services:
       redis:
         condition: service_healthy
 
-  grapl-model-plugin-deployer:
-    image: grapl/grapl-model-plugin-deployer:${TAG:-latest}
+  model-plugin-deployer:
+    image: grapl/model-plugin-deployer:${TAG:-latest}
     command: |
       /bin/sh -c '
         . venv/bin/activate &&
@@ -387,15 +387,15 @@ services:
       - LOCALSTACK_HOST
       - LOCALSTACK_PORT
     depends_on:
-      grapl-model-plugin-deployer:
+      model-plugin-deployer:
         condition: service_started
-      grapl-graphql-endpoint:
+      graphql-endpoint:
         condition: service_started
-      grapl-pulumi:
+      pulumi:
         # We must wait until Pulumi has created the API gateway so we
         # know what its URL is.
         condition: service_completed_successfully
-      grapl-engagement-view-uploader:
+      engagement-view-uploader:
         # nginx doesn't actually depend on engagement-view-uploader,
         # but we need *some* service to declare a dependency on the
         # engagement-view-uploader in order to catch non-0 exit codes
@@ -405,8 +405,8 @@ services:
         aliases:
           - ${GRAPL_API_HOST}
 
-  grapl-engagement-view-uploader:
-    image: grapl/grapl-engagement-view:${TAG:-latest}
+  engagement-view-uploader:
+    image: grapl/engagement-view:${TAG:-latest}
     command: |
       /bin/bash -c "./upload_local.sh"
     environment:
@@ -415,8 +415,8 @@ services:
       provisioner:
         condition: service_completed_successfully
 
-  grapl-graphql-endpoint:
-    image: grapl/grapl-graphql-endpoint:${TAG:-latest}
+  graphql-endpoint:
+    image: grapl/graphql-endpoint:${TAG:-latest}
     command: bash -c "./start_potentially_with_debugger.sh"
     environment:
       <<: *aws-env
@@ -444,7 +444,7 @@ services:
           - ${GRAPL_GRAPHQL_HOST}
 
   grapl-notebook:
-    image: grapl/grapl-notebook:${TAG:-latest}
+    image: grapl/notebook:${TAG:-latest}
     user: grapl
     environment:
       <<: *dgraph-env
@@ -457,8 +457,8 @@ services:
   # Utility Services
   ########################################################################
 
-  grapl-pulumi:
-    image: grapl/grapl-local-pulumi:${TAG:-latest}
+  pulumi:
+    image: grapl/local-pulumi:${TAG:-latest}
     command: |
       /bin/bash -c "
         cd grapl &&
@@ -513,7 +513,7 @@ services:
         condition: service_started
       localstack:
         condition: service_healthy
-      grapl-pulumi:
+      pulumi:
         condition: service_completed_successfully
 
 networks:

--- a/test/docker-compose.e2e-tests.yml
+++ b/test/docker-compose.e2e-tests.yml
@@ -4,7 +4,7 @@ version: "3.8"
 
 services:
 
-  grapl-e2e-tests:
+  e2e-tests:
     image: grapl/e2e-tests:${TAG:-latest}
     build:
       context: .

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -37,8 +37,8 @@ services:
       - ASSET_ID_MAPPINGS=${DEPLOYMENT_NAME}-asset_id_mappings
       - REDIS_ENDPOINT
 
-  grapl-analyzerlib-integration-tests:
-    image: grapl/grapl-analyzerlib-test:${TAG:-latest}
+  analyzerlib-integration-tests:
+    image: grapl/analyzerlib-test:${TAG:-latest}
     build:
       context: ${PWD}/src
       dockerfile: ./python/Dockerfile
@@ -55,7 +55,7 @@ services:
   # grapl-analyzer-deployer-integration-tests:
 
   analyzer-executor-integration-tests:
-    image: grapl/grapl-analyzer-executor-test:${TAG:-latest}
+    image: grapl/analyzer-executor-test:${TAG:-latest}
     build:
       context: ${PWD}/src
       dockerfile: ./python/Dockerfile

--- a/test/docker-compose.typecheck-tests.yml
+++ b/test/docker-compose.typecheck-tests.yml
@@ -1,8 +1,8 @@
 version: "3.8"
 
 services:
-  typecheck-grapl-analyzerlib:
-    image: grapl/grapl-analyzerlib-test:${TAG:-latest}
+  typecheck-analyzerlib:
+    image: grapl/analyzerlib-test:${TAG:-latest}
     build:
       context: ${PWD}/src
       dockerfile: ./python/Dockerfile

--- a/test/docker-compose.unit-tests-js.yml
+++ b/test/docker-compose.unit-tests-js.yml
@@ -4,16 +4,16 @@ version: "3.8"
 
 services:
 
-  grapl-engagement-view-test:
-    image: grapl/grapl-engagement-view-build:${TAG:-latest}
-    build: 
+  engagement-view-test:
+    image: grapl/engagement-view-build:${TAG:-latest}
+    build:
       context: ${PWD}/src
       dockerfile: js/engagement_view/Dockerfile
       target: engagement-view-deps
     command: sh -c 'CI=true yarn test'
 
-  grapl-graphql-endpoint-test:
-    image: grapl/grapl-graphql-endpoint:${TAG:-latest}
+  graphql-endpoint-test:
+    image: grapl/graphql-endpoint:${TAG:-latest}
     build:
       context: ${PWD}/src
       dockerfile: js/graphql_endpoint/Dockerfile

--- a/test/docker-compose.unit-tests-rust.yml
+++ b/test/docker-compose.unit-tests-rust.yml
@@ -4,7 +4,7 @@ version: "3.8"
 
 services:
 
-  grapl-rust-test:
+  rust-test:
     image: grapl/rust-test-unit:${TAG:-latest}
     build:
       context: ${PWD}/src


### PR DESCRIPTION
This is just redundant, particularly in a world where we'll be
uploading containers to a registry that already incorporates the name
"grapl".

Signed-off-by: Christopher Maier <chris@graplsecurity.com>