### PR TITLE
I screwed up some shell stuff in the AMI merge step

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -87,6 +87,7 @@ steps:
                 - "packer/"
                 - ".buildkite/scripts/build_packer_ci.sh"
                 - ".buildkite/scripts/lib/packer.sh"
+                - ".buildkite/scripts/lib/packer_constants.sh"
               config:
                 label: ":pipeline: Upload AMI Build"
                 command: "buildkite-agent pipeline upload .buildkite/pipeline.merge.ami-build.yml"

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -143,8 +143,11 @@ steps:
           diff: .buildkite/shared/scripts/diff.sh
           watch:
             - path:
-                - "packer/"
                 - ".buildkite/scripts/test_packer.sh"
+                - "packer/"
+                - ".buildkite/scripts/build_packer_ci.sh"
+                - ".buildkite/scripts/lib/packer.sh"
+                - ".buildkite/scripts/lib/packer_constants.sh"
               config:
                 label: ":pipeline: Upload AMI Test"
                 command: "buildkite-agent pipeline upload .buildkite/pipeline.verify.ami-test.yml"

--- a/.buildkite/scripts/lib/packer_constants.sh
+++ b/.buildkite/scripts/lib/packer_constants.sh
@@ -23,4 +23,4 @@ readonly PACKER_IMAGE_NAMES=(
     "grapl-nomad-consul-client"
 )
 
-readonly PACKER_MANIFEST_SUFFIX = ".packer-manifest.json"
+readonly PACKER_MANIFEST_SUFFIX=".packer-manifest.json"


### PR DESCRIPTION
fixes the following at the merge ami stage:
https://buildkite.com/grapl/grapl-merge/builds/54#b1d4a25f-f2f6-4d18-8a30-ca103b009e03
```
.buildkite/scripts/lib/packer_constants.sh: line 26: readonly: `=': not a valid identifier
.buildkite/scripts/lib/packer_constants.sh: line 26: readonly: `.packer-manifest.json': not a valid identifier
```