### PR TITLE
Use explicit entrypoints in the rest of our docker-compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -482,7 +482,8 @@ services:
 
   graphql-endpoint:
     image: grapl/graphql-endpoint:${TAG:-latest}
-    command: bash -c "./start_potentially_with_debugger.sh"
+    entrypoint: ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
+    command: ./start_potentially_with_debugger.sh
     environment:
       <<: *aws-env
       <<: *dgraph-env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,10 @@ services:
         rm -f /data/dump.rdb
         redis-server
     healthcheck:
-      test: bash -c 'redis-cli -h 127.0.0.1 ping | grep PONG'
+      test:
+        - CMD-SHELL
+        - |
+          redis-cli -h 127.0.0.1 ping | grep PONG
       interval: 5s
       timeout: 10s
       start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,12 +165,12 @@ services:
       - DATA_DIR=${DATA_DIR- }
     privileged: true # for docker lambda execution
     healthcheck:
-      test: |
-        bash -c '
-          export AWS_ACCESS_KEY_ID=${FAKE_AWS_ACCESS_KEY_ID} &&
-          export AWS_SECRET_ACCESS_KEY=${FAKE_AWS_SECRET_ACCESS_KEY} &&
+      test:
+        - CMD-SHELL
+        - |
+          export AWS_ACCESS_KEY_ID=${FAKE_AWS_ACCESS_KEY_ID}
+          export AWS_SECRET_ACCESS_KEY=${FAKE_AWS_SECRET_ACCESS_KEY}
           aws --endpoint-url=http://${LOCALSTACK_HOST}:${LOCALSTACK_PORT} s3 ls
-        '
       # Probe failure during this period will not be counted towards the maximum number of retries
       start_period: 30s
       # Health check is executed every `interval` seconds.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,12 +120,13 @@ services:
   # service... maybe transitory, this will eventually match prod
   redis:
     image: redis:latest
-    command: |
-      sh -c "
+    entrypoint: ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
+    command:
+      - |
         # hack from https://stackoverflow.com/questions/54533308/disable-redis-persistence-in-docker
         # to disable persistence
-        rm -f /data/dump.rdb && redis-server
-      "
+        rm -f /data/dump.rdb
+        redis-server
     healthcheck:
       test: bash -c 'redis-cli -h 127.0.0.1 ping | grep PONG'
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -572,10 +572,11 @@ services:
 
   provisioner:
     image: grapl/provisioner:${TAG:-latest}
-    command: |
-      /bin/bash -c "
-          python -c 'import lambdex_handler; lambdex_handler.handler(None, None)'
-      "
+    entrypoint: ["python", "-c"]
+    command:
+      - |
+        import lambdex_handler
+        lambdex_handler.handler(None, None)
     environment:
       <<: *aws-env
       <<: *dgraph-env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -576,7 +576,7 @@ services:
 
   provisioner:
     image: grapl/provisioner:${TAG:-latest}
-    entrypoint: ["python", "-c"]
+    entrypoint: ["python3", "-c"]
     command:
       - |
         import lambdex_handler

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -420,11 +420,11 @@ services:
 
   nginx:
     image: nginxinc/nginx-unprivileged
-    command: |
-      /bin/bash -c "
-        export API_GATEWAY_API_ID=$$(cat /pulumi-outputs/prod-api-id) &&
+    entrypoint: ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
+    command:
+      - |
+        export API_GATEWAY_API_ID=$$(cat /pulumi-outputs/prod-api-id)
         /docker-entrypoint.sh nginx -g 'daemon off;'
-      "
     volumes:
       - ./etc/local_grapl/nginx_templates:/etc/nginx/templates
       - type: volume

--- a/test/docker-compose.e2e-tests.yml
+++ b/test/docker-compose.e2e-tests.yml
@@ -34,7 +34,7 @@ services:
               --aws-profile default \
               upload sysmon \
               --logfile ./etc/sample_data/eventlog.xml
-        python -c 'import lambdex_handler; lambdex_handler.handler(None, None)'
+        python3 -c 'import lambdex_handler; lambdex_handler.handler(None, None)'
     volumes:
       - dynamodb_dump:/mnt/dynamodb_dump
       - ${PWD}/etc:/home/grapl/etc:ro

--- a/test/docker-compose.e2e-tests.yml
+++ b/test/docker-compose.e2e-tests.yml
@@ -10,31 +10,31 @@ services:
       dockerfile: ./src/python/e2e-test-runner/e2e-test-runner.Dockerfile
       args:
         - TAG=${TAG:-latest}
-    command: |
-      /bin/bash -c "
-          graplctl \
+    entrypoint: ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
+    command:
+      - |
+        graplctl \
               --grapl-region $AWS_REGION \
               --grapl-deployment-name $DEPLOYMENT_NAME \
               --grapl-version $DEPLOYMENT_NAME \
               --aws-profile default \
               upload analyzer \
-              --analyzer_main_py ./etc/local_grapl/suspicious_svchost/main.py && \
-          graplctl \
+              --analyzer_main_py ./etc/local_grapl/suspicious_svchost/main.py
+        graplctl \
               --grapl-region $AWS_REGION \
               --grapl-deployment-name $DEPLOYMENT_NAME \
               --grapl-version $DEPLOYMENT_NAME \
               --aws-profile default \
               upload analyzer \
-              --analyzer_main_py ./etc/local_grapl/unique_cmd_parent/main.py && \
-          graplctl \
+              --analyzer_main_py ./etc/local_grapl/unique_cmd_parent/main.py
+        graplctl \
               --grapl-region $AWS_REGION \
               --grapl-deployment-name $DEPLOYMENT_NAME \
               --grapl-version $DEPLOYMENT_NAME \
               --aws-profile default \
               upload sysmon \
-              --logfile ./etc/sample_data/eventlog.xml && \
-          python -c 'import lambdex_handler; lambdex_handler.handler(None, None)'
-      "
+              --logfile ./etc/sample_data/eventlog.xml
+        python -c 'import lambdex_handler; lambdex_handler.handler(None, None)'
     volumes:
       - dynamodb_dump:/mnt/dynamodb_dump
       - ${PWD}/etc:/home/grapl/etc:ro

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -144,11 +144,11 @@ services:
       context: ${PWD}
       dockerfile: ./src/python/Dockerfile
       target: graphql-endpoint-tests
-    command: |
-      /bin/bash -c '
-        cd graphql_endpoint_tests &&
+    entrypoint: ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
+    command:
+      - |
+        cd graphql_endpoint_tests
         py.test --capture=no -n 1 -m "integration_test"
-      '
     environment:
       - AWS_REGION
       - DEBUG_SERVICES=${DEBUG_SERVICES:-}

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -100,9 +100,11 @@ services:
       context: ${PWD}
       dockerfile: ./src/python/Dockerfile
       target: engagement-edge-test
-    command: bash -c '
-      cd engagement_edge &&
-      py.test -n auto -m "integration_test"'
+    entrypoint: ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
+    command:
+      - |
+        cd engagement_edge
+        py.test -n auto -m "integration_test"
     environment:
       - AWS_REGION
       - DEPLOYMENT_NAME

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -47,9 +47,11 @@ services:
       context: ${PWD}
       dockerfile: ./src/python/Dockerfile
       target: grapl-analyzerlib-test
-    command: bash -c '
-      cd grapl_analyzerlib &&
-      py.test -v -n auto -m "integration_test"'
+    entrypoint: ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
+    command:
+      - |
+        cd grapl_analyzerlib
+        py.test -v -n auto -m "integration_test"
     environment:
       - GRAPL_LOG_LEVEL=${GRAPL_LOG_LEVEL:-INFO}
       - DEPLOYMENT_NAME


### PR DESCRIPTION
This just continues work that was introduced in
- https://github.com/grapl-security/grapl/pull/1044
- https://github.com/grapl-security/grapl/pull/1045
- https://github.com/grapl-security/grapl/pull/1046
- https://github.com/grapl-security/grapl/pull/1047