### PR TITLE
A stab at improving the 'failed-to-place-allocation' failure in build…

### DIFF
--- a/nomad/local/nomad_run_local_infra.sh
+++ b/nomad/local/nomad_run_local_infra.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
 GRAPL_ROOT="$(git rev-parse --show-toplevel)"
+NOMAD_FILE="${GRAPL_ROOT}/nomad/local/grapl-local-infra.nomad"
 
 # shellcheck source-path=SCRIPTDIR
 source "${THIS_DIR}/nomad_cli_tools.sh"
@@ -11,7 +12,7 @@ echo "--- Deploying Nomad local infrastructure."
 
 # Wait a short period of time before attempting to deploy infrastructure
 # shellcheck disable=SC2016
-timeout 120 bash -c -- 'while [[ -z $(nomad status 2>&1 | grep running) ]]; do printf "Waiting for nomad-agent\n";sleep 1;done'
+timeout 60 bash -c -- 'while [[ -z $(nomad node status 2>&1 | grep ready) ]]; do printf "Waiting for nomad-agent\n";sleep 1;done'
 
 nomad job run -verbose \
     -var "KAFKA_JMX_PORT=${KAFKA_JMX_PORT}" \
@@ -21,7 +22,7 @@ nomad job run -verbose \
     -var "ZOOKEEPER_PORT=${ZOOKEEPER_PORT}" \
     -var "FAKE_AWS_ACCESS_KEY_ID=${FAKE_AWS_ACCESS_KEY_ID}" \
     -var "FAKE_AWS_SECRET_ACCESS_KEY=${FAKE_AWS_SECRET_ACCESS_KEY}" \
-    "${GRAPL_ROOT}"/nomad/local/grapl-local-infra.nomad
+    "${NOMAD_FILE}"
 
 echo "Nomad Job Run complete, checking for task failures"
 


### PR DESCRIPTION
We unexpectedly get exit code 2s from the `nomad job run` in this file due to "failed to place allocation"

I suspect that the existing heuristic was bad; it previously just waited for `nomad status` to say `no running jobs`. 

Now it waits for the node to say it's ready.

(related discussion: https://discuss.hashicorp.com/t/making-sense-of-failed-to-place-allocation-logs/30490 )