### PR TITLE
Pass buckets to analyzer-dispatcher

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -295,8 +295,15 @@ services:
 
   analyzer-dispatcher:
     image: grapl/analyzer-dispatcher:${TAG:-latest}
+    # The default entrypoint is ["/analyzer-dispatcher"];
+    # "/busybox/sh" is the shell present present in the
+    # distroless/cc:debug container.
+    entrypoint: ["/busybox/sh", "-o", "errexit", "-o", "nounset", "-c"]
+    command:
+      - |
+        export GRAPL_ANALYZERS_BUCKET=$$(cat /pulumi-outputs/analyzers-bucket)
+        /analyzer-dispatcher
     environment:
-      ANALYZER_BUCKET: "${DEPLOYMENT_NAME}-analyzers-bucket"
       <<: *aws-env
       DEAD_LETTER_QUEUE_URL: "${GRAPL_AWS_ENDPOINT}/queue/${DEPLOYMENT_NAME}-analyzer-dispatcher-dead-letter-queue"
       DEST_BUCKET_NAME: "${DEPLOYMENT_NAME}-dispatched-analyzer-bucket"
@@ -308,6 +315,14 @@ services:
     depends_on:
       localstack:
         condition: service_healthy
+      pulumi:
+        # We must wait until Pulumi has created the buckets to know what their names are
+        condition: service_completed_successfully
+    volumes:
+      - type: volume
+        source: pulumi_outputs
+        target: /pulumi-outputs
+        read_only: true
 
   ########################################################################
   # Python Services

--- a/pulumi/infra/analyzer_dispatcher.py
+++ b/pulumi/infra/analyzer_dispatcher.py
@@ -31,7 +31,7 @@ class AnalyzerDispatcher(FargateService):
                     "analyzer-dispatcher", ["RUST_LOG", "RUST_BACKTRACE"]
                 ),
                 "REDIS_ENDPOINT": cache.endpoint,
-                "ANALYZER_BUCKET": analyzers_bucket.bucket,
+                "GRAPL_ANALYZERS_BUCKET": analyzers_bucket.bucket,
             },
             input_emitter=input_emitter,
             output_emitter=output_emitter,

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -113,7 +113,11 @@ RUN mkdir -p /grapl/zips; \
 # More information about the base image used here can be found at: 
 # https://github.com/GoogleContainerTools/distroless/blob/main/cc/README.md.
 # For debugging see: https://github.com/GoogleContainerTools/distroless#debug-images
-FROM gcr.io/distroless/cc AS rust-dist
+
+# NOTE: we're using the debug containers at the moment so we have a
+# shell; this lets us inject our Pulumi outputs in Local Grapl. If
+# not for that, we could use the standard non-debug images.
+FROM gcr.io/distroless/cc:debug AS rust-dist
 
 USER nonroot
 

--- a/src/rust/analyzer-dispatcher/src/main.rs
+++ b/src/rust/analyzer-dispatcher/src/main.rs
@@ -123,7 +123,7 @@ where
         subgraph: Self::InputEvent,
         _completed: &mut CompletedEvents,
     ) -> Result<Self::OutputEvent, Result<(Self::OutputEvent, Self::Error), Self::Error>> {
-        let bucket = std::env::var("ANALYZER_BUCKET").expect("ANALYZER_BUCKET");
+        let bucket = std::env::var("GRAPL_ANALYZERS_BUCKET").expect("GRAPL_ANALYZERS_BUCKET");
 
         if subgraph.is_empty() {
             warn!("Attempted to handle empty subgraph");


### PR DESCRIPTION
Same principle as https://github.com/grapl-security/grapl/pull/1044.

Of particular note is the switch to `distroless/cc:debug` as the base container for our Rust containers. Read the individual commit messages for further details.