### PR TITLE
Multiline issues in our yaml caused merge_artifacts issues.

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -89,7 +89,7 @@ steps:
               config:
                 label: ":pipeline: Upload AMI Build"
                 command: "buildkite-agent pipeline upload .buildkite/pipeline.merge.ami-build.yml"
-  
+
   # This will also wait for the uploaded pipeline, if we did decide to upload it.
   - wait
 
@@ -97,10 +97,12 @@ steps:
   # uploaded to Buildkite from previous steps in this pipeline.
   - label: "Merge artifacts files"
     command:
-      - .buildkite/scripts/merge_artifact_files.sh \
-        lambda_artifacts.json \
-        container_artifacts.json \
-        grapl-nomad-consul-server.artifacts.json \
+      # yaml fyi: `>` collapses newlines into normal spaces
+      - >
+        .buildkite/scripts/merge_artifact_files.sh
+        lambda_artifacts.json
+        container_artifacts.json
+        grapl-nomad-consul-server.artifacts.json
         grapl-nomad-consul-client.artifacts.json
 
   - wait


### PR DESCRIPTION
### Which issue does this PR correspond to?
In this `grapl/merge` build:
https://buildkite.com/grapl/grapl-merge/builds/67#b36055fa-e73f-4da9-a136-67139eb99e7a
```
Download ' grapl-nomad-consul-client.artifacts.json' artifacts file | 0s
-- | --
  | 2021-07-13 21:13:44 INFO   Searching for artifacts: " grapl-nomad-consul-client.artifacts.json"
  | 2021-07-13 21:13:44 FATAL  Failed to download artifacts: No artifacts found for downloading
  | No file found
```
**Note the space in front of grapl-nomad.... ugh...**
getting rid of `\`s and using the `>` (which is tailor made for multi-line commands, it turns out) should theoretically solve this issue.

other approach: trim strings in `merge_artifact_files.sh` (i'd rather not) (apparently the best bash way to trim strings? xargs!)


<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
- got the string output of `yaml load`ing it
- copy paste into terminal
- correctly see that the quoted `--- Download "<filenamehere>"` doesn't have a space in front of it
![image](https://user-images.githubusercontent.com/69007229/125528610-3a6a48e7-354d-4250-a751-9df848f92409.png)

