### PR TITLE
Remove DEPLOYMENT_NAME from model-plugin-deployer

### DIFF
--- a/pulumi/infra/model_plugin_deployer.py
+++ b/pulumi/infra/model_plugin_deployer.py
@@ -44,7 +44,6 @@ class ModelPluginDeployer(pulumi.ComponentResource):
                     "JWT_SECRET_ID": secret.secret.arn
                     if not LOCAL_GRAPL
                     else "JWT_SECRET_ID",
-                    "DEPLOYMENT_NAME": pulumi.get_stack(),
                     "GRAPL_SCHEMA_PROPERTIES_TABLE": db.schema_properties_table.id,
                     "GRAPL_SCHEMA_TABLE": db.schema_table.id,
                 },

--- a/src/python/grapl-model-plugin-deployer/grapl_model_plugin_deployer.py
+++ b/src/python/grapl-model-plugin-deployer/grapl_model_plugin_deployer.py
@@ -71,8 +71,6 @@ if IS_LOCAL:
         except Exception as e:
             LOGGER.debug(e)
             time.sleep(1)
-
-    os.environ["DEPLOYMENT_NAME"] = "local-grapl"
 else:
     JWT_SECRET_ID = os.environ["JWT_SECRET_ID"]
 
@@ -196,9 +194,6 @@ def upload_plugin(s3_client: S3Client, key: str, contents: str) -> Optional[Resp
         return respond(
             err=msg,
         )
-
-
-DEPLOYMENT_NAME = os.environ["DEPLOYMENT_NAME"]
 
 
 # Sometimes we pass in a dict. Sometimes we pass the string "True". Weird.


### PR DESCRIPTION
It is no longer used.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>