### PR TITLE
Set Name tag automatically for ec2 servers

### DIFF
--- a/pulumi/infra/ec2_cluster.py
+++ b/pulumi/infra/ec2_cluster.py
@@ -54,6 +54,7 @@ class Ec2Cluster(pulumi.ComponentResource):
     ) -> List[aws.ec2.Instance]:
         instances = []
         for i in range(0, num_instances):
+            instance_tags["Name"] = f"{name}-{i}"
             instance = aws.ec2.Instance(
                 f"ec2-inst-{name}-{i}",
                 ami=ami,


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->
https://github.com/grapl-security/issue-tracker/issues/649
https://app.zenhub.com/workspaces/grapl-6036cbd36bacff000ef314f2/issues/grapl-security/issue-tracker/649


### What changes does this PR make to Grapl? Why?
Automatically sets a Name tag for ec2 servers. This will be the name passed to the server and the instance number. For example, when we spin up 3 Nomad servers we'll see nomad-servers-cluster-0, nomad-servers-cluster-1, nomad-servers-cluster-2
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Tested using pulumi up and seeing the diff, and then manually checked upon creation
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
