### PR TITLE
Add the step keys back to the lambda steps

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -5,6 +5,7 @@ env:
 steps:
 
   - label: ":aws-lambda::rust: Build Rust Lambdas"
+    key: "rust-lambdas"
     plugins:
       - chronotc/monorepo-diff#v2.0.4:
           diff: .buildkite/shared/scripts/diff.sh
@@ -21,6 +22,7 @@ steps:
                   queue: "docker"
 
   - label: ":aws-lambda::typescript: Build Typescript Lambdas"
+    key: "js-lambdas"
     plugins:
       - chronotc/monorepo-diff#v2.0.4:
           diff: .buildkite/shared/scripts/diff.sh
@@ -37,11 +39,11 @@ steps:
                   queue: "docker"
 
   - label: ":aws-lambda::python: Build Python Lambdas"
+    key: "python-lambdas"
     command:
       # Strictly speaking, this would also build Python wheels, but
       # those aren't named *-lambda.zip
       - "./pants --changed-since=internal/last-successful-merge --changed-dependees=transitive package"
-    key: "python-lambdas"
     artifact_paths:
       - "dist/*-lambda.zip"
 


### PR DESCRIPTION
These got inadvertently left out of the steps when they were converted
to use the monorepo-diff plugin.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
