### PR TITLE
Temporarily disable Pants caching plugin

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -24,5 +24,5 @@ pants_ignore = [
   ".cache/pants/lmdb_store",
 ]
 
-[auth]
-from_env_var = "TOOLCHAIN_AUTH_TOKEN"
+# [auth]
+# from_env_var = "TOOLCHAIN_AUTH_TOKEN"

--- a/pants.toml
+++ b/pants.toml
@@ -25,26 +25,26 @@ build_file_prelude_globs = [
 pants_ignore = [
 ]
 
-plugins = [
-  "toolchain.pants.plugin==0.13.0"
-]
+# plugins = [
+#   "toolchain.pants.plugin==0.13.0"
+# ]
 
-remote_cache_read = true
-remote_cache_write = true
-remote_store_address = "grpcs://cache.toolchain.com:443"
-remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
+# remote_cache_read = true
+# remote_cache_write = true
+# remote_store_address = "grpcs://cache.toolchain.com:443"
+# remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
 
-[toolchain-setup]
-repo = "grapl"
+# [toolchain-setup]
+# repo = "grapl"
 
-[buildsense]
-enable = true
+# [buildsense]
+# enable = true
 
-# See https://www.pantsbuild.org/docs/anonymous-telemetry
-[anonymous-telemetry]
-enabled = true
-# Randomly generated with `uuidgen --random`
-repo_id = "f416be7b-e109-4915-8eba-940bcfa310c1"
+# # See https://www.pantsbuild.org/docs/anonymous-telemetry
+# [anonymous-telemetry]
+# enabled = true
+# # Randomly generated with `uuidgen --random`
+# repo_id = "f416be7b-e109-4915-8eba-940bcfa310c1"
 
 # Given how our code is currently structured, with package and test
 # code for every project in their own directory, I believe we have to


### PR DESCRIPTION
For as-yet-undiagnosed reasons, the caching plugin stopped working
properly, preventing Pants from being able to run. It appears to have
something to do with a recent update to the Python `requests` library.

The engineers at Toolchain Labs are aware of the issue and are working
on a fix. In the meantime, and to unblock our pipelines, we're just
going to disable the plugin. Jobs may take a bit longer to run, but
they will at least be running.

As soon as we can re-enable the plugin, we will.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>