### PR TITLE
Add zlib back to the Rust Dockerfile

### DIFF
--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -7,6 +7,7 @@ SHELL ["/bin/bash", "-c"]
 # Necessary for rdkafka
 RUN --mount=type=cache,target=/var/lib/apt/lists \
     apt-get update && apt-get install -y --no-install-recommends \
+        zlib1g-dev \
         build-essential
 
 # Install rust toolchain before copying sources to avoid unecessarily


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

I'd merged https://github.com/grapl-security/grapl/pull/1064 to main without rebasing, as I should have, considering it branched from ~a month prior, and it broke main. Oops.

The error message was:
```
#75 5.148   = note: /usr/bin/ld: cannot find -lz
```

This PR adds zlib (`zlib1g-dev`) back into the Rust Dockerfile.

### How were these changes tested?

Ran the integration tests, which I'd previously broke.
