### PR TITLE
Localstack fork: Preload ElasticMQ to reduce load times and enable Nomad

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -125,6 +125,12 @@ services:
       context: .
       dockerfile: Dockerfile.pulumi
 
+  localstack:
+    image: ${DOCKER_REGISTRY:-docker.io}/grapl/localstack:${TAG:-latest}
+    build:
+      context: localstack
+      dockerfile: Dockerfile
+
   provisioner:
     image: ${DOCKER_REGISTRY:-docker.io}/grapl/provisioner:${TAG:-latest}
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,7 +135,8 @@ services:
           - ${REDIS_HOST}
 
   localstack:
-    image: localstack/localstack-full:0.12.15 # -full includes elasticmq
+    #image: localstack/localstack-full:0.12.15 # -full includes elasticmq
+    image: grapl/localstack:${TAG:-latest}
     ports:
       # We'll expose localstack's edge port for ease of use with
       # things like the AWS CLI, Pulumi, etc.

--- a/localstack/Dockerfile
+++ b/localstack/Dockerfile
@@ -1,0 +1,9 @@
+# Every time we bring up Localstack, it goes and downloads Elasticmq.
+# This "fork" just preloads it in the right spot.
+# Saves us time on bringing up Localstack, 
+# and avoids an issue wimax@ ran into when running under Nomad.
+
+FROM localstack/localstack-full:0.12.17 AS localstack-base
+RUN curl -O /opt/code/localstack/localstack/infra/elasticmq/elasticmq-server.jar \
+    https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.1.0.jar
+     

--- a/localstack/Dockerfile
+++ b/localstack/Dockerfile
@@ -3,7 +3,7 @@
 # Saves us time on bringing up Localstack, 
 # and avoids an issue wimax@ ran into when running under Nomad.
 
-FROM localstack/localstack-full:0.12.17 AS localstack-base
+FROM localstack/localstack-full:0.12.15 AS localstack-base
 RUN mkdir -p  /opt/code/localstack/localstack/infra/elasticmq/
 RUN wget https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.1.0.jar
 RUN mv elasticmq-server-1.1.0.jar /opt/code/localstack/localstack/infra/elasticmq/elasticmq-server.jar

--- a/localstack/Dockerfile
+++ b/localstack/Dockerfile
@@ -4,6 +4,6 @@
 # and avoids an issue wimax@ ran into when running under Nomad.
 
 FROM localstack/localstack-full:0.12.17 AS localstack-base
-RUN curl -O /opt/code/localstack/localstack/infra/elasticmq/elasticmq-server.jar \
-    https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.1.0.jar
-     
+RUN mkdir -p  /opt/code/localstack/localstack/infra/elasticmq/
+RUN wget https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.1.0.jar
+RUN mv elasticmq-server-1.1.0.jar /opt/code/localstack/localstack/infra/elasticmq/elasticmq-server.jar


### PR DESCRIPTION
- Whenever we bring up a Localstack container, it goes and downloads `elasticmq.jar` - a 32M download every time we `up` localstack!
- Downloading ElasticMQ to the container causes an unspecified error when running under Nomad. 
- I'm trying to just avoid that issue entirely.

This mysterious URL is the exact one that Localstack uses: 
https://github.com/localstack/localstack/blob/c2fa7bb5dba64d9318c7a5bbe295ac96ad3f2a02/localstack/constants.py

We can stop doing this all the moment we have Kafka.