### PR TITLE
Trigger a UX artifact build, with debug logging

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -94,10 +94,12 @@ steps:
     plugins:
       - chronotc/monorepo-diff#v2.0.4:
           diff: .buildkite/shared/scripts/diff.sh
+          log_level: "debug"
           watch:
             - path:
                 - "src/js/engagement_view"
                 - ".buildkite/scripts/build_and_upload_ux.sh"
+                - ".buildkite/pipeline.merge.yml" # just temporarily!
               config:
                 command:
                   - ".buildkite/scripts/build_and_upload_ux.sh"


### PR DESCRIPTION
The UX artifact build was not triggered when #1015 merged. This commit
should trigger a build, and with increased logging on the
`monorepo-diff` plugin to help sort out why.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>