### PR TITLE
Enable debug logging for all instances of the monorepo-diff plugin

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -8,6 +8,7 @@ steps:
     plugins:
       - chronotc/monorepo-diff#v2.0.4:
           diff: .buildkite/shared/scripts/diff.sh
+          log_level: "debug"
           watch:
             - path:
                 - "src/rust/" # This is not minimal, obviously
@@ -25,6 +26,7 @@ steps:
     plugins:
       - chronotc/monorepo-diff#v2.0.4:
           diff: .buildkite/shared/scripts/diff.sh
+          log_level: "debug"
           watch:
             - path:
                 - "src/js/" # This is not minimal, obviously
@@ -79,6 +81,7 @@ steps:
     plugins:
       - chronotc/monorepo-diff#v2.0.4:
           diff: .buildkite/shared/scripts/diff.sh
+          log_level: "debug"
           watch:
             - path:
                 - "packer/"

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -104,8 +104,7 @@ steps:
                 - ".buildkite/scripts/build_and_upload_ux.sh"
                 - ".buildkite/pipeline.merge.yml" # just temporarily!
               config:
-                command:
-                  - ".buildkite/scripts/build_and_upload_ux.sh"
+                command: ".buildkite/scripts/build_and_upload_ux.sh"
 
   - wait
 

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -147,6 +147,7 @@ steps:
     plugins:
       - chronotc/monorepo-diff#v2.0.4:
           diff: .buildkite/shared/scripts/diff.sh
+          log_level: "debug"
           watch:
             - path:
                 - ".buildkite/scripts/test_packer.sh"


### PR DESCRIPTION
There's not a lot of additional output, but it's helpful context to
have when debugging things. Seems worthwhile to just always have it.

Also fixes a misconfiguration of the diff plugin for generating the UX artifact.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
