### PR TITLE
Remove unnecessary quotes from Pulumi stack configuration

### DIFF
--- a/pulumi/grapl/Pulumi.testing.yaml
+++ b/pulumi/grapl/Pulumi.testing.yaml
@@ -1,33 +1,33 @@
 config:
-  aws:region: "us-east-1"
+  aws:region: us-east-1
   grapl:env_vars:
     analyzer-dispatcher:
       RUST_BACKTRACE: "1"
-      RUST_LOG: "DEBUG"
+      RUST_LOG: DEBUG
     analyzer-executor:
-      GRAPL_LOG_LEVEL: "DEBUG"
+      GRAPL_LOG_LEVEL: DEBUG
     dgraph-ttl:
-      GRAPL_LOG_LEVEL: "DEBUG"
+      GRAPL_LOG_LEVEL: DEBUG
     engagement-creator:
-      GRAPL_LOG_LEVEL: "DEBUG"
+      GRAPL_LOG_LEVEL: DEBUG
     engagement-edge:
-      GRAPL_LOG_LEVEL: "DEBUG"
+      GRAPL_LOG_LEVEL: DEBUG
     graph-merger:
       RUST_BACKTRACE: "1"
-      RUST_LOG: "DEBUG"
+      RUST_LOG: DEBUG
     metric-forwarder:
       RUST_BACKTRACE: "1"
-      RUST_LOG: "DEBUG"
+      RUST_LOG: DEBUG
     model-plugin-deployer:
-      GRAPL_LOG_LEVEL: "DEBUG"
+      GRAPL_LOG_LEVEL: DEBUG
     node-identifier:
       RUST_BACKTRACE: "1"
-      RUST_LOG: "DEBUG"
+      RUST_LOG: DEBUG
     osquery-generator:
       RUST_BACKTRACE: "1"
-      RUST_LOG: "DEBUG"
+      RUST_LOG: DEBUG
     sysmon-generator:
       RUST_BACKTRACE: "1"
-      RUST_LOG: "DEBUG"
+      RUST_LOG: DEBUG
     ux-router:
-      GRAPL_LOG_LEVEL: "DEBUG"
+      GRAPL_LOG_LEVEL: DEBUG


### PR DESCRIPTION
When you use Pulumi to manage your configuration (e.g., `pulumi config
set foo bar`), it will write the entire configuration file back out
according to its own notion of formatting. In our case, this means
that quotes that were manually added around string values will be
stripped.

Since we make heavy use of `pulumi config set` in our pipeline to set
and update artifact version pins, this means that commits to our `rc`
branch will always have spurious diffs around these stripped quotes.

We have lost the war of the YAML quotes.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>