### PR TITLE
Add --renew-anon-volumes to all docker-compose ups

### DIFF
--- a/.buildkite/pipeline.testing.yml
+++ b/.buildkite/pipeline.testing.yml
@@ -6,7 +6,6 @@ env:
 # from our grapl/testing stack.
 
 steps:
-
   # TODO: replace this with something meaningful
   - label: "Hello World :earth_asia::earth_americas::earth_africa:"
     command:

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -159,7 +159,6 @@ steps:
                 label: ":pipeline: Upload AMI Test"
                 command: "buildkite-agent pipeline upload .buildkite/pipeline.verify.ami-test.yml"
 
-
   - label: ":thinking_face::rust: Cargo Audit?"
     plugins:
       - chronotc/monorepo-diff#v2.0.4:

--- a/Makefile
+++ b/Makefile
@@ -368,7 +368,7 @@ up-detach: build-services ## Bring up local Grapl and detach to return control t
 	unset COMPOSE_FILE
 	docker-compose \
 		--file docker-compose.yml \
-		up --detach --force-recreate --always-recreate-deps
+		up --detach --force-recreate --always-recreate-deps --renew-anon-volumes
 
 .PHONY: down
 down: ## docker-compose down - both stops and removes the containers

--- a/test/docker-compose-with-error.sh
+++ b/test/docker-compose-with-error.sh
@@ -24,8 +24,8 @@ usage() {
 docker-compose up \
     --force-recreate \
     --always-recreate-deps \
-    --renew-anon-volumes
-${TARGETS}
+    --renew-anon-volumes \
+    ${TARGETS}
 
 # check for container exit codes other than 0
 EXIT_CODE=0

--- a/test/docker-compose-with-error.sh
+++ b/test/docker-compose-with-error.sh
@@ -21,7 +21,11 @@ usage() {
 }
 
 # Execute the 'up'
-docker-compose up --force-recreate --always-recreate-deps ${TARGETS}
+docker-compose up \
+    --force-recreate \
+    --always-recreate-deps \
+    --renew-anon-volumes
+${TARGETS}
 
 # check for container exit codes other than 0
 EXIT_CODE=0


### PR DESCRIPTION
Kafka and ZK's docker images retain data from run to run, even with `--force-recreate`. 
This flag cleans up that data. 