### PR TITLE
Remove DEPLOYMENT_NAME from engagement-edge

### DIFF
--- a/pulumi/infra/api.py
+++ b/pulumi/infra/api.py
@@ -223,7 +223,6 @@ class Api(pulumi.ComponentResource):
         self.engagement_edge = EngagementEdge(
             network=network,
             secret=secret,
-            ux_bucket=ux_bucket,
             db=db,
             notebook=self.notebook,
             forwarder=forwarder,

--- a/pulumi/infra/engagement_edge.py
+++ b/pulumi/infra/engagement_edge.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from infra import dynamodb
-from infra.bucket import Bucket
 from infra.config import configurable_envvars
 from infra.dgraph_cluster import DgraphCluster
 from infra.dynamodb import DynamoDB
@@ -21,7 +20,6 @@ class EngagementEdge(pulumi.ComponentResource):
         self,
         network: Network,
         secret: JWTSecret,
-        ux_bucket: Bucket,
         db: DynamoDB,
         dgraph_cluster: DgraphCluster,
         forwarder: MetricForwarder,
@@ -47,10 +45,6 @@ class EngagementEdge(pulumi.ComponentResource):
                     "MG_ALPHAS": dgraph_cluster.alpha_host_port,
                     "JWT_SECRET_ID": secret.secret.arn,
                     "USER_AUTH_TABLE": db.user_auth_table.name,
-                    # TODO: Not clear that this is even used.
-                    "UX_BUCKET_URL": pulumi.Output.concat(
-                        "https://", ux_bucket.bucket_regional_domain_name
-                    ),
                     # TODO: We *should* be passing in the name of the
                     # notebook here, rather than assuming the name is
                     # based on DEPLOYMENT_NAME.

--- a/pulumi/infra/engagement_edge.py
+++ b/pulumi/infra/engagement_edge.py
@@ -45,7 +45,6 @@ class EngagementEdge(pulumi.ComponentResource):
                     "MG_ALPHAS": dgraph_cluster.alpha_host_port,
                     "JWT_SECRET_ID": secret.secret.arn,
                     "USER_AUTH_TABLE": db.user_auth_table.name,
-                    "DEPLOYMENT_NAME": pulumi.get_stack(),
                     # TODO: This is a bit unfortunate... and only
                     # because Localstack doesn't support
                     # sagemaker. The alternative is to add additional

--- a/pulumi/infra/engagement_edge.py
+++ b/pulumi/infra/engagement_edge.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from infra import dynamodb
-from infra.config import configurable_envvars
+from infra.config import DEPLOYMENT_NAME, configurable_envvars
 from infra.dgraph_cluster import DgraphCluster
 from infra.dynamodb import DynamoDB
 from infra.ec2 import Ec2Port
@@ -45,10 +45,14 @@ class EngagementEdge(pulumi.ComponentResource):
                     "MG_ALPHAS": dgraph_cluster.alpha_host_port,
                     "JWT_SECRET_ID": secret.secret.arn,
                     "USER_AUTH_TABLE": db.user_auth_table.name,
-                    # TODO: We *should* be passing in the name of the
-                    # notebook here, rather than assuming the name is
-                    # based on DEPLOYMENT_NAME.
                     "DEPLOYMENT_NAME": pulumi.get_stack(),
+                    # TODO: This is a bit unfortunate... and only
+                    # because Localstack doesn't support
+                    # sagemaker. The alternative is to add additional
+                    # "IS_LOCAL" logic to the engagement-edge service.
+                    "GRAPL_NOTEBOOK_INSTANCE": notebook.name
+                    if notebook
+                    else f"{DEPLOYMENT_NAME}-Notebook",
                 },
                 timeout=25,
                 memory_size=256,

--- a/src/python/engagement_edge/engagement_edge/engagement_edge.py
+++ b/src/python/engagement_edge/engagement_edge/engagement_edge.py
@@ -25,7 +25,6 @@ import boto3
 import jwt
 from botocore.client import Config
 from chalice import Chalice, Response
-from engagement_edge.env_vars import GRAPL_LOG_LEVEL
 from engagement_edge.sagemaker import create_sagemaker_client
 from grapl_common.debugger.vsc_debugger import wait_for_vsc_debugger
 from grapl_common.env_helpers import (
@@ -39,6 +38,7 @@ if TYPE_CHECKING:
     Salt = bytes
 
 LOGGER = logging.getLogger(__name__)
+GRAPL_LOG_LEVEL = os.environ.get("GRAPL_LOG_LEVEL", "ERROR")
 LOGGER.setLevel(GRAPL_LOG_LEVEL)
 LOGGER.addHandler(logging.StreamHandler(stream=sys.stdout))
 

--- a/src/python/engagement_edge/engagement_edge/engagement_edge.py
+++ b/src/python/engagement_edge/engagement_edge/engagement_edge.py
@@ -25,7 +25,7 @@ import boto3
 import jwt
 from botocore.client import Config
 from chalice import Chalice, Response
-from engagement_edge.env_vars import DEPLOYMENT_NAME, GRAPL_LOG_LEVEL
+from engagement_edge.env_vars import GRAPL_LOG_LEVEL
 from engagement_edge.sagemaker import create_sagemaker_client
 from grapl_common.debugger.vsc_debugger import wait_for_vsc_debugger
 from grapl_common.env_helpers import (
@@ -66,6 +66,8 @@ class LazyJwtSecret:
 
 
 JWT_SECRET = LazyJwtSecret()
+
+NOTEBOOK_NAME = os.environ["GRAPL_NOTEBOOK_INSTANCE"]
 
 DYNAMO: Optional[DynamoDBServiceResource] = None
 
@@ -275,10 +277,8 @@ def check_login() -> Response:
 
 @requires_auth("/getNotebook")
 def get_notebook() -> Response:
-    # cross-reference with `engagement.ts` notebookInstanceName
-    notebook_name = f"{DEPLOYMENT_NAME}-Notebook"
     client = create_sagemaker_client()
-    url = client.get_presigned_url(notebook_name)
+    url = client.get_presigned_url(NOTEBOOK_NAME)
     return respond(err=None, res={"notebook_url": url})
 
 

--- a/src/python/engagement_edge/engagement_edge/env_vars.py
+++ b/src/python/engagement_edge/engagement_edge/env_vars.py
@@ -1,4 +1,0 @@
-import os
-
-GRAPL_LOG_LEVEL = os.environ.get("GRAPL_LOG_LEVEL", "ERROR")
-DEPLOYMENT_NAME = os.environ["DEPLOYMENT_NAME"]

--- a/test/docker-compose.integration-tests.yml
+++ b/test/docker-compose.integration-tests.yml
@@ -116,6 +116,7 @@ services:
       - GRAPL_TEST_USER_NAME
       - IS_LOCAL=True
       - UX_BUCKET_URL="ux_bucket_url"
+      - GRAPL_NOTEBOOK_INSTANCE="local-grapl-Notebook"
 
   # TODO: Re-enable these tests after the following issues are resolved:
   # - https://github.com/grapl-security/issue-tracker/issues/385


### PR DESCRIPTION
This was being used to generate a notebook name, but we can now just pass that in through the environment.

Removes some unused variables, as well; please read the individual commits for further details.