### PR TITLE
Makefile: remove the 'dist' target as it shouldn't be needed because we

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,16 +175,11 @@ graplctl: ## Build graplctl and install it to the project root
 build-ux: ## Build website assets
 	cd src/js/engagement_view && yarn install && yarn build
 
-# Create the dist directory if necessary; don't need to document this
-# formally for `make help`, though.
-dist:
-	mkdir dist
-
 # This is used to create the artifact that will be uploaded to our
 # artifact repository in CI, and will be the artifact that is used by
 # our Pulumi deployments.
 .PHONY: ux-tarball
-ux-tarball: build-ux dist ## Build website asset tarball
+ux-tarball: build-ux ## Build website asset tarball
 	tar \
 		--create \
 		--gzip \


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This just removes the `dist` Makefile target. It looks like it's no longer useful because the directory should always exist with `dist/.gitkeep` in git.

### How were these changes tested?

It looks like this target isn't used, I'll rely on CI tests.
