### PR TITLE
Perform a `pulumi preview` in the verify pipeline

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -177,3 +177,20 @@ steps:
               config:
                 label: ":pipeline: Upload Cargo Audit"
                 command: ".buildkite/pipeline.cargo-audit.sh | buildkite-agent pipeline upload"
+
+    # The preview mainly functions as a kind of smoke test here more
+    # than actually trying to do a meaningful preview. If we can do a
+    # successful preview, our code at least "compiles".
+  - label: ":pulumi: Pulumi Preview grapl/testing environment"
+    command:
+      # This is slightly hacky, but means we don't need to build packages locally first
+      - git fetch origin rc
+      - git show origin/rc:pulumi/grapl/Pulumi.testing.yaml > pulumi/grapl/Pulumi.testing.yaml
+      - pulumi/bin/prepare_grapl_ux_dependency.sh grapl/testing
+      - .buildkite/shared/steps/pulumi_preview.sh grapl/testing
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            PULUMI_ACCESS_TOKEN: "pulumi-token"
+    agents:
+      queue: "pulumi-staging"

--- a/pulumi/infra/ux.py
+++ b/pulumi/infra/ux.py
@@ -38,7 +38,7 @@ def populate_ux_bucket(ux_bucket: Bucket) -> None:
 
             If you have a pinned version for `grapl-ux` in your stack configuration, please run
 
-                pulumi/bin/prepare_grapl_ux_depencency.sh grapl/<STACK>
+                pulumi/bin/prepare_grapl_ux_dependency.sh grapl/<STACK>
 
             If you do *not* have a pinned version in your stack configuration, you can run the above, or
 


### PR DESCRIPTION
If we messed up our Pulumi code, it'd be better to know it before we
get to the provisioning stage of the pipeline!

As stated in the comments, this is more of a "smoke test" than any
real exhaustive exercising of the code.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
