### PR TITLE
Remove make package-python-libs in favor of make build-python-wheels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -401,10 +401,6 @@ format-hcl: ## Reformat all HCLs
 .PHONY: format
 format: format-python format-shell format-prettier format-rust format-hcl ## Reformat all code
 
-.PHONY: package-python-libs
-package-python-libs: ## Create Python distributions for public libraries
-	./pants filter --target-type=python_distribution :: | xargs ./pants package
-
 ##@ Local Grapl 💻
 
 .PHONY: up


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/651
https://app.zenhub.com/workspaces/internal-engineering-611d4aa8493fe3001b564b01/issues/grapl-security/issue-tracker/651

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
This removes make package-python-libs since its an exact duplicate of make build-python-wheels. Since build-python-wheels is more in line with our naming conventions and is already in the build section, we're keeping it.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
N/A removing a make command
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
