### PR TITLE
Change the Engagement View build to use Docker named volumes for caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,12 +259,15 @@ test-unit-shell: ## Run shunit2 tests under Pants
 	./pants filter --filter-target-type="shunit2_tests" :: \
 	| xargs ./pants test
 
+.PHONY: test-unit-engagement-view
+test-unit-engagement-view: ## Test Engagement View
+	$(MAKE) -C src/js/engagement_view test
+
 .PHONY: test-unit-js
 test-unit-js: export COMPOSE_PROJECT_NAME := grapl-test-unit-js
 test-unit-js: export COMPOSE_FILE := ./test/docker-compose.unit-tests-js.yml
-test-unit-js: build-test-unit-js ## Build and run unit tests - JavaScript only
+test-unit-js: build-test-unit-js test-unit-engagement-view ## Build and run unit tests - JavaScript only
 	test/docker-compose-with-error.sh
-	$(MAKE) -C src/js/engagement_view test
 
 .PHONY: test-typecheck
 test-typecheck: ## Typecheck Python Code
@@ -445,6 +448,8 @@ clean: ## Prune all docker build cache and remove Grapl containers and images
 	docker rm --volumes --force $$(docker ps --filter "name=grapl*" --all --quiet) 2>/dev/null || true
 	# Remove all Grapl images = continue on error (no images found)
 	docker rmi --force $$(docker images --filter reference="grapl/*" --quiet) 2>/dev/null || true
+	# Clean Engagement View
+	$(MAKE) -C src/js/engagement_view clean
 
 .PHONY: clean-mount-cache
 clean-mount-cache: ## Prune all docker mount cache (used by sccache)

--- a/src/js/engagement_view/.gitignore
+++ b/src/js/engagement_view/.gitignore
@@ -1,0 +1,14 @@
+# As recommended by https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
+.yarn/*
+.npm/*
+!.yarn/patches
+!.yarn/releases
+!.yarn/plugins
+!.yarn/sdks
+!.yarn/versions
+
+# We use this with Docker volumes for storing build state and cache
+!.yarn/state/.gitignore
+
+/coverage
+

--- a/src/js/engagement_view/.yarn/state/.gitignore
+++ b/src/js/engagement_view/.yarn/state/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+

--- a/src/js/engagement_view/.yarnrc.yml
+++ b/src/js/engagement_view/.yarnrc.yml
@@ -1,4 +1,13 @@
-yarnPath: ".yarn/releases/yarn-berry.cjs"
-nodeLinker: "node-modules"
-httpTimeout: 60000
+bstatePath: .yarn/state/build-state.yml
+
+cacheFolder: .yarn/state/cache
+
 httpRetry: 3
+
+httpTimeout: 60000
+
+installStatePath: .yarn/state/install-state.gz
+
+nodeLinker: node-modules
+
+yarnPath: .yarn/releases/yarn-berry.cjs

--- a/src/js/engagement_view/Makefile
+++ b/src/js/engagement_view/Makefile
@@ -4,27 +4,38 @@
 
 .DEFAULT_GOAL := build
 
-ASSET_FILTER = -not -path "./node_modules/*" -not -path "./.yarn/*" -not -path "./build/*" -not -path "./build"
-ASSET_DIRS = $(shell find . -type d $(ASSET_FILTER))
-ASSET_FILES = $(shell find . -type f $(ASSET_FILTER))
-
 DOCKER_RUN := docker run \
 		--rm \
 		--interactive \
 		--tty \
 		--user "$(shell id -u):$(shell id -g)" \
 		--workdir /engagement_view \
-		--mount type=bind,source="$(shell pwd)",target=/engagement_view \
 		--env HOME=/engagement_view \
-		node:16-buster-slim
+		--mount type=volume,source=grapl-yarn-state-engagement-view,target=/engagement_view/.yarn/state \
+		--mount type=volume,source=grapl-node-modules-engagement-view,target=/engagement_view/node_modules \
+		--mount type=bind,source="$(shell pwd)",target=/engagement_view \
+		grapl/engagement-view-build-env
 
-node_modules: package.json yarn.lock
+.PHONY: build-env-image
+build-env-image:
+	docker buildx build \
+		--tag grapl/engagement-view-build-env \
+		- < build-env.Dockerfile
+
+.PHONY: node_modules
+node_modules: build-env-image
 	$(DOCKER_RUN) yarn install
 
-build: node_modules $(ASSET_DIRS) $(ASSET_FILES)
-	echo "--- Building Engagement View"
+.PHONY: build
+build: node_modules
 	$(DOCKER_RUN) yarn build
 
 .PHONY: test
 test: node_modules
 	$(DOCKER_RUN) yarn test --coverage --watchAll=false --coverageDirectory=/engagement_view/coverage/
+
+.PHONY: clean
+clean:
+	docker volume rm \
+		grapl-node-modules-engagement-view \
+		grapl-yarn-state-engagement-view

--- a/src/js/engagement_view/build-env.Dockerfile
+++ b/src/js/engagement_view/build-env.Dockerfile
@@ -1,0 +1,8 @@
+FROM node:16-buster-slim
+
+SHELL ["/bin/bash", "-c"]
+
+# Manually create Docker volume mount points so we can set the mode
+# to make them a+w.
+RUN mkdir --mode=777 --parents /engagement_view/{.yarn/state,node_modules}
+


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This has Engagement View mount docker named volumes to cache locations. Previously rebuilds locally would be fast, as the Makefile leveraged non-`PHONY` targets. However, this wasn't great for CI because it'd rebuild from scratch each time (clean repo). This PR caches builds in Docker volumes so previous builds can be preserved across fresh repo clones, which is similar behavior to when we were building these sources in the Dockerfile.

### How were these changes tested?

I test locally by building and rebuilding, as well as building in CI and 'retry'ing a build to ensure the rebuild worked as expected.