### PR TITLE
Run e2e and integration tests on docker queue

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -111,7 +111,7 @@ steps:
     command:
       - .buildkite/scripts/integration.sh
     agents:
-      queue: "beefy"
+      queue: "docker"
     artifact_paths:
       - "test_artifacts/**/*"
 
@@ -119,6 +119,6 @@ steps:
     command:
       - .buildkite/scripts/e2e.sh
     agents:
-      queue: "beefy"
+      queue: "docker"
     artifact_paths:
       - "test_artifacts/**/*"


### PR DESCRIPTION
In preparation for creating container images for actual consumption in
our infrastructure in our new merge pipeline, I created a dedicated
"docker" agent queue. It has the same machine type as our "beefy"
queue, but instances hang around for much longer (3 hours of idle
time, as opposed to 10 minutes), and also have more
agents-per-machine (3 versus 1).

With this longer time, repeated runs of integration and e2e
tests (which currently rely heavily on containerized test runs) will
proceed faster because of the container layer cache. Furthermore,
since the same images we'll use in production get built in these
steps, it will also speed up those builds when we do them in the merge
pipeline.

We may adjust the idle time, agent density, and power of these
machines in the future, or shift to more intense use of `--cache-from`
in our builds, but for now, this change should speed things up pretty
noticeably.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>