### PR TITLE
Selectively build artifacts only if we need to

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -5,68 +5,42 @@ env:
 steps:
 
   - label: ":aws-lambda::rust: Build Rust Lambdas"
-    command:
-      - "make lambdas-rust"
-    key: "rust-lambdas"
-    artifact_paths:
-      - "dist/*-lambda.zip"
-    agents:
-      queue: "docker"
-
-    # TODO: Add this conditionality after the first run-through, so
-    # the tags the diffing logic is based on are created naturally.
-    #
-    # plugins:
-    #   - chronotc/monorepo-diff#v2.0.4:
-    #       diff: .buildkite/shared/scripts/diff.sh
-    #       watch:
-    #         - path:
-    #             - "src/rust/"  # This is not minimal, obviously
-    #             - "docker-compose.lambda-zips.rust.yml"
-    #           config:
-    #             command:
-    #               - "make lambdas-rust"
-    #             artifact_paths:
-    #               - "dist/*-lambda.zip"
-    #             agents:
-    #               queue: "docker"
+    plugins:
+      - chronotc/monorepo-diff#v2.0.4:
+          diff: .buildkite/shared/scripts/diff.sh
+          watch:
+            - path:
+                - "src/rust/"  # This is not minimal, obviously
+                - "docker-compose.lambda-zips.rust.yml"
+              config:
+                command:
+                  - "make lambdas-rust"
+                artifact_paths:
+                  - "dist/*-lambda.zip"
+                agents:
+                  queue: "docker"
 
   - label: ":aws-lambda::typescript: Build Typescript Lambdas"
-    command:
-      - "make lambdas-js"
-    key: "js-lambdas"
-    artifact_paths:
-      - "dist/*-lambda.zip"
-    agents:
-      queue: "docker"
-
-    # TODO: Add this conditionality after the first run-through, so
-    # the tags the diffing logic is based on are created naturally.
-    #
-    # plugins:
-    #   - chronotc/monorepo-diff#v2.0.4:
-    #       # diff: .buildkite/shared/scripts/diff.sh
-    #       watch:
-    #         - path:
-    #             - "src/js/"  # This is not minimal, obviously
-    #             - "docker-compose.lambda-zips.js.yml"
-    #           config:
-    #             command:
-    #               - "make lambdas-js"
-    #             artifact_paths:
-    #               - "dist/*-lambda.zip"
-    #             agents:
-    #               queue: "docker"
+    plugins:
+      - chronotc/monorepo-diff#v2.0.4:
+          diff: .buildkite/shared/scripts/diff.sh
+          watch:
+            - path:
+                - "src/js/"  # This is not minimal, obviously
+                - "docker-compose.lambda-zips.js.yml"
+              config:
+                command:
+                  - "make lambdas-js"
+                artifact_paths:
+                  - "dist/*-lambda.zip"
+                agents:
+                  queue: "docker"
 
   - label: ":aws-lambda::python: Build Python Lambdas"
     command:
-      - "make lambdas-python"
-      # TODO: Add this conditionality after the first run-through, so
-      # the tags the diffing logic is based on are created naturally.
-      #
       # Strictly speaking, this would also build Python wheels, but
       # those aren't named *-lambda.zip
-      # - "./pants --changed-since=internal/last-successful-merge --changed-dependees=transitive package"
+      - "./pants --changed-since=internal/last-successful-merge --changed-dependees=transitive package"
     key: "python-lambdas"
     artifact_paths:
       - "dist/*-lambda.zip"


### PR DESCRIPTION
Rather than creating new versions of every single artifact every time
we merge a PR, we will only build if something has changed that
requires a new artifact.

For our Python artifacts, we can rely on Pants' fine-grained
dependency awareness to only build the artifacts whose inputs have
changed since our last successful run through the merge pipeline.

For Rust- and Javascript-based artifacts, however, we have to use a
different approach (since Pants does not know about these languages
yet). Here, we'll use the `monorepo-diff` Buildkite plugin, along with
our tagging-convention-aware diff script. It is not a perfect
solution, since we currently either build all Rust containers or no
Rust containers, but it's a step forward.

(Absent code-aware "what changed" logic, we would have to maintain
detailed manual lists of all the inter-file dependencies across our
Rust workspace, which is tedious and error prone.)

Signed-off-by: Christopher Maier <chris@graplsecurity.com>