### PR TITLE
python integration tests now use a named-docker-volume for the Pants cache. Improve runtime of some hypothesis tests.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,6 +84,7 @@ BUILD @christophermaier
 /test/Dockerfile.cypress @inickles-grapl @andrea-grapl
 /test/package.json @inickles-grapl @andrea-grapl
 /test/yarn.lock @inickles-grapl @andrea-grapl
+/test/run @wimax-grapl
 
 # This needs to be kept at the end??
 .gitkeep @christophermaier

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -147,8 +147,8 @@ job "integration-tests" {
 
   group "python-integration-tests" {
     restart {
-      # I guess I can let it try 2x
-      attempts = 1
+      # Make this a one-shot job. Absolute worst case, Buildkite reruns it for us.
+      attempts = 0
     }
 
     network {
@@ -193,6 +193,18 @@ job "integration-tests" {
           source   = var.grapl_root
           target   = "/mnt/grapl-root"
           readonly = false
+        }
+
+        mount {
+          type = "volume"
+          target = "/mnt/pants-cache"
+          source = "pants-cache-volume"
+          readonly = false
+          volume_options {
+            # Upon initial creation of this volume, *do* copy in the current
+            # contents in the Docker image.
+            no_copy = false
+          }
         }
       }
 

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -196,9 +196,9 @@ job "integration-tests" {
         }
 
         mount {
-          type = "volume"
-          target = "/mnt/pants-cache"
-          source = "pants-cache-volume"
+          type     = "volume"
+          target   = "/mnt/pants-cache"
+          source   = "pants-cache-volume"
           readonly = false
           volume_options {
             # Upon initial creation of this volume, *do* copy in the current

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -91,4 +91,5 @@ ENV PANTS_LOCAL_STORE_DIR=/mnt/pants-cache/lmdb_store
 ENV PANTS_SETUP_CACHE=/mnt/pants-cache/setup
 
 # /mnt/grapl-root is mounted by `integration-tests.nomad` at runtime.
-ENTRYPOINT ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c", "cd /mnt/grapl-root && ./pants filter --filter-target-type='python_tests' :: | xargs ./pants --tag='-needs_work' test --pytest-args='-m integration_test'"]
+# -rA reports stdout/stderr for all tests, not just failed ones.
+ENTRYPOINT ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c", "cd /mnt/grapl-root && ./pants filter --filter-target-type='python_tests' :: | xargs ./pants --tag='-needs_work' test --pytest-args='-m integration_test -rA'"]

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -78,14 +78,17 @@ RUN adduser \
         --shell /bin/bash \
         --uid 2000 \
         pants_ci
-RUN mkdir -p /tmp/pants && chmod -R 777 /tmp/pants
-USER grapl
-RUN mkdir -p /tmp/pants/named_caches && chmod -R 777 /tmp/pants/named_caches
-RUN mkdir -p /tmp/pants/lmdb_store && chmod -R 777 /tmp/pants/lmdb_store
-RUN mkdir -p /tmp/pants/setup && chmod -R 777 /tmp/pants/setup
-ENV PANTS_NAMED_CACHES_DIR=/tmp/pants/named_caches
-ENV PANTS_LOCAL_STORE_DIR=/tmp/pants/lmdb_store
-ENV PANTS_SETUP_CACHE=/tmp/pants/setup
 
-# grapl-root is mounted by Nomad.
+# /mnt/pants-cache is mounted by `integration-tests.nomad` at runtime.
+# It will copy the existing directory structure in.
+RUN mkdir -p /mnt/pants-cache && chmod -R 777 /mnt/pants-cache
+USER grapl
+RUN mkdir -p /mnt/pants-cache/named_caches && chmod -R 777 /mnt/pants-cache/named_caches
+RUN mkdir -p /mnt/pants-cache/lmdb_store && chmod -R 777 /mnt/pants-cache/lmdb_store
+RUN mkdir -p /mnt/pants-cache/setup && chmod -R 777 /mnt/pants-cache/setup
+ENV PANTS_NAMED_CACHES_DIR=/mnt/pants-cache/named_caches
+ENV PANTS_LOCAL_STORE_DIR=/mnt/pants-cache/lmdb_store
+ENV PANTS_SETUP_CACHE=/mnt/pants-cache/setup
+
+# /mnt/grapl-root is mounted by `integration-tests.nomad` at runtime.
 ENTRYPOINT ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c", "cd /mnt/grapl-root && ./pants filter --filter-target-type='python_tests' :: | xargs ./pants --tag='-needs_work' test --pytest-args='-m integration_test'"]

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -91,5 +91,5 @@ ENV PANTS_LOCAL_STORE_DIR=/mnt/pants-cache/lmdb_store
 ENV PANTS_SETUP_CACHE=/mnt/pants-cache/setup
 
 # /mnt/grapl-root is mounted by `integration-tests.nomad` at runtime.
-# -rA reports stdout/stderr for all tests, not just failed ones.
-ENTRYPOINT ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c", "cd /mnt/grapl-root && ./pants filter --filter-target-type='python_tests' :: | xargs ./pants --tag='-needs_work' test --pytest-args='-m integration_test -rA'"]
+WORKDIR /mnt/grapl-root
+CMD ["./test/run/integration-tests-from-docker-container.sh"]

--- a/src/python/graphql_endpoint_tests/test_graphql_endpoint.py
+++ b/src/python/graphql_endpoint_tests/test_graphql_endpoint.py
@@ -42,7 +42,7 @@ class TestGraphqlEndpoint(TestCase):
     @hypothesis.given(
         asset_props=asset_props_strategy(),
     )
-    @hypothesis.settings(deadline=None)
+    @hypothesis.settings(deadline=None, max_examples=25)
     def test_create_lens_shows_up_in_graphql(
         self,
         asset_props: AssetProps,

--- a/src/python/grapl-tests-common/grapl_tests_common/setup_tests.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/setup_tests.py
@@ -42,7 +42,10 @@ def exec_pytest() -> int:
 
     result = pytest.main(
         [
-            "--capture=no",  # disable stdout capture
+            # Disables stdout capture. Different from `-rA` in that you can see
+            # the output streaming in real time, as opposed to just reported
+            # after the fact. This is convenient for the timeout-heavy e2e test
+            "--capture=no",
             f"--log-level={GRAPL_LOG_LEVEL}",
             f"--log-cli-level={GRAPL_LOG_LEVEL}",
             *pytest_args,

--- a/src/python/grapl-tests-common/grapl_tests_common/setup_tests.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/setup_tests.py
@@ -42,12 +42,12 @@ def exec_pytest() -> int:
 
     result = pytest.main(
         [
-            "--capture=no",
+            "--capture=no",  # disable stdout capture
             f"--log-level={GRAPL_LOG_LEVEL}",
             f"--log-cli-level={GRAPL_LOG_LEVEL}",
             *pytest_args,
         ]
-    )  # disable stdout capture
+    )
     _after_tests()
 
     return result

--- a/src/python/grapl_analyzerlib/tests/test_process_node.py
+++ b/src/python/grapl_analyzerlib/tests/test_process_node.py
@@ -66,9 +66,12 @@ def get_or_create_process_node_deprecated(
     )
 
 
+common_hypo_settings = hypothesis.settings(deadline=None, max_examples=25)
+
+
 @pytest.mark.integration_test
 class TestProcessQuery(unittest.TestCase):
-    @hypothesis.settings(deadline=None)
+    @hypothesis.settings(parent=common_hypo_settings)
     @given(process_props=process_props_strategy())
     def test_single_process_contains_key(self, process_props: ProcessProps) -> None:
         graph_client = GraphClient()
@@ -94,7 +97,7 @@ class TestProcessQuery(unittest.TestCase):
 
         assert not queried_proc.get_asset()
 
-    @hypothesis.settings(deadline=None)
+    @hypothesis.settings(parent=common_hypo_settings)
     @given(
         asset_props=asset_props_strategy(),
         process_props=process_props_strategy(),
@@ -131,7 +134,7 @@ class TestProcessQuery(unittest.TestCase):
 
     # Given that the code that generates timestamps only uses unsized types we can make some
     # assumptions about the data
-    @hypothesis.settings(deadline=None)
+    @hypothesis.settings(parent=common_hypo_settings)
     @given(process_props=process_props_strategy())
     def test_process_query_view_parity(self, process_props: ProcessProps):
         graph_client = GraphClient()
@@ -162,7 +165,7 @@ class TestProcessQuery(unittest.TestCase):
         assert process_props["image_name"] == queried_proc.get_image_name()
         assert process_props["process_name"] == queried_proc.get_process_name()
 
-    @hypothesis.settings(deadline=None)
+    @hypothesis.settings(parent=common_hypo_settings)
     @given(
         node_key=st.uuids(),
         process_id=st.integers(min_value=1, max_value=2 ** 32),
@@ -217,7 +220,7 @@ class TestProcessQuery(unittest.TestCase):
         assert image_name == queried_proc.get_image_name()
         assert process_name == queried_proc.get_process_name()
 
-    @hypothesis.settings(deadline=None)
+    @hypothesis.settings(parent=common_hypo_settings)
     @given(process_props=process_props_strategy())
     def test_process_query_view_miss(self, process_props: ProcessProps) -> None:
         graph_client = GraphClient()
@@ -249,7 +252,7 @@ class TestProcessQuery(unittest.TestCase):
     # Given that the code that generates timestamps only uses unsized types we can make some
     # assumptions about the data
 
-    @hypothesis.settings(deadline=None)
+    @hypothesis.settings(parent=common_hypo_settings)
     @given(
         node_key=st.uuids(),
         process_id=st.integers(min_value=1, max_value=2 ** 32),

--- a/test/run/BUILD
+++ b/test/run/BUILD
@@ -1,0 +1,1 @@
+shell_library()

--- a/test/run/integration-tests-from-docker-container.sh
+++ b/test/run/integration-tests-from-docker-container.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This script is meant to be run by the CMD in
+# python-integration-tests
+
+set -euo pipefail
+
+run_pants_python_tests() {
+    local -r pytest_args="$1"
+    ./pants filter --filter-target-type='python_tests' :: |
+        xargs ./pants --tag='-needs_work' test --pytest-args="${pytest_args}"
+}
+
+# -rA means "report stdout/stderr for all tests, not just failing tests"
+# -m integration_test limits it to integration tests.
+run_pants_python_tests "-m integration_test -rA"


### PR DESCRIPTION
### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/706

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Python integration tests now use a mounted Docker volume for caching. This will improve runtime in CI and locally (after an initial "slow" populate-stuff run.)
- Some slower Hypothesis tests were reduced from 100 examples to 25 examples.
- Modified behavior of stdout/stderr getting printed during integration-test time.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
`make test-integration`

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
