### PR TITLE
Remove manual unblocking of Pulumi deploy in provision pipeline

### DIFF
--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -14,8 +14,7 @@ steps:
     agents:
       queue: "pulumi-staging"
 
-  - block: ":rocket: Proceed?"
-    prompt: "Unblock to perform a pulumi update to the testing environment"
+  - wait
 
   - label: ":pulumi: Update grapl/testing environment in Staging account"
     command:


### PR DESCRIPTION
Having a manual gate here doesn't really buy us anything, and was more
of a demonstration of what was possible in Buildkite.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
