### PR TITLE
Fix provisioning pipeline

### DIFF
--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -5,6 +5,7 @@ env:
 steps:
   - label: ":pulumi: Preview grapl/testing environment changes in Staging account"
     command:
+      - pulumi/bin/prepare_grapl_ux_dependency.sh grapl/testing
       - .buildkite/shared/steps/pulumi_preview.sh grapl/testing
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -18,6 +19,7 @@ steps:
 
   - label: ":pulumi: Update grapl/testing environment in Staging account"
     command:
+      - pulumi/bin/prepare_grapl_ux_dependency.sh grapl/testing
       - .buildkite/shared/steps/pulumi_up.sh grapl/testing
     plugins:
       - seek-oss/aws-sm#v2.3.1:

--- a/pulumi/infra/config.py
+++ b/pulumi/infra/config.py
@@ -164,6 +164,16 @@ def configured_version_for(artifact_name: str) -> Optional[str]:
     """
     artifacts = pulumi.Config().get_object("artifacts") or {}
     version = artifacts.get(artifact_name)
+
+    if (not version) and REAL_DEPLOYMENT:
+        raise Exception(
+            f"""
+        Tried to deploy the {pulumi.get_stack()} stack, but no version for {artifact_name} was found!
+
+        This stack must have a version configured for ALL artifacts that it uses.
+        """
+        )
+
     return version
 
 

--- a/pulumi/infra/policies.py
+++ b/pulumi/infra/policies.py
@@ -5,6 +5,9 @@ from typing_extensions import Final
 
 import pulumi
 
+# TODO: Find a way to lazily instantiate these policies; we only need
+# to create them if we need them.
+
 SSM_POLICY: Final[aws.iam.Policy] = aws.iam.Policy(
     "demanaged-AmazonSSMManagedInstanceCore",
     policy=json.dumps(


### PR DESCRIPTION
Makes a few tweaks to ensure we can deploy Grapl from our provisioning pipeline.

The main new thing here is ensuring that we have version pins for all artifacts whenever we're deploying a Pulumi stack that we "care about" in CI.

Read individual commits for further details.