### PR TITLE
Enable automatic retries on e2e tests for now

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -129,6 +129,9 @@ steps:
       queue: "beefy"
     artifact_paths:
       - "test_artifacts/**/*"
+    retry:
+      automatic:
+        limit: 5
 
   - label: ":lint-roller::packer::nomad: Lint HCL files"
     command:


### PR DESCRIPTION
Until we track down the cause of intermittent timing-related failures
in the e2e tests, we'll allow Buildkite to automatically retry
failures on our behalf.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
