### PR TITLE
Stop explicitly managing network interfaces for our EC2 instances

### DIFF
--- a/pulumi/infra/ec2_cluster.py
+++ b/pulumi/infra/ec2_cluster.py
@@ -54,25 +54,12 @@ class Ec2Cluster(pulumi.ComponentResource):
     ) -> List[aws.ec2.Instance]:
         instances = []
         for i in range(0, num_instances):
-            network_interface = aws.ec2.NetworkInterface(
-                f"ec2-eni-{name}-{i}",
-                subnet_id=vpc_private_subnet.id,
-                security_groups=vpc_security_group_ids,
-                tags={
-                    "Name": "primary_network_interface",
-                },
-                opts=child_opts,
-            )
             instance = aws.ec2.Instance(
                 f"ec2-inst-{name}-{i}",
                 ami=ami,
                 instance_type=instance_type,
-                network_interfaces=[
-                    aws.ec2.InstanceNetworkInterfaceArgs(
-                        network_interface_id=network_interface.id,
-                        device_index=0,
-                    )
-                ],
+                subnet_id=vpc_private_subnet.id,
+                vpc_security_group_ids=vpc_security_group_ids,
                 credit_specification=aws.ec2.InstanceCreditSpecificationArgs(
                     cpu_credits="unlimited",
                 ),


### PR DESCRIPTION
The way we were managing things before this PR was causing problems
when the EC2 instances needed to be replaced (because we updated the
AMI they were using, for instance). The replacement instance would
come up, and then try to attach the specified network
interface. Unfortunately, this was still attached to the old instance,
which was still running.

One approach would be to use a [NetworkInterfaceAttachment][1] to
decouple the interface from the instance. However, this appears only
to be useful for managing secondary network interfaces, and not
primary ones.

That may be fine; however, we're opting to go for a simpler approach
here, and just configure the primary interface at the instance
level. This means that the interface just won't be shared at all.

I've confirmed that this code allows us to replace the EC2 instances
when we change the AMI.

[1]: https://www.pulumi.com/docs/reference/pkg/aws/ec2/networkinterfaceattachment/

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
