### PR TITLE
Pass bucket names to analyzer-executor directly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -315,6 +315,13 @@ services:
 
   analyzer-executor:
     image: grapl/analyzer-executor:${TAG:-latest}
+    entrypoint: ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
+    command:
+      - |
+        export GRAPL_ANALYZER_MATCHED_SUBGRAPHS_BUCKET=$$(cat /pulumi-outputs/analyzer-matched-subgraphs-bucket)
+        export GRAPL_ANALYZERS_BUCKET=$$(cat /pulumi-outputs/analyzers-bucket)
+        export GRAPL_MODEL_PLUGINS_BUCKET=$$(cat /pulumi-outputs/model-plugins-bucket)
+        python3 analyzer_executor/src/run.py
     environment:
       <<: *aws-env
       DEPLOYMENT_NAME: ${DEPLOYMENT_NAME}
@@ -342,6 +349,14 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      pulumi:
+        # We must wait until Pulumi has created the buckets to know what their names are
+        condition: service_completed_successfully
+    volumes:
+      - type: volume
+        source: pulumi_outputs
+        target: /pulumi-outputs
+        read_only: true
 
   model-plugin-deployer:
     image: grapl/model-plugin-deployer:${TAG:-latest}
@@ -484,6 +499,9 @@ services:
 
         # Write the necessary outputs to the shared volume, for access by other containers
         outputs=(
+          analyzer-matched-subgraphs-bucket
+          analyzers-bucket
+          model-plugins-bucket
           prod-api-id
         )
         for output in "$${outputs[@]}"; do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -324,7 +324,6 @@ services:
         python3 analyzer_executor/src/run.py
     environment:
       <<: *aws-env
-      DEPLOYMENT_NAME: ${DEPLOYMENT_NAME}
       DEBUG_SERVICES: "${DEBUG_SERVICES:-}"
       <<: *dgraph-env
       GRPC_ENABLE_FORK_SUPPORT: "1"

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -32,6 +32,8 @@ from infra.secret import JWTSecret, TestUserPassword
 from infra.service import ServiceLike
 from infra.sysmon_generator import SysmonGenerator
 
+import pulumi
+
 
 def _create_dgraph_cluster(network: Network) -> DgraphCluster:
     if LOCAL_GRAPL:
@@ -81,11 +83,17 @@ def main() -> None:
     subgraphs_generated_emitter = emitter.EventEmitter("subgraphs-generated")
     subgraphs_merged_emitter = emitter.EventEmitter("subgraphs-merged")
     dispatched_analyzer_emitter = emitter.EventEmitter("dispatched-analyzer")
+
     analyzer_matched_emitter = emitter.EventEmitter("analyzer-matched-subgraphs")
+    pulumi.export(
+        "analyzer-matched-subgraphs-bucket", analyzer_matched_emitter.bucket.bucket
+    )
 
     # TODO: No _infrastructure_ currently *writes* to this bucket
     analyzers_bucket = Bucket("analyzers-bucket", sse=True)
+    pulumi.export("analyzers-bucket", analyzers_bucket.bucket)
     model_plugins_bucket = Bucket("model-plugins-bucket", sse=False)
+    pulumi.export("model-plugins-bucket", model_plugins_bucket.bucket)
 
     services: List[ServiceLike] = []
 

--- a/pulumi/infra/analyzer_executor.py
+++ b/pulumi/infra/analyzer_executor.py
@@ -31,7 +31,9 @@ class AnalyzerExecutor(FargateService):
             ),
             env={
                 **configurable_envvars("analyzer-executor", ["GRAPL_LOG_LEVEL"]),
-                "ANALYZER_MATCH_BUCKET": analyzers_bucket.bucket,
+                "GRAPL_ANALYZERS_BUCKET": analyzers_bucket.bucket,
+                "GRAPL_MODEL_PLUGINS_BUCKET": model_plugins_bucket.bucket,
+                "GRAPL_ANALYZER_MATCHED_SUBGRAPHS_BUCKET": output_emitter.bucket.bucket,
                 "MG_ALPHAS": dgraph_cluster.alpha_host_port,
                 # TODO: We should modify this to use REDIS_ENDPOINT,
                 # like our other services.

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/plugin_retriever.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/plugin_retriever.py
@@ -17,9 +17,9 @@ LOGGER.setLevel(LEVEL)
 LOGGER.addHandler(logging.StreamHandler(stream=sys.stdout))
 
 
-def load_plugins(deployment_name: str, s3: S3Client, path=None) -> None:
+def load_plugins(model_plugins_bucket: str, s3: S3Client, path=None) -> None:
     PluginRetriever(
-        plugin_bucket=deployment_name + "-model-plugins-bucket",
+        plugin_bucket=model_plugins_bucket,
         plugin_directory="./model_plugins/",
         s3_client=s3,
     ).retrieve(overwrite=True, path=path)

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -2,6 +2,11 @@ version: "3.8"
 
 # environment variable PWD is assumed to be grapl root directory
 
+volumes:
+  # This is the same as defined in docker-compose.yml, and is provided
+  # here so we can have access to outputs from the stack in our tests.
+  pulumi_outputs:
+
 services:
   rust-integration-tests:
     image: grapl/rust-integration-tests:${TAG:-latest}
@@ -58,10 +63,15 @@ services:
       context: ${PWD}
       dockerfile: ./src/python/Dockerfile
       target: analyzer-executor-test
-    command: bash -c '
-      cd analyzer_executor &&
-      export PYTHONPATH="$${PYTHONPATH}:$$(pwd)/src" &&
-      py.test -n auto -m "integration_test"'
+    entrypoint: ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
+    command:
+      - |
+        export GRAPL_ANALYZER_MATCHED_SUBGRAPHS_BUCKET=$$(cat /pulumi-outputs/analyzer-matched-subgraphs-bucket) &&
+        export GRAPL_ANALYZERS_BUCKET=$$(cat /pulumi-outputs/analyzers-bucket)
+        export GRAPL_MODEL_PLUGINS_BUCKET=$$(cat /pulumi-outputs/model-plugins-bucket)
+        cd analyzer_executor
+        export PYTHONPATH="$${PYTHONPATH:-}:$$(pwd)/src"
+        py.test -n auto -m "integration_test"
     environment:
       - HITCACHE_ADDR=${REDIS_HOST}
       - HITCACHE_PORT=${REDIS_PORT}
@@ -69,6 +79,18 @@ services:
       - MESSAGECACHE_PORT=${REDIS_PORT}
       - GRAPL_LOG_LEVEL=${GRAPL_LOG_LEVEL:-INFO}
       - IS_RETRY=False
+    # In other services in docker.compose.yml that need Pulumi
+    # outputs, we use `depend_on` to declare this relationship (in
+    # addition to mounting the `pulumi_outputs` volume). Our current
+    # buildx setup does not permit this. In any event, the way we
+    # currently run these tests takes care of that for us, since we
+    # bring up the entire local Grapl instance first (which includes
+    # running Pulumi), and _then_ execute these tests.
+    volumes:
+      - type: volume
+        source: pulumi_outputs
+        target: /pulumi-outputs
+        read_only: true
 
   engagement-edge-integration-tests:
     image: grapl/grapl-engagement-edge-test:${TAG:-latest}


### PR DESCRIPTION
Rather than composing the names of our buckets using logic internal to the `analyzer-executor`, we will now pass the full name directly to the service using environment variables.

This will lay the groundwork for ultimately getting rid of concretely-managed bucket names in Pulumi.