### PR TITLE
Simplify makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ export EVERY_COMPOSE_FILE=--file docker-compose.yml \
 
 DOCKER_BUILDX_BAKE := docker buildx bake $(DOCKER_BUILDX_BAKE_OPTS)
 
+# https://www.docker.com/blog/faster-builds-in-compose-thanks-to-buildkit-support/
+DOCKER_COMPOSE_WITH_BUILDX := COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose
+
 COMPOSE_PROJECT_INTEGRATION_TESTS := grapl-integration_tests
 COMPOSE_PROJECT_E2E_TESTS := grapl-e2e_tests
 
@@ -312,11 +315,8 @@ lint-shell: ## Run Shell lint checks
 	./pants filter --target-type=shell_library,shunit2_tests :: | xargs ./pants lint
 
 .PHONY: lint-prettier
-lint-prettier: build-formatter ## Run ts/js/yaml lint checks
-	# `docker-compose run` will also propagate the correct exit code.
-	# We could explore tossing `docker-compose` and switching to `docker run`,
-	# like `grapl/grapl-rfcs`.
-	docker-compose \
+lint-prettier: ## Lint a number of filetypes, including js/ts/yaml/toml
+	$(DOCKER_COMPOSE_WITH_BUILDX) \
 		--file docker-compose.formatter.yml \
 		run lint-prettier
 
@@ -342,9 +342,8 @@ format-shell: ## Reformat all shell_libraries
 	./pants filter --target-type=shell_library,shunit2_tests :: | xargs ./pants fmt
 
 .PHONY: format-prettier
-format-prettier: build-formatter ## Reformat js/ts/yaml
-	# `docker-compose run` will also propagate the correct exit code.
-	docker-compose \
+format-prettier: ## Reformat a number of filetypes, including js/ts/yaml/toml
+	$(DOCKER_COMPOSE_WITH_BUILDX) \
 		--file docker-compose.formatter.yml \
 		run format-prettier
 

--- a/Makefile
+++ b/Makefile
@@ -124,37 +124,6 @@ help: ## Print this help
 
 ##@ Build 🔨
 
-.PHONY: build-test-unit
-build-test-unit:
-	$(DOCKER_BUILDX_BAKE) \
-		--file ./test/docker-compose.unit-tests-rust.yml \
-		--file ./test/docker-compose.unit-tests-js.yml
-
-.PHONY: build-test-unit-rust
-build-test-unit-rust:
-	$(DOCKER_BUILDX_BAKE) \
-		--file ./test/docker-compose.unit-tests-rust.yml
-
-.PHONY: build-test-unit-js
-build-test-unit-js:
-	$(DOCKER_BUILDX_BAKE) \
-		--file ./test/docker-compose.unit-tests-js.yml
-
-.PHONY: build-test-typecheck
-build-test-typecheck: build-python-wheels
-	$(DOCKER_BUILDX_BAKE) \
-		--file ./test/docker-compose.typecheck-tests.yml
-
-.PHONY: build-test-integration
-build-test-integration: build-services
-	$(WITH_LOCAL_GRAPL_ENV) \
-	$(DOCKER_BUILDX_BAKE) --file ./test/docker-compose.integration-tests.yml
-
-.PHONY: build-test-e2e
-build-test-e2e: build-services
-	$(WITH_LOCAL_GRAPL_ENV) \
-	$(DOCKER_BUILDX_BAKE) --file ./test/docker-compose.e2e-tests.yml
-
 .PHONY: build-python-wheels
 build-python-wheels:  ## Build all Python wheels
 	./pants filter --target-type=python_distribution :: | xargs ./pants package
@@ -221,13 +190,13 @@ test: test-unit test-integration test-e2e test-typecheck ## Run all tests
 .PHONY: test-unit
 test-unit: export COMPOSE_PROJECT_NAME := grapl-test-unit
 test-unit: export COMPOSE_FILE := ./test/docker-compose.unit-tests-rust.yml:./test/docker-compose.unit-tests-js.yml
-test-unit: build-test-unit test-unit-python test-unit-shell ## Build and run unit tests
+test-unit: test-unit-python test-unit-shell ## Build and run unit tests
 	test/docker-compose-with-error.sh
 
 .PHONY: test-unit-rust
 test-unit-rust: export COMPOSE_PROJECT_NAME := grapl-test-unit-rust
 test-unit-rust: export COMPOSE_FILE := ./test/docker-compose.unit-tests-rust.yml
-test-unit-rust: build-test-unit-rust ## Build and run unit tests - Rust only
+test-unit-rust: ## Build and run unit tests - Rust only
 	test/docker-compose-with-error.sh
 
 .PHONY: test-unit-python
@@ -247,13 +216,13 @@ test-unit-shell: ## Run shunit2 tests under Pants
 .PHONY: test-unit-js
 test-unit-js: export COMPOSE_PROJECT_NAME := grapl-test-unit-js
 test-unit-js: export COMPOSE_FILE := ./test/docker-compose.unit-tests-js.yml
-test-unit-js: build-test-unit-js ## Build and run unit tests - JavaScript only
+test-unit-js: ## Build and run unit tests - JavaScript only
 	test/docker-compose-with-error.sh
 
 .PHONY: test-typecheck-docker
 test-typecheck-docker: export COMPOSE_PROJECT_NAME := grapl-typecheck_tests
 test-typecheck-docker: export COMPOSE_FILE := ./test/docker-compose.typecheck-tests.yml
-test-typecheck-docker: build-test-typecheck ## Build and run typecheck tests (non-Pants)
+test-typecheck-docker: build-python-wheels ## Build and run typecheck tests (non-Pants)
 	test/docker-compose-with-error.sh
 
 .PHONY: test-typecheck-pants
@@ -266,13 +235,13 @@ test-typecheck: test-typecheck-docker test-typecheck-pants ## Typecheck all Pyth
 .PHONY: test-integration
 test-integration: export COMPOSE_PROJECT_NAME := $(COMPOSE_PROJECT_INTEGRATION_TESTS)
 test-integration: export COMPOSE_FILE := ./test/docker-compose.integration-tests.yml
-test-integration: build-test-integration ## Build and run integration tests
+test-integration: build-services ## Build and run integration tests
 	$(MAKE) test-with-env
 
 .PHONY: test-e2e
 test-e2e: export COMPOSE_PROJECT_NAME := $(COMPOSE_PROJECT_E2E_TESTS)
 test-e2e: export export COMPOSE_FILE := ./test/docker-compose.e2e-tests.yml
-test-e2e: build-test-e2e ## Build and run e2e tests
+test-e2e: build-services ## Build and run e2e tests
 	$(MAKE) test-with-env
 
 # This target is not intended to be used directly from the command line, it's

--- a/test/docker-compose-with-error.sh
+++ b/test/docker-compose-with-error.sh
@@ -21,6 +21,7 @@ usage() {
 }
 
 # Execute the 'up'
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 \
 docker-compose up \
     --force-recreate \
     --always-recreate-deps \


### PR DESCRIPTION
Simplify makefile by removing some of the 'build-test-*' targets and using build-during-compose-up
