### PR TITLE
Add back libzstd-dev to Rust containers

### DIFF
--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -7,6 +7,7 @@ SHELL ["/bin/bash", "-c"]
 # Necessary for rdkafka
 RUN --mount=type=cache,target=/var/lib/apt/lists \
     apt-get update && apt-get install -y --no-install-recommends \
+        libzstd-dev \
         build-essential
 
 # Install rust toolchain before copying sources to avoid unecessarily


### PR DESCRIPTION
Signed-off-by: Christopher Maier <chris@graplsecurity.com>
