### PR TITLE
Delete the TestUserPassword immediately

### DIFF
--- a/pulumi/infra/secret.py
+++ b/pulumi/infra/secret.py
@@ -92,6 +92,7 @@ class TestUserPassword(pulumi.ComponentResource):
             "test-user-password",
             name=f"{DEPLOYMENT_NAME}-TestUserPassword",
             description="The Grapl test user's password",
+            recovery_window_in_days=0,  # delete immediately
             opts=pulumi.ResourceOptions(parent=self),
         )
 


### PR DESCRIPTION
Otherwise it's difficult to create and destroy sandbox stacks because
the leftover secret remains around for 7 days by default.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
