### PR TITLE
Ensure we're using a clean git checkout before diffing against tags

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -5,6 +5,9 @@ env:
 steps:
   - label: ":aws-lambda::rust: Build Rust Lambdas"
     key: "rust-lambdas"
+    env:
+      # Ensure we get the most up-to-date git tags to compare against
+      BUILDKITE_CLEAN_CHECKOUT: true
     plugins:
       - chronotc/monorepo-diff#v2.0.4:
           diff: .buildkite/shared/scripts/diff.sh
@@ -23,6 +26,9 @@ steps:
 
   - label: ":aws-lambda::typescript: Build Typescript Lambdas"
     key: "js-lambdas"
+    env:
+      # Ensure we get the most up-to-date git tags to compare against
+      BUILDKITE_CLEAN_CHECKOUT: true
     plugins:
       - chronotc/monorepo-diff#v2.0.4:
           diff: .buildkite/shared/scripts/diff.sh
@@ -78,6 +84,9 @@ steps:
       queue: "artifact-uploaders"
 
   - label: ":thinking_face: AMI Build?"
+    env:
+      # Ensure we get the most up-to-date git tags to compare against
+      BUILDKITE_CLEAN_CHECKOUT: true
     plugins:
       - chronotc/monorepo-diff#v2.0.4:
           diff: .buildkite/shared/scripts/diff.sh
@@ -94,6 +103,9 @@ steps:
                 command: "buildkite-agent pipeline upload .buildkite/pipeline.merge.ami-build.yml"
 
   - label: ":thinking_face: UX Build?"
+    env:
+      # Ensure we get the most up-to-date git tags to compare against
+      BUILDKITE_CLEAN_CHECKOUT: true
     plugins:
       - chronotc/monorepo-diff#v2.0.4:
           diff: .buildkite/shared/scripts/diff.sh

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -144,6 +144,9 @@ steps:
     # building the image does exactly the same thing. We don't want to
     # waste time.
     if: build.env("BUILDKITE_PIPELINE_NAME") == "grapl/verify"
+    env:
+      # Ensure we get the most up-to-date git tags to compare against
+      BUILDKITE_CLEAN_CHECKOUT: true
     plugins:
       - chronotc/monorepo-diff#v2.0.4:
           diff: .buildkite/shared/scripts/diff.sh


### PR DESCRIPTION
I recently noticed some erroneous builds based on the diff
plugin. Since our tags are changing, it's possible that we're not
getting the most up-to-date tags, particularly on machines that have
been servicing other jobs.

We'll explicitly declare that we want a clean checkout on these jobs
to help remedy this.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
