### PR TITLE
Remove local registry

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -111,7 +111,6 @@ steps:
 
   - label: ":hammer: Integration Tests"
     command:
-      - make run-registry
       - make test-integration
     env:
       GRAPL_LOG_LEVEL: "DEBUG"

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ build-test-typecheck: build-python-wheels
 		--file ./test/docker-compose.typecheck-tests.yml
 
 .PHONY: build-test-integration
-build-test-integration: build
+build-test-integration: build-local
 	$(WITH_LOCAL_GRAPL_ENV) \
 	$(DOCKER_BUILDX_BAKE) --file ./test/docker-compose.integration-tests.yml
 
@@ -209,6 +209,9 @@ build-docker-images: graplctl
 
 .PHONY: build
 build: build-lambda-zips build-docker-images ## Build Grapl services
+
+.PHONY: build-local
+build: build-lambda-zips build-docker-images-local ## Build Grapl services
 
 .PHONY: build-formatter
 build-formatter:
@@ -423,7 +426,7 @@ up: build ## Build Grapl services and launch docker-compose up
 	docker-compose -f docker-compose.yml up
 
 .PHONY: up-detach
-up-detach: build ## Bring up local Grapl and detach to return control to tty
+up-detach: build-local ## Bring up local Grapl and detach to return control to tty
 	# Primarily used for bringing up an environment for integration testing.
 	# For use with a project name consider setting COMPOSE_PROJECT_NAME env var
 	# Usage: `make up-detach`

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 .DEFAULT_GOAL := help
 
 -include .env
-TAG ?= latest
+TAG ?= dev
 RUST_BUILD ?= debug
 UID = $(shell id -u)
 GID = $(shell id -g)

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,6 @@ build-python-wheels:  ## Build all Python wheels
 build-docker-images-local: 
 	$(WITH_LOCAL_GRAPL_ENV) \
 	$(MAKE) build-docker-images
-	$(MAKE) push-local
 
 .PHONY: build-docker-images
 build-docker-images: graplctl
@@ -303,7 +302,6 @@ test-integration: export COMPOSE_PROJECT_NAME := $(COMPOSE_PROJECT_INTEGRATION_T
 #test-integration: export COMPOSE_FILE := ./test/docker-compose.integration-tests.yml
 test-integration: build-test-integration ## Build and run integration tests
 	$(WITH_LOCAL_GRAPL_ENV)
-	docker-compose --file=test/docker-compose.integration-tests.yml push
 	export SHOULD_DEPLOY_INTEGRATION_TESTS=True  # This gets read in by `docker-compose.yml`'s pulumi
 	$(MAKE) test-with-env EXEC_TEST_COMMAND=nomad/local/run_integration_tests.sh
 
@@ -476,12 +474,8 @@ clean-mount-cache: ## Prune all docker mount cache (used by sccache)
 clean-artifacts: ## Remove all dumped artifacts from test runs (see dump_artifacts.py)
 	rm -Rf test_artifacts
 
-.PHONY: run-registry
-run-registry: ## Ensure that a local docker registry is running (which is required for local Nomad deployments.
-	nomad/local/local_grapl_registry.sh
-
 .PHONY: start-nomad-dev
-start-nomad-dev: push-local  ## Start the Nomad development environment
+start-nomad-dev:  ## Start the Nomad development environment
 	$(WITH_LOCAL_GRAPL_ENV)
 	nomad/local/start_development_environment_tmux.sh
 
@@ -492,7 +486,7 @@ local-pulumi:  ## launch pulumi via docker-compose up
 	docker-compose -f docker-compose.yml run pulumi
 
 .PHONY: start-nomad-detach
-start-nomad-detach: push-local  ## Start the Nomad environment, detached
+start-nomad-detach:  ## Start the Nomad environment, detached
 	$(WITH_LOCAL_GRAPL_ENV)
 	nomad/local/start_detach.sh
 
@@ -503,11 +497,6 @@ stop-nomad-detach:  ## Stop Nomad CI environment
 .PHONY: push
 push: build-docker-images ## Push Grapl containers to supplied DOCKER_REGISTRY
 	docker-compose --file=docker-compose.build.yml push
-
-.PHONY: push-local
-push-local: ## Push Grapl container to local registry
-	$(MAKE) run-registry
-	$(WITH_LOCAL_GRAPL_ENV) $(MAKE) push
 
 .PHONY: e2e-logs
 e2e-logs: ## All docker-compose logs

--- a/Makefile
+++ b/Makefile
@@ -439,7 +439,7 @@ up-detach: build-local ## Bring up local Grapl and detach to return control to t
 	unset COMPOSE_FILE
 	docker-compose \
 		--file docker-compose.yml \
-		up --detach --force-recreate --always-recreate-deps --renew-anon-volumes pulumi
+		run pulumi
 
 .PHONY: down
 down: ## docker-compose down - both stops and removes the containers

--- a/Makefile
+++ b/Makefile
@@ -439,7 +439,9 @@ up-detach: build-local ## Bring up local Grapl and detach to return control to t
 	unset COMPOSE_FILE
 	docker-compose \
 		--file docker-compose.yml \
-		run pulumi
+		up --force-recreate --always-recreate-deps --renew-anon-volumes \
+		--exit-code-from pulumi \
+		pulumi
 
 .PHONY: down
 down: ## docker-compose down - both stops and removes the containers

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ build-docker-images: graplctl
 build: build-lambda-zips build-docker-images ## Build Grapl services
 
 .PHONY: build-local
-build: build-lambda-zips build-docker-images-local ## Build Grapl services
+build-local: build-lambda-zips build-docker-images-local ## Build Grapl services
 
 .PHONY: build-formatter
 build-formatter:

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -12,7 +12,7 @@ services:
   ########################################################################
 
   sysmon-generator:
-    image: ${DOCKER_REGISTRY:-docker.io}/grapl/sysmon-generator:${TAG:-latest}
+    image: grapl/sysmon-generator:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -21,7 +21,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   osquery-generator:
-    image: ${DOCKER_REGISTRY:-docker.io}/grapl/osquery-generator:${TAG:-latest}
+    image: grapl/osquery-generator:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -30,7 +30,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   node-identifier:
-    image: ${DOCKER_REGISTRY:-docker.io}/grapl/node-identifier:${TAG:-latest}
+    image: grapl/node-identifier:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -48,7 +48,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   graph-merger:
-    image: ${DOCKER_REGISTRY:-docker.io}/grapl/graph-merger:${TAG:-latest}
+    image: grapl/graph-merger:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -57,7 +57,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   analyzer-dispatcher:
-    image: ${DOCKER_REGISTRY:-docker.io}/grapl/analyzer-dispatcher:${TAG:-latest}
+    image: grapl/analyzer-dispatcher:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -71,7 +71,7 @@ services:
 
   # should match `pulumi/infra/analyzer_executor.py`'s GraplDockerBuild
   analyzer-executor:
-    image: ${DOCKER_REGISTRY:-docker.io}/grapl/analyzer-executor:${TAG:-latest}
+    image: grapl/analyzer-executor:${TAG:-latest}
     build:
       context: .
       dockerfile: ./src/python/Dockerfile
@@ -81,7 +81,7 @@ services:
   # to deploy model-plugin-deployer as an actual Lambda there, we can
   # get rid of this.
   model-plugin-deployer:
-    image: ${DOCKER_REGISTRY:-docker.io}/grapl/model-plugin-deployer:${TAG:-latest}
+    image: grapl/model-plugin-deployer:${TAG:-latest}
     build:
       context: .
       dockerfile: ./src/python/Dockerfile
@@ -92,7 +92,7 @@ services:
   ########################################################################
 
   engagement-view-uploader:
-    image: ${DOCKER_REGISTRY:-docker.io}/grapl/engagement-view:${TAG:-latest}
+    image: grapl/engagement-view:${TAG:-latest}
     build:
       context: src/js/engagement_view
       dockerfile: Dockerfile
@@ -102,14 +102,14 @@ services:
   # to deploy graphql-endpoint as an actual Lambda there, we can get
   # rid of this.
   graphql-endpoint:
-    image: ${DOCKER_REGISTRY:-docker.io}/grapl/graphql-endpoint:${TAG:-latest}
+    image: grapl/graphql-endpoint:${TAG:-latest}
     build:
       context: src/js/graphql_endpoint
       dockerfile: Dockerfile
       target: graphql-endpoint-deploy
 
   notebook:
-    image: ${DOCKER_REGISTRY:-docker.io}/grapl/notebook:${TAG:-latest}
+    image: grapl/notebook:${TAG:-latest}
     build:
       context: .
       dockerfile: ./src/python/Dockerfile
@@ -120,19 +120,19 @@ services:
   ########################################################################
 
   pulumi:
-    image: ${DOCKER_REGISTRY:-docker.io}/grapl/local-pulumi:${TAG:-latest}
+    image: grapl/local-pulumi:${TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.pulumi
 
   localstack:
-    image: ${DOCKER_REGISTRY:-docker.io}/grapl/localstack:${TAG:-latest}
+    image: grapl/localstack:${TAG:-latest}
     build:
       context: localstack
       dockerfile: Dockerfile
 
   provisioner:
-    image: ${DOCKER_REGISTRY:-docker.io}/grapl/provisioner:${TAG:-latest}
+    image: grapl/provisioner:${TAG:-latest}
     build:
       context: .
       dockerfile: ./src/python/lambdas.Dockerfile

--- a/local-grapl.env
+++ b/local-grapl.env
@@ -116,4 +116,7 @@ DEPLOYMENT_NAME=local-grapl
 # This must be the same as the value defined in pulumi/infra/config.py
 GRAPL_TEST_USER_NAME=${DEPLOYMENT_NAME}-grapl-test-user
 # Determines the registry to build and push against.
-DOCKER_REGISTRY=localhost:5000
+# Locally this should be empty so that Nomad picks up local images
+DOCKER_REGISTRY=""
+# Nomad won't pick up local images that are tagged with latest
+TAG=dev

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -5,8 +5,8 @@ variable "rust_log" {
 
 variable "container_registry" {
   type        = string
-  default     = "localhost:5000"
-  description = "The container registry in which we can find Grapl services."
+  default     = ""
+  description = "The container registry in which we can find Grapl services. Requires a trailing /"
 }
 
 variable "aws_access_key_id" {
@@ -58,7 +58,7 @@ variable "analyzer_dispatcher_dead_letter_queue" {
 
 variable "analyzer_dispatcher_tag" {
   type        = string
-  default     = "latest"
+  default     = "dev"
   description = "The tagged version of the analyzer-dispatcher we should deploy."
 }
 
@@ -74,7 +74,7 @@ variable "analyzer_executor_queue" {
 
 variable "analyzer_executor_tag" {
   type        = string
-  default     = "latest"
+  default     = "dev"
   description = "The tagged version of the analyzer-executor we should deploy."
 }
 
@@ -123,7 +123,7 @@ variable "num_graph_mergers" {
 
 variable "graph_merger_tag" {
   type        = string
-  default     = "latest"
+  default     = "dev"
   description = "The tagged version of the graph_merger we should deploy."
 }
 
@@ -160,7 +160,7 @@ variable "num_node_identifier_retries" {
 
 variable "node_identifier_tag" {
   type        = string
-  default     = "latest"
+  default     = "dev"
   description = "The tagged version of the node_identifier and the node_identifier_retry we should deploy."
 }
 
@@ -178,7 +178,7 @@ variable "node_identifier_retry_queue" {
 
 variable "provisioner_tag" {
   type        = string
-  default     = "latest"
+  default     = "dev"
   description = "The tagged version of the provisioner we should deploy."
 }
 
@@ -194,7 +194,7 @@ variable "subgraphs_generated_bucket" {
 
 variable "engagement_view_tag" {
   type        = string
-  default     = "latest"
+  default     = "dev"
   description = "The image tag for the engagement view."
 }
 
@@ -205,7 +205,7 @@ variable "ux_bucket" {
 
 variable "graphql_endpoint_tag" {
   type        = string
-  default     = "latest"
+  default     = "dev"
   description = "The image tag for the graphql endpoint docker image."
 }
 
@@ -504,7 +504,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image        = "${var.container_registry}/grapl/graph-merger:${var.graph_merger_tag}"
+        image        = "${var.container_registry}grapl/graph-merger:${var.graph_merger_tag}"
         network_mode = "grapl-network"
       }
 
@@ -555,7 +555,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}/grapl/provisioner:${var.provisioner_tag}"
+        image = "${var.container_registry}grapl/provisioner:${var.provisioner_tag}"
       }
 
       lifecycle {
@@ -611,7 +611,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image        = "${var.container_registry}/grapl/node-identifier:${var.node_identifier_tag}"
+        image        = "${var.container_registry}grapl/node-identifier:${var.node_identifier_tag}"
         network_mode = "grapl-network"
       }
 
@@ -650,7 +650,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image        = "${var.container_registry}/grapl/node-identifier-retry:${var.node_identifier_tag}"
+        image        = "${var.container_registry}grapl/node-identifier-retry:${var.node_identifier_tag}"
         network_mode = "grapl-network"
       }
 
@@ -684,7 +684,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image        = "${var.container_registry}/grapl/analyzer-dispatcher:${var.analyzer_dispatcher_tag}"
+        image        = "${var.container_registry}grapl/analyzer-dispatcher:${var.analyzer_dispatcher_tag}"
         network_mode = "grapl-network"
       }
 
@@ -717,7 +717,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image        = "${var.container_registry}/grapl/analyzer-executor:${var.analyzer_executor_tag}"
+        image        = "${var.container_registry}grapl/analyzer-executor:${var.analyzer_executor_tag}"
         network_mode = "grapl-network"
       }
 
@@ -766,7 +766,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image        = "${var.container_registry}/grapl/engagement-view:${var.engagement_view_tag}"
+        image        = "${var.container_registry}grapl/engagement-view:${var.engagement_view_tag}"
         network_mode = "grapl-network"
       }
 
@@ -789,7 +789,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image        = "${var.container_registry}/grapl/graphql-endpoint:${var.graphql_endpoint_tag}"
+        image        = "${var.container_registry}grapl/graphql-endpoint:${var.graphql_endpoint_tag}"
         network_mode = "grapl-network"
       }
 

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -1,7 +1,13 @@
 variable "container_registry" {
   type        = string
-  default     = "localhost:5000"
-  description = "The container registry in which we can find Grapl services."
+  default     = ""
+  description = "The container registry in which we can find Grapl services. Requires a trailing /"
+}
+
+variable "localstack_tag" {
+  type = string
+  default = "dev"
+  description = "The tagged version of localstack we should deploy."
 }
 
 # The following variables are all-caps to clue in users that they're
@@ -122,7 +128,7 @@ job "grapl-local-infra" {
 
       config {
         # Once we move to Kafka, we can go back to the non-fork.
-        image = "${var.container_registry}/grapl/localstack:latest"
+        image = "${var.container_registry}grapl/localstack:${var.localstack_tag}"
         # Was running into this: https://github.com/localstack/localstack/issues/1349
         memory_hard_limit = 2048
         ports             = ["localstack"]

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -5,8 +5,8 @@ variable "container_registry" {
 }
 
 variable "localstack_tag" {
-  type = string
-  default = "dev"
+  type        = string
+  default     = "dev"
   description = "The tagged version of localstack we should deploy."
 }
 

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -34,36 +34,6 @@ variable "aws_endpoint" {
   description = "The endpoint in which we can expect to find and interact with AWS."
 }
 
-variable "analyzer_executor_integration_tests_tag" {
-  type        = string
-  default     = "dev"
-  description = "The tagged version of the analyzer_executor_integration_tests we should deploy."
-}
-
-variable "analyzerlib_integration_tests_tag" {
-  type        = string
-  default     = "dev"
-  description = "The tagged version of the analyzerlib_integration_tests we should deploy."
-}
-
-variable "engagement_edge_integration_tests_tag" {
-  type        = string
-  default     = "dev"
-  description = "The tagged version of the engagement_edge_integration_tests we should deploy."
-}
-
-variable "graphql_endpoint_tests_tag" {
-  type        = string
-  default     = "dev"
-  description = "The tagged version of the graphql_endpoint_tests we should deploy."
-}
-
-variable "rust_integration_tests_tag" {
-  type        = string
-  default     = "dev"
-  description = "The tagged version of the rust-integration-tests we should deploy."
-}
-
 variable "redis_endpoint" {
   type        = string
   description = "Where can services find redis?"
@@ -123,7 +93,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/rust-integration-tests:${var.rust_integration_tests_tag}"
+        image = "${var.container_registry}grapl/rust-integration-tests:dev"
       }
 
       env {
@@ -172,7 +142,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}grapl/analyzerlib-test:${var.analyzerlib_integration_tests_tag}"
+        image      = "${var.container_registry}grapl/analyzerlib-test:dev"
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command    = "cd grapl_analyzerlib && py.test -v -n auto -m 'integration_test'"
       }
@@ -220,7 +190,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}grapl/analyzer-executor-test:${var.analyzer_executor_integration_tests_tag}"
+        image      = "${var.container_registry}grapl/analyzer-executor-test:dev"
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command    = "cd analyzer_executor && export PYTHONPATH=\"$(pwd)/src\"; py.test -n auto -m 'integration_test'"
       }
@@ -283,7 +253,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}grapl/graphql-endpoint-tests:${var.graphql_endpoint_tests_tag}"
+        image      = "${var.container_registry}grapl/graphql-endpoint-tests:dev"
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command    = "cd graphql_endpoint_tests; py.test --capture=no -n 1 -m 'integration_test'"
       }
@@ -340,7 +310,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}grapl/grapl-engagement-edge-test:${var.engagement_edge_integration_tests_tag}"
+        image      = "${var.container_registry}grapl/grapl-engagement-edge-test:dev"
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command    = "cd engagement_edge; py.test -n auto -m 'integration_test'"
       }

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -34,6 +34,36 @@ variable "aws_endpoint" {
   description = "The endpoint in which we can expect to find and interact with AWS."
 }
 
+variable "analyzer_executor_integration_tests_tag" {
+  type        = string
+  default     = "dev"
+  description = "The tagged version of the analyzer_executor_integration_tests we should deploy."
+}
+
+variable "analyzerlib_integration_tests_tag" {
+  type        = string
+  default     = "dev"
+  description = "The tagged version of the analyzerlib_integration_tests we should deploy."
+}
+
+variable "engagement_edge_integration_tests_tag" {
+  type        = string
+  default     = "dev"
+  description = "The tagged version of the engagement_edge_integration_tests we should deploy."
+}
+
+variable "graphql_endpoint_tests_tag" {
+  type        = string
+  default     = "dev"
+  description = "The tagged version of the graphql_endpoint_tests we should deploy."
+}
+
+variable "rust_integration_tests_tag" {
+  type        = string
+  default     = "dev"
+  description = "The tagged version of the rust-integration-tests we should deploy."
+}
+
 variable "redis_endpoint" {
   type        = string
   description = "Where can services find redis?"
@@ -93,7 +123,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/rust-integration-tests:latest"
+        image = "${var.container_registry}grapl/rust-integration-tests:${var.rust_integration_tests_tag}"
       }
 
       env {
@@ -142,7 +172,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}grapl/analyzerlib-test:latest"
+        image      = "${var.container_registry}grapl/analyzerlib-test:${var.analyzerlib_integration_tests_tag}"
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command    = "cd grapl_analyzerlib && py.test -v -n auto -m 'integration_test'"
       }
@@ -190,7 +220,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}grapl/analyzer-executor-test:latest"
+        image      = "${var.container_registry}grapl/analyzer-executor-test:${var.analyzer_executor_integration_tests_tag}"
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command    = "cd analyzer_executor && export PYTHONPATH=\"$(pwd)/src\"; py.test -n auto -m 'integration_test'"
       }
@@ -253,7 +283,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}grapl/graphql-endpoint-tests:latest"
+        image      = "${var.container_registry}grapl/graphql-endpoint-tests:${var.graphql_endpoint_tests_tag}"
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command    = "cd graphql_endpoint_tests; py.test --capture=no -n 1 -m 'integration_test'"
       }
@@ -310,7 +340,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}grapl/grapl-engagement-edge-test:latest"
+        image      = "${var.container_registry}grapl/grapl-engagement-edge-test:${var.engagement_edge_integration_tests_tag}"
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command    = "cd engagement_edge; py.test -n auto -m 'integration_test'"
       }

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -4,8 +4,8 @@
 # 
 variable "container_registry" {
   type        = string
-  default     = "localhost:5000"
-  description = "The container registry in which we can find Grapl services."
+  default     = ""
+  description = "The container registry in which we can find Grapl services. Requires a trailing /"
 }
 
 variable "aws_region" {
@@ -93,7 +93,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}/grapl/rust-integration-tests:latest"
+        image = "${var.container_registry}grapl/rust-integration-tests:latest"
       }
 
       env {
@@ -142,7 +142,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}/grapl/analyzerlib-test:latest"
+        image      = "${var.container_registry}grapl/analyzerlib-test:latest"
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command    = "cd grapl_analyzerlib && py.test -v -n auto -m 'integration_test'"
       }
@@ -190,7 +190,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}/grapl/analyzer-executor-test:latest"
+        image      = "${var.container_registry}grapl/analyzer-executor-test:latest"
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command    = "cd analyzer_executor && export PYTHONPATH=\"$(pwd)/src\"; py.test -n auto -m 'integration_test'"
       }
@@ -253,7 +253,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}/grapl/graphql-endpoint-tests:latest"
+        image      = "${var.container_registry}grapl/graphql-endpoint-tests:latest"
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command    = "cd graphql_endpoint_tests; py.test --capture=no -n 1 -m 'integration_test'"
       }
@@ -310,7 +310,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}/grapl/grapl-engagement-edge-test:latest"
+        image      = "${var.container_registry}grapl/grapl-engagement-edge-test:latest"
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command    = "cd engagement_edge; py.test -n auto -m 'integration_test'"
       }

--- a/nomad/local/run_integration_tests.sh
+++ b/nomad/local/run_integration_tests.sh
@@ -12,6 +12,10 @@ source "${THIS_DIR}/nomad_cli_tools.sh"
 # Now we have to actually dispatch a job; Pulumi simply uploaded
 # the jobspec, since it's a Parameterized Batch Job.
 
+# There's a potential race condition where pulumi may not have finished uploading the jobspec
+# shellcheck disable=SC2016
+timeout 30 bash -c -- 'while [[ -z $(nomad job inspect integration-tests 2>&1 | grep running) ]]; do printf "Waiting for jobspec\n";sleep 1;done'
+
 echo "--- Dispatching integration tests"
 
 job_id=$(nomad_dispatch integration-tests)

--- a/nomad/local/run_integration_tests.sh
+++ b/nomad/local/run_integration_tests.sh
@@ -11,11 +11,6 @@ source "${THIS_DIR}/nomad_cli_tools.sh"
 
 # Now we have to actually dispatch a job; Pulumi simply uploaded
 # the jobspec, since it's a Parameterized Batch Job.
-
-# There's a potential race condition where pulumi may not have finished uploading the jobspec
-# shellcheck disable=SC2016
-timeout 30 bash -c -- 'while [[ -z $(nomad job inspect integration-tests 2>&1 | grep running) ]]; do printf "Waiting for jobspec\n";sleep 1;done'
-
 echo "--- Dispatching integration tests"
 
 job_id=$(nomad_dispatch integration-tests)

--- a/nomad/local/start_detach.sh
+++ b/nomad/local/start_detach.sh
@@ -27,7 +27,8 @@ NOMAD_LOGS_DEST=/tmp/nomad-agent.log
 CONSUL_LOGS_DEST=/tmp/consul-agent.log
 echo "Starting nomad and consul locally. Logs @ ${NOMAD_LOGS_DEST} and ${CONSUL_LOGS_DEST}."
 # These will run forever until `make stop-nomad-ci` is invoked."
-sudo nomad agent -config="nomad-agent-conf.nomad" -dev-connect | tee "${NOMAD_LOGS_DEST}" &
+# shellcheck disable=SC2024
+sudo nomad agent -config="nomad-agent-conf.nomad" -dev-connect > "${NOMAD_LOGS_DEST}" &
 consul agent -dev > "${CONSUL_LOGS_DEST}" &
 
 ./nomad_run_local_infra.sh


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/676
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
This removes all the local registry pieces since apparently Nomad doesn't need that.
Nomad will pick up local images as long as they are not tagged with latest, who knew?

You'll notice that test-integration runs in about 7 minutes and change instead of the 30+ minutes previously 🥳 
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
make test-integration
Nomad should run through everything without any docker pull related failures (tests may still fail since integration test suites are not passing yet)

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
