### PR TITLE
Remove UX artifact build gate

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -81,20 +81,6 @@ steps:
     artifact_paths:
       - "*.grapl-artifacts.json"
 
-  - label: ":thinking_face: UX Build?"
-    plugins:
-      - chronotc/monorepo-diff#v2.0.4:
-          diff: .buildkite/shared/scripts/diff.sh
-          log_level: "debug"
-          watch:
-            - path:
-                - "src/js/engagement_view/"
-                - ".buildkite/scripts/upload_ux_assets.sh"
-                - ".buildkite/pipeline.merge.ux-build.yml"
-              config:
-                label: ":pipeline: Upload UX Build"
-                command: "buildkite-agent pipeline upload .buildkite/pipeline.merge.ux-build.yml"
-
   - wait
 
   # Downloads and operates on all the *.grapl-artifacts.json files


### PR DESCRIPTION
Building a separate UX artifact was removed, along with the scripts
and Buildkite pipeline to do it, but this test to determine if we
needed to build the artifact in the first place was left behind,
causing overall pipeline failures if the source code for the
engagement view changed (because the separate pipeline file no longer
exists).

Signed-off-by: Christopher Maier <chris@graplsecurity.com>