### PR TITLE
Ensure we build Python wheels before building containers in CI

### DIFF
--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -41,6 +41,8 @@ cloudsmith_tag() {
     local -r tag="${2}"
     echo "${CLOUDSMITH_DOCKER_REGISTRY}/${service}:${tag}"
 }
+echo "--- :python: Building required Python wheels"
+make build-python-wheels
 
 for service in "${services[@]}"; do
     # Build a single service


### PR DESCRIPTION
This should be a temporary state as we continue working toward
streamlining our Docker build process.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>