### PR TITLE
Remove perma-xfailed tests from e2e model plugin deployer

### DIFF
--- a/src/python/e2e-test-runner/e2e_test_runner/test_model_plugin_deployer.py
+++ b/src/python/e2e-test-runner/e2e_test_runner/test_model_plugin_deployer.py
@@ -24,25 +24,6 @@ def test_upload_plugin(jwt: str) -> None:
     assert "IamRole" in gql_client.get_scope_query()
 
 
-@pytest.mark.xfail  # TODO: Remove once list plugins is resolved
-def test_list_plugin(jwt: str) -> None:
-    _get_plugin_list(model_plugin_client=ModelPluginDeployerClient.from_env(), jwt=jwt)
-
-
-@pytest.mark.xfail  # TODO: once list plugins is resolved, we can fix delete plugins :)
-def test_delete_plugin(jwt: str) -> None:
-    # Hard Code for now
-    _delete_model_plugin(
-        model_plugin_client=ModelPluginDeployerClient.from_env(),
-        plugin_to_delete="aws_plugin",
-        jwt=jwt,
-    )  # TODO: we need to change the plugin name when this endpoint gets fixed
-
-
-# The below functions seem nice and composable, so I will keep them separate from
-# the above tests (despite the fact that they could all just be 1 thing together)
-
-
 def _upload_model_plugin(
     model_plugin_client: ModelPluginDeployerClient,
     jwt: str,
@@ -58,26 +39,3 @@ def _upload_model_plugin(
     logging.info(f"UploadRequest: {plugin_upload.json()}")
     upload_status = plugin_upload.json()["success"]["Success"] == True
     assert upload_status
-
-
-def _get_plugin_list(model_plugin_client: ModelPluginDeployerClient, jwt: str) -> None:
-    get_plugin_list = model_plugin_client.list_plugins(
-        jwt,
-    )
-    logging.info(f"UploadRequest: {get_plugin_list.json()}")
-    upload_status = get_plugin_list.json()["success"]["plugin_list"]
-    assert upload_status
-
-
-def _delete_model_plugin(
-    model_plugin_client: ModelPluginDeployerClient,
-    plugin_to_delete: str,
-    jwt: str,
-) -> None:
-    delete_plugin = model_plugin_client.delete_model_plugin(
-        jwt,
-        plugin_to_delete,
-    )
-    logging.info(f"Deleting Plugin: {plugin_to_delete}")
-    deleted = delete_plugin.json()["success"]["plugins_to_delete"]
-    assert deleted


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/626

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Remove xfailed tests that we have no short-term plan to reintroduce.
Feel free to revert this commit once those broken routes are implemented.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
it's a removal of tests.