### PR TITLE
Fix issue in etc/formatter/Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,9 @@ lint-prettier: build-formatter ## Run ts/js/yaml lint checks
 	# `docker-compose run` will also propagate the correct exit code.
 	# We could explore tossing `docker-compose` and switching to `docker run`,
 	# like `grapl/grapl-rfcs`.
-	docker-compose -f docker-compose.formatter.yml run lint-prettier
+	docker-compose \
+		--file docker-compose.formatter.yml \
+		run lint-prettier
 
 .PHONY: lint-packer
 lint-packer: ## Check to see if Packer templates are formatted properly
@@ -339,7 +341,9 @@ format-python: ## Reformat all Python code
 .PHONY: format-prettier
 format-prettier: build-formatter ## Reformat js/ts/yaml
 	# `docker-compose run` will also propagate the correct exit code.
-	docker-compose -f docker-compose.formatter.yml run format-prettier
+	docker-compose \
+		--file docker-compose.formatter.yml \
+		run format-prettier
 
 .PHONY: format-packer
 format-packer: ## Reformat all Packer HCLs

--- a/docker-compose.formatter.yml
+++ b/docker-compose.formatter.yml
@@ -17,7 +17,9 @@ services:
   lint-prettier:
     <<: *formatter-image
     command: /bin/bash -c 'cd /mnt/grapl_repo_rw/src/js; bin/format.sh --check'
+    user: ${UID}:${GID}
 
   format-prettier:
     <<: *formatter-image
     command: /bin/bash -c 'cd /mnt/grapl_repo_rw/src/js; bin/format.sh --update'
+    user: ${UID}:${GID}

--- a/etc/formatter/Dockerfile
+++ b/etc/formatter/Dockerfile
@@ -1,10 +1,10 @@
 FROM debian:buster-slim AS formatter
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         netbase \
-        curl \
-    && rm -rf /var/lib/apt/lists/*
+        curl
 
 # Install npm, Prettier
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
@@ -14,4 +14,3 @@ RUN npm install -g prettier@2.2.1
 # TODO:
 # In later iterations, we can also install all the Rustup cargofmt stuff here
 # as well as Pants to perform containerized linting.
-USER "${UID}:${GID}"


### PR DESCRIPTION
### Which issue does this PR correspond to?

Unfiled: The following is a no-op: https://github.com/grapl-security/grapl/blob/86533bd12ae5b66be3f73f992368d4e6ba36af00/etc/formatter/Dockerfile#L17. It effectively resets USER to root.

### What changes does this PR make to Grapl? Why?

This removes the no-op mentioned above and does what I believe was the original intention was, and what I believe should be done: Set the user id and group id in the container to match that of the host user invoking these containers. Previously these commands were running as root.

### How were these changes tested?

I made a simple change to test:

```
--- a/docker-compose.formatter.yml
+++ b/docker-compose.formatter.yml
@@ -16,7 +16,7 @@ services:
 
   lint-prettier:
     <<: *formatter-image
-    command: /bin/bash -c 'cd /mnt/grapl_repo_rw/src/js; bin/format.sh --check'
+    command: /bin/bash -c 'cd /mnt/grapl_repo_rw/src/js; bin/format.sh --check; id'
     user: ${UID}:${GID}
```

Before:
```
$ make lint-prettier
...
All matched files use Prettier code style!
uid=0(root) gid=0(root) groups=0(root)
$
```

After:
```
$ make lint-prettier
...
All matched files use Prettier code style!
uid=1000 gid=1000 groups=1000
$
```