### PR TITLE
Add container_repo to images

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -974,7 +974,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/grapl-web-ui:${var.web_ui_tag}"
+        image = "${var.container_registry}grapl/${var.container_repo}grapl-web-ui:${var.web_ui_tag}"
         ports = ["web-ui-port"]
       }
 
@@ -1054,7 +1054,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/osquery-generator:${var.sysmon_generator_tag}"
+        image = "${var.container_registry}grapl/${var.container_repo}osquery-generator:${var.sysmon_generator_tag}"
       }
 
       template {

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1054,7 +1054,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}osquery-generator:${var.sysmon_generator_tag}"
+        image = "${var.container_registry}grapl/${var.container_repo}osquery-generator:${var.osquery_generator_tag}"
       }
 
       template {

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -8,6 +8,12 @@ variable "container_registry" {
   description = "The container registry in which we can find Grapl services. Requires a trailing /"
 }
 
+variable "container_repo" {
+  type        = string
+  default     = ""
+  description = "The container repo inside the registry in which we can find Grapl services. Requires a trailing / if not empty string"
+}
+
 variable "aws_region" {
   type = string
 }
@@ -119,7 +125,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/rust-integration-tests:dev"
+        image = "${var.container_registry}grapl/${var.container_repo}rust-integration-tests:dev"
       }
 
       env {
@@ -180,7 +186,7 @@ job "integration-tests" {
       user   = var.docker_user
 
       config {
-        image = "${var.container_registry}grapl/python-integration-tests:dev"
+        image = "${var.container_registry}grapl/${var.container_repo}python-integration-tests:dev"
         # Pants caches requirements per-user. So when we run a Docker container
         # with the host's userns, this lets us reuse the pants cache.
         # (This descreases runtime on my personal laptop from 390s to 190s)


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Some of our images in nomad files were missing the container_repo variable. This caused them to fail to be pulled in Nomad in AWS. I've also added them to the integration tests since we may want to run those in AWS at some point. Notably local-grapl does not have this nor do containers pulled from outside of cloudsmith such as dgraph (if we chose to mirror these containers we would need to add them)
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Did a test deploy to Nomad in AWS
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
