### PR TITLE
Clean up and clarify Pulumi container commands in docker-compose.yml

### DIFF
--- a/Dockerfile.pulumi
+++ b/Dockerfile.pulumi
@@ -1,7 +1,5 @@
 FROM python:3.7-slim-buster as grapl-local-pulumi
 
-SHELL ["/bin/bash", "-c"]
-
 RUN apt-get update && apt-get install --yes \
     build-essential \
     curl \
@@ -61,6 +59,9 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 COPY --chown=grapl pulumi pulumi
+
+# We need to parse the following command with `bash`, not `sh`
+SHELL ["/bin/bash", "-c"]
 
 RUN pip install --upgrade pip wheel && \
     pip install -r <(./pants dependencies --type=3rdparty pulumi::)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -474,16 +474,22 @@ services:
 
   pulumi:
     image: grapl/local-pulumi:${TAG:-latest}
-    command: |
-      /bin/bash -c "
-        cd grapl &&
-        pulumi login --local &&
-        pulumi stack init local-grapl --non-interactive &&
-        pulumi up --yes --skip-preview --stack=local-grapl &&
+    entrypoint: ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
+    command:
+      - |
+        cd grapl
+        pulumi login --local
+        pulumi stack init local-grapl --non-interactive
+        pulumi up --yes --skip-preview --stack=local-grapl
 
         # Write the necessary outputs to the shared volume, for access by other containers
-        pulumi stack output prod-api-id > /home/grapl/pulumi-outputs/prod-api-id
-      "
+        outputs=(
+          prod-api-id
+        )
+        for output in "$${outputs[@]}"; do
+          pulumi stack output "$${output}" > "/home/grapl/pulumi-outputs/$${output}"
+        done
+
     # Our local-grapl Pulumi stack is configured to communicate with
     # localhost. By participating in the network namespace of our
     # localstack container, we can use the same stack configuration


### PR DESCRIPTION
There are a few things going on here, but it's all in service of being
more strict, clear, and extensible with what is going on in our Pulumi
container. These approaches should also be extended to our other
Docker Compose services, but this deals just with the Pulumi container.

First, we set an explicit `ENTRYPOINT` for our Pulumi container,
rather than passing a command starting with `/bin/bash -c`. This
protects us in case our base container ever changes and sets its own
`ENTRYPOINT` (our current one happens to not have one, though).

(With the changes to the command that we're making, we also _have_ to
set an entrypoint, because the long string we're generating is not
going to be an executable that exists in the container.)

We also get a bit more leeway to tighten up exactly how we invoke
`bash` here. We're adding the `-o errexit` and `-o nounset` options to
the entrypoint, meaning that any command failures (handy for multiple
commands!) will immediately fail the container, as will any unset
variables. I've previously seen failures of the Pulumi code that ended
up _not_ short-circuiting the whole `docker-compose` run for our
tests, making it difficult to track down the problem. Now, everything
fails fast.

(I could have just used `/bin/bash -euc`, but I generally favor being
more explicit, particularly in this scenario.)

Next, we express our command using the `- |` trick. We're using array
syntax, rather than a string (triggered by `-`), and we're preserving
any newlines in the following string (triggered by the `|`). By using
a single-element array, this entire string is passed to `bash -c` and
invoked. Expressing the command like this means we don't have to worry
about whether or not we need `&&` or `;` between commands, or anything
else like that; we can just write a straightforward bash script. We
also don't have to worry about extra levels of quoting, which has
often confused my editor's formatting.

Because of this, we also unlock the ability to do some
repetition-saving loops in our command. At the moment, this is
overkill, since we're only exporting a single stack output. However,
future PRs will be adding to this; by expressing this in a loop, we'll
make it easier to extend, and cut down on copy-paste errors.

Finally, the `SHELL` directive in `Dockerfile.pulumi` is moved closer to
where it's actually needed, for clarity.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>