### PR TITLE
Register nomad services in consul with better names

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -526,23 +526,24 @@ job "grapl-core" {
       }
     }
 
-    //    service {
-    //      connect {
-    //        sidecar_service {
-    //          proxy {
-    //            dynamic "upstreams" {
-    //              iterator = alpha
-    //              for_each = local.dgraph_alphas
-    //
-    //              content {
-    //                destination_name = "dgraph-alpha-${alpha.value.id}-grpc-public"
-    //                local_bind_port  = alpha.value.grpc_public_port
-    //              }
-    //            }
-    //          }
-    //        }
-    //      }
-    //    }
+    service {
+      name = "graph-merger"
+      //      connect {
+      //        sidecar_service {
+      //          proxy {
+      //            dynamic "upstreams" {
+      //              iterator = alpha
+      //              for_each = local.dgraph_alphas
+      //
+      //              content {
+      //                destination_name = "dgraph-alpha-${alpha.value.id}-grpc-public"
+      //                local_bind_port  = alpha.value.grpc_public_port
+      //              }
+      //            }
+      //          }
+      //        }
+      //      }
+    }
   }
 
   group "provisioner" {
@@ -580,6 +581,7 @@ job "grapl-core" {
     }
 
     service {
+      name = "provisioner"
       connect {
         sidecar_service {
           proxy {
@@ -630,6 +632,10 @@ job "grapl-core" {
         SOURCE_QUEUE_URL      = var.node_identifier_queue
         DEAD_LETTER_QUEUE_URL = var.node_identifier_retry_queue
       }
+
+      service {
+        name = "node-identifier"
+      }
     }
   }
 
@@ -664,6 +670,11 @@ job "grapl-core" {
         SOURCE_QUEUE_URL            = var.node_identifier_retry_queue
         DEAD_LETTER_QUEUE_URL       = var.node_identifier_dead_letter_queue
       }
+
+      service {
+        name = "node-identifier-retry"
+      }
+
     }
   }
 
@@ -692,6 +703,11 @@ job "grapl-core" {
         DEAD_LETTER_QUEUE_URL  = var.analyzer_dispatcher_queue
         SOURCE_QUEUE_URL       = var.analyzer_dispatcher_dead_letter_queue
       }
+
+      service {
+        name = "analyzer-dispatcher"
+      }
+
     }
 
   }
@@ -727,6 +743,11 @@ job "grapl-core" {
         MESSAGECACHE_ADDR                       = local.redis_host
         MESSAGECACHE_PORT                       = local.redis_port
       }
+
+      service {
+        name = "analyzer-executor"
+      }
+
     }
   }
 
@@ -789,13 +810,13 @@ job "grapl-core" {
       }
     }
 
-    //    service {
-    //      name = "graphql-endpoint"
-    //      port = "graphql-endpoint"
-    //
-    //      connect {
-    //        sidecar_service {}
-    //      }
-    //    }
+    service {
+      name = "graphql-endpoint"
+      //      port = "graphql-endpoint"
+      //
+      //      connect {
+      //        sidecar_service {}
+      //      }
+    }
   }
 }

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -83,6 +83,26 @@ job "grapl-local-infra" {
 
       service {
         name = "redis"
+
+        check {
+          type    = "script"
+          name    = "check_redis"
+          command = "/bin/bash"
+          # Interpolated by bash, not nomad
+          args = [
+            "-o", "errexit", "-o", "nounset",
+            "-c",
+            "redis-cli ping || exit 1",
+          ]
+          interval = "20s"
+          timeout  = "10s"
+
+          check_restart {
+            limit           = 2
+            grace           = "30s"
+            ignore_warnings = false
+          }
+        }
       }
     }
   }

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -125,6 +125,7 @@ job "grapl-local-infra" {
       }
 
       service {
+        name = "localstack"
         check {
           type    = "script"
           name    = "check_s3_ls"
@@ -217,6 +218,7 @@ job "grapl-local-infra" {
       }
 
       service {
+        name = "kafka"
         check {
           type    = "script"
           name    = "check_kafka"
@@ -265,6 +267,7 @@ job "grapl-local-infra" {
       }
 
       service {
+        name = "zookeeper"
         check {
           type    = "script"
           name    = "check_zookeeper"

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -80,6 +80,10 @@ job "grapl-local-infra" {
         image = "redis:latest"
         ports = ["redis"]
       }
+
+      service {
+        name = "redis"
+      }
     }
   }
 
@@ -163,6 +167,10 @@ job "grapl-local-infra" {
       config {
         image = "dgraph/ratel:latest"
         ports = ["ratel"]
+      }
+
+      service {
+        name = "ratel"
       }
     }
   }

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -75,6 +75,7 @@ job "integration-tests" {
 
     # Enable service discovery
     service {
+      name = "rust-integration-tests"
       connect {
         sidecar_service {
           proxy {
@@ -123,6 +124,7 @@ job "integration-tests" {
 
     # Enable service discovery
     service {
+      name = "analyzerlib-integration-tests"
       connect {
         sidecar_service {
           proxy {
@@ -171,6 +173,7 @@ job "integration-tests" {
 
     # Enable service discovery
     service {
+      name = "analyzer-executor-integration-tests"
       connect {
         sidecar_service {
           proxy {
@@ -233,6 +236,7 @@ job "integration-tests" {
 
     # Enable service discovery
     service {
+      name = "graphql-endpoint-tests"
       connect {
         sidecar_service {
           proxy {
@@ -289,6 +293,7 @@ job "integration-tests" {
 
     # Enable service discovery
     service {
+      name = "engagement-edge-integration-tests"
       connect {
         sidecar_service {
           proxy {


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/602

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
This registers all remaining services in consul if they were not already registering.
This sets specific names for the services so we don't end up with integration-tests-rust-integration-tests-rust-integration-tests as the name for services.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
export KEEP_TEST_ENV=1
make test-integration
In your browser go to http://localhost:8500/
Confirm that there are no long names using the default job-group-task mechanism but instead are short-names

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
