### PR TITLE
Configure the Stale bot to close old PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,14 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+pulls:
+  daysUntilStale: 7
+  daysUntilClose: 1
+  markComment: >
+    This pull request has been automatically marked as stale because
+    it has not had recent activity. It will be closed if no further
+    activity occurs. Thank you for your contributions.
+  closeComment: >
+    This pull request has been automatically closed due to
+    inactivity. Please feel free to reopen / resubmit your
+    contribution if it is still applicable.
+  staleLabel: Stale


### PR DESCRIPTION
This enables the Stale bot (https://github.com/probot/stale) to close
PRs that have not had activity in a while.

As configured, a PR must have one week (7 days) of inactivity before
being marked as "stale". If it experiences one more day without any
interaction, it will be closed.

This is in the interest of keeping our PR list up to date, and make it
easy to see what is currently being worked on and reviewed.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
