### PR TITLE
Quick fix for 'build-test-typecheck' Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,8 @@ build-test-unit-js:
 
 .PHONY: build-test-typecheck
 build-test-typecheck: build-python-wheels
-	docker buildx bake --file ./test/docker-compose.typecheck-tests.yml
+	$(DOCKER_BUILDX_BAKE) \
+		--file ./test/docker-compose.typecheck-tests.yml
 
 .PHONY: build-test-integration
 build-test-integration: build-services


### PR DESCRIPTION
### Which issue does this PR correspond to?

Unfiled.

### What changes does this PR make to Grapl? Why?

The `build-test-typecheck` Make target was calling `docker buildx bake` directly instead of using `DOCKER_BUILDX_BAKE`, which is useful when someone wants to pass additional arguments to invocations of `buildx bake`.

### How were these changes tested?

I ran `make test-typecheck`, which uses the changed target.
