### PR TITLE
Nomad: Exit early if local infra failed to deploy

### DIFF
--- a/nomad/local/nomad_run_local_infra.sh
+++ b/nomad/local/nomad_run_local_infra.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
 GRAPL_ROOT="$(git rev-parse --show-toplevel)"
+
+# shellcheck source-path=SCRIPTDIR
+source "${THIS_DIR}/nomad_cli_tools.sh"
 
 echo "--- Deploying Nomad local infrastructure."
 
@@ -21,5 +25,7 @@ nomad job run \
     -var "FAKE_AWS_ACCESS_KEY_ID=${FAKE_AWS_ACCESS_KEY_ID}" \
     -var "FAKE_AWS_SECRET_ACCESS_KEY=${FAKE_AWS_SECRET_ACCESS_KEY}" \
     "${GRAPL_ROOT}"/nomad/local/grapl-local-infra.nomad
+
+check_for_task_failures_in_job "grapl-local-infra"
 
 echo "--- Nomad local-infra deployed!"


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
none
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
I'm not sure why this isn't necessarily a failure case for `nomad job run`, but, yeah - this will exit early if local infra fails in some way.
(Pulumi-deployed jobs seem to fail automatically as one would expect.)

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I mucked with a health check on a local-infra task, and it exited as expected due to `check_for_task_failures_in_job`.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
