### PR TITLE
Use our hcl-formatter image to lint and format all HCL files

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -128,15 +128,9 @@ steps:
     artifact_paths:
       - "test_artifacts/**/*"
 
-  - label: ":packer::lint-roller: Packer Linting"
+  - label: ":lint-roller::packer::nomad: Lint HCL files"
     command:
-      # Since we run it in a container, we can't use the `make` for it
-      - .buildkite/scripts/lint_packer.sh
-    # Silently hangs unless the following is specified.
-    plugins:
-      - docker#v3.8.0:
-          image: "hashicorp/packer:1.7.2"
-          entrypoint: bash
+      - make lint-hcl
 
   - label: ":thinking_face: AMI Test?"
     # Don't want to run this again in the merge pipeline, since

--- a/.buildkite/scripts/format_nomad.sh
+++ b/.buildkite/scripts/format_nomad.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Nomad doesn't have a `fmt` command but packer's works
-# Packer, however, won't pick up nomad files (even if their extension is .hcl)
-# so we're going to pass in each nomad file, individually
-
-find nomad/ -type f -name "*.nomad" -print0 | xargs --null -n 1 packer fmt

--- a/.buildkite/scripts/lint_nomad.sh
+++ b/.buildkite/scripts/lint_nomad.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-echo "--- Linting Nomad"
-find nomad/ -type f -name "*.nomad" -print0 | xargs -n 1 --null packer fmt -check -diff

--- a/.buildkite/scripts/lint_packer.sh
+++ b/.buildkite/scripts/lint_packer.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-echo "--- Linting Packer"
-packer fmt -check -diff -recursive packer

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ RUST_BUILD ?= debug
 UID = $(shell id -u)
 GID = $(shell id -g)
 PWD = $(shell pwd)
+COMPOSE_USER=${UID}:${GID}
 DOCKER_BUILDX_BAKE_OPTS ?=
 ifneq ($(GRAPL_RUST_ENV_FILE),)
 DOCKER_BUILDX_BAKE_OPTS += --set *.secrets=id=rust_env,src="$(GRAPL_RUST_ENV_FILE)"
@@ -350,8 +351,7 @@ lint-prettier: build-formatter ## Run ts/js/yaml lint checks
 
 .PHONY: lint-hcl
 lint-hcl: ## Check to see if Packer templates are formatted properly
-	.buildkite/scripts/lint_packer.sh
-	.buildkite/scripts/lint_nomad.sh
+	docker-compose --file=docker-compose.check.yml run --rm hcl-lint
 
 .PHONY: lint-proto
 lint-proto: ## Lint all protobuf definitions
@@ -387,8 +387,7 @@ format-prettier: build-formatter ## Reformat js/ts/yaml
 
 .PHONY: format-hcl
 format-hcl: ## Reformat all HCLs
-	packer fmt -recursive packer/
-	.buildkite/scripts/format_nomad.sh
+	docker-compose --file=docker-compose.check.yml run --rm --user=${COMPOSE_USER} hcl-format
 
 .PHONY: format
 format: format-python format-shell format-prettier format-rust format-hcl ## Reformat all code

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,15 @@ DOCKER_BUILDX_BAKE := docker buildx bake $(DOCKER_BUILDX_BAKE_OPTS)
 COMPOSE_PROJECT_INTEGRATION_TESTS := grapl-integration_tests
 COMPOSE_PROJECT_E2E_TESTS := grapl-e2e_tests
 
+# All the services defined in the docker-compose.check.yml file are
+# run with the same general arguments; just supply the service name to
+# run.
+#
+# While we would ultimately like to run all these containers as a
+# non-root user, some currently seem to require that; to accommodate
+# all such images, we provide two helpful macros.
+DOCKER_COMPOSE_CHECK := docker-compose --file=docker-compose.check.yml run --rm
+NONROOT_DOCKER_COMPOSE_CHECK := ${DOCKER_COMPOSE_CHECK} --user=${COMPOSE_USER}
 
 # Use a single shell for each of our targets, which allows us to use the 'trap'
 # built-in in our targets. We set the 'errexit' shell option to preserve
@@ -351,15 +360,15 @@ lint-prettier: build-formatter ## Run ts/js/yaml lint checks
 
 .PHONY: lint-hcl
 lint-hcl: ## Check to see if Packer templates are formatted properly
-	docker-compose --file=docker-compose.check.yml run --rm hcl-lint
+	${NONROOT_DOCKER_COMPOSE_CHECK} hcl-lint
 
 .PHONY: lint-proto
 lint-proto: ## Lint all protobuf definitions
-	docker-compose --file=docker-compose.check.yml run --rm buf-lint
+	${DOCKER_COMPOSE_CHECK} buf-lint
 
 .PHONY: lint-proto-breaking
 lint-proto-breaking: ## Check protobuf definitions for breaking changes
-	docker-compose --file=docker-compose.check.yml run --rm buf-breaking-change
+	${DOCKER_COMPOSE_CHECK} buf-breaking-change
 
 .PHONY: lint
 lint: lint-python lint-prettier lint-rust lint-shell lint-hcl lint-proto lint-proto-breaking ## Run all lint checks
@@ -387,7 +396,7 @@ format-prettier: build-formatter ## Reformat js/ts/yaml
 
 .PHONY: format-hcl
 format-hcl: ## Reformat all HCLs
-	docker-compose --file=docker-compose.check.yml run --rm --user=${COMPOSE_USER} hcl-format
+	${NONROOT_DOCKER_COMPOSE_CHECK} hcl-format
 
 .PHONY: format
 format: format-python format-shell format-prettier format-rust format-hcl ## Reformat all code

--- a/docker-compose.check.yml
+++ b/docker-compose.check.yml
@@ -6,6 +6,11 @@ x-common-variables:
     source: .
     target: /workdir
     read_only: true
+  read-write-workdir: &read-write-workdir
+    type: bind
+    source: .
+    target: /workdir
+    read_only: false
 
 services:
   buf-lint:
@@ -21,3 +26,15 @@ services:
     working_dir: /workdir
     volumes:
       - *read-only-workdir
+
+  hcl-lint:
+    image: docker.cloudsmith.io/grapl/releases/hcl-formatter:1.7.4
+    command: lint
+    volumes:
+      - *read-only-workdir
+
+  hcl-format:
+    image: docker.cloudsmith.io/grapl/releases/hcl-formatter:1.7.4
+    command: format
+    volumes:
+      - *read-write-workdir


### PR DESCRIPTION
This has the added benefit of removing a few scripts. It also makes it
more clear that we're doing the exact same thing in CI that we do
locally.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
