### PR TITLE
Use new queues in CI

### DIFF
--- a/.buildkite/pipeline.merge.ami-build.yml
+++ b/.buildkite/pipeline.merge.ami-build.yml
@@ -17,7 +17,7 @@ steps:
       - docker#v3.8.0:
           image: "hashicorp/packer:1.7.2"
           entrypoint: bash
-          propagate-environment: true
+          propagate-aws-auth-tokens: true
           environment:
             - "BUILDKITE_BRANCH"
             - "BUILDKITE_BUILD_NUMBER"
@@ -26,18 +26,16 @@ steps:
             - "BUILDKITE_STEP_KEY"
             - "PACKER_IMAGE_NAME=grapl-nomad-consul-server"
     agents:
-      # TODO: change this to a different queue
-      # https://github.com/grapl-security/issue-tracker/issues/613
-      queue: "packer"
+      queue: "packer-staging"
 
   - label: ":packer: AMI Build Client"
     command: ".buildkite/scripts/build_packer_ci.sh"
-    key: "ami-build-client"
+    key: "ami-build-client" # Used to tag the Packer Builder instance
     plugins:
       - docker#v3.8.0:
           image: "hashicorp/packer:1.7.2"
           entrypoint: bash
-          propagate-environment: true
+          propagate-aws-auth-tokens: true
           environment:
             - "BUILDKITE_BRANCH"
             - "BUILDKITE_BUILD_NUMBER"
@@ -46,9 +44,7 @@ steps:
             - "BUILDKITE_STEP_KEY"
             - "PACKER_IMAGE_NAME=grapl-nomad-consul-client"
     agents:
-      # TODO: change this to a different queue
-      # https://github.com/grapl-security/issue-tracker/issues/613
-      queue: "packer"
+      queue: "packer-staging"
 
   - wait
 

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -121,7 +121,7 @@ steps:
     agents:
       # Has to be pulumi, even though we're not *running* pulumi; we
       # just have to log in so we can manipulate pulumi configs.
-      queue: "pulumi"
+      queue: "pulumi-staging"
 
   - wait
 

--- a/.buildkite/pipeline.verify.ami-test.yml
+++ b/.buildkite/pipeline.verify.ami-test.yml
@@ -12,13 +12,12 @@ env:
 
 steps:
   - label: ":packer: AMI Test Build: Server"
-    key: "ami-test-server" # Used to tag the Packer Builder instance
     command: ".buildkite/scripts/tests_in_ci/packer_integration_test.sh"
     plugins:
       - docker#v3.8.0:
           image: "hashicorp/packer:1.7.2"
           entrypoint: bash
-          # No need for propagate-aws-auth-tokens - packer automatically uses the metadata
+          propagate-aws-auth-tokens: true
           environment:
             - "BUILDKITE_BRANCH"
             - "BUILDKITE_BUILD_NUMBER"
@@ -27,17 +26,15 @@ steps:
             - "BUILDKITE_STEP_KEY"
             - "PACKER_IMAGE_NAME=grapl-nomad-consul-server"
     agents:
-      # TODO: change this to a different queue
-      # https://github.com/grapl-security/issue-tracker/issues/613
-      queue: "packer"
+      queue: "packer-staging"
 
   - label: ":packer: AMI Test Build: Client"
-    key: "ami-test-client" # Used to tag the Packer Builder instance
     command: ".buildkite/scripts/tests_in_ci/packer_integration_test.sh"
     plugins:
       - docker#v3.8.0:
           image: "hashicorp/packer:1.7.2"
           entrypoint: bash
+          propagate-aws-auth-tokens: true
           environment:
             - "BUILDKITE_BRANCH"
             - "BUILDKITE_BUILD_NUMBER"
@@ -46,6 +43,4 @@ steps:
             - "BUILDKITE_STEP_KEY"
             - "PACKER_IMAGE_NAME=grapl-nomad-consul-client"
     agents:
-      # TODO: change this to a different queue
-      # https://github.com/grapl-security/issue-tracker/issues/613
-      queue: "packer"
+      queue: "packer-staging"


### PR DESCRIPTION
Switches our `pulumi` and `packer` queue usage to the new `pulumi-staging` and `packer-staging` queues, allowing us to retire the old queues.