### PR TITLE
Create a provisioning and testing pipeline

### DIFF
--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -1,0 +1,44 @@
+---
+env:
+  PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
+
+steps:
+  - label: ":pulumi: Preview grapl/testing environment changes in Staging account"
+    command:
+      - .buildkite/shared/steps/pulumi_preview.sh grapl/testing
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            PULUMI_ACCESS_TOKEN: "pulumi-token"
+    agents:
+      queue: "pulumi-staging"
+
+  - block: ":rocket: Proceed?"
+    prompt: "Unblock to perform a pulumi update to the testing environment"
+
+  - label: ":pulumi: Update grapl/testing environment in Staging account"
+    command:
+      - .buildkite/shared/steps/pulumi_up.sh grapl/testing
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            PULUMI_ACCESS_TOKEN: "pulumi-token"
+    agents:
+      queue: "pulumi-staging"
+
+  - wait
+
+  - trigger: "grapl-testing"
+    label: ":rocket: Trigger testing pipeline"
+    # Since this is asynchronous, this pipeline will pass or fail
+    # based on whether the triggered pipeline passes or fails.
+    async: false
+    build:
+      commit: "${BULIDKITE_COMMIT}"
+      branch: "${BUILDKITE_BRANCH}"
+
+  - wait
+
+  - label: ":writing_hand: Record successful build"
+    command:
+      - .buildkite/shared/steps/record_successful_pipeline_run.sh

--- a/.buildkite/pipeline.testing.yml
+++ b/.buildkite/pipeline.testing.yml
@@ -1,0 +1,13 @@
+---
+env:
+  PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
+
+# This pipeline is for running tests against deployed infrastructure
+# from our grapl/testing stack.
+
+steps:
+
+  # TODO: replace this with something meaningful
+  - label: "Hello World :earth_asia::earth_americas::earth_africa:"
+    command:
+      - echo 'Hello World'

--- a/.buildkite/shared/lib/json_tools.sh
+++ b/.buildkite/shared/lib/json_tools.sh
@@ -14,8 +14,8 @@ flatten_json() {
     local -r input_json="${1}"
     # https://stackoverflow.com/a/37557003
     jq -r '
-        . as $in 
-        | reduce leaf_paths as $path (
+        . as $in
+        | reduce paths(scalars) as $path (
             {};
             . + { ($path | map(tostring) | join(".")): $in | getpath($path) }
         )

--- a/.buildkite/shared/steps/pulumi_preview.sh
+++ b/.buildkite/shared/steps/pulumi_preview.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Run a `pulumi preview` on a given Pulumi stack.
+#
+# Assumptions:
+# - Python virtualenv is managed by Pants via `build-support/manage_virtualenv.sh`
+# - All Pulumi projects are stored in `pulumi/<project_name>`
+# - Projects are named in kebab-case, but directories for the projects
+#   are snake_case
+
+set -euo pipefail
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/pulumi.sh"
+
+# Given as "project/stack"
+readonly project_stack="${1}"
+
+echo -e "--- :python: Installing dependencies"
+build-support/manage_virtualenv.sh populate
+
+# shellcheck disable=SC1091
+source build-support/venv/bin/activate
+
+echo -e "--- :pulumi: Log in"
+pulumi login
+
+echo -e "--- :pulumi: Previewing changes to ${project_stack} infrastructure"
+pulumi preview \
+    --cwd="$(project_directory "${project_stack}")" \
+    --stack="$(fully_qualified_stack_name "${project_stack}")" \
+    --show-replacement-steps \
+    --non-interactive \
+    --diff \
+    --message="Previewing from ${BUILDKITE_BUILD_URL}"

--- a/.buildkite/shared/steps/pulumi_up.sh
+++ b/.buildkite/shared/steps/pulumi_up.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Run a `pulumi up` on a given Pulumi stack.
+#
+# Assumptions:
+# - Python virtualenv is managed by Pants via `build-support/manage_virtualenv.sh`
+# - All Pulumi projects are stored in `pulumi/<project_name>`
+# - Projects are named in kebab-case, but directories for the projects
+#   are snake_case
+
+set -euo pipefail
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/pulumi.sh"
+
+# Given as "project/stack"
+readonly project_stack="${1}"
+
+echo -e "--- :python: Installing dependencies"
+build-support/manage_virtualenv.sh populate
+
+# shellcheck disable=SC1091
+source build-support/venv/bin/activate
+
+echo -e "--- :pulumi: Log in"
+pulumi login
+
+echo -e "--- :pulumi: Update ${project_stack} infrastructure"
+pulumi up \
+    --cwd="$(project_directory "${project_stack}")" \
+    --stack="$(fully_qualified_stack_name "${project_stack}")" \
+    --show-replacement-steps \
+    --non-interactive \
+    --yes \
+    --diff \
+    --message="Updating from ${BUILDKITE_BUILD_URL}"

--- a/Makefile
+++ b/Makefile
@@ -429,6 +429,6 @@ repl: ## Run an interactive ipython repl that can import from grapl-common etc
 .PHONY: pulumi-prep
 pulumi-prep: graplctl lambdas build-ux ## Prepare some artifacts in advance of running a Pulumi update (does not run Pulumi!)
 
-.PHONY: update-shared
+.PHONY: update-buildkite-shared
 update-buildkite-shared: ## Pull in changes from grapl-security/buildkite-common
 	git subtree pull --prefix .buildkite/shared git@github.com:grapl-security/buildkite-common.git main --squash


### PR DESCRIPTION
After a successful `merge` pipeline run, this pipeline will kick off, provisioning our testing stack into our Staging AWS environment. A "dummy" testing pipeline has also been added, to be fleshed out later.

(Note: we can ultimately add as many different deployments and testing pipelines here as we like; we're just starting with one for simplicity.)
