### PR TITLE
add dist/codegen to pyrightconfig.json

### DIFF
--- a/build-support/editor_setup.py
+++ b/build-support/editor_setup.py
@@ -97,6 +97,7 @@ def src_python_execution_environment() -> Dict[str, Union[str, List[str]]]:
         )
     ]
     relativized = [root.lstrip("/") for root in filtered]
+    relativized.append("dist/codegen")
 
     return {"root": "src/python", "extraPaths": relativized}
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
NA
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
update `build-support/editor_setup.py` to emit a pyright config which ideally should make pyright aware of the generated protobuf stubs emitted by pants with `./pants export-codegen ::`
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
checked that `dist/codegen` is in the `"extraPaths"` for the `"src/python"` execution environment
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
