### PR TITLE
Various Engagement View Dockerfile improvements

### DIFF
--- a/src/js/engagement_view/Dockerfile
+++ b/src/js/engagement_view/Dockerfile
@@ -22,8 +22,6 @@ FROM engagement-view-deps AS engagement-view-build
 RUN yarn add react-scripts
 RUN yarn build
 
-# no-op the base image cmd, so it doesn't launch a Node repl
-CMD :
 
 # create an image that we can deploy from locally
 ################################################################################

--- a/src/js/engagement_view/Dockerfile
+++ b/src/js/engagement_view/Dockerfile
@@ -19,7 +19,6 @@ COPY js/engagement_view .
 FROM engagement-view-deps AS engagement-view-build
 
 # build sources
-RUN yarn add react-scripts
 RUN yarn build
 
 

--- a/src/js/engagement_view/Dockerfile
+++ b/src/js/engagement_view/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:alpine3.10 AS engagement-view-deps
 
-RUN apk add bash yarn
 WORKDIR /grapl
 
 # install deps as separate steps to leverage build cache

--- a/src/js/engagement_view/Dockerfile
+++ b/src/js/engagement_view/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine3.10 AS engagement-view-deps
+FROM node:16-buster-slim AS engagement-view-deps
 
 WORKDIR /grapl
 


### PR DESCRIPTION
### Which issue does this PR correspond to?

NA

### What changes does this PR make to Grapl? Why?

This makes a number of changes to the Engagement View Dockerfile, most notably:
- Use cache mount for package installation instead of relying on image fs layer.
- Change the base image from `node:alpine3.10` to `node:16-buster-slim`, which will put the base image more inline with other Dockerfiles we have and will now explicitly set the node version to use. The `node:alpine3.10` image is no longer in the list of supported images: https://hub.docker.com/_/node.

### How were these changes tested?

Using CI tests.
