### PR TITLE
Drop IAM role after building AMIs, before uploading artifacts

### DIFF
--- a/.buildkite/pipeline.merge.ami-build.yml
+++ b/.buildkite/pipeline.merge.ami-build.yml
@@ -25,6 +25,10 @@ steps:
             - "BUILDKITE_PIPELINE_NAME"
             - "BUILDKITE_STEP_KEY"
             - "PACKER_IMAGE_NAME=grapl-nomad-consul-server"
+            # I hate these last two, but it seems to be necessary at
+            # the moment while this runs inside a Docker container.
+            - "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"
+            - "BUILDKITE_S3_DEFAULT_REGION"
     agents:
       queue: "packer-staging"
 
@@ -43,6 +47,10 @@ steps:
             - "BUILDKITE_PIPELINE_NAME"
             - "BUILDKITE_STEP_KEY"
             - "PACKER_IMAGE_NAME=grapl-nomad-consul-client"
+            # I hate these last two, but it seems to be necessary at
+            # the moment while this runs inside a Docker container.
+            - "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"
+            - "BUILDKITE_S3_DEFAULT_REGION"
     agents:
       queue: "packer-staging"
 

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -89,6 +89,7 @@ steps:
                 - ".buildkite/scripts/record_artifacts.sh"
                 - ".buildkite/scripts/lib/packer.sh"
                 - ".buildkite/scripts/lib/packer_constants.sh"
+                - ".buildkite/pipeline.merge.ami-build.yml"
               config:
                 label: ":pipeline: Upload AMI Build"
                 command: "buildkite-agent pipeline upload .buildkite/pipeline.merge.ami-build.yml"

--- a/.buildkite/scripts/build_packer_ci.sh
+++ b/.buildkite/scripts/build_packer_ci.sh
@@ -8,6 +8,7 @@
 
 set -euo pipefail
 
+source .buildkite/scripts/lib/aws.sh
 source .buildkite/scripts/lib/packer.sh
 
 export GIT_SHA="${BUILDKITE_COMMIT}"
@@ -18,11 +19,20 @@ export GIT_BRANCH="${BUILDKITE_BRANCH}"
 # shellcheck disable=SC2153
 : "${PACKER_IMAGE_NAME}"
 
+# As long as this is running inside a Docker container, we have to
+# make sure we pass these in.
+: "${BUILDKITE_ARTIFACT_UPLOAD_DESTINATION}"
+: "${BUILDKITE_S3_DEFAULT_REGION}"
+
 build_packer_ci() {
     echo -e "--- :packer: Performing build of AMI"
 
     # Both defined in packer.sh
     build_ami "${PACKER_IMAGE_NAME}"
+
+    # HACK; see documentation of this function for details
+    unset_aws_variables
+
     upload_manifest "${PACKER_IMAGE_NAME}"
 }
 

--- a/.buildkite/scripts/lib/aws.sh
+++ b/.buildkite/scripts/lib/aws.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Unsets AWS credential environment variables. This can be used to
+# e.g., drop a previously assumed IAM role and fall back to an EC2
+# instance role.
+#
+# NOTE: This is essentially a hack until we work around some issues in
+# our Buildkite + AWS environment, and how some of our jobs are
+# structured. Unless you are *absolutely certain* you need to use this
+# function, don't use this function.
+#
+# Please see
+# https://github.com/grapl-security/issue-tracker/issues/620 for
+# additional context.
+unset_aws_variables() {
+    echo -e "--- :aws: Unsetting AWS credential environment variables"
+    _unset_and_log AWS_ACCESS_KEY_ID
+    _unset_and_log AWS_SECRET_ACCESS_KEY
+    _unset_and_log AWS_SESSION_TOKEN
+}
+
+# Just logs when we unset a variable, for better visibility in our
+# Buildkite logs.
+_unset_and_log() {
+    local -r variable="${1}"
+
+    echo "Unsetting ${variable} environment variable"
+    unset "${variable}"
+}


### PR DESCRIPTION
This is a stop-gap measure to ensure that our manifest files are going
to the proper place (our private artifact bucket). It is
emphatically *not* intended to be a permanent solution.

I'm continuing to research alternatives, and am in communication with
Buildkite Support; for now, this seems to be the most straightforward
solution.

Read documentation comments for further background on this, as well as
grapl-security/issue-tracker#620