### PR TITLE
Change name of managed virtualenv to simply "venv"

### DIFF
--- a/build-support/manage_virtualenv.sh
+++ b/build-support/manage_virtualenv.sh
@@ -9,7 +9,7 @@ readonly UNDERLINE="\\u001b[4m"
 
 # Additional constants
 readonly python=python3
-readonly virtualenv=build-support/grapl-venv
+readonly virtualenv=build-support/venv
 readonly pip="${virtualenv}/bin/pip"
 readonly requirements_file=3rdparty/python/requirements.txt
 readonly constraints_file=3rdparty/python/constraints.txt
@@ -70,7 +70,7 @@ function exit_message() {
     log
     log "Alternatively, if using 'direnv', add the following 2 lines to an '.envrc' file in the repository root:"
     log
-    log "export VIRTUAL_ENV=build-support/grapl-venv"
+    log "export VIRTUAL_ENV=${virtualenv}"
     log "PATH_add \${VIRTUAL_ENV}/bin"
 }
 


### PR DESCRIPTION
Now that we're using shared scripts to manage our Pulumi operations in
CI, it's even more important that we adhere to the common conventions
of those scripts.

Here, that means using the same name for the Python virtual
environment in our `manage_virtualenv.sh` script. It doesn't need to
be "grapl-venv" anymore (you can probably assume it's for Grapl since
it's in the `grapl` repository, after all).

You'll want to run `build-support/manage_virtualenv.sh populate` after
this lands, and activate the new one. As always, following the
instructions output by the script will help you out with this.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
