### PR TITLE
Ensure that manage_virtualenv.sh runs from the repository root

### DIFF
--- a/build-support/manage_virtualenv.sh
+++ b/build-support/manage_virtualenv.sh
@@ -99,18 +99,24 @@ EOF
 
 }
 
-case "${1:-help}" in
-    populate)
-        populate
-        ;;
-    regenerate-constraints)
-        regenerate_constraints
-        ;;
-    help)
-        usage
-        ;;
-    *)
-        usage
-        exit 1
-        ;;
-esac
+REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
+readonly REPOSITORY_ROOT
+
+(
+    cd "${REPOSITORY_ROOT}"
+    case "${1:-help}" in
+        populate)
+            populate
+            ;;
+        regenerate-constraints)
+            regenerate_constraints
+            ;;
+        help)
+            usage
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+)


### PR DESCRIPTION
Previously, if the script was executed from another
directory (particularly `build-support` itself), it would fail, but
leave behind an extra `venv` directory, which caused subsequent
problems with Pants.

Now, all the logic takes place from the repository root, eliminating
these issues.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
