### PR TITLE
Build UX tarball in the merge pipeline

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -90,7 +90,18 @@ steps:
                 label: ":pipeline: Upload AMI Build"
                 command: "buildkite-agent pipeline upload .buildkite/pipeline.merge.ami-build.yml"
 
-  # This will also wait for the uploaded pipeline, if we did decide to upload it.
+  - label: "Build UX Assets"
+    plugins:
+      - chronotc/monorepo-diff#v2.0.4:
+          diff: .buildkite/shared/scripts/diff.sh
+          watch:
+            - path:
+                - "src/js/engagement_view"
+                - ".buildkite/scripts/build_and_upload_ux.sh"
+              config:
+                command:
+                  - ".buildkite/scripts/build_and_upload_ux.sh"
+
   - wait
 
   # The names of the input files depend on the files that can be
@@ -104,6 +115,7 @@ steps:
         container_artifacts.json
         grapl-nomad-consul-server.artifacts.json
         grapl-nomad-consul-client.artifacts.json
+        ux_artifacts.json
 
   - wait
 

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -100,6 +100,13 @@ steps:
     command:
       - make lint-prettier
 
+  - label: ":yarn: Build UX"
+    command: make build-ux
+    plugins:
+      - docker#v3.8.0:
+          # This container actually contains `make`, too!
+          image: "node:16.5.0"
+
   - label: ":aws-lambda::package: Create Lambda Zips"
     command:
       - make lambdas

--- a/.buildkite/scripts/build_and_upload_ux.sh
+++ b/.buildkite/scripts/build_and_upload_ux.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source .buildkite/scripts/lib/artifacts.sh
+source .buildkite/scripts/lib/cloudsmith.sh
+source .buildkite/scripts/lib/version.sh
+
+# This is the name defined in the top-level Makefile in the
+# `ux-tarball` target.
+readonly UX_FILENAME="grapl-ux.tar.gz"
+readonly UX_ARTIFACTS_FILE="ux_artifacts.json"
+
+echo "--- :yarn: Building Grapl UX Artifact"
+make ux-tarball
+
+version=$(timestamp_and_sha_version)
+readonly version
+
+echo "--- :cloudsmith: Uploading ${UX_FILENAME} version ${version}"
+# The Makefile puts the tarball into our `dist` directory.
+upload_raw_file_to_cloudsmith "dist/${UX_FILENAME}" "${version}"
+
+artifact_json "${version}" "${UX_FILENAME}" > "${UX_ARTIFACTS_FILE}"
+
+echo "--- :buildkite: Uploading ${UX_ARTIFACTS_FILE} file"
+buildkite-agent artifact upload "${UX_ARTIFACTS_FILE}"

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,24 @@ graplctl: ## Build graplctl and install it to the project root
 build-ux: ## Build website assets
 	cd src/js/engagement_view && yarn install && yarn build
 
+# Create the dist directory if necessary; don't need to document this
+# formally for `make help`, though.
+dist:
+	mkdir dist
+
+# This is used to create the artifact that will be uploaded to our
+# artifact repository in CI, and will be the artifact that is used by
+# our Pulumi deployments.
+.PHONY: ux-tarball
+ux-tarball: build-ux dist ## Build website asset tarball
+	tar \
+		--create \
+		--gzip \
+		--verbose \
+		--file="dist/grapl-ux.tar.gz" \
+		--directory=src/js/engagement_view/build \
+		.
+
 .PHONY: lambdas
 lambdas: lambdas-rust lambdas-js lambdas-python ## Generate all lambda zip files
 

--- a/pulumi/bin/prepare_grapl_ux_dependency.sh
+++ b/pulumi/bin/prepare_grapl_ux_dependency.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# Since Pulumi does not appear to have a native way to extract a
+# tarball into an S3 bucket, we need to have a bit of external logic
+# to download the artifact for our UX assets to the local machine and
+# extract it into a well-known directory (here,
+# /dist/grapl-ux-<VERSION>) that is accessible to our Pulumi code.
+#
+# If the Pulumi stack being deployed has a pinned version for the
+# grapl-ux artifact, this script should be run prior to `pulumi up`.
+
+set -euo pipefail
+
+# A Pulumi stack name, such as "grapl/testing".
+#
+# This should correspond to a stack from our `pulumi/grapl` project.
+readonly stack="${1}"
+
+# Download a tar.gz artifact from Cloudsmith to `/tmp`, then extract
+# it into the `dist` directory.
+#
+#    retrieve_targz_from_cloudsmith foo 0.0.1
+#    # => Downloads foo.tar.gz, version 0.0.1 from our Cloudsmith
+#    #    "raw" repository
+#
+retrieve_targz_from_cloudsmith() {
+    # e.g. foo, not foo.tar.gz
+    local -r base_filename="${1}"
+
+    # This is the name of the "package" in the repository
+    local -r file="${base_filename}.tar.gz"
+
+    # This is the version of the package in the repository
+    local -r version="${2}"
+
+    # This is the name of the repository, not the artifact type
+    # (though the artifact type is also "raw"). This may change in the
+    # future as we mature in our repository usage patterns.
+    local -r repository="raw"
+
+    # We'll save the downloaded artifact in /tmp
+    local -r savename="/tmp/${base_filename}-${version}.tar.gz"
+
+    curl --output "${savename}" \
+        "https://dl.cloudsmith.io/public/grapl/${repository}/raw/versions/${version}/${file}"
+
+    # Extract the artifact into our dist directory. The directory has
+    # the version appended to it to ensure that we're using the
+    # correct assets in Pulumi.
+    mkdir -p "dist/${base_filename}-${version}"
+    tar --extract \
+        --gunzip \
+        --verbose \
+        --directory="dist/${base_filename}-${version}" \
+        --file="${savename}"
+}
+
+########################################################################
+# Main Logic
+########################################################################
+
+(
+    # NOTE: For simplicity and flexibility, all the functions,
+    # directory references, etc., in this script are written assuming
+    # they are being executed from the root of this repository.
+    #
+    # However, by running the main logic in a subshell and changing to
+    # the root as our first operation, we can allow the script to be
+    # run from any subdirectory.
+    REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
+    readonly REPOSITORY_ROOT
+    cd "${REPOSITORY_ROOT}" || exit 2
+
+    ux_version=$(
+        cd pulumi/grapl || exit 1
+        pulumi config get --path artifacts.grapl-ux --stack="${stack}"
+    ) || true
+    readonly ux_version
+
+    if [ -n "${ux_version}" ]; then
+        # We have a version; retrieve and unpack
+        retrieve_targz_from_cloudsmith grapl-ux "${ux_version}"
+    else
+        # We don't have a version; use local build
+        make build-ux
+    fi
+)

--- a/pulumi/bin/prepare_grapl_ux_dependency.sh
+++ b/pulumi/bin/prepare_grapl_ux_dependency.sh
@@ -69,10 +69,10 @@ retrieve_targz_from_cloudsmith() {
     # run from any subdirectory.
     REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
     readonly REPOSITORY_ROOT
-    cd "${REPOSITORY_ROOT}" || exit 2
+    cd "${REPOSITORY_ROOT}"
 
     ux_version=$(
-        cd pulumi/grapl || exit 1
+        cd pulumi/grapl
         pulumi config get --path artifacts.grapl-ux --stack="${stack}"
     ) || true
     readonly ux_version

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -13,7 +13,7 @@ from infra.api import Api
 from infra.autotag import register_auto_tags
 from infra.bucket import Bucket
 from infra.cache import Cache
-from infra.config import DEPLOYMENT_NAME, LOCAL_GRAPL
+from infra.config import DEPLOYMENT_NAME, LOCAL_GRAPL, configured_version_for
 from infra.dgraph_cluster import DgraphCluster, LocalStandInDgraphCluster
 from infra.dgraph_ttl import DGraphTTL
 from infra.e2e_test_runner import E2eTestRunner
@@ -227,13 +227,44 @@ def main() -> None:
         # Not doing this in Local Grapl at the moment, as we have
         # another means of doing this. We should harmonize this, of
         # course.
-        ENGAGEMENT_VIEW_DIR = repository_path("src/js/engagement_view/build").resolve()
+        # If we have a version for the grapl-ux, we should have
+        # downloaded the artifact from the artifact repository and
+        # unpacked it into a version-tagged directory for us to pull
+        # from.
+        #
+        # We have to do this because there isn't an apparent way in
+        # Pulumi to expand a tarball into an S3 bucket. If that every
+        # becomes possible, we should us it, by all means!
+        #
+        # If there's no configured version, we just pull from the
+        # build directory in the local source tree (it will need to
+        # have been built first, too).
+        grapl_ux_version = configured_version_for("grapl-ux")
+        directory = (
+            f"dist/grapl-ux-{grapl_ux_version}"
+            if grapl_ux_version
+            else "src/js/engagement_view/build"
+        )
+        ENGAGEMENT_VIEW_DIR = repository_path(directory).resolve()
+
         try:
             ux_bucket.upload_to_bucket(
                 ENGAGEMENT_VIEW_DIR, root_path=ENGAGEMENT_VIEW_DIR
             )
         except FileNotFoundError as e:
-            raise Exception("You probably need to `make pulumi-prep` first") from e
+            raise Exception(
+                """
+            You need to either build or download UX assets first.
+
+            If you have a pinned version for `grapl-ux` in your stack configuration, please run
+
+                pulumi/bin/prepare_grapl_ux_depencency.sh grapl/<STACK>
+
+            If you do *not* have a pinned version in your stack configuration, you can run the above, or
+
+                make build-ux
+            """
+            ) from e
 
         Provisioner(
             network=network,

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -13,7 +13,7 @@ from infra.api import Api
 from infra.autotag import register_auto_tags
 from infra.bucket import Bucket
 from infra.cache import Cache
-from infra.config import DEPLOYMENT_NAME, LOCAL_GRAPL, configured_version_for
+from infra.config import DEPLOYMENT_NAME, LOCAL_GRAPL
 from infra.dgraph_cluster import DgraphCluster, LocalStandInDgraphCluster
 from infra.dgraph_ttl import DGraphTTL
 from infra.e2e_test_runner import E2eTestRunner
@@ -220,51 +220,14 @@ def main() -> None:
         forwarder=forwarder,
         dgraph_cluster=dgraph_cluster,
     )
-    # Note: This requires `yarn build` to have been run first
+
     if not LOCAL_GRAPL:
-        from infra.config import repository_path
+        from infra.ux import populate_ux_bucket
 
-        # Not doing this in Local Grapl at the moment, as we have
-        # another means of doing this. We should harmonize this, of
-        # course.
-        # If we have a version for the grapl-ux, we should have
-        # downloaded the artifact from the artifact repository and
-        # unpacked it into a version-tagged directory for us to pull
-        # from.
-        #
-        # We have to do this because there isn't an apparent way in
-        # Pulumi to expand a tarball into an S3 bucket. If that every
-        # becomes possible, we should us it, by all means!
-        #
-        # If there's no configured version, we just pull from the
-        # build directory in the local source tree (it will need to
-        # have been built first, too).
-        grapl_ux_version = configured_version_for("grapl-ux")
-        directory = (
-            f"dist/grapl-ux-{grapl_ux_version}"
-            if grapl_ux_version
-            else "src/js/engagement_view/build"
-        )
-        ENGAGEMENT_VIEW_DIR = repository_path(directory).resolve()
-
-        try:
-            ux_bucket.upload_to_bucket(
-                ENGAGEMENT_VIEW_DIR, root_path=ENGAGEMENT_VIEW_DIR
-            )
-        except FileNotFoundError as e:
-            raise Exception(
-                """
-            You need to either build or download UX assets first.
-
-            If you have a pinned version for `grapl-ux` in your stack configuration, please run
-
-                pulumi/bin/prepare_grapl_ux_depencency.sh grapl/<STACK>
-
-            If you do *not* have a pinned version in your stack configuration, you can run the above, or
-
-                make build-ux
-            """
-            ) from e
+        # TODO: We are not populating the UX bucket in Local Grapl at
+        # the moment, as we have another means of doing this. We
+        # should harmonize this, of course.
+        populate_ux_bucket(ux_bucket)
 
         Provisioner(
             network=network,

--- a/pulumi/infra/ux.py
+++ b/pulumi/infra/ux.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from infra.bucket import Bucket
+from infra.config import configured_version_for, repository_path
+
+
+def _ux_source_directory() -> Path:
+    # If we have a pinned version for the grapl-ux set in our stack
+    # configuration, we should have downloaded the artifact from the
+    # artifact repository and unpacked it into a version-tagged
+    # directory for us to pull from.
+    #
+    # We have to do this because there isn't an apparent way in
+    # Pulumi to expand a tarball into an S3 bucket. If that every
+    # becomes possible, we should us it, by all means!
+    #
+    # If there's no configured version, we just pull from the
+    # build directory in the local source tree (it will need to
+    # have been built first, too).
+    grapl_ux_version = configured_version_for("grapl-ux")
+    directory = (
+        f"dist/grapl-ux-{grapl_ux_version}"
+        if grapl_ux_version
+        else "src/js/engagement_view/build"
+    )
+    return repository_path(directory).resolve()
+
+
+def populate_ux_bucket(ux_bucket: Bucket) -> None:
+    source_dir = _ux_source_directory()
+
+    try:
+        ux_bucket.upload_to_bucket(source_dir, root_path=source_dir)
+    except FileNotFoundError as e:
+        raise Exception(
+            """
+            You need to either build or download UX assets first.
+
+            If you have a pinned version for `grapl-ux` in your stack configuration, please run
+
+                pulumi/bin/prepare_grapl_ux_depencency.sh grapl/<STACK>
+
+            If you do *not* have a pinned version in your stack configuration, you can run the above, or
+
+                make build-ux
+            """
+        ) from e


### PR DESCRIPTION
A new makefile target, `ux-tarball`, has been added, which creates a
`tar.gz` file containing the UX assets. This is then used in our CI
merge pipeline when we generate artifacts, pushing it to Cloudsmith
and adding the version to our Pulumi stack(s) as we do with our other
artifacts.

The Pulumi code has been modified slightly to take this into
account. One wrinkle is that Pulumi has no native way to expand a
tarball into an S3 bucket, which is how our frontend is currently
deployed. To get around this, a helper script
`pulumi/bin/prepare_grapl_ux_dependency.sh` has been added. When given
the name of a Pulumi stack, it will prepare the UX assets as
appropriate. If a version pin for the UX is present in the stack, that
version will be downloaded from Cloudsmith and expanded into
`dist/grapl-ux-<VERSION>`. If a version pin is not present, we run
`make build-ux` on the source code that is present. In either case,
Pulumi will pull the code from the correct location and deploy.

If we ever change our deployment approach, or Pulumi gets new
abilities to unpack tarballs into S3 buckets, we should *definitely*
revisit this situation.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>