### PR TITLE
Removed broken link for Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ querying capabilities.
 
 
 ## Setup
-Grapl can run locally on your computer, or you can deploy to AWS.
+You can setup Grapl to run...
+- [locally on your computer](https://www.graplsecurity.com/post/how-to-run-grapl-on-your-computer-in-15-minutes)
+- [deploy on AWS](https://grapl.readthedocs.io/en/main/setup/aws.html#aws-setup) for optimal experience
 
-https://grapl.readthedocs.io/en/main/setup/local.html


### PR DESCRIPTION
Added links to run grapl on your computer and to deploy on AWS under Setup.


### Which issue does this PR correspond to?

Updated Setup section under ReadMe to link to running locally and deploying to AWS.

### What changes does this PR make to Grapl? Why?

Good to have working links, especially to learn about setting up Grapl.

### How were these changes tested?

I clicked on the links and verified that they work.
