### PR TITLE
Check for bridge networking hack when on cros (and fix a missed gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ src/js/engagement_view/.yarn/*
 !src/js/engagement_view/.yarn/versions
 src/js/engagement_view/coverage
 
+# Web UI frontend artifacts
+src/rust/grapl-web-ui/frontend/*
 
 # Distribution / packaging
 build/

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -54,9 +54,7 @@ The following environment variables can affect the build and test environments:
   images. For local builds `latest` is fine. Production builds should have a
 specific version e.g. `v1.2.3`. Users may want to use a tag that includes
 version and/or branch information for tracking purposes (ex:
-`v1.2.3-my_feature`). This value corresponds to the `graplVersion` parameter in
-the CDK project for deploying to AWS, and is used to name the zip files in the
-Make `zip` target.
+`v1.2.3-my_feature`).
 - `CARGO_PROFILE` (default: `debug`) - Can either be `debug` or `release`. These
   roughly translate to the [Cargo
 profiles](https://doc.rust-lang.org/cargo/reference/profiles.html) to be used
@@ -72,13 +70,6 @@ so it should be suitable secrets like S3 credentials for use with sccache.
   buildx](https://github.com/docker/buildx). You can pass additional arguments
 to the `docker buildx build` commands by setting this option (ex: `--progress
 plain`).
-
-#### CDK deployment parameters
-
-Arguments to the CDK deployment parameters can be supplied via environment
-variables documented in [docs/setup/aws.md](./docs/setup/aws.md#configure). By
-using `make deploy` to execute a CDK deploy, the environment variables can be
-read from a `.env` in the root of the Grapl respository.
 
 ### sccache
 

--- a/nomad/local/start_detach.sh
+++ b/nomad/local/start_detach.sh
@@ -8,7 +8,25 @@ THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
 readonly THIS_DIR
 cd "${THIS_DIR}"
 
+ensure_cros_bridge_networking_workaround() {
+    # Suggest the Noamd bridge networking hack in building.md if module is not found
+    # Due to https://github.com/hashicorp/nomad/issues/10902
+
+    # "is this crOS?" per
+    # reddit.com/r/Crostini/comments/kuhwky/how_to_test_in_shell_script_whether_inside/girzz2y/
+    if [[ -f /dev/.cros_milestone ]]; then
+        module_filepath="/lib/modules/$(uname -r)/modules.builtin"
+        if ! grep -q "_/bridge.ko" "$module_filepath"; then
+            echo "It looks like you're on ChromeOS, but haven't installed the Nomad bridge networking workaround."
+            echo "Please see Grapl's BUILDING.md 'Nomad local development setup' for instructions."
+            exit 1
+        fi
+    fi
+}
+
 ensure_valid_env() {
+    ensure_cros_bridge_networking_workaround
+
     # Ensure script is being run with `local-grapl.env` variables
     # via `make start-nomad-ci`
     if [[ ! -v DOCKER_REGISTRY ]]; then


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None.
Jesse ran into this silent failure
and i thought it'd be nice to spend 10m to help prevent people from running in to it in the future.
![image](https://user-images.githubusercontent.com/69007229/136242330-a7e3e56e-2288-46b9-9b28-4ef632439cf5.png)


<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Check for bridge networking when on chrome os
- gitignore something that should have been gitignored
- remove some CDK instructions from building.md

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
tested on my machine with
valid module file
module file sans bridge.ko
no module file

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
