### PR TITLE
Gather Rust unit test coverage statistics

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -40,23 +40,6 @@ steps:
 
   - label: ":rust: Unit Tests"
     command:
-      - cd src/rust
-      - cargo test
-    agents:
-      queue: "beefy"
-
-  - label: ":rust: Unit Tests via Docker plugin"
-    command:
-      - cd src/rust
-      - cargo test
-    plugins:
-      - docker#v3.8.0:
-          image: "rust:1.51.0"
-    agents:
-      queue: "beefy"
-
-  - label: ":rust::docker: Unit Tests"
-    command:
       - make test-unit-rust
       - codecov --file=dist/coverage/rust/cobertura.xml
     agents:

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -58,6 +58,7 @@ steps:
   - label: ":rust::docker: Unit Tests"
     command:
       - make test-unit-rust
+      - codecov --file=dist/coverage/rust/cobertura.xml
     agents:
       queue: "beefy"
   

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -4,11 +4,14 @@ ARG RUST_BUILD=debug
 
 SHELL ["/bin/bash", "-c"]
 
-# Necessary for rdkafka
+# Necessary for rdkafka; pkg-config & libssl-dev for cargo-tarpaulin build
 RUN --mount=type=cache,target=/var/lib/apt/lists \
     apt-get update && apt-get install -y --no-install-recommends \
         zlib1g-dev \
-        build-essential
+        build-essential \
+        pkg-config \
+        libssl-dev
+
 
 # Install rust toolchain before copying sources to avoid unecessarily
 # resinstalling on source file changes.
@@ -60,6 +63,10 @@ RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
 FROM base AS build-test
 
 ENV RUST_INTEGRATION_TEST_FEATURES="node-identifier/integration,sqs-executor/integration,kafka-metrics-exporter/integration"
+
+# For test coverage reports
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo install cargo-tarpaulin
 
 # At the end of the test run, save the mount cache to the Docker image, as
 # these files are needed for running the integration tests in containers. 

--- a/test/docker-compose.unit-tests-rust.yml
+++ b/test/docker-compose.unit-tests-rust.yml
@@ -11,4 +11,20 @@ services:
       target: build-test
       args:
         - RUST_BUILD=test
-    command: cargo test
+    security_opt:
+      # Required for Tarpaulin to work in Docker
+      - seccomp:unconfined
+    entrypoint: ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
+    command:
+      - |
+        cargo tarpaulin --out=Xml --output-dir=/dist/coverage/rust
+        # This `chown` is a hack to be able to run Tarpaulin in the
+        # container (as it is currently configured), but also
+        # outputting the coverage file to the workstation without it
+        # being owned by root.
+        chown --recursive ${UID}:${GID} /dist/coverage/rust
+    volumes:
+      - type: bind
+        source: ${PWD}/dist
+        target: /dist
+        read_only: false


### PR DESCRIPTION
Does what #1108 and #1116 did, but for Rust code, using [tarpaulin](https://crates.io/crates/cargo-tarpaulin)