### PR TITLE
Fix up FargateService abstraction w/r/t entrypoint and command

### DIFF
--- a/pulumi/infra/analyzer_dispatcher.py
+++ b/pulumi/infra/analyzer_dispatcher.py
@@ -25,7 +25,6 @@ class AnalyzerDispatcher(FargateService):
                 target="analyzer-dispatcher-deploy",
                 context=str(repository_path("src")),
             ),
-            command="/analyzer-dispatcher",
             env={
                 **configurable_envvars(
                     "analyzer-dispatcher", ["RUST_LOG", "RUST_BACKTRACE"]

--- a/pulumi/infra/graph_merger.py
+++ b/pulumi/infra/graph_merger.py
@@ -28,7 +28,6 @@ class GraphMerger(FargateService):
                 target="graph-merger-deploy",
                 context=str(repository_path("src")),
             ),
-            command="/graph-merger",
             env={
                 **configurable_envvars("graph-merger", ["RUST_LOG", "RUST_BACKTRACE"]),
                 "REDIS_ENDPOINT": cache.endpoint,

--- a/pulumi/infra/node_identifier.py
+++ b/pulumi/infra/node_identifier.py
@@ -31,8 +31,6 @@ class NodeIdentifier(FargateService):
                 target="node-identifier-retry-deploy",
                 context=str(repository_path("src")),
             ),
-            command="/node-identifier",
-            retry_command="/node-identifier-retry",
             env={
                 **configurable_envvars(
                     "node-identifier", ["RUST_LOG", "RUST_BACKTRACE"]

--- a/pulumi/infra/osquery_generator.py
+++ b/pulumi/infra/osquery_generator.py
@@ -22,7 +22,6 @@ class OSQueryGenerator(FargateService):
                 target="osquery-generator-deploy",
                 context=str(repository_path("src")),
             ),
-            command="/osquery-generator",
             env={
                 **configurable_envvars(
                     "osquery-generator", ["RUST_LOG", "RUST_BACKTRACE"]

--- a/pulumi/infra/sysmon_generator.py
+++ b/pulumi/infra/sysmon_generator.py
@@ -24,7 +24,6 @@ class SysmonGenerator(FargateService):
                 target="sysmon-generator-deploy",
                 context=str(repository_path("src")),
             ),
-            command="/sysmon-generator",
             env={
                 **configurable_envvars(
                     "sysmon-generator", ["RUST_LOG", "RUST_BACKTRACE"]


### PR DESCRIPTION
Previously, we were simply passing a single string as a command to
most of our Fargate containers.

However, with the recent change of our Rust containers to have an
entrypoint, rather than a command, these will no longer work; we would
be executing `/analyzer-dispatcher /analyzer-dispatcher`, for example.

We now remove our existing uses of `command` in our Fargate services,
because now they just aren't needed.

Though strictly not necessary at the moment, the type of `command` was
changed from `Optional[str]` to `Optional[List[str]]`, to better
reflect the underlying primitives. Additionally, a corresponding
`entrypoint` argument was also added, in case we should ever need to
make use of that in the future.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
