### PR TITLE
Add tags to Packer Builder instances for tracking

### DIFF
--- a/.buildkite/pipeline.merge.ami-build.yml
+++ b/.buildkite/pipeline.merge.ami-build.yml
@@ -12,10 +12,18 @@ env:
 steps:
   - label: ":packer: AMI Build"
     command: ".buildkite/scripts/build_packer_ci.sh"
+    key: "ami-build" # Used to tag the Packer Builder instance
     plugins:
       - docker#v3.8.0:
           image: "hashicorp/packer:1.7.2"
           entrypoint: bash
+          environment:
+            - "BUILDKITE_BRANCH"
+            - "BUILDKITE_BUILD_NUMBER"
+            - "BUILDKITE_COMMIT"
+            - "BUILDKITE_PIPELINE_NAME"
+            - "BUILDKITE_STEP_KEY"
+
           propagate-environment: true
     agents:
       # TODO: change this to a different queue

--- a/.buildkite/pipeline.verify.ami-test.yml
+++ b/.buildkite/pipeline.verify.ami-test.yml
@@ -13,11 +13,18 @@ env:
 steps:
   - label: ":packer: AMI Test Build"
     command: ".buildkite/scripts/test_packer.sh"
+    key: "ami-test" # Used to tag the Packer Builder instance
     plugins:
       - docker#v3.8.0:
           image: "hashicorp/packer:1.7.2"
           entrypoint: bash
-          # No need for propagate-aws-auth-tokens - packer automatically uses the metadata
+          environment:
+            - "BUILDKITE_BRANCH"
+            - "BUILDKITE_BUILD_NUMBER"
+            - "BUILDKITE_COMMIT"
+            - "BUILDKITE_PIPELINE_NAME"
+            - "BUILDKITE_STEP_KEY"
+
     agents:
       # TODO: change this to a different queue
       # https://github.com/grapl-security/issue-tracker/issues/613


### PR DESCRIPTION
I recently discovered a number of long-lived Packer Builder instances
still running. Tagging them with some extra metadata should help make
it easier to figure out what's going on.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>