### PR TITLE
Remove stub_env argument to fake_os_env

### DIFF
--- a/src/python/analyzer_executor/tests/test_cache_integration.py
+++ b/src/python/analyzer_executor/tests/test_cache_integration.py
@@ -27,13 +27,9 @@ class AnalyzerExecutorCacheDeleters:
 
 
 def fake_os_env(
-    stub_env: bool = False,
     env_addr: Optional[str] = None,
     env_port: Optional[str] = None,
 ) -> Mapping[str, str]:
-    if not stub_env:
-        return os.environ
-
     new_os_environ = deepcopy(os.environ)
     if env_addr:
         new_os_environ["MESSAGECACHE_ADDR"] = env_addr
@@ -58,19 +54,13 @@ def test_connection_info() -> None:
     """
 
     with pytest.raises(ValueError):
-        ae = AnalyzerExecutor.from_env(
-            fake_os_env(stub_env=True, env_addr=SAMPLE_ADDR, env_port=None)
-        )
+        ae = AnalyzerExecutor.from_env(fake_os_env(env_addr=SAMPLE_ADDR, env_port=None))
 
     with pytest.raises(ValueError):
-        ae = AnalyzerExecutor.from_env(
-            fake_os_env(stub_env=True, env_addr=None, env_port=SAMPLE_PORT)
-        )
+        ae = AnalyzerExecutor.from_env(fake_os_env(env_addr=None, env_port=SAMPLE_PORT))
 
     with pytest.raises(ValueError):
-        ae = AnalyzerExecutor.from_env(
-            fake_os_env(stub_env=True, env_addr=None, env_port=None)
-        )
+        ae = AnalyzerExecutor.from_env(fake_os_env(env_addr=None, env_port=None))
 
 
 @hypothesis.given(
@@ -92,7 +82,7 @@ def test_hit_cache(
     Initializes the AnalyzerExecutor singleton with Redis connection params
     sourced from the environment, expecting hit cache to populate.
     """
-    ae = AnalyzerExecutor.from_env(fake_os_env(stub_env=False))
+    ae = AnalyzerExecutor.from_env()
 
     assert not ae.check_hit_cache(k1, k2)
     ae.update_hit_cache(k1, k2)
@@ -123,7 +113,7 @@ def test_message_cache(
     Initializes the AnalyzerExecutor singleton with Redis connection params
     sourced from the environment, expecting message cache to populate.
     """
-    ae = AnalyzerExecutor.from_env(fake_os_env(stub_env=False))
+    ae = AnalyzerExecutor.from_env()
 
     assert not ae.check_msg_cache(k1, k2, k3)
     ae.update_msg_cache(k1, k2, k3)


### PR DESCRIPTION
When `stub_env=False`, `fake_os_env` just returns the OS environment
map; `fake_os_env(stub_env=False)` is just another way of saying
"give me a fake OS environment, but actually give me the real OS
environment".

Furthermore, calling `AnalyzerExecutor.from_env()`, with no arguments,
just uses the OS environment anyway, so we can just simplify things.

Now, you only call `fake_os_env` when you actually need something
that's not the raw OS environment.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
