### PR TITLE
Fix pants/protos stuff for jesse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ test-unit-rust: build-test-unit-rust ## Build and run unit tests - Rust only
 # If you need to `pdb` these tests, add a `--debug` after `./pants test`
 test-unit-python: ## Run Python unit tests under Pants
 	./pants filter --filter-target-type="python_tests" :: \
-	| xargs ./pants --print-stacktrace --tag="-needs_work" test --pytest-args="-m \"not integration_test\""
+	| xargs ./pants --tag="-needs_work" test --pytest-args="-m \"not integration_test\""
 
 
 .PHONY: test-unit-shell

--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ test-unit-rust: build-test-unit-rust ## Build and run unit tests - Rust only
 # If you need to `pdb` these tests, add a `--debug` after `./pants test`
 test-unit-python: ## Run Python unit tests under Pants
 	./pants filter --filter-target-type="python_tests" :: \
-	| xargs ./pants --tag="-needs_work" test --pytest-args="-m \"not integration_test\""
+	| xargs ./pants --print-stacktrace --tag="-needs_work" test --pytest-args="-m \"not integration_test\""
 
 
 .PHONY: test-unit-shell

--- a/pants.toml
+++ b/pants.toml
@@ -61,7 +61,7 @@ root_patterns = [
   "/pants-plugins",
   "/pulumi",
   "/src/aws-provision",
-  "/src/proto/graplinc",
+  "/src/proto",
   "/src/python/analyzer_executor/src",
   "/src/python/analyzer_executor/tests",
   "/src/python/e2e-test-runner",

--- a/src/python/analyzer_executor/src/analyzer_executor_lib/BUILD
+++ b/src/python/analyzer_executor/src/analyzer_executor_lib/BUILD
@@ -1,5 +1,5 @@
 python_library(
     dependencies = [
-        "src/python/python-proto:python_proto",
+        "src/python/python-proto",
     ]
 )

--- a/src/python/analyzer_executor/src/analyzer_executor_lib/analyzer_executor.py
+++ b/src/python/analyzer_executor/src/analyzer_executor_lib/analyzer_executor.py
@@ -38,7 +38,7 @@ from grapl_analyzerlib.subgraph_view import SubgraphView
 from grapl_common.env_helpers import S3ResourceFactory
 from grapl_common.grapl_logger import get_module_grapl_logger
 from grapl_common.metrics.metric_reporter import MetricReporter, TagPair
-from python_proto.envelope import Envelope, Metadata
+from python_proto.pipeline import Envelope, Metadata
 
 if TYPE_CHECKING:
     from mypy_boto3_s3 import S3ServiceResource

--- a/src/python/grapl-tests-common/grapl_tests_common/BUILD
+++ b/src/python/grapl-tests-common/grapl_tests_common/BUILD
@@ -1,6 +1,6 @@
 python_library(
     dependencies=[
-        "src/python/python-proto:python_proto",
+        "src/python/python-proto",
     ]
 )
 

--- a/src/python/grapl_analyzerlib/grapl_analyzerlib/BUILD
+++ b/src/python/grapl_analyzerlib/grapl_analyzerlib/BUILD
@@ -3,8 +3,7 @@ python_library(
         # TODO: Ideally, this would be picked up by Pants' automatic
         # dependency resolution, but something appears to be off with
         # it.
-        "src/proto:graplinc"
-        "src/python/python-proto:python_proto",
+        "src/python/python-proto",
     ],
     skip_mypy=True
 )


### PR DESCRIPTION
Getting much closer, now the issue is

src/python/analyzer_executor/src/analyzer_executor_lib/analyzer_executor.py:41: in <module>
    from python_proto.envelope import Envelope, Metadata
E   ModuleNotFoundError: No module named 'python_proto.envelope'