### PR TITLE
Fix linter exit code stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,10 @@ lint-shell: ## Run Shell lint checks
 
 .PHONY: lint-prettier
 lint-prettier: build-formatter ## Run ts/js/yaml lint checks
-	docker-compose -f docker-compose.formatter.yml up lint-prettier
+	# `docker-compose run` will also propagate the correct exit code.
+	# We could explore tossing `docker-compose` and switching to `docker run`,
+	# like `grapl/grapl-rfcs`.
+	docker-compose -f docker-compose.formatter.yml run lint-prettier
 
 .PHONY: lint-packer
 lint-packer: ## Check to see if Packer templates are formatted properly
@@ -335,7 +338,8 @@ format-python: ## Reformat all Python code
 
 .PHONY: format-prettier
 format-prettier: build-formatter ## Reformat js/ts/yaml
-	docker-compose -f docker-compose.formatter.yml up format-prettier
+	# `docker-compose run` will also propagate the correct exit code.
+	docker-compose -f docker-compose.formatter.yml run format-prettier
 
 .PHONY: format-packer
 format-packer: ## Reformat all Packer HCLs

--- a/docs/queryable.md
+++ b/docs/queryable.md
@@ -147,9 +147,10 @@ ProcessQuery()
 
 ##### All Together
 
-This query matches a process with a process_name that either is _not_ 'foo' but
-ends with '.exe', _or_ it will match a process with a process containing "bar"
-_and_ "baz".
+This query matches a process with:
+
+- a `process_name` that is _not_ 'foo' but ends with '.exe'
+- _or_ a `process_name` that contains both "bar" _and_ "baz".
 
 ```python3
 ProcessQuery()


### PR DESCRIPTION
`docker-compose up` does not propagate exit code, even when it's a single job. Woops!

Also it was formatting `queryable.md` oddly before (it was treating the `_` in `process_name` funkily - so I just reformatted that section of documentation.