### PR TITLE
Autofix local nomad chrome workaround

### DIFF
--- a/etc/chromeos/BUILD
+++ b/etc/chromeos/BUILD
@@ -1,0 +1,1 @@
+shell_library()

--- a/etc/chromeos/lib/BUILD
+++ b/etc/chromeos/lib/BUILD
@@ -1,0 +1,1 @@
+shell_library()

--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# This is a WIP set up script for chromeOS. Some commands may break by the time the script is next used
-# TODO ensure idempotency
 
 ## helper functions
 get_latest_release() {
@@ -100,23 +98,11 @@ install_cni_plugins() {
     curl -sL https://github.com/containernetworking/plugins/releases/latest | grep "linux-amd64" | grep -v "sha" | grep -v "span" | awk '{ print $2 }' | awk -F'"' '{ print "https://github.com"$2 }' | wget -qi -
     sudo tar -xf "cni-plugins-linux-amd64-$VERSION.tgz"
     sudo rm "cni-plugins-linux-amd64-$VERSION.tgz"
+}
 
+install_nomad_chromeos_workaround() {
     echo "Setting up workaround for Nomad linux fingerprinting bug"
     echo "See https://github.com/hashicorp/nomad/issues/10902 for more context"
     sudo mkdir -p "/lib/modules/$(uname -r)/"
     echo '_/bridge.ko' | sudo tee -a "/lib/modules/$(uname -r)/modules.builtin"
 }
-
-echo "Starting ChromeOS automated setup"
-update_linux
-fix_shell_completion
-install_build_tooling
-install_docker
-install_rust_and_utilities
-install_pyenv
-install_nvm
-install_awsv2
-install_pulumi
-install_utilities
-install_hashicorp_tools
-install_cni_plugins

--- a/etc/chromeos/setup_chromeos.sh
+++ b/etc/chromeos/setup_chromeos.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# This is a WIP set up script for chromeOS. Some commands may break by the time the script is next used
+# TODO ensure idempotency
+
+source etc/chromeos/lib/installs.sh
+
+echo "Starting ChromeOS automated setup"
+update_linux
+fix_shell_completion
+install_build_tooling
+install_docker
+install_rust_and_utilities
+install_pyenv
+install_nvm
+install_awsv2
+install_pulumi
+install_utilities
+install_hashicorp_tools
+install_cni_plugins
+install_nomad_chromeos_workaround

--- a/nomad/local/start_detach.sh
+++ b/nomad/local/start_detach.sh
@@ -18,8 +18,8 @@ ensure_cros_bridge_networking_workaround() {
         module_filepath="/lib/modules/$(uname -r)/modules.builtin"
         if ! grep -q "_/bridge.ko" "$module_filepath"; then
             echo "It looks like you're on ChromeOS, but haven't installed the Nomad bridge networking workaround."
-            echo "Please see Grapl's BUILDING.md 'Nomad local development setup' for instructions."
-            exit 1
+            source etc/chromeos/lib/installs.sh
+            install_nomad_chromeos_workaround
         fi
     fi
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Automatically fix the chrome workaround. This will be a recurring issue whenever the chromeos linux kernel updates

I've moved the setup script, and split it into a library file and an exec file. 
I've then updated start_detach to try autofixing the nomad issue using the workaround function

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
