### PR TITLE
Buildkite: Use pulumi-cicd for create_rc; expand sections when downloading fails

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -121,7 +121,8 @@ steps:
     agents:
       # Has to be pulumi, even though we're not *running* pulumi; we
       # just have to log in so we can manipulate pulumi configs.
-      queue: "pulumi-staging"
+      # `pulumi-cicd` chosen due to https://github.com/grapl-security/issue-tracker/issues/618
+      queue: "pulumi-cicd"
 
   - wait
 

--- a/.buildkite/scripts/create_new_rc.sh
+++ b/.buildkite/scripts/create_new_rc.sh
@@ -23,6 +23,7 @@ echo -e "--- :buildkite: Download artifacts file"
 if (buildkite-agent artifact download "${ALL_ARTIFACTS_JSON_FILE}" .); then
     artifacts_json="$(cat "${ALL_ARTIFACTS_JSON_FILE}")"
 else
+    echo "^^^ +++" # Un-collapses this section in Buildkite, making it more obvious we couldn't download
     artifacts_json="{}"
 fi
 

--- a/.buildkite/scripts/lib/artifacts.sh
+++ b/.buildkite/scripts/lib/artifacts.sh
@@ -40,6 +40,7 @@ download_artifact_file() {
     mkdir -p "${ARTIFACT_FILE_DIRECTORY}"
     echo -e "--- :buildkite: Download '${artifacts_file}' artifacts file"
     if ! (buildkite-agent artifact download "${artifacts_file}" "${ARTIFACT_FILE_DIRECTORY}"); then
+        echo "^^^ +++" # Un-collapses this section in Buildkite, making it more obvious we couldn't download
         echo "No file found"
     fi
     # TODO: Would be nice to validate the artifacts. Right now there are some restrictions:

--- a/.buildkite/scripts/upload_lambda_artifacts.sh
+++ b/.buildkite/scripts/upload_lambda_artifacts.sh
@@ -35,5 +35,6 @@ if (buildkite-agent artifact download "dist/*${LAMBDA_SUFFIX}" .); then
     echo "--- :buildkite: Uploading ${LAMBDA_ARTIFACTS_FILE} file"
     buildkite-agent artifact upload "${LAMBDA_ARTIFACTS_FILE}"
 else
+    echo "^^^ +++" # Un-collapses this section in Buildkite, making it more obvious we couldn't download
     echo "No artifacts to upload"
 fi

--- a/packer/hax_change_this_to_trigger_ami_build.txt
+++ b/packer/hax_change_this_to_trigger_ami_build.txt
@@ -1,0 +1,6 @@
+# Sometimes we need to manually retrigger an AMI build.
+# So, as a hack, just change this file to trigger that build.
+# (It is read in `pipeline.merge.yml`'s diff)
+
+# add to this int i guess? leave a funny comment?
+0


### PR DESCRIPTION
# The `echo`s:
This would've helped me debug "why is my merge receiving a `{}`?" quicker.

Downloading failing is an acceptable state with defaults, but we should make it obvious to the viewer that's what happened.

# pulumi-cicd:
https://github.com/grapl-security/issue-tracker/issues/618