### PR TITLE
Provide a TIMEOUT_SECS variable to adjust timeouts for e2e tests

### DIFF
--- a/.buildkite/scripts/e2e_in_aws.sh
+++ b/.buildkite/scripts/e2e_in_aws.sh
@@ -42,11 +42,5 @@ echo "--- :arrow_up::cloud: Uploading sample data"
 ./bin/graplctl-pulumi.sh upload sysmon \
     --logfile etc/sample_data/eventlog.xml
 
-echo "--- :sob: Sleep a little while for Reasons (TM)"
-for i in {1..120}; do
-    echo "Sleeping ${i}/120 seconds"
-    sleep 1
-done
-
 echo "--- :running::running::running: Running tests"
 ./bin/graplctl-pulumi.sh aws test

--- a/pulumi/infra/e2e_test_runner.py
+++ b/pulumi/infra/e2e_test_runner.py
@@ -49,6 +49,7 @@ class E2eTestRunner(pulumi.ComponentResource):
                     "GRAPL_API_HOST": api.invoke_url.apply(
                         lambda url: urlparse(url).netloc
                     ),
+                    "TIMEOUT_SECS": "500",
                 },
                 timeout=60 * 15,  # 15 minutes
                 memory_size=256,

--- a/src/python/e2e-test-runner/e2e_test_runner/test_main.py
+++ b/src/python/e2e-test-runner/e2e_test_runner/test_main.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Any, Dict, Mapping
 
 from grapl_analyzerlib.nodes.lens import LensQuery, LensView
@@ -14,6 +15,8 @@ from grapl_tests_common.wait import (
 LENS_NAME = "DESKTOP-FVSHABR"
 GqlLensDict = Dict[str, Any]
 
+TIMEOUT_SECS = int(os.getenv("TIMEOUT_SECS", "300"))
+
 
 def test_expected_data_in_dgraph(jwt: str) -> None:
     # There is some unidentified, nondeterministic failure with e2e.
@@ -23,7 +26,7 @@ def test_expected_data_in_dgraph(jwt: str) -> None:
     # - Lens with 4 scope
     # - Lens with 5 scope (correct)
     query = LensQuery().with_lens_name(LENS_NAME)
-    lens: LensView = wait_for_one(WaitForQuery(query), timeout_secs=120)
+    lens: LensView = wait_for_one(WaitForQuery(query), timeout_secs=TIMEOUT_SECS)
     assert lens.get_lens_name() == LENS_NAME
     # lens scope is not atomic
 
@@ -38,7 +41,7 @@ def test_expected_data_in_dgraph(jwt: str) -> None:
             5,
         )
 
-    wait_for_one(WaitForCondition(scope_has_N_items), timeout_secs=300)
+    wait_for_one(WaitForCondition(scope_has_N_items), timeout_secs=TIMEOUT_SECS)
 
     # Now that we've confirmed that the expected data has shown up in dgraph,
     # let's see what the GraphQL endpoint says.
@@ -50,7 +53,7 @@ def test_expected_data_in_dgraph(jwt: str) -> None:
         WaitForNoException(
             lambda: ensure_graphql_lens_scope_no_errors(gql_client, LENS_NAME)
         ),
-        timeout_secs=300,
+        timeout_secs=TIMEOUT_SECS,
     )
 
 


### PR DESCRIPTION
Rather than providing a fixed timeout in our AWS e2e tests (to account
for the different times it takes to run there), we'll instead provide
a way to change the timeout values within the code based on an
environment variable.

This will be a better approach, because it takes some of the guesswork
out of the problem, and also allows the tests to take only as long as
they need.

It does allow our LensView query to run longer (300 vs 120 seconds) in
our Docker Compose environment, but I felt the simplicity of having
one timeout value outweighed the complexity of multiple timeouts, or
computing relative timeouts.

Apart from that, this should behave identically in our Docker Compose
setup.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
