### PR TITLE
Issue 431: Node Identifier and Retry should be different

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,13 +135,12 @@ services:
           - ${REDIS_HOST}
 
   localstack:
-    image: localstack/localstack:0.12.15
+    image: localstack/localstack-full:0.12.15 # -full includes elasticmq
     ports:
       # We'll expose localstack's edge port for ease of use with
       # things like the AWS CLI, Pulumi, etc.
       - 127.0.0.1:${LOCALSTACK_PORT}:${LOCALSTACK_PORT}
     environment:
-      - IMAGE_NAME=localstack/localstack:0.12.15
       - EDGE_PORT=${LOCALSTACK_PORT}
       - HOSTNAME_EXTERNAL=${LOCALSTACK_HOST}
       - SERVICES=apigateway,cloudwatch,dynamodb,ec2,events,iam,lambda,logs,s3,secretsmanager,sns,sqs
@@ -157,6 +156,9 @@ services:
       # Without this, the lambda containers are attached to the bridge network
       - LAMBDA_DOCKER_NETWORK=grapl-network
       - DATA_DIR=${DATA_DIR- }
+      # The default SQS implementation uses `moto`; `elasticmq` is much more
+      # fully-featured.
+      - SQS_PROVIDER=elasticmq
     privileged: true # for docker lambda execution
     healthcheck:
       test:

--- a/src/rust/node-identifier/src/bin/node-identifier.rs
+++ b/src/rust/node-identifier/src/bin/node-identifier.rs
@@ -4,5 +4,5 @@ use node_identifier::handler;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    handler(true).await
+    handler(false).await
 }

--- a/src/rust/node-identifier/src/lib.rs
+++ b/src/rust/node-identifier/src/lib.rs
@@ -286,6 +286,17 @@ where
     }
 }
 
+/// # Arguments
+/// ## should_default
+/// should_default (and, further into the code, should_guess) controls the
+/// node identification process behavior around Session-strategy nodes.
+/// If a node uses the Session strategy (common for processes, or network
+/// connections) then the behavior is non-deterministic and heuristic-based.
+/// This argument dictates if a new "session" should be created for a node
+/// if the identification process failed.
+/// New session tracking is expected behavior for the retry handler,
+/// but not for the first-pass node identifier (so additional context can
+/// be received before we determine that a node needs a new session).
 pub async fn handler(should_default: bool) -> Result<(), Box<dyn std::error::Error>> {
     let (env, _guard) = grapl_config::init_grapl_env!();
     let source_queue_url = grapl_config::source_queue_url();


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/431

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Oh boy. There's a lot!
- We only try in Default Queue 1x before sending to Retry Queue
- Localstack now uses `elasticmq` for its SQS mock, which supports redrive policies natively.
- Node Identifier / Node Identifier Retry now accurately have different behaviors.
- Document the hell out of `should_default`. 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
e2e; I noted that a message did make it to try retry service's logs.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
