### PR TITLE
Use some globs in the packer-build pipelines. Unrelated: Also, add some ymls to the formatter.

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -86,8 +86,7 @@ steps:
             - path:
                 - "packer/"
                 - ".buildkite/scripts/build_packer_ci.sh"
-                - ".buildkite/scripts/lib/packer.sh"
-                - ".buildkite/scripts/lib/packer_constants.sh"
+                - ".buildkite/scripts/lib/packer*.sh"
               config:
                 label: ":pipeline: Upload AMI Build"
                 command: "buildkite-agent pipeline upload .buildkite/pipeline.merge.ami-build.yml"

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -3,7 +3,6 @@ env:
   PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
 
 steps:
-
   - label: ":aws-lambda::rust: Build Rust Lambdas"
     key: "rust-lambdas"
     plugins:
@@ -11,7 +10,7 @@ steps:
           diff: .buildkite/shared/scripts/diff.sh
           watch:
             - path:
-                - "src/rust/"  # This is not minimal, obviously
+                - "src/rust/" # This is not minimal, obviously
                 - "docker-compose.lambda-zips.rust.yml"
               config:
                 command:
@@ -28,7 +27,7 @@ steps:
           diff: .buildkite/shared/scripts/diff.sh
           watch:
             - path:
-                - "src/js/"  # This is not minimal, obviously
+                - "src/js/" # This is not minimal, obviously
                 - "docker-compose.lambda-zips.js.yml"
               config:
                 command:

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -10,7 +10,6 @@ env:
 # TODO: possibly just us Docker for caching?
 
 steps:
-
   - label: ":github: Validate CODEOWNERS"
     command: ".buildkite/scripts/validate_codeowners.sh"
     plugins:
@@ -122,7 +121,7 @@ steps:
       queue: "beefy"
     artifact_paths:
       - "test_artifacts/**/*"
-  
+
   - label: ":packer::lint-roller: Packer Linting"
     command:
       # Since we run it in a container, we can't use the `make` for it
@@ -132,7 +131,7 @@ steps:
       - docker#v3.8.0:
           image: "hashicorp/packer:1.7.2"
           entrypoint: bash
-  
+
   - label: ":thinking_face: AMI Test?"
     # Don't want to run this again in the merge pipeline, since
     # building the image does exactly the same thing. We don't want to

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -143,11 +143,10 @@ steps:
           diff: .buildkite/shared/scripts/diff.sh
           watch:
             - path:
-                - ".buildkite/scripts/test_packer.sh"
                 - "packer/"
                 - ".buildkite/scripts/build_packer_ci.sh"
-                - ".buildkite/scripts/lib/packer.sh"
-                - ".buildkite/scripts/lib/packer_constants.sh"
+                - ".buildkite/scripts/test_packer.sh"
+                - ".buildkite/scripts/lib/packer*.sh"
               config:
                 label: ":pipeline: Upload AMI Test"
                 command: "buildkite-agent pipeline upload .buildkite/pipeline.verify.ami-test.yml"

--- a/.buildkite/scripts/test_packer.sh
+++ b/.buildkite/scripts/test_packer.sh
@@ -8,4 +8,8 @@ echo -e "--- :packer: Performing test build of AMI"
 
 source .buildkite/scripts/lib/packer.sh
 
+# We don't actually use anything in `constants` here, but make sure we can
+# source it without errors.
+source .buildkite/scripts/lib/packer_constants.sh
+
 PACKER_VARS="-var build_ami=false" build_ami

--- a/src/js/bin/format.sh
+++ b/src/js/bin/format.sh
@@ -81,4 +81,6 @@ prettier \
     --config prettierrc-yaml.toml \
     ${prettier_arg} \
     ${repo_root}/**/*.yml \
-    ${repo_root}/**/*.yaml
+    ${repo_root}/**/*.yaml \
+    ${repo_root}/.buildkite/**/*.yml \
+    ${repo_root}/.github/**/*.yml


### PR DESCRIPTION
using globs was requested by cm previously in https://github.com/grapl-security/grapl/pull/987
but that PR has since been merged.

unrelated (and should probably be a different PR, but I am lazy):
also, realized hidden files are not automatically picked up by the prettier **/* glob, so manually specified buildkite and github ymls.