### PR TITLE
Ensure that the Record AMI ID step waits properly

### DIFF
--- a/.buildkite/pipeline.merge.ami-build.yml
+++ b/.buildkite/pipeline.merge.ami-build.yml
@@ -22,9 +22,10 @@ steps:
       # https://github.com/grapl-security/issue-tracker/issues/613
       queue: "packer"
 
+  - wait
+
   # This just has to extract the AMI ID and jam it into the artifact
   # store to pick up later.
   - label: ":writing_hand: Record AMI ID"
     command:
       - .buildkite/scripts/record_artifacts.sh
-    depends_on: "ami-build"


### PR DESCRIPTION
In a previous iteration, the build step was defined with a key of
"ami-build". However, that was removed for other reasons.

Instead of using a key, here we can just use a wait step.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>