### PR TITLE
Add code coverage for JS/TS code

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -94,6 +94,7 @@ steps:
   - label: ":typescript::docker: Unit Tests"
     command:
       - make test-unit-js
+      - codecov --file=dist/coverage/js/**/clover.xml
 
   - label: ":typescript::yaml::lint-roller: Lint using Prettier"
     command:

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -94,8 +94,8 @@ services:
   engagement-view-uploader:
     image: ${DOCKER_REGISTRY:-docker.io}/grapl/engagement-view:${TAG:-latest}
     build:
-      context: src
-      dockerfile: js/engagement_view/Dockerfile
+      context: src/js/engagement_view
+      dockerfile: Dockerfile
       target: engagement-view-local-deploy
 
   # This container build exists only for Local Grapl; if we are able

--- a/src/js/engagement_view/Dockerfile
+++ b/src/js/engagement_view/Dockerfile
@@ -3,16 +3,16 @@ FROM node:16-buster-slim AS engagement-view-deps
 WORKDIR /grapl
 
 # install deps as separate steps to leverage build cache
-COPY js/engagement_view/package.json package.json
-COPY js/engagement_view/yarn.lock yarn.lock
-COPY js/engagement_view/.yarnrc.yml .yarnrc.yml
-COPY js/engagement_view/.yarn/releases .yarn/releases
+COPY package.json package.json
+COPY yarn.lock yarn.lock
+COPY .yarnrc.yml .yarnrc.yml
+COPY .yarn/releases .yarn/releases
 
 RUN yarn set version berry
 RUN yarn install
 
 # now copy all sources
-COPY js/engagement_view .
+COPY . .
 
 # create production build
 ################################################################################

--- a/src/js/graphql_endpoint/package.json
+++ b/src/js/graphql_endpoint/package.json
@@ -4,7 +4,8 @@
   "description": "grapl graphql server",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "jest"
   },
   "author": "Grapl Inc.",
   "license": "ISC",

--- a/test/docker-compose.unit-tests-js.yml
+++ b/test/docker-compose.unit-tests-js.yml
@@ -6,8 +6,8 @@ services:
   engagement-view-test:
     image: grapl/engagement-view-build:${TAG:-latest}
     build:
-      context: ${PWD}/src
-      dockerfile: js/engagement_view/Dockerfile
+      context: ${PWD}/src/js/engagement_view
+      dockerfile: Dockerfile
       target: engagement-view-deps
     command: sh -c 'CI=true yarn test'
 

--- a/test/docker-compose.unit-tests-js.yml
+++ b/test/docker-compose.unit-tests-js.yml
@@ -2,6 +2,13 @@ version: "3.8"
 
 # environment variable PWD is assumed to be grapl root directory
 
+x-common-variables:
+  dist-for-coverage-mnt: &dist-for-coverage-mnt
+    type: bind
+    source: ${PWD}/dist
+    target: /dist
+    read_only: false
+
 services:
   engagement-view-test:
     image: grapl/engagement-view-build:${TAG:-latest}
@@ -9,7 +16,10 @@ services:
       context: ${PWD}/src/js/engagement_view
       dockerfile: Dockerfile
       target: engagement-view-deps
-    command: yarn test --coverage --watchAll=false
+    user: ${UID}:${GID}
+    command: yarn test --coverage --watchAll=false --coverageDirectory=/dist/coverage/js/engagement-view
+    volumes:
+      - *dist-for-coverage-mnt
 
   graphql-endpoint-test:
     image: grapl/graphql-endpoint:${TAG:-latest}
@@ -17,5 +27,8 @@ services:
       context: ${PWD}/src/js/graphql_endpoint
       dockerfile: Dockerfile
       target: graphql-endpoint-deploy
+    user: ${UID}:${GID}
     working_dir: /home/grapl/lambda
-    command: yarn test --coverage --watchAll=false
+    command: yarn test --coverage --watchAll=false --coverageDirectory=/dist/coverage/js/graphql-endpoint
+    volumes:
+      - *dist-for-coverage-mnt

--- a/test/docker-compose.unit-tests-js.yml
+++ b/test/docker-compose.unit-tests-js.yml
@@ -9,9 +9,7 @@ services:
       context: ${PWD}/src/js/engagement_view
       dockerfile: Dockerfile
       target: engagement-view-deps
-    command: yarn test
-    environment:
-      CI: "true"
+    command: yarn test --coverage --watchAll=false
 
   graphql-endpoint-test:
     image: grapl/graphql-endpoint:${TAG:-latest}
@@ -20,4 +18,4 @@ services:
       dockerfile: Dockerfile
       target: graphql-endpoint-deploy
     working_dir: /home/grapl/lambda
-    command: npx jest
+    command: yarn test --coverage --watchAll=false

--- a/test/docker-compose.unit-tests-js.yml
+++ b/test/docker-compose.unit-tests-js.yml
@@ -9,7 +9,9 @@ services:
       context: ${PWD}/src/js/engagement_view
       dockerfile: Dockerfile
       target: engagement-view-deps
-    command: sh -c 'CI=true yarn test'
+    command: yarn test
+    environment:
+      CI: "true"
 
   graphql-endpoint-test:
     image: grapl/graphql-endpoint:${TAG:-latest}
@@ -17,5 +19,5 @@ services:
       context: ${PWD}/src/js/graphql_endpoint
       dockerfile: Dockerfile
       target: graphql-endpoint-deploy
-    command: bash -c "
-      cd .. && npx jest"
+    working_dir: /home/grapl/lambda
+    command: npx jest


### PR DESCRIPTION
Does what #1108 did, but for our JavaScript / TypeScript code.

Run `make test-unit-js` to see it work.

Did a bit of tidying up of the relevant Docker setup while I was here; please read individual commits for details.