### PR TITLE
Nomad - remove more defaults from grapl-core.nomad; ensure keys exist when copying keys to integration tests

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -11,13 +11,11 @@ variable "container_registry" {
 
 variable "aws_access_key_id" {
   type        = string
-  default     = "test"
   description = "The aws access key id used to interact with AWS."
 }
 
 variable "aws_access_key_secret" {
   type        = string
-  default     = "test"
   description = "The aws access key secret used to interact with AWS."
 }
 
@@ -143,7 +141,6 @@ variable "graph_merger_dead_letter_queue" {
 variable "grapl_test_user_name" {
   type        = string
   description = "The name of the test user"
-  default     = "grapl-test-user"
 }
 
 variable "model_plugins_bucket" {

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -19,13 +19,11 @@ variable "deployment_name" {
 
 variable "aws_access_key_id" {
   type        = string
-  default     = "test"
   description = "The aws access key id used to interact with AWS."
 }
 
 variable "aws_access_key_secret" {
   type        = string
-  default     = "test"
   description = "The aws access key secret used to interact with AWS."
 }
 

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -191,18 +191,15 @@ def main() -> None:
                 # Filter out which vars we need
                 subset_keys = {
                     "analyzer_bucket",
+                    "aws_access_key_id",
+                    "aws_access_key_secret",
                     "_aws_endpoint",
                     "aws_region",
                     "deployment_name",
                     "_redis_endpoint",
-                    "schema_properties_table_name",
-                    "schema_table_name",
                 }
 
-                subset = {
-                    k: inputs[k]
-                    for k in subset_keys
-                }
+                subset = {k: inputs[k] for k in subset_keys}
 
                 integration_test_only_job_vars = {
                     "_kafka_endpoint": kafka_endpoint,

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -148,6 +148,8 @@ def main() -> None:
             analyzer_executor_queue=analyzer_executor_queue.main_queue_url,
             analyzer_matched_subgraphs_bucket=analyzer_matched_emitter.bucket.bucket,
             analyzer_dispatcher_dead_letter_queue=analyzer_dispatcher_queue.dead_letter_queue_url,
+            aws_access_key_id=aws.config.access_key,
+            aws_access_key_secret=aws.config.secret_key,
             graph_merger_queue=graph_merger_queue.main_queue_url,
             graph_merger_dead_letter_queue=graph_merger_queue.dead_letter_queue_url,
             session_table_name=dynamodb_tables.dynamic_session_table.name,
@@ -187,18 +189,21 @@ def main() -> None:
                 inputs: Mapping[str, Any]
             ) -> Mapping[str, Any]:
                 # Filter out which vars we need
+                subset_keys = {
+                    "analyzer_bucket",
+                    "_aws_endpoint",
+                    "aws_region",
+                    "deployment_name",
+                    "_redis_endpoint",
+                    "schema_properties_table_name",
+                    "schema_table_name",
+                }
+
                 subset = {
                     k: inputs[k]
-                    for k in inputs.keys()
-                    & {
-                        "aws_access_key_id",
-                        "aws_access_key_secret",
-                        "_aws_endpoint",
-                        "aws_region",
-                        "deployment_name",
-                        "_redis_endpoint",
-                    }
+                    for k in subset_keys
                 }
+
                 integration_test_only_job_vars = {
                     "_kafka_endpoint": kafka_endpoint,
                 }

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -190,7 +190,6 @@ def main() -> None:
             ) -> Mapping[str, Any]:
                 # Filter out which vars we need
                 subset_keys = {
-                    "analyzer_bucket",
                     "aws_access_key_id",
                     "aws_access_key_secret",
                     "_aws_endpoint",


### PR DESCRIPTION
turns out we never specified aws_access_key_id/secret_key in Pulumi-Nomad

This change:
- fixes that
- removes some defaults
- helps us catch it (the new `subset_keys` check is better than the & - it fails if we specify a key that wasn't there before)