### PR TITLE
Begin passing some infrastructure values to graplctl directly

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,2 +1,2 @@
-*
-!.gitignore
+# This binary is generated and put here by `make graplctl`
+graplctl

--- a/bin/BUILD
+++ b/bin/BUILD
@@ -1,0 +1,1 @@
+shell_library()

--- a/bin/graplctl-pulumi.sh
+++ b/bin/graplctl-pulumi.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# Call `graplctl` with awareness of the outputs of a particular
+# Pulumi stack.
+########################################################################
+#
+# This script is intended to be a drop-in replacement for any call to
+# `graplctl` directly. All options and arguments passed to this script
+# will be passed to `graplctl` without any changes.
+#
+# In order to specify the Pulumi stack to operate on, you must set
+# `GRAPLCTL_PULUMI_STACK` in your environment. The value must be the
+# name of a Pulumi stack from the `grapl` project (i.e., from
+# `pulumi/grapl` in this repository).
+#
+# All the outputs of this stack will be injected into the environment
+# that `graplctl` will ultimately be called in. In this way, users
+# will not need to manually compose long invocations with many
+# required arguments, nor will they have to manually juggle
+# environment variables as they switch among multiple Pulumi stacks,
+# or among different incarnations of the same stack.
+#
+# Note that this script does not magically take care of all arguments
+# that `graplctl` takes, nor does it handle the values of all
+# environment variables to which `graplctl` responds. It *only*
+# injects Pulumi stack outputs into the environment, and then calls
+# `graplctl` in that environment. Any values that do not come from a
+# Pulumi stack are still the responsibility of the user.
+#
+# Stack output names are converted to SCREAMING_SNAKE_CASE, and
+# prepended with "GRAPL_" before being injected into the
+# environment. Thus, a stack output of `dgraph-config-bucket` becomes
+# `GRAPL_DGRAPH_CONFIG_BUCKET`. These environment variable names will
+# correspond to an argument of a `graplctl` command.
+#
+# Currently, no special handling is given to secret outputs, or
+# outputs with non-scalar values, simply because `graplctl` has no
+# need to access such values. This wrapper script is anticipated to be
+# needed for a relatively short amount of time, so this "shortcut"
+# should be fine.
+#
+# It should be noted that this wrapper script does not have to be
+# used; it is merely a convenience. Users may continue to specify all
+# argument values for graplctl explicitly, and call that binary
+# directly.
+#
+# This script assumes that a `graplctl` binary is present in the `bin`
+# directory at the root of the repository (as you would get from
+# running `make graplctl`). This script also assumes that it is being
+# called from within the grapl repository (though not necessarily
+# directly from the root of the repository).
+#
+# Invocation Example
+########################################################################
+#
+#     export GRAPLCTL_PULUMI_STACK=grapl/my-sandbox
+#     graplctl-pulumi.sh dgraph create --instance-type=i3.large
+#     # etc.
+
+set -euo pipefail
+
+########################################################################
+# Helper Functions
+########################################################################
+
+# Dump Pulumi stack outputs from the `grapl` project as JSON.
+#
+# DOES NOT currently decode any secrets!
+#
+# Assumes it is being invoked from the root of the grapl repository.
+stack_outputs() {
+    local -r stack="${1}"
+    pulumi stack output \
+        --cwd="pulumi/grapl" \
+        --json \
+        --stack="${stack}"
+}
+
+# Converts Pulumi stack outputs into environment variables.
+#
+# Hyphens are converted to underscores, "GRAPL_" is prepended, and
+# everything is uppercased.
+#
+# Implicitly assumes outputs are a flat object; that is, that all
+# values are scalars.
+#
+# Output is `<ENV_VAR>=<VALUE>`, one per line, e.g.:
+#
+#     GRAPL_FOO=one
+#     GRAPL_BAR=two
+#     GRAPL_BAZ=three
+#
+grapl_envvars_from_outputs() {
+    local -r json="${1}"
+    jq --raw-output \
+        'to_entries | .[] |
+       "GRAPL_" + (.key | gsub("-";"_") | ascii_upcase) + "=" + .value' \
+        <<< "${json}"
+}
+
+########################################################################
+# Main Script Logic
+########################################################################
+
+# Requires this environment variable to have already been set.
+readonly pulumi_stack="${GRAPLCTL_PULUMI_STACK}"
+
+(
+    # Perform these operations from the root of the repository, to
+    # make locating the Pulumi data and the `graplctl` binary more
+    # straightforward.
+    REPOSITORY_ROOT="$(git rev-parse --show-toplevel)"
+    readonly REPOSITORY_ROOT
+    cd "${REPOSITORY_ROOT}"
+
+    # Collect the outputs of the given stack
+    stack_json="$(stack_outputs "${pulumi_stack}")"
+
+    # Export all the stack outputs into the environment of this script
+    set -o allexport
+    # shellcheck disable=SC1090
+    source <(grapl_envvars_from_outputs "${stack_json}")
+    set +o allexport
+
+    # Invoke graplctl, passing along all the arguments unchanged
+    ./bin/graplctl "${@}"
+)

--- a/docs/setup/aws.md
+++ b/docs/setup/aws.md
@@ -108,6 +108,18 @@ it as a parameter:
 - as a command line invocation parameter
 - as an environmenal variable
 
+#### Usage with Pulumi
+
+Several commands will need references to things like S3 buckets or AWS log
+groups. While you can pass these values directly, you can also pull them from a
+Pulumi stack's outputs automatically.
+
+To do this, you will need to export `GRAPLCTL_PULUMI_STACK` in your environment,
+and then use the `./bin/graplctl-pulumi.sh` wrapper _instead_ of invoking
+`graplctl` directly.
+
+For further details, please read the documentation in that script.
+
 ### How to spin up DGraph
 
 _Warning: these commands spin up infrastructure in your AWS account. Running

--- a/pulumi/infra/dgraph_cluster.py
+++ b/pulumi/infra/dgraph_cluster.py
@@ -51,6 +51,8 @@ class DgraphCluster(pulumi.ComponentResource):
             logical_bucket_name="dgraph-config-bucket",
             opts=child_opts,
         )
+        pulumi.export("dgraph-config-bucket", self.dgraph_config_bucket.bucket)
+
         self.dgraph_config_bucket.grant_get_and_list_to(self.swarm.role)
         self.dgraph_config_bucket.upload_to_bucket(DGRAPH_CONFIG_DIR)
 

--- a/pulumi/infra/swarm.py
+++ b/pulumi/infra/swarm.py
@@ -31,6 +31,7 @@ class Swarm(pulumi.ComponentResource):
             retention_in_days=DGRAPH_LOG_RETENTION_DAYS,
             opts=child_opts,
         )
+        pulumi.export("dgraph-logs-group", self.log_group.name)
 
         self.security_group = aws.ec2.SecurityGroup(
             f"{name}-sec-group",
@@ -92,6 +93,8 @@ class Swarm(pulumi.ComponentResource):
             logical_bucket_name="swarm-config-bucket",
             opts=child_opts,
         )
+        pulumi.export("swarm-config-bucket", self.swarm_config_bucket.bucket)
+
         self.swarm_config_bucket.grant_get_and_list_to(self.role)
         self.swarm_config_bucket.upload_to_bucket(SWARM_INIT_DIR)
 

--- a/src/aws-provision/dgraph/dgraph_deploy.py
+++ b/src/aws-provision/dgraph/dgraph_deploy.py
@@ -4,26 +4,29 @@ from typing import Iterator, Tuple
 
 
 def _deploy_dgraph(
-    deployment_name: str,
     manager_hostname: str,
     worker_hostnames: Tuple[str, str],
+    dgraph_config_bucket: str,
+    dgraph_logs_group: str,
 ) -> Iterator[str]:
     """Deploy DGraph on a docker swarm cluster"""
+
     commands = [
         [
             "aws",
             "s3",
             "cp",
-            f"s3://{deployment_name.lower()}-dgraph-config-bucket/dgraph_deploy.sh",
+            f"s3://{dgraph_config_bucket}/dgraph_deploy.sh",
             ".",
         ],
         [
             "bash",
             "dgraph_deploy.sh",
-            deployment_name.lower(),
             manager_hostname,
             worker_hostnames[0],
             worker_hostnames[1],
+            dgraph_config_bucket,
+            dgraph_logs_group,
         ],
         ["sleep", "15"],
         ["docker", "service", "ls"],
@@ -40,17 +43,24 @@ def _deploy_dgraph(
 
 
 def main(
-    deployment_name: str,
     manager_hostname: str,
     worker_hostnames: Tuple[str, str],
+    dgraph_config_bucket: str,
+    dgraph_logs_group: str,
 ) -> None:
-    for result in _deploy_dgraph(deployment_name, manager_hostname, worker_hostnames):
+    for result in _deploy_dgraph(
+        manager_hostname,
+        worker_hostnames,
+        dgraph_config_bucket,
+        dgraph_logs_group,
+    ):
         sys.stdout.write(result)
 
 
 if __name__ == "__main__":
     main(
-        deployment_name=sys.argv[1],
-        manager_hostname=sys.argv[2],
-        worker_hostnames=(sys.argv[3], sys.argv[4]),
+        manager_hostname=sys.argv[1],
+        worker_hostnames=(sys.argv[2], sys.argv[3]),
+        dgraph_config_bucket=sys.argv[4],
+        dgraph_logs_group=sys.argv[5],
     )

--- a/src/aws-provision/dgraph/dgraph_deploy.sh
+++ b/src/aws-provision/dgraph/dgraph_deploy.sh
@@ -3,21 +3,23 @@
 set -euo pipefail
 
 echo "--- Deploying dgraph ---"
-readonly grapl_deploy_name="$1"
-readonly manager="${2}"
-readonly worker1="${3}"
-readonly worker2="${4}"
 
-sudo -u ec2-user -- aws s3 cp "s3://${grapl_deploy_name}-dgraph-config-bucket/docker-compose-dgraph.yml" ~ec2-user/
-sudo -u ec2-user -- aws s3 cp "s3://${grapl_deploy_name}-dgraph-config-bucket/envoy.yaml" ~ec2-user/
+readonly manager_hostname="${1}"
+readonly worker_0_hostname="${2}"
+readonly worker_1_hostname="${3}"
+readonly dgraph_config_bucket="${4}"
+readonly dgraph_logs_group="${5}"
+
+sudo -u ec2-user -- aws s3 cp "s3://${dgraph_config_bucket}/docker-compose-dgraph.yml" ~ec2-user/
+sudo -u ec2-user -- aws s3 cp "s3://${dgraph_config_bucket}/envoy.yaml" ~ec2-user/
 
 sudo -u ec2-user \
     --login \
     PWD=~ec2-user \
-    AWS01_NAME="${manager}" \
-    AWS02_NAME="${worker1}" \
-    AWS03_NAME="${worker2}" \
-    AWS_LOGS_GROUP="${grapl_deploy_name}-grapl-dgraph" \
+    AWS01_NAME="${manager_hostname}" \
+    AWS02_NAME="${worker_0_hostname}" \
+    AWS03_NAME="${worker_1_hostname}" \
+    AWS_LOGS_GROUP="${dgraph_logs_group}" \
     -- docker stack deploy -c docker-compose-dgraph.yml dgraph
 
 echo "--- Deployed dgraph ---"

--- a/src/aws-provision/dgraph/dgraph_init.py
+++ b/src/aws-provision/dgraph/dgraph_init.py
@@ -3,7 +3,7 @@ import sys
 from typing import Iterator
 
 
-def _init_dgraph(deployment_name: str) -> Iterator[str]:
+def _init_dgraph(dgraph_config_bucket: str) -> Iterator[str]:
     """Initialize a DGraph instance. Make sure the instance_init.py
     command has completed before running this command."""
     commands = [
@@ -11,7 +11,7 @@ def _init_dgraph(deployment_name: str) -> Iterator[str]:
             "aws",
             "s3",
             "cp",
-            f"s3://{deployment_name.lower()}-dgraph-config-bucket/dgraph_init.sh",
+            f"s3://{dgraph_config_bucket}/dgraph_init.sh",
             ".",
         ],
         ["bash", "dgraph_init.sh"],
@@ -21,9 +21,9 @@ def _init_dgraph(deployment_name: str) -> Iterator[str]:
         yield result.stdout.decode("utf-8")
 
 
-def main(deployment_name: str) -> None:
+def main(dgraph_config_bucket: str) -> None:
     # run all the command to initialize the instance
-    for result in _init_dgraph(deployment_name):
+    for result in _init_dgraph(dgraph_config_bucket):
         sys.stdout.write(result)
 
 

--- a/src/python/graplctl/graplctl/dgraph/commands.py
+++ b/src/python/graplctl/graplctl/dgraph/commands.py
@@ -28,13 +28,47 @@ def dgraph(
     help="EC2 instance type for swarm nodes",
     required=True,
 )
+@click.option(
+    "-b",
+    "--dgraph-config-bucket",
+    help="Name of the S3 bucket with Dgraph config files for the cluster",
+    type=click.STRING,
+    required=True,
+    envvar="GRAPL_DGRAPH_CONFIG_BUCKET",
+)
+@click.option(
+    "-l",
+    "--dgraph-logs-group",
+    help="The name of the AWS logs group to which the containers of the Dgraph Swarm cluster will send their log streams",
+    type=click.STRING,
+    required=True,
+    envvar="GRAPL_DGRAPH_LOGS_GROUP",
+)
+@click.option(
+    "-s",
+    "--swarm-config-bucket",
+    type=click.STRING,
+    help="Name of the S3 bucket with Swarm config files for the cluster",
+    required=True,
+    envvar="GRAPL_SWARM_CONFIG_BUCKET",
+)
 @pass_graplctl_state
-def create(graplctl_state: State, instance_type: InstanceTypeType) -> None:
+def create(
+    graplctl_state: State,
+    instance_type: InstanceTypeType,
+    dgraph_config_bucket: str,
+    dgraph_logs_group: str,
+    swarm_config_bucket: str,
+) -> None:
     """spin up a swarm cluster and deploy dgraph on it"""
     # TODO: Make idempotent
     click.echo(f"creating dgraph cluster of {instance_type} instances")
     if not dgraph_ops.create_dgraph(
-        graplctl_state=graplctl_state, instance_type=instance_type
+        graplctl_state=graplctl_state,
+        instance_type=instance_type,
+        dgraph_config_bucket=dgraph_config_bucket,
+        dgraph_logs_group=dgraph_logs_group,
+        swarm_config_bucket=swarm_config_bucket,
     ):
         click.echo("dgraph cluster already exists")
         return


### PR DESCRIPTION
Most of the work here is removing _some_ (not all) of `graplctl`'s use of a "deployment name" to construct the names of infrastructure resources it must interact with. It is mainly focused on the Dgraph and Swarm configuration buckets, as well as the Dgraph AWS logs group. Now, these pieces of data are plumbed through to the CLI itself, allowing users to directly specify the values.

To make it easier to interact with these additional required arguments, a wrapper script has been added that is a drop-in replacement for `graplctl`, but one that knows how to inject Pulumi stack outputs into the environment, such that `graplctl` can automatically pick up the values for these new required arguments.

This has been tested in AWS.

The PR is broken up into two commits; one does the plumbing, the other adds the wrapper. Please read the commit messages and internal documentation comments for further details.