### PR TITLE
Fixed missing nomad lint and linted nomad job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,9 +347,10 @@ lint-prettier: build-formatter ## Run ts/js/yaml lint checks
 		--file docker-compose.formatter.yml \
 		run --rm lint-prettier
 
-.PHONY: lint-packer
-lint-packer: ## Check to see if Packer templates are formatted properly
+.PHONY: lint-hcl
+lint-hcl: ## Check to see if Packer templates are formatted properly
 	.buildkite/scripts/lint_packer.sh
+	.buildkite/scripts/lint_nomad.sh
 
 .PHONY: lint
 lint: lint-python lint-prettier lint-rust lint-shell lint-hcl ## Run all lint checks

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -60,12 +60,12 @@ variable "graph_merger_tag" {
 }
 
 variable "graph_merger_queue" {
-  type = string
+  type    = string
   default = "http://localhost:9324/000000000000/graph-merger-queue"
 }
 
 variable "graph_merger_dead_letter_queue" {
-  type = string
+  type    = string
   default = "http://localhost:9324/000000000000/graph-merger-dead-letter-queue"
 }
 
@@ -88,24 +88,24 @@ variable "node_identifier_tag" {
 }
 
 variable "node_identifier_queue" {
-  type = string
+  type    = string
   default = "http://localhost:9324/000000000000/node-identifier-queue"
 }
 
 variable "node_identifier_dead_letter_queue" {
-  type = string
+  type    = string
   default = "http://localhost:9324/000000000000/node-identifier-dead-letter-queue"
 }
 
 variable "subgraphs_merged_bucket" {
-  type = string
-  default = "subgraphs-merged-bucket"
+  type        = string
+  default     = "subgraphs-merged-bucket"
   description = "The destination bucket for merged subgraphs. Used by Graph Merger."
 }
 
 variable "subgraphs_generated_bucket" {
-  type = string
-  default = "subgraphs-generated-bucket"
+  type        = string
+  default     = "subgraphs-generated-bucket"
   description = "The destination bucket for generated subgraphs. Used by Node identifier."
 }
 


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

Adds back the missing `lint-hcl` make and fixes the nomad formatting as it was not formatted properly.