### PR TITLE
Add support for shellcheck to mac

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -165,5 +165,6 @@ global_report = "true"
 # configuration values.
 version = "v0.7.2"
 known_versions = [
+  "v0.7.2|darwin|969bd7ef668e8167cfbba569fb9f4a0b2fc1c4021f87032b6a0b0e525fb77369|3988092",
   "v0.7.2|linux|70423609f27b504d6c0c47e340f33652aea975e45f312324f2dbf91c95a3b188|1382204"
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://app.zenhub.com/workspaces/grapl-6036cbd36bacff000ef314f2/issues/grapl-security/issue-tracker/630
https://github.com/grapl-security/issue-tracker/issues/630
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Adds support for shellcheck on mac. Until this is added running make lint (or really gmake lint on mac) will error out
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
gmake lint # when you run bew install make on mac it gets named gmake to signify that its gnu make

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
Test Results:
Before:
```
Exception message: 1 Exception encountered:

  UnknownVersion: No known version of shellcheck v0.7.2 for darwin found in ('v0.7.2|linux|70423609f27b504d6c0c47e340f33652aea975e45f312324f2dbf91c95a3b188|1382204',)
```
After
```
18:01:20.16 [INFO] Completed: lint - shfmt succeeded.
18:01:21.39 [INFO] Completed: lint - Shellcheck succeeded.

✓ Shellcheck succeeded.
✓ shfmt succeeded.
```
