### PR TITLE
Add some makefile targets to aid UX development against Local Grapl

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,7 @@ BUILD @christophermaier
 .gitignore @christophermaier
 /LICENSE @christophermaier
 /local-grapl.env @christophermaier
+/LOCAL_UI_WORKFLOW.md @christophermaier
 /Makefile @christophermaier
 /nomad @d0nut-grapl
 /packer/ @wimax-grapl @christophermaier

--- a/LOCAL_UI_WORKFLOW.md
+++ b/LOCAL_UI_WORKFLOW.md
@@ -1,0 +1,21 @@
+# Local UI Development Workflow
+
+The following describes a basic workflow for developing the Grapl
+frontend locally. The commands should be run from the repository root.
+
+---
+
+Run `make up`; this will just be going in a terminal in the
+background. If you need to tear this all down and start over at any
+point, make sure you run `make down` before running make up again.
+
+Run `make local-ux-upload`. This will will do a `yarn` build (if
+necessary) for the engagement view and then upload it to the
+appropriate S3 bucket in the local Grapl running under
+`docker-compose`. Do this as many times as you like.
+
+Run `make local-graplctl-setup`. This will upload the local analyzers
+and the sysmon dataset to the local Grapl instance. Do this as many
+times as you like.
+
+The UI should be available at http://localhost:1234/index.html

--- a/Makefile
+++ b/Makefile
@@ -486,3 +486,21 @@ update-buildkite-shared: ## Pull in changes from grapl-security/buildkite-common
 .PHONY: build-docs
 build-docs: ## Build the Sphinx docs
 	./docs/build_docs.sh
+
+.PHONY: local-ux-upload
+local-ux-upload: ## Upload local engagement-view assets to a running Local Grapl (make sure to have done `make up` first)
+	$(DOCKER_BUILDX_BAKE) --file=docker-compose.build.yml engagement-view-uploader &&
+	COMPOSE_PROJECT_NAME=grapl \
+	docker-compose --env-file=local-grapl.env \
+	--file=docker-compose.yml \
+	run --no-deps engagement-view-uploader
+
+.PHONY: local-graplctl-setup
+local-graplctl-setup: ## Upload analyzers and data to a running Local Grapl (make sure to have done `make up` first)
+	COMPOSE_PROJECT_NAME=grapl \
+	COMPOSE_DOCKER_CLI_BUILD=1 \
+	DOCKER_BUILDKIT=1 \
+	docker-compose --env-file=local-grapl.env \
+	--file=docker-compose.yml \
+	--file=docker-compose.local-dev.yml \
+	run local-graplctl

--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -1,0 +1,65 @@
+# This is provided just to help make local development of the UI a bit
+# easier by encapsulating some commonly-needed graplctl commands
+# together in a way that they can be easily used against a Grapl
+# system brought up using our `make up` target.
+#
+# If you find a better way to do this, by all means, DO IT! :)
+
+version: "3.8"
+
+x-common-variables:
+  read-only-pulumi-mnt: &read-only-pulumi-mnt
+    type: volume
+    source: pulumi_outputs
+    target: /mnt/pulumi-outputs
+    read_only: true
+  aws-env: &aws-env
+    GRAPL_AWS_ENDPOINT: ${GRAPL_AWS_ENDPOINT}
+    GRAPL_AWS_ACCESS_KEY_ID: ${GRAPL_AWS_ACCESS_KEY_ID}
+    GRAPL_AWS_ACCESS_KEY_SECRET: ${GRAPL_AWS_ACCESS_KEY_SECRET}
+    AWS_DEFAULT_REGION: ${AWS_REGION} # boto3 prefers this one
+    AWS_REGION: ${AWS_REGION}
+
+services:
+  local-graplctl:
+    image: grapl/local-graplctl
+    build:
+      context: .
+      dockerfile: ./src/python/lambdas.Dockerfile
+      target: grapl-python-runner-base
+    entrypoint: ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
+    command:
+      - |
+        export GRAPL_ANALYZERS_BUCKET=$$(cat /mnt/pulumi-outputs/analyzers-bucket)
+        export GRAPL_OSQUERY_GENERATOR_QUEUE=$$(cat /mnt/pulumi-outputs/osquery-generator-queue)
+        export GRAPL_OSQUERY_LOG_BUCKET=$$(cat /mnt/pulumi-outputs/osquery-log-bucket)
+        export GRAPL_SYSMON_GENERATOR_QUEUE=$$(cat /mnt/pulumi-outputs/sysmon-generator-queue)
+        export GRAPL_SYSMON_LOG_BUCKET=$$(cat /mnt/pulumi-outputs/sysmon-log-bucket)
+        export GRAPL_SCHEMA_TABLE=$$(cat /mnt/pulumi-outputs/schema-table)
+        export GRAPL_SCHEMA_PROPERTIES_TABLE=$$(cat /mnt/pulumi-outputs/schema-properties-table)
+
+        graplctl \
+              upload analyzer \
+              --analyzer_main_py ./etc/local_grapl/suspicious_svchost/main.py
+        graplctl \
+              upload analyzer \
+              --analyzer_main_py ./etc/local_grapl/unique_cmd_parent/main.py
+        graplctl \
+              upload sysmon \
+              --logfile ./etc/sample_data/eventlog.xml
+    working_dir: /workdir
+    volumes:
+      - type: bind
+        source: .
+        target: /workdir
+        read_only: true
+        volume:
+          nocopy: true
+      - *read-only-pulumi-mnt
+    environment:
+      GRAPL_REGION: ${AWS_REGION}
+      DEPLOYMENT_NAME: local-grapl
+      GRAPL_VERSION: ${DEPLOYMENT_NAME}
+      GRAPL_AWS_ACCESS_KEY_ID:
+      GRAPL_AWS_ACCESS_KEY_SECRET:
+      GRAPL_AWS_ENDPOINT:

--- a/test/docker-compose.e2e-tests.yml
+++ b/test/docker-compose.e2e-tests.yml
@@ -28,21 +28,12 @@ services:
         export GRAPL_SCHEMA_PROPERTIES_TABLE=$$(cat /mnt/pulumi-outputs/schema-properties-table)
 
         graplctl \
-              --grapl-region $AWS_REGION \
-              --grapl-deployment-name $DEPLOYMENT_NAME \
-              --grapl-version $DEPLOYMENT_NAME \
               upload analyzer \
               --analyzer_main_py ./etc/local_grapl/suspicious_svchost/main.py
         graplctl \
-              --grapl-region $AWS_REGION \
-              --grapl-deployment-name $DEPLOYMENT_NAME \
-              --grapl-version $DEPLOYMENT_NAME \
               upload analyzer \
               --analyzer_main_py ./etc/local_grapl/unique_cmd_parent/main.py
         graplctl \
-              --grapl-region $AWS_REGION \
-              --grapl-deployment-name $DEPLOYMENT_NAME \
-              --grapl-version $DEPLOYMENT_NAME \
               upload sysmon \
               --logfile ./etc/sample_data/eventlog.xml
         python3 -c 'import lambdex_handler; lambdex_handler.handler(None, None)'
@@ -64,6 +55,8 @@ services:
       - IS_LOCAL=True
       - MG_ALPHAS
       - VSC_DEBUGGER_PORT
+      - GRAPL_VERSION=${DEPLOYMENT_NAME}
+      - GRAPL_REGION=${AWS_REGION}
     ports:
       - ${VSC_DEBUGGER_PORT_FOR_GRAPL_E2E_TESTS}:${VSC_DEBUGGER_PORT_FOR_GRAPL_E2E_TESTS}
 


### PR DESCRIPTION
There have been a lot of changes in how Grapl runs on a local
workstation. This commit introduces a few new makefile targets and
supporting code to help automate as much as possible to make it easier
to iteratively develop the Grapl UI locally.

Documentation is added in the new `LOCAL_UI_WORKFLOW.md` file.