### PR TITLE
Stop container builds of graphql-endpoint and model-plugin-deployer

### DIFF
--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -23,13 +23,13 @@ export TAG
 # TODO: This name may change
 readonly CLOUDSMITH_DOCKER_REGISTRY="docker.cloudsmith.io/grapl/raw"
 
-# These are defined in docker-compose.build.yml
+# These are defined in docker-compose.build.yml. There are other
+# services defined in that file for other reasons; we do not need to
+# build them all.
 services=(
     analyzer-dispatcher
     analyzer-executor
     graph-merger
-    graphql-endpoint
-    model-plugin-deployer
     node-identifier
     node-identifier-retry
     osquery-generator

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -77,6 +77,9 @@ services:
       dockerfile: ./src/python/Dockerfile
       target: analyzer-executor-deploy
 
+  # This container build exists only for Local Grapl; if we are able
+  # to deploy model-plugin-deployer as an actual Lambda there, we can
+  # get rid of this.
   model-plugin-deployer:
     image: grapl/model-plugin-deployer:${TAG:-latest}
     build:
@@ -95,6 +98,9 @@ services:
       dockerfile: js/engagement_view/Dockerfile
       target: engagement-view-local-deploy
 
+  # This container build exists only for Local Grapl; if we are able
+  # to deploy graphql-endpoint as an actual Lambda there, we can get
+  # rid of this.
   graphql-endpoint:
     image: grapl/graphql-endpoint:${TAG:-latest}
     build:


### PR DESCRIPTION
These two services are the only Lambda ZIP-deployed services that we
are not actually running as Lambdas in Local Grapl; for that
environment, these run as separate container services.

Unfortunately we were erroneously building these containers in CI and
uploading them to our artifact repository. As a result, the version
pins for these Lambda services in our Pulumi stack configurations were
frequently getting masked by the new container versions (we're still
building the Lambda versions in CI, but only when their code changes;
we don't have as good tooling to do that with the containers yet, so
they get built every time through the pipeline.)

As a result of this, Pulumi updates will fail because Cloudsmith does
not have a "raw" artifact for these service/version pairs. It does
have a container artifact for them, but these are two different
download paths (you don't download a ZIP file using `docker pull`, and
you don't pull a container using `curl`).

All we do here is remove these containers from the list of services we
build containers for in CI, and add some more comments so this doesn't
trip us up again before we can remove those containers altogether.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>