### PR TITLE
Generalize artifact handling code

### DIFF
--- a/.buildkite/pipeline.merge.ami-build.yml
+++ b/.buildkite/pipeline.merge.ami-build.yml
@@ -61,3 +61,5 @@ steps:
   - label: ":writing_hand: Record AMI IDs"
     command:
       - .buildkite/scripts/record_artifacts.sh
+    artifact_paths:
+      - "artifact_manifests/*.json"

--- a/.buildkite/pipeline.merge.ami-build.yml
+++ b/.buildkite/pipeline.merge.ami-build.yml
@@ -62,4 +62,4 @@ steps:
     command:
       - .buildkite/scripts/record_artifacts.sh
     artifact_paths:
-      - "artifact_manifests/*.grapl-artifacts.json"
+      - "*.grapl-artifacts.json"

--- a/.buildkite/pipeline.merge.ami-build.yml
+++ b/.buildkite/pipeline.merge.ami-build.yml
@@ -62,4 +62,4 @@ steps:
     command:
       - .buildkite/scripts/record_artifacts.sh
     artifact_paths:
-      - "artifact_manifests/*.json"
+      - "artifact_manifests/*.grapl-artifacts.json"

--- a/.buildkite/pipeline.merge.ux-build.yml
+++ b/.buildkite/pipeline.merge.ux-build.yml
@@ -22,3 +22,5 @@ steps:
             CLOUDSMITH_API_KEY: "cloudsmith-token"
     agents:
       queue: "artifact-uploaders"
+    artifact_paths:
+      - "artifact_manifests/*.json"

--- a/.buildkite/pipeline.merge.ux-build.yml
+++ b/.buildkite/pipeline.merge.ux-build.yml
@@ -23,4 +23,4 @@ steps:
     agents:
       queue: "artifact-uploaders"
     artifact_paths:
-      - "artifact_manifests/*.json"
+      - "artifact_manifests/*.grapl-artifacts.json"

--- a/.buildkite/pipeline.merge.ux-build.yml
+++ b/.buildkite/pipeline.merge.ux-build.yml
@@ -23,4 +23,4 @@ steps:
     agents:
       queue: "artifact-uploaders"
     artifact_paths:
-      - "artifact_manifests/*.grapl-artifacts.json"
+      - "*.grapl-artifacts.json"

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -118,7 +118,7 @@ steps:
       - >
         .buildkite/scripts/merge_artifact_files.sh
         artifact_manifests/lambda_artifacts.json
-        container_artifacts.json
+        artifact_manifests/container_artifacts.json
         grapl-nomad-consul-server.artifacts.json
         grapl-nomad-consul-client.artifacts.json
         ux_artifacts.json

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -119,8 +119,8 @@ steps:
         .buildkite/scripts/merge_artifact_files.sh
         artifact_manifests/lambda_artifacts.json
         artifact_manifests/container_artifacts.json
-        grapl-nomad-consul-server.artifacts.json
-        grapl-nomad-consul-client.artifacts.json
+        artifact_manifests/grapl-nomad-consul-server.artifacts.json
+        artifact_manifests/grapl-nomad-consul-client.artifacts.json
         ux_artifacts.json
 
   - wait

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -62,6 +62,8 @@ steps:
           server: docker.cloudsmith.io
     agents:
       queue: "docker"
+    artifact_paths:
+      - "artifact_manifests/*.json"
 
   - label: ":aws-lambda::cloudsmith: Upload Lambda ZIPs"
     command:

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -78,6 +78,8 @@ steps:
             CLOUDSMITH_API_KEY: "cloudsmith-token"
     agents:
       queue: "artifact-uploaders"
+    artifact_paths:
+      - "artifact_manifests/*.json"
 
   - label: ":thinking_face: AMI Build?"
     plugins:

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -121,7 +121,7 @@ steps:
         artifact_manifests/container_artifacts.json
         artifact_manifests/grapl-nomad-consul-server.artifacts.json
         artifact_manifests/grapl-nomad-consul-client.artifacts.json
-        ux_artifacts.json
+        artifact_manifests/ux_artifacts.json
 
   - wait
 

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -114,8 +114,8 @@ steps:
 
   - wait
 
-  # Downloads and operates on all the artifact.json files that were
-  # uploaded in any previous steps of this pipeline.
+  # Downloads and operates on all the *.grapl-artifacts.json files
+  # that were uploaded in any previous steps of this pipeline.
   - label: "Merge artifacts files"
     command:
       - .buildkite/scripts/merge_artifact_files.sh

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -110,18 +110,11 @@ steps:
 
   - wait
 
-  # The names of the input files depend on the files that can be
-  # uploaded to Buildkite from previous steps in this pipeline.
+  # Downloads and operates on all the artifact.json files that were
+  # uploaded in any previous steps of this pipeline.
   - label: "Merge artifacts files"
     command:
-      # yaml fyi: `>` collapses newlines into normal spaces
-      - >
-        .buildkite/scripts/merge_artifact_files.sh
-        artifact_manifests/lambda_artifacts.json
-        artifact_manifests/container_artifacts.json
-        artifact_manifests/grapl-nomad-consul-server.artifacts.json
-        artifact_manifests/grapl-nomad-consul-client.artifacts.json
-        artifact_manifests/ux_artifacts.json
+      - .buildkite/scripts/merge_artifact_files.sh
 
   - wait
 

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -117,7 +117,7 @@ steps:
       # yaml fyi: `>` collapses newlines into normal spaces
       - >
         .buildkite/scripts/merge_artifact_files.sh
-        lambda_artifacts.json
+        artifact_manifests/lambda_artifacts.json
         container_artifacts.json
         grapl-nomad-consul-server.artifacts.json
         grapl-nomad-consul-client.artifacts.json

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -63,7 +63,7 @@ steps:
     agents:
       queue: "docker"
     artifact_paths:
-      - "artifact_manifests/*.json"
+      - "artifact_manifests/*.grapl-artifacts.json"
 
   - label: ":aws-lambda::cloudsmith: Upload Lambda ZIPs"
     command:

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -79,7 +79,7 @@ steps:
     agents:
       queue: "artifact-uploaders"
     artifact_paths:
-      - "artifact_manifests/*.json"
+      - "artifact_manifests/*.grapl-artifacts.json"
 
   - label: ":thinking_face: AMI Build?"
     plugins:

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -63,7 +63,7 @@ steps:
     agents:
       queue: "docker"
     artifact_paths:
-      - "artifact_manifests/*.grapl-artifacts.json"
+      - "*.grapl-artifacts.json"
 
   - label: ":aws-lambda::cloudsmith: Upload Lambda ZIPs"
     command:
@@ -79,7 +79,7 @@ steps:
     agents:
       queue: "artifact-uploaders"
     artifact_paths:
-      - "artifact_manifests/*.grapl-artifacts.json"
+      - "*.grapl-artifacts.json"
 
   - label: ":thinking_face: AMI Build?"
     plugins:

--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -76,6 +76,3 @@ artifact_file="container_artifacts.json"
 # promoting containers across repositories
 mkdir "${ARTIFACT_FILE_DIRECTORY}"
 artifact_json "${TAG}" "${services[@]}" > "${ARTIFACT_FILE_DIRECTORY}/${artifact_file}"
-
-echo "--- :buildkite: Uploading ${ARTIFACT_FILE_DIRECTORY}/${artifact_file} file"
-buildkite-agent artifact upload "${ARTIFACT_FILE_DIRECTORY}/${artifact_file}"

--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -74,7 +74,8 @@ artifact_file="container_artifacts.json"
 # TODO: Do we want to put the complete container image name in for
 # each service? Perhaps not, particularly if we're going to be
 # promoting containers across repositories
-artifact_json "${TAG}" "${services[@]}" > "${artifact_file}"
+mkdir "${ARTIFACT_FILE_DIRECTORY}"
+artifact_json "${TAG}" "${services[@]}" > "${ARTIFACT_FILE_DIRECTORY}/${artifact_file}"
 
-echo "--- :buildkite: Uploading ${artifact_file} file"
-buildkite-agent artifact upload "${artifact_file}"
+echo "--- :buildkite: Uploading ${ARTIFACT_FILE_DIRECTORY}/${artifact_file} file"
+buildkite-agent artifact upload "${ARTIFACT_FILE_DIRECTORY}/${artifact_file}"

--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -68,11 +68,7 @@ for service in "${services[@]}"; do
 
 done
 
-# TODO: Add this to a separate file
-artifact_file="container_artifacts.json"
-
 # TODO: Do we want to put the complete container image name in for
 # each service? Perhaps not, particularly if we're going to be
 # promoting containers across repositories
-mkdir "${ARTIFACT_FILE_DIRECTORY}"
-artifact_json "${TAG}" "${services[@]}" > "${ARTIFACT_FILE_DIRECTORY}/${artifact_file}"
+artifact_json "${TAG}" "${services[@]}" > "$(artifacts_file_for containers)"

--- a/.buildkite/scripts/lib/artifacts.sh
+++ b/.buildkite/scripts/lib/artifacts.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-readonly ARTIFACT_FILE_DIRECTORY=all_artifacts_files
+readonly ARTIFACT_FILE_DIRECTORY=artifact_manifests
 
 # The name of the file that we will merge all artifact JSON
 # information into.

--- a/.buildkite/scripts/lib/artifacts.sh
+++ b/.buildkite/scripts/lib/artifacts.sh
@@ -29,26 +29,6 @@ artifact_json() {
     done | jq --null-input '[inputs] | from_entries'
 }
 
-# Download a given artifact file from Buildkite into
-# `$ARTIFACT_FILE_DIRECTORY`.
-#
-# Does not fail if the file was not generated and uploaded during the
-# current Buildkite pipeline (which is a legitimate scenario - for example,
-# we only *sometimes* generate new AMI IDs.)
-download_artifact_file() {
-    local -r artifacts_file="${1}"
-    mkdir -p "${ARTIFACT_FILE_DIRECTORY}"
-    echo -e "--- :buildkite: Download '${artifacts_file}' artifacts file"
-    if ! (buildkite-agent artifact download "${artifacts_file}" "${ARTIFACT_FILE_DIRECTORY}"); then
-        echo "^^^ +++" # Un-collapses this section in Buildkite, making it more obvious we couldn't download
-        echo "No file found"
-    fi
-    # TODO: Would be nice to validate the artifacts. Right now there are some restrictions:
-    # - json file must be a flat associative array of key -> primitive (no nested maps, arrays)
-    #     bad: {"im": {"nested": true}}
-    #     good: {"im.nested": true}
-}
-
 # Given a directory of JSON files (assumed to represent JSON objects),
 # merge them into a single JSON object, sent to standard output.
 #

--- a/.buildkite/scripts/lib/artifacts.sh
+++ b/.buildkite/scripts/lib/artifacts.sh
@@ -45,3 +45,25 @@ _merge_artifact_files_impl() {
 merge_artifact_files() {
     _merge_artifact_files_impl "${ARTIFACT_FILE_DIRECTORY}"
 }
+
+# Generate a file name for an artifacts.json file. The `slug` is just
+# a meaningful name you give to describe the file. The
+# `${BUILDKITE_JOB_ID}` is also incorporated into the file name, meaning
+# that you don't have to care about naming collisions between artifact
+# files that are uploaded by different jobs. All you have to do is
+# make sure the `slug` is unique within the job.
+#
+# Additionally, these paths are all inside the
+# `${ARTIFACT_FILE_DIRECTORY}`. As a convenience, this function call
+# also creates that directory if it does not already exist, ensuring
+# that you can use this path without any additional work.
+#
+#     $ artifacts_file_for monkeypants
+#     # => artifact_manifests/monkeypants-e44f9784-e20e-4b93-a21d-f41fd5869db9.artifacts.json
+#
+artifacts_file_for() {
+    local -r slug="${1}"
+
+    mkdir -p "${ARTIFACT_FILE_DIRECTORY}"
+    echo "${ARTIFACT_FILE_DIRECTORY}/${slug}-${BUILDKITE_JOB_ID}.artifacts.json"
+}

--- a/.buildkite/scripts/lib/artifacts_test.sh
+++ b/.buildkite/scripts/lib/artifacts_test.sh
@@ -37,13 +37,13 @@ EOF
         "${actual}"
 }
 
-test__merge_artifact_files_impl() {
+test_merge_artifact_files() {
     echo '{"first": 1}' > "first.${ARTIFACTS_FILE_EXTENSION}"
     echo '{"second": 2}' > "second.${ARTIFACTS_FILE_EXTENSION}"
     echo '{"third": 3}' > "third.${ARTIFACTS_FILE_EXTENSION}"
     echo '{"first": "overwritten!"}' > "fourth.${ARTIFACTS_FILE_EXTENSION}"
 
-    actual="$(_merge_artifact_files_impl .)"
+    actual="$(merge_artifact_files)"
 
     expected=$(
         cat << EOF
@@ -56,6 +56,18 @@ EOF
     )
 
     assertEquals "Failed to generate expected JSON" \
+        "${expected}" \
+        "${actual}"
+}
+
+test_artifacts_file_for() {
+    actual=$(
+        export BUILDKITE_JOB_ID="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        artifacts_file_for stuff
+    )
+
+    expected="stuff-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.grapl-artifacts.json"
+    assertEquals "Failed to generate expected artifacts file name!" \
         "${expected}" \
         "${actual}"
 }

--- a/.buildkite/scripts/lib/artifacts_test.sh
+++ b/.buildkite/scripts/lib/artifacts_test.sh
@@ -38,10 +38,10 @@ EOF
 }
 
 test__merge_artifact_files_impl() {
-    echo '{"first": 1}' > first.json
-    echo '{"second": 2}' > second.json
-    echo '{"third": 3}' > third.json
-    echo '{"first": "overwritten!"}' > fourth.json
+    echo '{"first": 1}' > "first.${ARTIFACTS_FILE_EXTENSION}"
+    echo '{"second": 2}' > "second.${ARTIFACTS_FILE_EXTENSION}"
+    echo '{"third": 3}' > "third.${ARTIFACTS_FILE_EXTENSION}"
+    echo '{"first": "overwritten!"}' > "fourth.${ARTIFACTS_FILE_EXTENSION}"
 
     actual="$(_merge_artifact_files_impl .)"
 

--- a/.buildkite/scripts/lib/packer_constants.sh
+++ b/.buildkite/scripts/lib/packer_constants.sh
@@ -8,15 +8,6 @@
 # SCREAMING_SNAKE_CASE, and ordered alphabetically when possible.
 ########################################################################
 
-# This file contains a single flat JSON object describing
-# artifact/version pairs for adding to the `artifacts` object in our
-# Pulumi stack configuration files.
-#
-# When a pipeline generates artifacts, it should record this in a file
-# of this name and upload it as a Buildkite artifact for consumption
-# in other jobs.
-readonly ARTIFACTS_FILE_SUFFIX=".artifacts.json"
-
 # These are specified in `local.image_name`
 readonly PACKER_IMAGE_NAME_SERVER="grapl-nomad-consul-server"
 readonly PACKER_IMAGE_NAME_CLIENT="grapl-nomad-consul-client"

--- a/.buildkite/scripts/merge_artifact_files.sh
+++ b/.buildkite/scripts/merge_artifact_files.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 source .buildkite/scripts/lib/artifacts.sh
 
 echo "--- :buildkite: Downloading all artifact files"
-buildkite-agent artifact download "${ARTIFACT_FILE_DIRECTORY}/*" .
+buildkite-agent artifact download "*.${ARTIFACTS_FILE_EXTENSION}" .
 
 merge_artifact_files > "${ALL_ARTIFACTS_JSON_FILE}"
 

--- a/.buildkite/scripts/merge_artifact_files.sh
+++ b/.buildkite/scripts/merge_artifact_files.sh
@@ -13,11 +13,8 @@ set -euo pipefail
 
 source .buildkite/scripts/lib/artifacts.sh
 
-all_files=("$@")
-
-for file in "${all_files[@]}"; do
-    download_artifact_file "${file}"
-done
+echo "--- :buildkite: Downloading all artifact files"
+buildkite-agent artifact download "${ARTIFACT_FILE_DIRECTORY}/*" .
 
 merge_artifact_files > "${ALL_ARTIFACTS_JSON_FILE}"
 

--- a/.buildkite/scripts/record_artifacts.sh
+++ b/.buildkite/scripts/record_artifacts.sh
@@ -15,7 +15,7 @@ generate_artifacts_file() {
     # e.g. "grapl-service.packer-manifest.json"
     local -r manifest_file="${packer_image_name}${PACKER_MANIFEST_SUFFIX}"
     # e.g. "grapl-service.artifacts.json"
-    local -r artifacts_file="${ARTIFACT_FILE_DIRECTORY}/${packer_image_name}${ARTIFACTS_FILE_SUFFIX}"
+    local -r artifacts_file="$(artifacts_file_for "${packer_image_name}")"
 
     # Download Packer manifest
     echo -e "--- :buildkite: Download Packer manifest"
@@ -38,7 +38,6 @@ generate_artifacts_file() {
     echo "${ami_ids_dict}" > "${artifacts_file}"
 }
 
-mkdir "${ARTIFACT_FILE_DIRECTORY}"
 for image_name in "${PACKER_IMAGE_NAMES[@]}"; do
     generate_artifacts_file "${image_name}"
 done

--- a/.buildkite/scripts/record_artifacts.sh
+++ b/.buildkite/scripts/record_artifacts.sh
@@ -6,7 +6,7 @@ source .buildkite/scripts/lib/artifacts.sh
 source .buildkite/scripts/lib/packer_constants.sh
 readonly jq_filter_path=".buildkite/scripts/lib/extract_ami_id_dict.jq"
 
-upload_artifacts_file() {
+generate_artifacts_file() {
     # Takes in the name of an image, like "image_name", and expects to find
     # a corresponding packer manifest names "image_name.packer-manifest.json".
 
@@ -36,14 +36,9 @@ upload_artifacts_file() {
     # Creating artifacts file
     echo -c "--- :gear: Creating ${artifacts_file} file"
     echo "${ami_ids_dict}" > "${artifacts_file}"
-
-    # Uploading artifacts file
-    echo -c "--- :buildkite: Uploading ${ARTIFACT_FILE_DIRECTORY}/${artifacts_file} file"
-    buildkite-agent artifact upload "${ARTIFACT_FILE_DIRECTORY}/${artifacts_file}"
-    # This artifact then gets picked up by the "Merge artifacts files" step in Buildkite
 }
 
 mkdir "${ARTIFACT_FILE_DIRECTORY}"
 for image_name in "${PACKER_IMAGE_NAMES[@]}"; do
-    upload_artifacts_file "${image_name}"
+    generate_artifacts_file "${image_name}"
 done

--- a/.buildkite/scripts/record_artifacts.sh
+++ b/.buildkite/scripts/record_artifacts.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+source .buildkite/scripts/lib/artifacts.sh
 source .buildkite/scripts/lib/packer_constants.sh
 readonly jq_filter_path=".buildkite/scripts/lib/extract_ami_id_dict.jq"
 
@@ -14,7 +15,7 @@ upload_artifacts_file() {
     # e.g. "grapl-service.packer-manifest.json"
     local -r manifest_file="${packer_image_name}${PACKER_MANIFEST_SUFFIX}"
     # e.g. "grapl-service.artifacts.json"
-    local -r artifacts_file="${packer_image_name}${ARTIFACTS_FILE_SUFFIX}"
+    local -r artifacts_file="${ARTIFACT_FILE_DIRECTORY}/${packer_image_name}${ARTIFACTS_FILE_SUFFIX}"
 
     # Download Packer manifest
     echo -e "--- :buildkite: Download Packer manifest"
@@ -37,11 +38,12 @@ upload_artifacts_file() {
     echo "${ami_ids_dict}" > "${artifacts_file}"
 
     # Uploading artifacts file
-    echo -c "--- :buildkite: Uploading ${artifacts_file} file"
-    buildkite-agent artifact upload "${artifacts_file}"
+    echo -c "--- :buildkite: Uploading ${ARTIFACT_FILE_DIRECTORY}/${artifacts_file} file"
+    buildkite-agent artifact upload "${ARTIFACT_FILE_DIRECTORY}/${artifacts_file}"
     # This artifact then gets picked up by the "Merge artifacts files" step in Buildkite
 }
 
+mkdir "${ARTIFACT_FILE_DIRECTORY}"
 for image_name in "${PACKER_IMAGE_NAMES[@]}"; do
     upload_artifacts_file "${image_name}"
 done

--- a/.buildkite/scripts/upload_lambda_artifacts.sh
+++ b/.buildkite/scripts/upload_lambda_artifacts.sh
@@ -30,8 +30,7 @@ if (buildkite-agent artifact download "dist/*${LAMBDA_SUFFIX}" .); then
     done
 
     # Generate artifacts JSON file for lambda zip files
-    mkdir "${ARTIFACT_FILE_DIRECTORY}"
-    artifact_json "${version}" "${lambda_artifacts[@]}" > "${ARTIFACT_FILE_DIRECTORY}/${LAMBDA_ARTIFACTS_FILE}"
+    artifact_json "${version}" "${lambda_artifacts[@]}" > "$(artifacts_file_for lambdas)"
 else
     echo "^^^ +++" # Un-collapses this section in Buildkite, making it more obvious we couldn't download
     echo "No artifacts to upload"

--- a/.buildkite/scripts/upload_lambda_artifacts.sh
+++ b/.buildkite/scripts/upload_lambda_artifacts.sh
@@ -30,10 +30,11 @@ if (buildkite-agent artifact download "dist/*${LAMBDA_SUFFIX}" .); then
     done
 
     # Generate artifacts JSON file for lambda zip files
-    artifact_json "${version}" "${lambda_artifacts[@]}" > "${LAMBDA_ARTIFACTS_FILE}"
+    mkdir "${ARTIFACT_FILE_DIRECTORY}"
+    artifact_json "${version}" "${lambda_artifacts[@]}" > "${ARTIFACT_FILE_DIRECTORY}/${LAMBDA_ARTIFACTS_FILE}"
 
-    echo "--- :buildkite: Uploading ${LAMBDA_ARTIFACTS_FILE} file"
-    buildkite-agent artifact upload "${LAMBDA_ARTIFACTS_FILE}"
+    echo "--- :buildkite: Uploading ${ARTIFACT_FILE_DIRECTORY}/${LAMBDA_ARTIFACTS_FILE} file"
+    buildkite-agent artifact upload "${ARTIFACT_FILE_DIRECTORY}/${LAMBDA_ARTIFACTS_FILE}"
 else
     echo "^^^ +++" # Un-collapses this section in Buildkite, making it more obvious we couldn't download
     echo "No artifacts to upload"

--- a/.buildkite/scripts/upload_lambda_artifacts.sh
+++ b/.buildkite/scripts/upload_lambda_artifacts.sh
@@ -32,9 +32,6 @@ if (buildkite-agent artifact download "dist/*${LAMBDA_SUFFIX}" .); then
     # Generate artifacts JSON file for lambda zip files
     mkdir "${ARTIFACT_FILE_DIRECTORY}"
     artifact_json "${version}" "${lambda_artifacts[@]}" > "${ARTIFACT_FILE_DIRECTORY}/${LAMBDA_ARTIFACTS_FILE}"
-
-    echo "--- :buildkite: Uploading ${ARTIFACT_FILE_DIRECTORY}/${LAMBDA_ARTIFACTS_FILE} file"
-    buildkite-agent artifact upload "${ARTIFACT_FILE_DIRECTORY}/${LAMBDA_ARTIFACTS_FILE}"
 else
     echo "^^^ +++" # Un-collapses this section in Buildkite, making it more obvious we couldn't download
     echo "No artifacts to upload"

--- a/.buildkite/scripts/upload_ux_assets.sh
+++ b/.buildkite/scripts/upload_ux_assets.sh
@@ -23,9 +23,6 @@ main() {
 
     mkdir "${ARTIFACT_FILE_DIRECTORY}"
     artifact_json "${version}" "grapl-ux" > "${ARTIFACT_FILE_DIRECTORY}/${UX_ARTIFACTS_FILE}"
-
-    echo "--- :buildkite: Uploading ${ARTIFACT_FILE_DIRECTORY}/${UX_ARTIFACTS_FILE} file"
-    buildkite-agent artifact upload "${ARTIFACT_FILE_DIRECTORY}/${UX_ARTIFACTS_FILE}"
 }
 
 main

--- a/.buildkite/scripts/upload_ux_assets.sh
+++ b/.buildkite/scripts/upload_ux_assets.sh
@@ -21,10 +21,11 @@ main() {
     echo "--- :cloudsmith: Uploading ${UX_FILENAME} version ${version}"
     upload_raw_file_to_cloudsmith "dist/${UX_FILENAME}" "${version}" raw
 
-    artifact_json "${version}" "grapl-ux" > "${UX_ARTIFACTS_FILE}"
+    mkdir "${ARTIFACT_FILE_DIRECTORY}"
+    artifact_json "${version}" "grapl-ux" > "${ARTIFACT_FILE_DIRECTORY}/${UX_ARTIFACTS_FILE}"
 
-    echo "--- :buildkite: Uploading ${UX_ARTIFACTS_FILE} file"
-    buildkite-agent artifact upload "${UX_ARTIFACTS_FILE}"
+    echo "--- :buildkite: Uploading ${ARTIFACT_FILE_DIRECTORY}/${UX_ARTIFACTS_FILE} file"
+    buildkite-agent artifact upload "${ARTIFACT_FILE_DIRECTORY}/${UX_ARTIFACTS_FILE}"
 }
 
 main

--- a/.buildkite/scripts/upload_ux_assets.sh
+++ b/.buildkite/scripts/upload_ux_assets.sh
@@ -11,7 +11,6 @@ main() {
     # This is the name defined in the top-level Makefile in the
     # `ux-tarball` target.
     local -r UX_FILENAME="grapl-ux.tar.gz"
-    local -r UX_ARTIFACTS_FILE="ux_artifacts.json"
 
     echo "--- :buildkite: Retrieving UX tarball"
     buildkite-agent artifact download "dist/${UX_FILENAME}" .
@@ -21,8 +20,7 @@ main() {
     echo "--- :cloudsmith: Uploading ${UX_FILENAME} version ${version}"
     upload_raw_file_to_cloudsmith "dist/${UX_FILENAME}" "${version}" raw
 
-    mkdir "${ARTIFACT_FILE_DIRECTORY}"
-    artifact_json "${version}" "grapl-ux" > "${ARTIFACT_FILE_DIRECTORY}/${UX_ARTIFACTS_FILE}"
+    artifact_json "${version}" "grapl-ux" > "$(artifacts_file_for ux)"
 }
 
 main


### PR DESCRIPTION
Rather than concern ourselves with the specific names of each JSON artifacts file we create in our merge pipeline, we generalize our handling of this information to be more decoupled and open to future expansion.

Now, rather than having a concrete name for each such file we create, and requiring the identity of this file to be known in the final artifact merge step, we create the names programmatically. When given a descriptive "slug" (say, "containers"), we generate a filename that includes the unique Buildkite job ID, along with a special file extension, `grapl-artifacts.json`. This yields artifact files with names like `containers-e44f9784-e20e-4b93-a21d-f41fd5869db9.grapl-artifacts.json`. The nice thing about this is that the incorporation of the job ID eliminates the possibility of artifact file naming conflicts across the entire pipeline; all you have to do is make sure the "slug" provided is unique within a given job (a much simpler task).

We've also tightened up the naming; now _all_ artifacts files have the `grapl-artifacts.json` (previously, some ended in `_artifacts.json`, while others were `.artifacts.json`. By unifying behind a very company-specific extension, we can take advantage of globbing when uploading and downloading files without fear of accidentally pulling in other files. We also don't need to bother isolating the files in a particular directory, either, which simplifies the code further. 

Another simplification is the removal of the "manual" file upload steps _within_ a job's code, in favor of using the `artifact_paths` configuration for the job itself. Not only does this remove a lot of "glue" code, it also makes the job code more general by reducing its coupling with Buildkite itself. This in turn opens the way to more reuse and easier testing. It also helps to make the overall information flow of the pipeline more obvious when looking at the corresponding pipeline YAML file.

Overall, this PR reduces coupling between jobs, reduces coupling to Buildkite itself, reduces custom code, makes the flow of logic more obvious, and makes it easier to introduce or modify additional artifact-creating steps. 