### PR TITLE
Unified env_helpers.ts for our typescript stuff

### DIFF
--- a/src/js/graphql_endpoint/modules/env_helpers.ts
+++ b/src/js/graphql_endpoint/modules/env_helpers.ts
@@ -1,0 +1,30 @@
+/**
+ * TODO: Move this to some shared library accessible by all Typescript services
+ */
+
+import * as aws_types from "@aws-sdk/types";
+
+type Constructable<T> = {
+    new (...args: any[]): T;
+};
+
+export function getAwsClient<T>(clientType: Constructable<T>): T {
+    if ("GRAPL_AWS_ENDPOINT" in process.env) {
+        // Running locally
+        console.debug("Creating a local client");
+        const credentials: aws_types.Credentials = {
+            accessKeyId: process.env.GRAPL_AWS_ACCESS_KEY_ID,
+            secretAccessKey: process.env.GRAPL_AWS_ACCESS_KEY_SECRET,
+        };
+        const endpoint = process.env.GRAPL_AWS_ENDPOINT;
+        const region = process.env.AWS_DEFAULT_REGION || process.env.AWS_REGION;
+        return new clientType({
+            endpoint: endpoint,
+            credentials: credentials,
+            region: region,
+        });
+    } else {
+        // Running on AWS
+        return new clientType({});
+    }
+}

--- a/src/js/graphql_endpoint/modules/jwt.ts
+++ b/src/js/graphql_endpoint/modules/jwt.ts
@@ -3,7 +3,6 @@ import * as jwt from "jsonwebtoken";
 import * as AWS from "aws-sdk";
 import { getAwsClient } from "./env_helpers";
 
-const IS_LOCAL = process.env.IS_LOCAL == "True" || null; // get this from environment
 const JWT_SECRET_ID = process.env.JWT_SECRET_ID; // get this from environment
 
 // Acts as a local cache of the secret so we don't have to refetch it every time

--- a/src/js/graphql_endpoint/modules/jwt.ts
+++ b/src/js/graphql_endpoint/modules/jwt.ts
@@ -1,6 +1,7 @@
 import * as express from "express";
 import * as jwt from "jsonwebtoken";
 import * as AWS from "aws-sdk";
+import { getAwsClient } from "./env_helpers";
 
 const IS_LOCAL = process.env.IS_LOCAL == "True" || null; // get this from environment
 const JWT_SECRET_ID = process.env.JWT_SECRET_ID; // get this from environment
@@ -9,17 +10,7 @@ const JWT_SECRET_ID = process.env.JWT_SECRET_ID; // get this from environment
 let JWT_SECRET: string = "";
 
 function getSecretsManagerClient(): AWS.SecretsManager {
-    // TODO: This code should be unified with the dynamodb stuff in schema_client;
-    // or perhaps even create a typescript equivalent of env_helpers
-    return new AWS.SecretsManager({
-        apiVersion: "2017-10-17",
-        region: IS_LOCAL ? process.env.AWS_REGION : undefined,
-        accessKeyId: IS_LOCAL ? process.env.GRAPL_AWS_ACCESS_KEY_ID : undefined,
-        secretAccessKey: IS_LOCAL
-            ? process.env.GRAPL_AWS_ACCESS_KEY_SECRET
-            : undefined,
-        endpoint: IS_LOCAL ? process.env.GRAPL_AWS_ENDPOINT : undefined,
-    });
+    return getAwsClient(AWS.SecretsManager);
 }
 
 async function fetchJwtSecret(): Promise<string> {

--- a/src/js/graphql_endpoint/modules/schema_client.ts
+++ b/src/js/graphql_endpoint/modules/schema_client.ts
@@ -1,23 +1,10 @@
 import * as dynamodb from "@aws-sdk/client-dynamodb";
 import * as util_dynamodb from "@aws-sdk/util-dynamodb";
 
-import * as aws_types from "@aws-sdk/types";
+import { getAwsClient } from "./env_helpers";
 
-function getDynamodbClient() {
-    if ("GRAPL_AWS_ENDPOINT" in process.env) {
-        // Running locally
-        const credentials: aws_types.Credentials = {
-            accessKeyId: process.env.GRAPL_AWS_ACCESS_KEY_ID,
-            secretAccessKey: process.env.GRAPL_AWS_ACCESS_KEY_SECRET,
-        };
-        return new dynamodb.DynamoDB({
-            endpoint: process.env.GRAPL_AWS_ENDPOINT,
-            credentials: credentials,
-        });
-    } else {
-        // Running on AWS
-        return new dynamodb.DynamoDB({});
-    }
+function getDynamodbClient(): dynamodb.DynamoDB {
+    return getAwsClient(dynamodb.DynamoDB);
 }
 
 export interface Schema {


### PR DESCRIPTION
This is a PR I've had on my disk for a while.

Basically, bring the `env_helpers` stuff we use in python/rust to TS as well.

We don't have a shared code library like `grapl-common` for TS yet - there's only 2 services right now, might not even be worth it - but that'd be our next step.