### PR TITLE
Flatten the AMI IDs map, so that create_rc can use it to do pulumi config set stuff

### DIFF
--- a/.buildkite/scripts/lib/artifacts.sh
+++ b/.buildkite/scripts/lib/artifacts.sh
@@ -42,6 +42,10 @@ download_artifact_file() {
     if ! (buildkite-agent artifact download "${artifacts_file}" "${ARTIFACT_FILE_DIRECTORY}"); then
         echo "No file found"
     fi
+    # TODO: Would be nice to validate the artifacts. Right now there are some restrictions:
+    # - json file must be a flat associative array of key -> primitive (no nested maps, arrays)
+    #     bad: {"im": {"nested": true}}
+    #     good: {"im.nested": true}
 }
 
 # Given a directory of JSON files (assumed to represent JSON objects),

--- a/.buildkite/scripts/lib/extract_ami_id_dict.jq
+++ b/.buildkite/scripts/lib/extract_ami_id_dict.jq
@@ -11,6 +11,8 @@
 # [ ["us-east-1": "ami-111"], ...]
 | map(split(":"))
 
+# sample output:
+# { "us-east-1": "ami-111", }
 | reduce .[] as $region_and_ami_id(
     {};  # becomes `.` in below context
     .[$region_and_ami_id[0]] = $region_and_ami_id[1]  # {[k] = v}

--- a/.buildkite/scripts/lib/extract_ami_id_dict.jq
+++ b/.buildkite/scripts/lib/extract_ami_id_dict.jq
@@ -12,8 +12,10 @@
 | map(split(":"))
 
 # sample output:
-# { "us-east-1": "ami-111", }
+# { "imgname.us-east-1": "ami-111", ...}
 | reduce .[] as $region_and_ami_id(
-    {};  # becomes `.` in below context
-    .[$region_and_ami_id[0]] = $region_and_ami_id[1]  # {[k] = v}
+    {};  # becomes the self - or `.` in below context
+    # We use a period delimiter in the key so that, much later down the pipeline,  
+    # we can shove it into `pulumi config set --path artifacts.imagename.region`
+    .[$IMAGE_NAME + "." + $region_and_ami_id[0]] = $region_and_ami_id[1]  # {[k] = v}
 )

--- a/.buildkite/scripts/lib/extract_ami_id_dict_test.sh
+++ b/.buildkite/scripts/lib/extract_ami_id_dict_test.sh
@@ -9,10 +9,10 @@ test_extract_ami_id_dict() {
     expected=$(
         cat << EOF
 {
-  "us-east-1": "ami-111",
-  "us-east-2": "ami-222",
-  "us-west-1": "ami-333",
-  "us-west-2": "ami-444"
+  "imgname.us-east-1": "ami-111",
+  "imgname.us-east-2": "ami-222",
+  "imgname.us-west-1": "ami-333",
+  "imgname.us-west-2": "ami-444"
 }
 EOF
     )

--- a/.buildkite/scripts/lib/extract_ami_id_dict_test.sh
+++ b/.buildkite/scripts/lib/extract_ami_id_dict_test.sh
@@ -4,7 +4,8 @@ readonly jq_filter_path=".buildkite/scripts/lib/extract_ami_id_dict.jq"
 readonly example_manifest_file=".buildkite/scripts/lib/example_packer_artifact.json"
 
 test_extract_ami_id_dict() {
-    actual=$(jq --raw-output --from-file "${jq_filter_path}" "${example_manifest_file}")
+    packer_image_name="imgname"
+    actual=$(jq --raw-output --arg IMAGE_NAME ${packer_image_name} --from-file "${jq_filter_path}" "${example_manifest_file}")
     expected=$(
         cat << EOF
 {

--- a/.buildkite/scripts/record_artifacts.sh
+++ b/.buildkite/scripts/record_artifacts.sh
@@ -10,11 +10,11 @@ upload_artifacts_file() {
     # a corresponding packer manifest names "image_name.packer-manifest.json".
 
     # e.g. "grapl-service"
-    local -r root_name=$1
+    local -r packer_image_name=$1
     # e.g. "grapl-service.packer-manifest.json"
-    local -r manifest_file="${root_name}${PACKER_MANIFEST_SUFFIX}"
+    local -r manifest_file="${packer_image_name}${PACKER_MANIFEST_SUFFIX}"
     # e.g. "grapl-service.artifacts.json"
-    local -r artifacts_file="${root_name}${ARTIFACTS_FILE_SUFFIX}"
+    local -r artifacts_file="${packer_image_name}${ARTIFACTS_FILE_SUFFIX}"
 
     # Download Packer manifest
     echo -e "--- :buildkite: Download Packer manifest"
@@ -29,12 +29,12 @@ upload_artifacts_file() {
 
     # Creates a dict that looks like
     # { "us-east-1": "ami-111", "us-east-2": "ami-222", ...}
-    local -r ami_ids_dict=$(jq --raw-output --from-file "${jq_filter_path}" "${manifest_file}")
+    local -r ami_ids_dict=$(jq --raw-output --arg IMAGE_NAME ${packer_image_name} --from-file "${jq_filter_path}" "${manifest_file}")
     echo "${ami_ids_dict}"
 
     # Creating artifacts file
     echo -c "--- :gear: Creating ${artifacts_file} file"
-    echo "{\"${root_name}-amis\": ${ami_ids_dict}}" > "${artifacts_file}"
+    echo "{\"${packer_image_name}-amis\": ${ami_ids_dict}}" > "${artifacts_file}"
     jq '.' "${artifacts_file}"
 
     # Uploading artifacts file

--- a/.buildkite/scripts/record_artifacts.sh
+++ b/.buildkite/scripts/record_artifacts.sh
@@ -29,7 +29,7 @@ upload_artifacts_file() {
 
     # Creates a dict that looks like
     # { "imagename.us-east-1": "ami-111", "imagename.us-east-2": "ami-222", ...}
-    local -r ami_ids_dict=$(jq --raw-output --arg IMAGE_NAME ${packer_image_name} --from-file "${jq_filter_path}" "${manifest_file}")
+    local -r ami_ids_dict=$(jq --raw-output --arg IMAGE_NAME "${packer_image_name}" --from-file "${jq_filter_path}" "${manifest_file}")
     echo "${ami_ids_dict}"
 
     # Creating artifacts file

--- a/.buildkite/scripts/record_artifacts.sh
+++ b/.buildkite/scripts/record_artifacts.sh
@@ -28,14 +28,13 @@ upload_artifacts_file() {
     # The raw artifact ID is like: "us-east-1:ami-0123456789abcdef0";
 
     # Creates a dict that looks like
-    # { "us-east-1": "ami-111", "us-east-2": "ami-222", ...}
+    # { "imagename.us-east-1": "ami-111", "imagename.us-east-2": "ami-222", ...}
     local -r ami_ids_dict=$(jq --raw-output --arg IMAGE_NAME ${packer_image_name} --from-file "${jq_filter_path}" "${manifest_file}")
     echo "${ami_ids_dict}"
 
     # Creating artifacts file
     echo -c "--- :gear: Creating ${artifacts_file} file"
-    echo "{\"${packer_image_name}-amis\": ${ami_ids_dict}}" > "${artifacts_file}"
-    jq '.' "${artifacts_file}"
+    echo "${ami_ids_dict}" > "${artifacts_file}"
 
     # Uploading artifacts file
     echo -c "--- :buildkite: Uploading ${artifacts_file} file"


### PR DESCRIPTION
```jq stuff - basically turn
{ 
"some-ami-name": {
  "us-east-1": "ami-1234"
}
}
into
{ "some-ami-name.us-east-1": "ami-1234" }
```

see https://grapl-internal.slack.com/archives/C017DKYF55H/p1626220139413700 for more context

i'm tackling this by changing the input, not the receiving side