### PR TITLE
GraphClient alter now does retries on alters

### DIFF
--- a/src/python/e2e-test-runner/e2e_test_runner/test_model_plugin_deployer.py
+++ b/src/python/e2e-test-runner/e2e_test_runner/test_model_plugin_deployer.py
@@ -9,7 +9,6 @@ from grapl_tests_common.clients.model_plugin_deployer_client import (
 )
 
 
-@pytest.mark.xfail(reason="https://github.com/grapl-security/issue-tracker/issues/625")
 def test_upload_plugin(jwt: str) -> None:
     # We haven't uploaed `schemas.py` yet, so IamRole shouldn't exist in
     # the graphql schema.

--- a/src/python/e2e-test-runner/e2e_test_runner/test_model_plugin_deployer.py
+++ b/src/python/e2e-test-runner/e2e_test_runner/test_model_plugin_deployer.py
@@ -2,7 +2,6 @@ import logging
 import os
 from pathlib import Path
 
-import pytest
 from grapl_tests_common.clients.graphql_endpoint_client import GraphqlEndpointClient
 from grapl_tests_common.clients.model_plugin_deployer_client import (
     ModelPluginDeployerClient,

--- a/src/python/grapl-common/grapl_common/retry.py
+++ b/src/python/grapl-common/grapl_common/retry.py
@@ -34,6 +34,8 @@ def retry(
         each retry
     """
 
+    assert backoff >= 1, "Backoff must be 1 (linear) or greater (exponential)"
+
     def deco_retry(f: F) -> F:
         @wraps(f)
         def f_retry(*args: Any, **kwargs: Any) -> Any:

--- a/src/python/grapl-common/grapl_common/retry.py
+++ b/src/python/grapl-common/grapl_common/retry.py
@@ -9,7 +9,7 @@ F = TypeVar("F", bound=Callable)
 def retry(
     exception_cls: Type[Exception],
     logger: logging.Logger,
-    on_falsey: bool = True,
+    on_falsey: bool = False,
     tries: int = 3,
     delay: float = 0.5,
     backoff: int = 2,
@@ -39,16 +39,19 @@ def retry(
         def f_retry(*args: Any, **kwargs: Any) -> Any:
             mtries, mdelay = tries, delay
             while mtries > 1:
+
                 try:
                     result = f(*args, **kwargs)
 
                     if on_falsey and not result:
                         time.sleep(mdelay)
                     else:
+                        logger.debug(f"{retry_label} success")
                         return result
                 except exception_cls as e:
                     iteration = tries - mtries + 1
-                    logger.warn(f"@retry: {iteration}/{tries} failed due to: {e}")
+                    retry_label = f"@retry: {iteration}/{tries}"
+                    logger.debug(f"{retry_label} failed due to {e}")
                     time.sleep(mdelay)
                 finally:
                     mtries -= 1

--- a/src/python/grapl-common/grapl_common/retry.py
+++ b/src/python/grapl-common/grapl_common/retry.py
@@ -46,7 +46,6 @@ def retry(
                     if on_falsey and not result:
                         time.sleep(mdelay)
                     else:
-                        logger.debug(f"{retry_label} success")
                         return result
                 except exception_cls as e:
                     iteration = tries - mtries + 1

--- a/src/python/grapl-common/grapl_common/time_utils.py
+++ b/src/python/grapl-common/grapl_common/time_utils.py
@@ -4,18 +4,21 @@ from typing import NewType
 # we have a bunch of bare ints around the codebase
 # representing timestamps, this makes it slightly easier
 # to reason about
-Millis = NewType("Millis", int)
+MillisSinceEpoch = NewType("MillisSinceEpoch", int)
 
 # and for millisecond-durations that have nothing to do with Unix Time:
 MillisDuration = NewType("MillisDuration", int)
 
+# for second-durations that have nothing to do with Unix Time:
+SecsDuration = NewType("SecsDuration", int)
 
-def as_datetime(millis: Millis) -> datetime:
+
+def as_datetime(millis: MillisSinceEpoch) -> datetime:
     return datetime.fromtimestamp(millis / 1000.0)
 
 
-def as_millis(dt: datetime) -> Millis:
-    return Millis(int(dt.timestamp() * 1000))
+def as_millis(dt: datetime) -> MillisSinceEpoch:
+    return MillisSinceEpoch(int(dt.timestamp() * 1000))
 
 
 def as_millis_duration(delta: timedelta) -> MillisDuration:

--- a/src/python/grapl-model-plugin-deployer/grapl_model_plugin_deployer.py
+++ b/src/python/grapl-model-plugin-deployer/grapl_model_plugin_deployer.py
@@ -138,7 +138,7 @@ def provision_schemas(graph_client: GraphClient, raw_schemas: List[bytes]) -> No
 
     # Now fetch the schemas back, as Python classes, from meta_globals
     schemas = list(get_schema_objects(meta_globals).values())
-    LOGGER.info(f"deploying schemas: {[s.self_type() for s in schemas]}")
+    LOGGER.info(f"Deploying schemas: {[s.self_type() for s in schemas]}")
 
     LOGGER.info("init_reverse")
     for schema in schemas:
@@ -167,6 +167,7 @@ def provision_schemas(graph_client: GraphClient, raw_schemas: List[bytes]) -> No
     for schema in schemas:
         provision_common.store_schema(schema_table, schema)
         provision_common.store_schema_properties(schema_properties_table, schema)
+    LOGGER.info("provision_schemas() complete")
 
 
 def upload_plugin(s3_client: S3Client, key: str, contents: str) -> Optional[Response]:
@@ -339,11 +340,13 @@ def upload_plugins(
                 if upload_resp:
                     return upload_resp
         finally:
+            LOGGER.debug("upload_plugins() awaiting futures")
             for completed_future in concurrent.futures.as_completed(
                 [provision_schema_fut]
             ):
                 # This will also propagate any exceptions from that thread into the main thread
                 completed_future.result()
+            LOGGER.debug("upload_plugins() futures completed")
         return None
 
 

--- a/src/python/grapl-tests-common/grapl_tests_common/wait.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/wait.py
@@ -8,8 +8,11 @@ from typing import Any, Callable, Dict, Mapping, Optional, Sequence
 import botocore
 from grapl_analyzerlib.grapl_client import GraphClient
 from grapl_analyzerlib.nodes.base import BaseQuery, BaseView
+from grapl_common.grapl_logger import get_module_grapl_logger
 from grapl_common.retry import retry
 from typing_extensions import Protocol
+
+LOGGER = get_module_grapl_logger()
 
 
 class WaitForResource(Protocol):
@@ -100,7 +103,7 @@ class WaitForQuery(WaitForResource):
         self.query = query
         self.graph_client = graph_client or GraphClient()
 
-    @retry()
+    @retry(exception_cls=Exception, logger=LOGGER)
     def acquire(self) -> Optional[BaseView]:
         result = self.query.query_first(self.graph_client)
         return result

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/grapl_client.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/grapl_client.py
@@ -54,8 +54,8 @@ class GraphClient(DgraphClient):
             txn.discard()
 
     @retry(
-        exception_cls=pydgraph.RetriableError, 
-        logger=LOGGER, 
+        exception_cls=pydgraph.RetriableError,
+        logger=LOGGER,
         tries=10,
         backoff=1,  # linear, not exponential
     )

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/grapl_client.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/grapl_client.py
@@ -3,13 +3,10 @@ import os
 from typing import Iterator, List, Optional, Tuple
 from grpc import CallCredentials
 
-from pydgraph import DgraphClient, DgraphClientStub, Txn
+from pydgraph import DgraphClient, DgraphClientStub, Txn, RetriableError, Operation
+from contextlib import contextmanager
 from grapl_common.grapl_logger import get_module_grapl_logger
 from grapl_common.retry import retry
-from contextlib import contextmanager
-
-import pydgraph
-
 from grapl_common.time_utils import SecsDuration
 
 LOGGER = get_module_grapl_logger()
@@ -54,14 +51,14 @@ class GraphClient(DgraphClient):
             txn.discard()
 
     @retry(
-        exception_cls=pydgraph.RetriableError,
+        exception_cls=RetriableError,
         logger=LOGGER,
         tries=10,
         backoff=1,  # linear, not exponential
     )
     def alter(
         self,
-        operation: pydgraph.Operation,
+        operation: Operation,
         timeout: Optional[SecsDuration] = None,
         metadata: Optional[DgraphMetadata] = None,
         credentials: Optional[CallCredentials] = None,

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/grapl_client.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/grapl_client.py
@@ -4,12 +4,15 @@ from typing import Iterator, List, Optional, Tuple
 from grpc import CallCredentials
 
 from pydgraph import DgraphClient, DgraphClientStub, Txn
+from grapl_common.grapl_logger import get_module_grapl_logger
 from grapl_common.retry import retry
 from contextlib import contextmanager
 
 import pydgraph
 
 from grapl_common.time_utils import SecsDuration
+
+LOGGER = get_module_grapl_logger()
 
 # https://dgraph.io/docs/clients/python/#setting-metadata-headers
 DgraphMetadata = List[Tuple[str, str]]
@@ -18,7 +21,7 @@ DgraphMetadata = List[Tuple[str, str]]
 def mg_alphas() -> Iterator[Tuple[str, int]]:
     # MG_ALPHAS being the list of "master graph alphas"
     # (master graph is an outdated term we don't really use in grapl anymore)
-    # alpha being one of the Dgraph cluster's node types 
+    # alpha being one of the Dgraph cluster's node types
     # (https://dgraph.io/docs/get-started/#dgraph)
     mg_alphas = os.environ["MG_ALPHAS"].split(",")
     for mg_alpha in mg_alphas:
@@ -50,7 +53,7 @@ class GraphClient(DgraphClient):
         finally:
             txn.discard()
 
-    @retry(ExceptionToCheck=pydgraph.RetriableError)
+    @retry(exception_cls=pydgraph.RetriableError, logger=LOGGER)
     def alter(
         self,
         operation: pydgraph.Operation,

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/grapl_client.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/grapl_client.py
@@ -53,7 +53,12 @@ class GraphClient(DgraphClient):
         finally:
             txn.discard()
 
-    @retry(exception_cls=pydgraph.RetriableError, logger=LOGGER, tries=10)
+    @retry(
+        exception_cls=pydgraph.RetriableError, 
+        logger=LOGGER, 
+        tries=10,
+        backoff=1,  # linear, not exponential
+    )
     def alter(
         self,
         operation: pydgraph.Operation,

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/grapl_client.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/grapl_client.py
@@ -53,7 +53,7 @@ class GraphClient(DgraphClient):
         finally:
             txn.discard()
 
-    @retry(exception_cls=pydgraph.RetriableError, logger=LOGGER)
+    @retry(exception_cls=pydgraph.RetriableError, logger=LOGGER, tries=10)
     def alter(
         self,
         operation: pydgraph.Operation,

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/provision/provision_common.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/provision/provision_common.py
@@ -116,8 +116,9 @@ def format_schemas(schema_defs: List[BaseSchema]) -> str:
 
 def set_schema(client: GraphClient, schema: str) -> None:
     op = pydgraph.Operation(schema=schema, run_in_background=True)
-    LOGGER.info(f"setting dgraph schema {schema}")
+    LOGGER.info(f"Setting dgraph schema: {schema}")
     client.alter(op)
+    LOGGER.info(f"Completed setting dgraph schema")
 
 
 def _get_reverse_edge(schema_table: Table, schema: BaseSchema, f_edge) -> str:

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/provision/provision_common.py
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/provision/provision_common.py
@@ -17,6 +17,8 @@ from grapl_analyzerlib.schema import Schema
 from grapl_analyzerlib.nodes.base import BaseSchema
 import pydgraph
 
+from grapl_common.time_utils import SecsDuration
+
 if TYPE_CHECKING:
     from mypy_boto3_dynamodb.service_resource import Table
 
@@ -117,7 +119,7 @@ def format_schemas(schema_defs: List[BaseSchema]) -> str:
 def set_schema(client: GraphClient, schema: str) -> None:
     op = pydgraph.Operation(schema=schema, run_in_background=True)
     LOGGER.info(f"Setting dgraph schema: {schema}")
-    client.alter(op)
+    client.alter(op, timeout=SecsDuration(5))
     LOGGER.info(f"Completed setting dgraph schema")
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
We found the [following bug](https://grapl-internal.slack.com/archives/C0176MS6LBY/p1627481777056000) in #bugs today:
```

2021-07-28T15:02:17.765310873Z Traceback (most recent call last):
2021-07-28T15:02:17.765318545Z   File "/home/grapl/app/app.py", line 279, in inner_route
2021-07-28T15:02:17.765326666Z     return route_fn()
2021-07-28T15:02:17.765334384Z   File "/home/grapl/app/app.py", line 366, in deploy
2021-07-28T15:02:17.765342459Z     upload_plugins_resp = upload_plugins(s3, plugins)
2021-07-28T15:02:17.765350371Z   File "/home/grapl/app/app.py", line 346, in upload_plugins
2021-07-28T15:02:17.765358382Z     completed_future.result()
2021-07-28T15:02:17.765366067Z   File "/usr/local/lib/python3.7/concurrent/futures/_base.py", line 428, in result
2021-07-28T15:02:17.765374125Z     return self.__get_result()
2021-07-28T15:02:17.765381794Z   File "/usr/local/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
2021-07-28T15:02:17.765390267Z     raise self._exception
2021-07-28T15:02:17.765398057Z   File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
2021-07-28T15:02:17.765406310Z     result = self.fn(*self.args, **self.kwargs)
2021-07-28T15:02:17.765414194Z   File "/home/grapl/app/app.py", line 162, in provision_schemas
2021-07-28T15:02:17.765422248Z     provision_common.set_schema(graph_client, schema_str)
2021-07-28T15:02:17.765432005Z   File "/home/grapl/venv/lib/python3.7/site-packages/grapl_analyzerlib/provision/provision_common.py", line 120, in set_schema
2021-07-28T15:02:17.765440658Z     client.alter(op)
2021-07-28T15:02:17.765448407Z   File "/home/grapl/venv/lib/python3.7/site-packages/pydgraph/client.py", line 112, in alter
2021-07-28T15:02:17.765456055Z     self._common_except_alter(error)
2021-07-28T15:02:17.765463707Z   File "/home/grapl/venv/lib/python3.7/site-packages/pydgraph/client.py", line 117, in _common_except_alter
2021-07-28T15:02:17.765472032Z     raise errors.RetriableError(error)
2021-07-28T15:02:17.765479059Z pydgraph.errors.RetriableError: <_InactiveRpcError of RPC that terminated with:
2021-07-28T15:02:17.765487254Z  status = StatusCode.UNKNOWN
2021-07-28T15:02:17.765495440Z  details = "Pending transactions found. Please retry operation"
2021-07-28T15:02:17.765503907Z  debug_error_string = "{"created":"@1627484537.755986116","description":"Error received from peer ipv4:192.168.96.4:9080","file":"src/core/lib/surface/call.cc","file_line":1069,"grpc_message":"Pending transactions found. Please retry operation","grpc_status":2}"
```

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Add a @retry wrapper on alter(); the exception message is relatively straightforward in recommending that be tried. 

What this does not do:
- ensuring that all of the alters happen before reads/writes
(that will be a followup PR) (I also don't know how exactly to do this?)

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
CI on this PR. Going to ask jgrillo to give it a shot as well.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
