### PR TITLE
Transfer code ownership of `nomad` directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@ BUILD @christophermaier
 /local-grapl.env @christophermaier
 /LOCAL_UI_WORKFLOW.md @christophermaier
 /Makefile @christophermaier
-/nomad @d0nut-grapl
+/nomad @twunderlich-grapl
 /pants @christophermaier
 /pants.ci.toml @christophermaier
 /pants-plugins/ @christophermaier


### PR DESCRIPTION
Signed-off-by: Christopher Maier <chris@graplsecurity.com>
