### PR TITLE
Remove unused apt packages from Rust Dockerfile

### DIFF
--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -7,10 +7,7 @@ SHELL ["/bin/bash", "-c"]
 # Necessary for rdkafka
 RUN --mount=type=cache,target=/var/lib/apt/lists \
     apt-get update && apt-get install -y --no-install-recommends \
-        cmake \
-        libzstd-dev \
-        build-essential \
-        zlib1g-dev
+        build-essential
 
 # Install rust toolchain before copying sources to avoid unecessarily
 # resinstalling on source file changes.

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -7,7 +7,6 @@ SHELL ["/bin/bash", "-c"]
 # Necessary for rdkafka
 RUN --mount=type=cache,target=/var/lib/apt/lists \
     apt-get update && apt-get install -y --no-install-recommends \
-        python3 \
         cmake \
         libzstd-dev \
         build-essential \


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

The addition of the rdkafka crate to Rust[1] required the addition of some system packages so rdkafka can build libkafka. However, some of these packages are not used given the current rdkafka crate features configured, and one package, `python3` would never be used. This PR removes the unused packages.

[1] https://github.com/grapl-security/grapl/commit/41968243c464fd130c7ae27674285dd98756c8e1#diff-fced7b1d032ab8c938ca99a5697d58f745f962904b5a63ad6960f67a8eaec189

### How were these changes tested?

I built the Rust sources locally with these changes.