### PR TITLE
Fix up and better formalize our SQS queue usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -348,7 +348,7 @@ services:
       - |
         export GRAPL_ANALYZERS_BUCKET=$$(cat /mnt/pulumi-outputs/analyzers-bucket)
         export DEST_BUCKET_NAME=$$(cat /mnt/pulumi-outputs/dispatched-analyzer-bucket)
-        export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/analyzer-dispatcher-dead-letter-queue)
+        export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/analyzer-dispatcher-retry-queue)
         export SOURCE_QUEUE_URL=$$(cat /mnt/pulumi-outputs/analyzer-dispatcher-queue)
         /analyzer-dispatcher
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,7 +192,7 @@ services:
       - |
         # TODO: Rename this variable to be in line with our others?
         export DEST_BUCKET_NAME=$$(cat /mnt/pulumi-outputs/unid-subgraphs-generated-bucket)
-        export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/sysmon-generator-dead-letter-queue)
+        export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/sysmon-generator-retry-queue)
         export SOURCE_QUEUE_URL=$$(cat /mnt/pulumi-outputs/sysmon-generator-queue)
         /sysmon-generator
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,7 +221,7 @@ services:
       - |
         # TODO: Rename this variable to be in line with our others?
         export DEST_BUCKET_NAME=$$(cat /mnt/pulumi-outputs/unid-subgraphs-generated-bucket)
-        export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/osquery-generator-dead-letter-queue)
+        export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/osquery-generator-retry-queue)
         export SOURCE_QUEUE_URL=$$(cat /mnt/pulumi-outputs/osquery-generator-queue)
         /osquery-generator
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,7 +193,6 @@ services:
         # TODO: Rename this variable to be in line with our others?
         export DEST_BUCKET_NAME=$$(cat /mnt/pulumi-outputs/unid-subgraphs-generated-bucket)
         export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/sysmon-generator-dead-letter-queue)
-        export RETRY_QUEUE_URL=$$(cat /mnt/pulumi-outputs/sysmon-generator-retry-queue)
         export SOURCE_QUEUE_URL=$$(cat /mnt/pulumi-outputs/sysmon-generator-queue)
         /sysmon-generator
     environment:
@@ -223,7 +222,6 @@ services:
         # TODO: Rename this variable to be in line with our others?
         export DEST_BUCKET_NAME=$$(cat /mnt/pulumi-outputs/unid-subgraphs-generated-bucket)
         export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/osquery-generator-dead-letter-queue)
-        export RETRY_QUEUE_URL=$$(cat /mnt/pulumi-outputs/osquery-generator-retry-queue)
         export SOURCE_QUEUE_URL=$$(cat /mnt/pulumi-outputs/osquery-generator-queue)
         /osquery-generator
     environment:
@@ -255,7 +253,6 @@ services:
         export GRAPL_STATIC_MAPPING_TABLE=$$(cat /mnt/pulumi-outputs/static-mapping-table)
         export GRAPL_DYNAMIC_SESSION_TABLE=$$(cat /mnt/pulumi-outputs/dynamic-session-table)
         export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/node-identifier-dead-letter-queue)
-        export RETRY_QUEUE_URL=$$(cat /mnt/pulumi-outputs/node-identifier-retry-queue)
         export SOURCE_QUEUE_URL=$$(cat /mnt/pulumi-outputs/node-identifier-queue)
         /node-identifier
     environment:
@@ -287,7 +284,6 @@ services:
         export GRAPL_STATIC_MAPPING_TABLE=$$(cat /mnt/pulumi-outputs/static-mapping-table)
         export GRAPL_DYNAMIC_SESSION_TABLE=$$(cat /mnt/pulumi-outputs/dynamic-session-table)
         export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/node-identifier-dead-letter-queue)
-        export RETRY_QUEUE_URL=$$(cat /mnt/pulumi-outputs/node-identifier-dead-letter-queue)
         export SOURCE_QUEUE_URL=$$(cat /mnt/pulumi-outputs/node-identifier-retry-queue)
         /node-identifier-retry
     environment:
@@ -318,7 +314,6 @@ services:
         export DEST_BUCKET_NAME=$$(cat /mnt/pulumi-outputs/subgraphs-merged-bucket)
         export GRAPL_SCHEMA_TABLE=$$(cat /mnt/pulumi-outputs/schema-table)
         export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/graph-merger-dead-letter-queue)
-        export RETRY_QUEUE_URL=$$(cat /mnt/pulumi-outputs/graph-merger-retry-queue)
         export SOURCE_QUEUE_URL=$$(cat /mnt/pulumi-outputs/graph-merger-queue)
         /graph-merger
     environment:
@@ -354,7 +349,6 @@ services:
         export GRAPL_ANALYZERS_BUCKET=$$(cat /mnt/pulumi-outputs/analyzers-bucket)
         export DEST_BUCKET_NAME=$$(cat /mnt/pulumi-outputs/dispatched-analyzer-bucket)
         export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/analyzer-dispatcher-dead-letter-queue)
-        export RETRY_QUEUE_URL=$$(cat /mnt/pulumi-outputs/analyzer-dispatcher-retry-queue)
         export SOURCE_QUEUE_URL=$$(cat /mnt/pulumi-outputs/analyzer-dispatcher-queue)
         /analyzer-dispatcher
     environment:
@@ -383,7 +377,6 @@ services:
         export GRAPL_ANALYZER_MATCHED_SUBGRAPHS_BUCKET=$$(cat /mnt/pulumi-outputs/analyzer-matched-subgraphs-bucket)
         export GRAPL_ANALYZERS_BUCKET=$$(cat /mnt/pulumi-outputs/analyzers-bucket)
         export GRAPL_MODEL_PLUGINS_BUCKET=$$(cat /mnt/pulumi-outputs/model-plugins-bucket)
-        export RETRY_QUEUE_URL=$$(cat /mnt/pulumi-outputs/analyzer-executor-retry-queue)
         export SOURCE_QUEUE_URL=$$(cat /mnt/pulumi-outputs/analyzer-executor-queue)
         python3 analyzer_executor/src/run.py
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -313,7 +313,7 @@ services:
         # TODO: Rename this variable to be in line with our others?
         export DEST_BUCKET_NAME=$$(cat /mnt/pulumi-outputs/subgraphs-merged-bucket)
         export GRAPL_SCHEMA_TABLE=$$(cat /mnt/pulumi-outputs/schema-table)
-        export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/graph-merger-dead-letter-queue)
+        export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/graph-merger-retry-queue)
         export SOURCE_QUEUE_URL=$$(cat /mnt/pulumi-outputs/graph-merger-queue)
         /graph-merger
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -252,7 +252,7 @@ services:
         export DEST_BUCKET_NAME=$$(cat /mnt/pulumi-outputs/subgraphs-generated-bucket)
         export GRAPL_STATIC_MAPPING_TABLE=$$(cat /mnt/pulumi-outputs/static-mapping-table)
         export GRAPL_DYNAMIC_SESSION_TABLE=$$(cat /mnt/pulumi-outputs/dynamic-session-table)
-        export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/node-identifier-dead-letter-queue)
+        export DEAD_LETTER_QUEUE_URL=$$(cat /mnt/pulumi-outputs/node-identifier-retry-queue)
         export SOURCE_QUEUE_URL=$$(cat /mnt/pulumi-outputs/node-identifier-queue)
         /node-identifier
     environment:

--- a/pulumi/infra/fargate_service.py
+++ b/pulumi/infra/fargate_service.py
@@ -204,7 +204,6 @@ class _AWSFargateService(pulumi.ComponentResource):
             family=f"{DEPLOYMENT_NAME}-{name}-task",
             container_definitions=pulumi.Output.all(
                 queue_url=queue.main_queue_url,
-                retry_url=queue.retry_queue_url,
                 dead_letter_url=queue.dead_letter_queue_url,
                 log_group=self.log_group.name,
                 bucket=output_emitter.bucket.bucket,
@@ -226,7 +225,6 @@ class _AWSFargateService(pulumi.ComponentResource):
                                     "DEST_BUCKET_NAME": inputs["bucket"],
                                     "DEPLOYMENT_NAME": DEPLOYMENT_NAME,
                                     "DEAD_LETTER_QUEUE_URL": inputs["dead_letter_url"],
-                                    "RETRY_QUEUE_URL": inputs["retry_url"],
                                     **inputs["env"],
                                 }
                             ),

--- a/pulumi/infra/queue_policy.py
+++ b/pulumi/infra/queue_policy.py
@@ -42,37 +42,6 @@ def consumption_policy(queue: aws.sqs.Queue, role: aws.iam.Role) -> None:
     )
 
 
-def send_policy(queue: aws.sqs.Queue, role: aws.iam.Role) -> None:
-    """
-    Adds an inline policy to `role` for sending messages into `queue`.
-
-    The resulting `RolePolicy` resource is a child of the role.
-    """
-    aws.iam.RolePolicy(
-        f"{role._name}-writes-to-{queue._name}",
-        role=role.name,
-        policy=queue.arn.apply(
-            lambda arn: json.dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Action": [
-                                "sqs:SendMessage",
-                                "sqs:GetQueueAttributes",
-                                "sqs:GetQueueUrl",
-                            ],
-                            "Resource": arn,
-                        }
-                    ],
-                }
-            )
-        ),
-        opts=pulumi.ResourceOptions(parent=role),
-    )
-
-
 def allow_send_from_topic(queue: aws.sqs.Queue, topic: aws.sns.Topic) -> None:
     """
     Set a policy on Queue

--- a/src/python/analyzer_executor/src/run.py
+++ b/src/python/analyzer_executor/src/run.py
@@ -20,9 +20,7 @@ LOGGER = get_module_grapl_logger()
 async def main() -> None:
     """
     Some TODOs:
-    - make sure SOURCE_QUEUE_URL is also specified in CDK
     - add
-      RETRY_QUEUE_URL
       DEAD_LETTER_QUEUE_URL
       DEST_QUEUE_URL
     - pull the manual eventing out of `handle_events` and into an EventEmitter (maybe?)

--- a/src/rust/analyzer-dispatcher/src/main.rs
+++ b/src/rust/analyzer-dispatcher/src/main.rs
@@ -176,7 +176,9 @@ async fn handler() -> Result<(), Box<dyn std::error::Error>> {
     let sqs_client = SqsClient::from_env();
     let _s3_client = S3Client::from_env();
     let source_queue_url = grapl_config::source_queue_url();
+    let dead_letter_queue_url = grapl_config::dead_letter_queue_url();
     debug!("Queue Url: {}", source_queue_url);
+    debug!("Dead-Letter Queue Url: {}", dead_letter_queue_url);
 
     let cache = &mut make_ten(async {
         NopCache {} // the AnalyzerDispatcher is not idempotent :(
@@ -205,7 +207,7 @@ async fn handler() -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting process_loop");
     sqs_executor::process_loop(
         source_queue_url,
-        std::env::var("DEAD_LETTER_QUEUE_URL").expect("DEAD_LETTER_QUEUE_URL"),
+        dead_letter_queue_url,
         cache,
         sqs_client.clone(),
         analyzer_dispatcher,

--- a/src/rust/generators/graph-generator-lib/src/lib.rs
+++ b/src/rust/generators/graph-generator-lib/src/lib.rs
@@ -79,11 +79,9 @@ pub async fn run_graph_generator<
     .await;
 
     info!("Starting process_loop");
-    let queue_url = grapl_config::source_queue_url();
-
     sqs_executor::process_loop(
-        queue_url,
-        std::env::var("DEAD_LETTER_QUEUE_URL").expect("DEAD_LETTER_QUEUE_URL"),
+        grapl_config::source_queue_url(),
+        grapl_config::dead_letter_queue_url(),
         cache,
         sqs_client.clone(),
         subgraph_generator,

--- a/src/rust/grapl-config/src/lib.rs
+++ b/src/rust/grapl-config/src/lib.rs
@@ -117,10 +117,6 @@ pub fn dead_letter_queue_url() -> String {
     std::env::var("DEAD_LETTER_QUEUE_URL").expect("DEAD_LETTER_QUEUE_URL")
 }
 
-pub fn retry_queue_url() -> String {
-    std::env::var("RETRY_QUEUE_URL").expect("RETRY_QUEUE_URL")
-}
-
 pub fn mg_alphas() -> Vec<String> {
     return std::env::var("MG_ALPHAS")
         .expect("MG_ALPHAS")

--- a/src/rust/node-identifier/src/lib.rs
+++ b/src/rust/node-identifier/src/lib.rs
@@ -330,7 +330,7 @@ pub async fn handler(should_default: bool) -> Result<(), Box<dyn std::error::Err
     info!("Starting process_loop");
     sqs_executor::process_loop(
         grapl_config::source_queue_url(),
-        std::env::var("DEAD_LETTER_QUEUE_URL").expect("DEAD_LETTER_QUEUE_URL"),
+        grapl_config::dead_letter_queue_url(),
         cache,
         sqs_client.clone(),
         node_identifier,


### PR DESCRIPTION
Our "service queue" abstraction has the following structure:

    main queue --> retry queue --> dead-letter queue

Our services are split into two paired variants: the main service and the retry service.

The main service should pull from the main queue and write failed messages to the retry queue. On the other hand, the retry service should read from the _retry_ queue, and write failed messages to the _dead-letter_ queue.

In reality, our services in AWS were actually configured to be passed all three queues, and they all had read and write access to all three queues. In Local Grapl, the identities of many queues were incorrect (retry queues were passed in with an unused `RETRY_QUEUE_URL` environment variable, while dead-letter queues were _always_ passed in with `DEAD_LETTER_QUEUE_URL` variables).

Now, the proper queues are passed to the appropriate services. Additionally, IAM permissions have been restricted to the minimum needed; services can only read from their input queue and can only write to their output queue.

Additional cleanups and refactorings were also made, as appropriate.