### PR TITLE
Fix Model Plugin Deployer permissions (and a threading issue)

### DIFF
--- a/pulumi/infra/model_plugin_deployer.py
+++ b/pulumi/infra/model_plugin_deployer.py
@@ -61,7 +61,9 @@ class ModelPluginDeployer(pulumi.ComponentResource):
         secret.grant_read_permissions_to(self.role)
 
         dynamodb.grant_read_on_tables(self.role, [db.user_auth_table])
-        dynamodb.grant_read_write_on_tables(self.role, [db.schema_table])
+        dynamodb.grant_read_write_on_tables(
+            self.role, [db.schema_table, db.schema_properties_table]
+        )
 
         plugins_bucket.grant_read_write_permissions_to(self.role)
 


### PR DESCRIPTION

### Which issue does this PR correspond to?
None

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Previously when uploading a plugin in prod, you'd get
```
2021-07-27T12:06:18.160-07:00 | [INFO] 2021-07-27T19:06:18.159Z 4c312216-6074-4eeb-9cb8-2e4e9de3c8d4 Merge the schemas with what exists in the graph
-- | --
  | 2021-07-27T12:06:18.483-07:00 | Exception in thread Thread-1:
  | 2021-07-27T12:06:18.483-07:00 | Traceback (most recent call last):
  | 2021-07-27T12:06:18.483-07:00 | File "/var/lang/lib/python3.7/threading.py", line 926, in _bootstrap_inner
  | 2021-07-27T12:06:18.483-07:00 | self.run()
  | 2021-07-27T12:06:18.483-07:00 | File "/var/lang/lib/python3.7/threading.py", line 870, in run
  | 2021-07-27T12:06:18.483-07:00 | self._target(*self._args, **self._kwargs)
  | 2021-07-27T12:06:18.483-07:00 | File "/var/task/grapl_model_plugin_deployer.py", line 156, in provision_schemas
  | 2021-07-27T12:06:18.483-07:00 | provision_common.store_schema_properties(schema_properties_table, schema)
  | 2021-07-27T12:06:18.483-07:00 | File "/var/task/grapl_analyzerlib/provision/provision_common.py", line 80, in store_schema_properties
  | 2021-07-27T12:06:18.483-07:00 | "display_property": schema.get_display_property(),
  | 2021-07-27T12:06:18.483-07:00 | File "/var/runtime/boto3/resources/factory.py", line 520, in do_action
  | 2021-07-27T12:06:18.483-07:00 | response = action(self, *args, **kwargs)
  | 2021-07-27T12:06:18.483-07:00 | File "/var/runtime/boto3/resources/action.py", line 83, in __call__
  | 2021-07-27T12:06:18.483-07:00 | response = getattr(parent.meta.client, operation_name)(*args, **params)
  | 2021-07-27T12:06:18.483-07:00 | File "/var/runtime/botocore/client.py", line 386, in _api_call
  | 2021-07-27T12:06:18.483-07:00 | return self._make_api_call(operation_name, kwargs)
  | 2021-07-27T12:06:18.483-07:00 | File "/var/runtime/botocore/client.py", line 705, in _make_api_call
  | 2021-07-27T12:06:18.483-07:00 | raise error_class(parsed_response, operation_name)
  | 2021-07-27T12:06:18.483-07:00 | botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the PutItem operation: User: arn:aws:sts::516043817266:assumed-role/model-plugin-deployer-execution-role-03999c8/model-plugin-deployer is not authorized to perform: dynamodb:PutItem on resource: arn:aws:dynamodb:us-east-1:516043817266:table/jul27-grapl_schema_properties_table
```

So, two problems:
- Any exceptions occurring in `provision_schemas` were silently swallowed (except for logging it) due to use of `threading`
- We didn't have the right permissions for the dynamodb tables on MPD.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
./bin/graplctl aws test - 7/7 passed !!!!!