### PR TITLE
Use our codecov Buildkite plugin for coverage collection

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -41,10 +41,11 @@ steps:
   - label: ":rust: Unit Tests"
     command:
       - make test-unit-rust
-      - codecov --file=dist/coverage/rust/cobertura.xml
+    plugins:
+      - grapl-security/codecov#v0.1.0
     agents:
       queue: "beefy"
-  
+
   - label: ":writing_hand: Test Grapl Template Generator"
     command:
       - make test-grapl-template-generator
@@ -62,8 +63,8 @@ steps:
   - label: ":python::jeans: Unit Tests"
     command:
       - make test-unit-python
-      # TODO: abstract this to a hook/plugin
-      - codecov --file=dist/coverage/python/coverage.xml
+    plugins:
+      - grapl-security/codecov#v0.1.0
 
   - label: ":python::jeans: Typechecking"
     command:
@@ -78,7 +79,8 @@ steps:
   - label: ":typescript::docker: Unit Tests"
     command:
       - make test-unit-js
-      - codecov --file=dist/coverage/js/**/clover.xml
+    plugins:
+      - grapl-security/codecov#v0.1.0
 
   - label: ":typescript::yaml::lint-roller: Lint using Prettier"
     command:


### PR DESCRIPTION
Ultimately this will lead to more flexibility in piecing together our
pipeline jobs, as well as sharing the logic across multiple
repositories.

The default configuration of the plugin is to pull all XML files from
`dist/coverage/**`, which is where we put all our coverage statistics,
following the pattern established by Pants' default configuration.

Currently, the plugin is pinned to the current commit on the `main`
branch at
https://github.com/grapl-security/codecov-buildkite-plugin. Look there
for further details about how the plugin works.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
