### PR TITLE
Swap the base image used for Rust service containers.

### DIFF
--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -110,14 +110,12 @@ RUN mkdir -p /grapl/zips; \
 
 # images for running services
 ################################################################################
-FROM debian:buster-slim AS rust-dist
+# More information about the base image used here can be found at: 
+# https://github.com/GoogleContainerTools/distroless/blob/main/cc/README.md.
+# For debugging see: https://github.com/GoogleContainerTools/distroless#debug-images
+FROM gcr.io/distroless/cc AS rust-dist
 
-RUN --mount=type=cache,target=/var/lib/apt/lists \
-    apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        netbase
-
-USER nobody
+USER nonroot
 
 # analyzer-dispatcher
 FROM rust-dist AS analyzer-dispatcher-deploy


### PR DESCRIPTION
### Which issue does this PR correspond to?

NA

### What changes does this PR make to Grapl? Why?

The Rust service containers were previously built from the `debian:buster-slim` image from Docker Hub. This changes that to use `gcr.io/distroless/cc`[1] instead, which is a much smaller image that contains a minimal environment for running our Rust services. The distroless image is significantly smaller than the buster-slim image:

```
debian                                      buster-slim          7c5871f12659   9 days ago           69.2MB
...
gcr.io/distroless/cc                        latest    2d782957ae08   51 years ago         21.2MB
```

Note: this is pulling from Google's registry, not Docker Hub.

[1] https://github.com/GoogleContainerTools/distroless/blob/main/cc/README.md

### How were these changes tested?

I tested locally by running the E2E tests.
