### PR TITLE
Rearrange and clarify Make targets, and use docker run to extract from images

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -15,7 +15,7 @@ steps:
                 - "docker-compose.lambda-zips.rust.yml"
               config:
                 command:
-                  - "make lambdas-rust"
+                  - "make build-lambda-zips-rust"
                 artifact_paths:
                   - "dist/*-lambda.zip"
                 agents:
@@ -33,7 +33,7 @@ steps:
                 - "docker-compose.lambda-zips.js.yml"
               config:
                 command:
-                  - "make lambdas-js"
+                  - "make build-lambda-zips-js"
                 artifact_paths:
                   - "dist/*-lambda.zip"
                 agents:

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -104,7 +104,7 @@ steps:
 
   - label: ":aws-lambda::package: Create Lambda Zips"
     command:
-      - make lambdas
+      - make build-lambda-zips
     agents:
       queue: "beefy"
     # There are some issues with the docker nature of this step at the

--- a/Makefile
+++ b/Makefile
@@ -153,24 +153,28 @@ build-test-e2e: build
 build-lambda-zips: build-lambda-zips-rust build-lambda-zips-js build-lambda-zips-python ## Generate all lambda zip files
 
 .PHONY: build-lambda-zips-rust
-build-lambda-zips-rust: export COMPOSE_FILE := docker-compose.lambda-zips.rust.yml
 build-lambda-zips-rust: ## Build Rust lambda zips
-	$(DOCKER_BUILDX_BAKE) --file "${COMPOSE_FILE}"
+	$(DOCKER_BUILDX_BAKE) \
+		--file docker-compose.lambda-zips.rust.yml
 	# Extract the zip from the Docker image.
 	# Rely on the default CMD for copying artifact to /dist mount point.
-	docker-compose run \
+	docker-compose \
+		--file docker-compose.lambda-zips.rust.yml \
+		run \
 		--rm \
 		--user "${UID}:${GID}" \
 		--volume="${PWD}/dist":/dist \
 		metric-forwarder-zip
 
 .PHONY: build-lambda-zips-js
-build-lambda-zips-js: export COMPOSE_FILE := docker-compose.lambda-zips.js.yml
 build-lambda-zips-js: ## Build JS lambda zips
-	$(DOCKER_BUILDX_BAKE) --file "${COMPOSE_FILE}"
+	$(DOCKER_BUILDX_BAKE) \
+		--file docker-compose.lambda-zips.js.yml
 	# Extract the zip from the Docker image.
 	# Rely on the default CMD for copying artifact to /dist mount point.
-	docker-compose run \
+	docker-compose \
+		--file docker-compose.lambda-zips.js.yml \
+		run \
 		--rm \
 		--user "${UID}:${GID}" \
 		--volume="${PWD}/dist":/dist \

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -104,8 +104,8 @@ services:
   graphql-endpoint:
     image: grapl/graphql-endpoint:${TAG:-latest}
     build:
-      context: src
-      dockerfile: js/graphql_endpoint/Dockerfile
+      context: src/js/graphql_endpoint
+      dockerfile: Dockerfile
       target: graphql-endpoint-deploy
 
   notebook:

--- a/docker-compose.lambda-zips.js.yml
+++ b/docker-compose.lambda-zips.js.yml
@@ -4,11 +4,6 @@ services:
   graphql-endpoint-zip:
     image: grapl/graphql-endpoint-zip:${TAG:-latest}
     build:
-      context: src
-      dockerfile: js/graphql_endpoint/Dockerfile
+      context: src/js/graphql_endpoint
+      dockerfile: Dockerfile
       target: graphql-endpoint-zip
-    volumes:
-      - ./dist:/grapl
-    user: ${UID}:${GID}
-    working_dir: /grapl
-    command: cp /home/grapl/lambda.zip graphql-endpoint-lambda.zip

--- a/docker-compose.lambda-zips.rust.yml
+++ b/docker-compose.lambda-zips.rust.yml
@@ -9,8 +9,3 @@ services:
       target: metric-forwarder-zip
       args:
         - RUST_BUILD=${RUST_BUILD:-debug}
-    volumes:
-      - ./dist:/tmp/zips
-    user: ${UID}:${GID}
-    working_dir: /grapl/zips
-    command: sh -c 'cp /grapl/zips/metric-forwarder.zip /tmp/zips/metric-forwarder-lambda.zip'

--- a/src/js/graphql_endpoint/Dockerfile
+++ b/src/js/graphql_endpoint/Dockerfile
@@ -22,17 +22,17 @@ RUN mkdir -p lambda
 
 # Install the dependencies separately to leverage Docker cache
 WORKDIR /home/grapl/lambda
-COPY --chown=grapl js/graphql_endpoint/tsconfig.json tsconfig.json
-COPY --chown=grapl js/graphql_endpoint/package.json package.json
-COPY --chown=grapl js/graphql_endpoint/jest.config.js jest.config.js
-COPY --chown=grapl js/graphql_endpoint/package-lock.json package-lock.json
+COPY --chown=grapl tsconfig.json tsconfig.json
+COPY --chown=grapl package.json package.json
+COPY --chown=grapl jest.config.js jest.config.js
+COPY --chown=grapl package-lock.json package-lock.json
 RUN npm install
 RUN rm -rf node_modules/grpc/build/
 
 # Copy graphql sources
-COPY --chown=grapl js/graphql_endpoint/modules modules
-COPY --chown=grapl js/graphql_endpoint/tests tests
-COPY --chown=grapl js/graphql_endpoint/server.ts server.ts
+COPY --chown=grapl modules modules
+COPY --chown=grapl tests tests
+COPY --chown=grapl server.ts server.ts
 
 # This compiles the typescript and spits out the built js files to `lambda/ts_compiled'
 RUN npx tsc
@@ -40,14 +40,22 @@ RUN cp -r ./node_modules ./ts_compiled/node_modules
 
 WORKDIR /home/grapl
 
+
 # zip
+################################################################################
 FROM graphql-endpoint-build AS graphql-endpoint-zip
 
 RUN test -d lambda/ts_compiled/node_modules && echo "Okay, found node_modules"
 RUN cd lambda/ts_compiled && \
-    zip -q9r /home/grapl/lambda.zip ./
+    zip -q9r /home/grapl/graphql-endpoint-lambda.zip ./
+
+# This defines a default command for extracting the metric-forwarder zip to a
+# container mount point at /dist
+CMD [ "cp", "/home/grapl/graphql-endpoint-lambda.zip", "/dist/" ]
+
 
 # deploy... this is only used in Local Grapl at the moment
+################################################################################
 FROM node:14.16-buster-slim AS graphql-endpoint-deploy
 
 RUN adduser \
@@ -64,9 +72,8 @@ COPY --chown=grapl --from=graphql-endpoint-build /home/grapl/lambda lambda
 
 WORKDIR /home/grapl/lambda/ts_compiled
 
-COPY --chown=grapl js/graphql_endpoint/package.json package.json
-COPY --chown=grapl js/graphql_endpoint/package-lock.json package-lock.json
-COPY --chown=grapl js/graphql_endpoint/start_potentially_with_debugger.sh \
-  start_potentially_with_debugger.sh
+COPY --chown=grapl package.json package.json
+COPY --chown=grapl package-lock.json package-lock.json
+COPY --chown=grapl start_potentially_with_debugger.sh start_potentially_with_debugger.sh
 
 CMD yarn start

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -47,8 +47,8 @@ RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
 # Copy the build outputs to location that's not a cache mount.
 # TODO: switch to using --out-dir when stable: https://github.com/rust-lang/cargo/issues/6790
 RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
-    mkdir -p /dist && \
-    find "/grapl/rust/target/${RUST_BUILD}" -maxdepth 1 -type f -executable -exec cp {} /dist \;
+    mkdir -p /outputs && \
+    find "/grapl/rust/target/${RUST_BUILD}" -maxdepth 1 -type f -executable -exec cp {} /outputs \;
 
 
 # build-test
@@ -99,10 +99,14 @@ RUN mkdir -p /grapl/zips; \
     grapl-zip() { \
       TMPDIR="$(mktemp -d)"; \
       cd "$TMPDIR"; \
-      cp "/dist/${1}" bootstrap && \
-      zip --quiet -9 "/grapl/zips/${1}.zip" bootstrap; \
+      cp "/outputs/${1}" bootstrap && \
+      zip --quiet -9 "/grapl/zips/${1}-lambda.zip" bootstrap; \
     }; \
     grapl-zip metric-forwarder
+
+# This defines a default command for extracting the metric-forwarder zip to a
+# container mount point at /dist
+CMD [ "cp", "/grapl/zips/metric-forwarder-lambda.zip", "/dist" ]
 
 
 # images for running services
@@ -121,41 +125,41 @@ USER nonroot
 # analyzer-dispatcher
 FROM rust-dist AS analyzer-dispatcher-deploy
 
-COPY --from=build /dist/analyzer-dispatcher /
+COPY --from=build /outputs/analyzer-dispatcher /
 ENTRYPOINT ["/analyzer-dispatcher"]
 
 # generic-subgraph-generator
 FROM rust-dist AS generic-subgraph-generator-deploy
 
-COPY --from=build /dist/generic-subgraph-generator /
+COPY --from=build /outputs/generic-subgraph-generator /
 ENTRYPOINT ["/generic-subgraph-generator"]
 
 # graph-merger
 FROM rust-dist AS graph-merger-deploy
 
-COPY --from=build /dist/graph-merger /
+COPY --from=build /outputs/graph-merger /
 ENTRYPOINT ["/graph-merger"]
 
 # node-identifier
 FROM rust-dist AS node-identifier-deploy
 
-COPY --from=build /dist/node-identifier /
+COPY --from=build /outputs/node-identifier /
 ENTRYPOINT ["/node-identifier"]
 
 # node-identifier-retry
 FROM rust-dist AS node-identifier-retry-deploy
 
-COPY --from=build /dist/node-identifier-retry /
+COPY --from=build /outputs/node-identifier-retry /
 ENTRYPOINT ["/node-identifier-retry"]
 
 # sysmon-generator
 FROM rust-dist AS sysmon-generator-deploy
 
-COPY --from=build /dist/sysmon-generator /
+COPY --from=build /outputs/sysmon-generator /
 ENTRYPOINT ["/sysmon-generator"]
 
 # osquery-generator
 FROM rust-dist AS osquery-generator-deploy
 
-COPY --from=build /dist/osquery-generator /
+COPY --from=build /outputs/osquery-generator /
 ENTRYPOINT ["/osquery-generator"]

--- a/test/docker-compose.unit-tests-js.yml
+++ b/test/docker-compose.unit-tests-js.yml
@@ -14,8 +14,8 @@ services:
   graphql-endpoint-test:
     image: grapl/graphql-endpoint:${TAG:-latest}
     build:
-      context: ${PWD}/src
-      dockerfile: js/graphql_endpoint/Dockerfile
+      context: ${PWD}/src/js/graphql_endpoint
+      dockerfile: Dockerfile
       target: graphql-endpoint-deploy
     command: bash -c "
       cd .. && npx jest"


### PR DESCRIPTION
### Which issue does this PR correspond to?

NA

### What changes does this PR make to Grapl? Why?

This does a number a few things for clarifying and simplifying the build process:
- Consolidate the Docker image build steps that were in docker-compose.lambda-zips.js.yml and docker-compose.lambda-zips.rust.yml to docker-compose.build.yml, where the other image build specs are.
- Use `docker run` instead of docker-compose to create the containers used to pull AWS Lambda zips out of previously built Docker images.
- Delete docker-compose.lambda-zips.js.yml and docker-compose.lambda-zips.rust.yml as they are no longer needed.
- Rename the `lambdas` Make targets we had to names that speak more to what they're doing. `lambdas-python` -> `build-python-lambda-zips`, `lambdas-rust` -> `extract-lambda-zips-rust`, ...
- Clean up Make target dependencies accordingly

### How were these changes tested?

Using the test suite we have.
