### PR TITLE
Remove `--aws-profile` option for graplctl

### DIFF
--- a/src/python/graplctl/graplctl/cli.py
+++ b/src/python/graplctl/graplctl/cli.py
@@ -57,14 +57,6 @@ Ec2Instance = common.Ec2Instance
     required=True,
 )
 @click.option(
-    "-p",
-    "--aws-profile",
-    type=click.STRING,
-    envvar="AWS_PROFILE",
-    help='aws auth profile [$AWS_PROFILE] ("default")',
-    default="default",
-)
-@click.option(
     "--schema-table",
     type=click.STRING,
     envvar="GRAPL_SCHEMA_TABLE",
@@ -88,12 +80,11 @@ def main(
     grapl_region: str,
     grapl_deployment_name: str,
     grapl_version: str,
-    aws_profile: str,
     schema_table: str,
     schema_properties_table: str,
     dynamic_session_table: str,
 ) -> None:
-    session = boto3.session.Session(profile_name=aws_profile)
+    session = boto3.session.Session()
     config = Config(region_name=grapl_region)
     lambda_config = Config(
         read_timeout=60 * 15 + 10  # 10s longer than e2e-test-runner and provisioner
@@ -102,7 +93,6 @@ def main(
         grapl_region,
         grapl_deployment_name,
         grapl_version,
-        aws_profile,
         cloudwatch=CloudWatchClientFactory(session).from_env(config=config),
         dynamodb=DynamoDBResourceFactory(session).from_env(config=config),
         ec2=EC2ResourceFactory(session).from_env(config=config),

--- a/src/python/graplctl/graplctl/common.py
+++ b/src/python/graplctl/graplctl/common.py
@@ -41,7 +41,6 @@ class State:
     grapl_region: str
     grapl_deployment_name: str
     grapl_version: str
-    aws_profile: str
     schema_table: str
     schema_properties_table: str
     dynamic_session_table: str

--- a/src/python/lambdas.Dockerfile
+++ b/src/python/lambdas.Dockerfile
@@ -21,10 +21,6 @@ ENV USER=grapl
 WORKDIR /home/grapl
 RUN mkdir -p /home/grapl/bin
 
-# Boto expects to see the default AWS profile in ~/.aws/config.
-RUN mkdir -p /home/grapl/.aws
-RUN echo "[default]" > /home/grapl/.aws/credentials
-
 ENV PATH=/home/grapl/bin:$PATH
 
 # Copy in graplctl

--- a/test/docker-compose.e2e-tests.yml
+++ b/test/docker-compose.e2e-tests.yml
@@ -31,21 +31,18 @@ services:
               --grapl-region $AWS_REGION \
               --grapl-deployment-name $DEPLOYMENT_NAME \
               --grapl-version $DEPLOYMENT_NAME \
-              --aws-profile default \
               upload analyzer \
               --analyzer_main_py ./etc/local_grapl/suspicious_svchost/main.py
         graplctl \
               --grapl-region $AWS_REGION \
               --grapl-deployment-name $DEPLOYMENT_NAME \
               --grapl-version $DEPLOYMENT_NAME \
-              --aws-profile default \
               upload analyzer \
               --analyzer_main_py ./etc/local_grapl/unique_cmd_parent/main.py
         graplctl \
               --grapl-region $AWS_REGION \
               --grapl-deployment-name $DEPLOYMENT_NAME \
               --grapl-version $DEPLOYMENT_NAME \
-              --aws-profile default \
               upload sysmon \
               --logfile ./etc/sample_data/eventlog.xml
         python3 -c 'import lambdex_handler; lambdex_handler.handler(None, None)'


### PR DESCRIPTION
By not requiring a profile, we make graplctl more flexible. The
underlying Boto library can recognize environmentally-configured
credentials already, so if a particular profile is desired, a user can
just set `AWS_PROFILE` in their environment as usual.

It also recognizes the EC2 instance metadata service, making it easy
to run in our CI/CD environment.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
