### PR TITLE
Nomad integration tests are now deployed by Pulumi (this is going into origin/nomad-integ-tests)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,7 @@ test-typecheck: test-typecheck-docker test-typecheck-pants ## Typecheck all Pyth
 test-integration: export COMPOSE_PROJECT_NAME := $(COMPOSE_PROJECT_INTEGRATION_TESTS)
 test-integration: export COMPOSE_FILE := ./test/docker-compose.integration-tests.yml
 test-integration: build-test-integration ## Build and run integration tests
+	export SHOULD_DEPLOY_INTEGRATION_TESTS=True  # This gets read in by `docker-compose.yml`'s pulumi
 	$(MAKE) test-with-env EXEC_TEST_COMMAND=nomad/local/run_integration_tests.sh
 
 .PHONY: test-grapl-template-generator

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -318,6 +318,8 @@ services:
     environment:
       TAG:
       PULUMI_CONFIG_PASSPHRASE: local-grapl-passphrase
+      # This gets exported to True by `make test-integration`
+      SHOULD_DEPLOY_INTEGRATION_TESTS: "${SHOULD_DEPLOY_INTEGRATION_TESTS:-False}"
       # Other environment variables like MG_ALPHAS are passed in via
       # Pulumi.local-grapl.yaml
     extra_hosts:

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -33,8 +33,7 @@ EOF
 }
 
 variable "aws_region" {
-  type    = string
-  default = "us-west-2"
+  type = string
 }
 
 variable "analyzer_bucket" {

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -9,8 +9,7 @@ variable "container_registry" {
 }
 
 variable "aws_region" {
-  type    = string
-  default = "us-west-2"
+  type = string
 }
 
 variable "deployment_name" {

--- a/nomad/local/run_integration_tests.sh
+++ b/nomad/local/run_integration_tests.sh
@@ -7,24 +7,10 @@ THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
 # shellcheck source-path=SCRIPTDIR
 source "${THIS_DIR}/nomad_cli_tools.sh"
 
-echo "--- Deploying integration tests"
+# The Nomad integration test _definition_ is uploaded as part of
+# __main__.py's `nomad_integration_tests`.
 
-# Wait a short period of time before attempting to deploy infrastructure
-# shellcheck disable=SC2016
-timeout 30 bash -c -- 'while [[ -z $(nomad status 2>&1 | grep running) ]]; do printf "Waiting for nomad-agent\n";sleep 1;done'
-
-nomad job run \
-    -var "aws_region=${AWS_REGION}" \
-    -var "deployment_name=${DEPLOYMENT_NAME}" \
-    -var "aws_access_key_id=${FAKE_AWS_ACCESS_KEY_ID}" \
-    -var "aws_access_key_secret=${FAKE_AWS_SECRET_ACCESS_KEY}" \
-    -var "aws_endpoint=${GRAPL_AWS_ENDPOINT}" \
-    -var "redis_endpoint=${REDIS_ENDPOINT}" \
-    "${GRAPL_ROOT}"/nomad/local/integration-tests.nomad
-
-echo "--- Integration tests deployed!"
-
-# Now we have to actually dispatch a job; the above command simply uploaded
+# Now we have to actually dispatch a job; Pulumi simply uploaded
 # the jobspec, since it's a Parameterized Batch Job.
 
 echo "--- Dispatching integration tests"

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 sys.path.insert(0, "..")
 
@@ -19,6 +20,7 @@ from infra.config import (
     GRAPL_TEST_USER_NAME,
     LOCAL_GRAPL,
     REAL_DEPLOYMENT,
+    SHOULD_DEPLOY_INTEGRATION_TESTS,
 )
 from infra.dgraph_cluster import DgraphCluster, LocalStandInDgraphCluster
 from infra.dgraph_ttl import DGraphTTL
@@ -143,7 +145,7 @@ def main() -> None:
         if False:
             kafka = Kafka("kafka")
 
-        job_vars = pulumi.Output.all(
+        grapl_core_job_vars = pulumi.Output.all(
             analyzer_bucket=analyzers_bucket.bucket,
             analyzer_dispatched_bucket=dispatched_analyzer_emitter.bucket.bucket,
             analyzer_dispatcher_queue=analyzer_dispatcher_queue.main_queue_url,
@@ -170,13 +172,41 @@ def main() -> None:
                 "deployment_name": DEPLOYMENT_NAME,
                 "grapl_test_user_name": GRAPL_TEST_USER_NAME,
                 "redis_endpoint": pulumi.Config().get("REDIS_ENDPOINT"),
-                # "aws_region": aws.get_region(),
+                "aws_region": aws.get_region().name,
                 # TODO: consider replacing with the previous per-service `configurable_envvars`
                 "rust_log": "DEBUG",
                 **inputs,
             }
         )
-        nomad_job = NomadJob("grapl-core", job_vars)
+
+        nomad_grapl_core = NomadJob(
+            "grapl-core",
+            jobspec=Path("../../nomad/grapl-core.nomad").resolve(),
+            vars=grapl_core_job_vars,
+        )
+
+        if SHOULD_DEPLOY_INTEGRATION_TESTS:
+            # Filter out which vars we need
+            integration_test_job_vars = grapl_core_job_vars.apply(
+                lambda inputs: {
+                    k: inputs[k]
+                    for k in inputs.keys()
+                    & {
+                        "aws_region",
+                        "deployment_name",
+                        "aws_access_key_id",
+                        "aws_access_key_secret",
+                        "aws_endpoint",
+                        "redis_endpoint",
+                    }
+                }
+            )
+
+            nomad_integration_tests = NomadJob(
+                "integration-tests",
+                jobspec=Path("../../nomad/local/integration-tests.nomad").resolve(),
+                vars=integration_test_job_vars,
+            )
 
     else:
         nomad_cluster = NomadCluster(

--- a/pulumi/infra/config.py
+++ b/pulumi/infra/config.py
@@ -1,7 +1,7 @@
 import os
 import re
 from pathlib import Path
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence, Union
 
 import pulumi_aws as aws
 from typing_extensions import Final
@@ -17,6 +17,25 @@ GRAPL_TEST_USER_NAME = f"{DEPLOYMENT_NAME}-grapl-test-user"
 # Sometimes we need to refer to other code or artifacts relative to
 # the repository root.
 REPOSITORY_ROOT = os.path.join(os.path.dirname(__file__), "../..")
+
+
+def to_bool(input: Optional[Union[str, bool]]) -> Optional[bool]:
+    if isinstance(input, bool):
+        return input
+    elif input is None:
+        return None
+    elif input in ("True", "true"):
+        return True
+    elif input in ("False", "false"):
+        return False
+    else:
+        raise ValueError(f"Invalid bool value: {repr(input)}")
+
+
+# If true, optionally deploy integration tests to Nomad (without running them).
+SHOULD_DEPLOY_INTEGRATION_TESTS = to_bool(
+    os.getenv("SHOULD_DEPLOY_INTEGRATION_TESTS", False)
+)
 
 
 def repository_path(relative_path: str) -> Path:

--- a/pulumi/infra/nomad_job.py
+++ b/pulumi/infra/nomad_job.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Optional
 
 import pulumi_nomad as nomad
@@ -10,14 +11,15 @@ class NomadJob(pulumi.ComponentResource):
     def __init__(
         self,
         name: str,
+        jobspec: Path,
         vars: pulumi.Output,
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
         super().__init__("grapl:NomadJob", name, None, opts)
 
         self.grapl_core = nomad.Job(
-            resource_name=f"{DEPLOYMENT_NAME}-grapl-core-job",
-            jobspec=self._file_contents("../../nomad/grapl-core.nomad"),
+            resource_name=f"{DEPLOYMENT_NAME}-{name}-job",
+            jobspec=self._file_contents(str(jobspec)),
             hcl2=nomad.JobHcl2Args(enabled=True, vars=vars),
             opts=pulumi.ResourceOptions(parent=self),
         )


### PR DESCRIPTION
Instead of deploying via `run_integration_tests.sh`, we do it in Pulumi.
Seems nice and functional and not awful.