### PR TITLE
Switch integration and e2e tests back to "beefy" queue

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -111,7 +111,7 @@ steps:
     command:
       - .buildkite/scripts/integration.sh
     agents:
-      queue: "docker"
+      queue: "beefy"
     artifact_paths:
       - "test_artifacts/**/*"
 
@@ -119,6 +119,6 @@ steps:
     command:
       - .buildkite/scripts/e2e.sh
     agents:
-      queue: "docker"
+      queue: "beefy"
     artifact_paths:
       - "test_artifacts/**/*"


### PR DESCRIPTION
These shouldn't actually run on our "docker" queue as it exists right
now, because more than one agent can run on those machines. These
tests don't seem to be able to tolerate having multiple instances
running at once on a single machine.

For now, we'll just move back to the "beefy" queue, which is one agent
per machine, pending further investigation.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
