### PR TITLE
Make our AMIs public

### DIFF
--- a/packer/nomad-server-client/image.pkr.hcl
+++ b/packer/nomad-server-client/image.pkr.hcl
@@ -133,7 +133,7 @@ source "amazon-ebs" "amazon-linux-2-amd64-ami" {
   source_ami   = data.amazon-ami.amazon-linux-2-x86_64.id
   ssh_username = "ec2-user"
   # Make the image public.
-  # As such - obvi we should not bake credentials of any kind into the image
+  # As such, we should not bake credentials of any kind into the image
   ami_groups = ["all"]
 
   tag {

--- a/packer/nomad-server-client/image.pkr.hcl
+++ b/packer/nomad-server-client/image.pkr.hcl
@@ -132,6 +132,9 @@ source "amazon-ebs" "amazon-linux-2-amd64-ami" {
   ami_regions  = local.copy_ami_to_regions
   source_ami   = data.amazon-ami.amazon-linux-2-x86_64.id
   ssh_username = "ec2-user"
+  # Make the image public.
+  # As such - obvi we should not bake credentials of any kind into the image
+  ami_groups = ["all"]
 
   tag {
     key   = "BuiltBy"


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/599
https://github.com/grapl-security/issue-tracker/issues/600

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
I was making the pulumi resource for the servers and got
```
  aws:ec2:Instance (ec2-inst-nomad-servers-quorum-0-1):
    error: 1 error occurred:
        * Error launching source instance: AuthFailure: Not authorized for images: [ami-0a6df91454eef493c]
        status code: 400, request id: ecb76a36-c7a5-468e-ba7f-44dadd414619
```

woops!!
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
cant run packer locally, so, our CI

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
