### PR TITLE
Port docs builds to Myst instead of eol Recommonmark; upgrade Sphinx.

### DIFF
--- a/docs/analyzers/deploying.md
+++ b/docs/analyzers/deploying.md
@@ -1,3 +1,5 @@
+# Deploying Analyzers
+
 Once you've written your Analyzers you'll want to deploy them to Grapl.
 
 Analyzers live in the `<DEPLOYMENT_NAME>-grapl-analyzers`, so all we need to do
@@ -34,7 +36,7 @@ As an example,
 [insanitybit/grapl-analyzers](https://github.com/insanitybit/grapl-analyzers) is
 set up to use this webhook.
 
-#### Deploy
+### Deploy
 
 To get started you'll need to install [npm](https://www.npmjs.com/),
 [typescript](https://www.typescriptlang.org/index.html#download-links), and the

--- a/docs/analyzers/implementing.md
+++ b/docs/analyzers/implementing.md
@@ -1,11 +1,11 @@
-## Analyzers
+# Analyzers
 
 Analyzers are the attack signatures that power Grapl's realtime detection logic.
 
 Though implementing analyzers is simple, we can build extremely powerful and
 efficient logic to catch all sorts of attacker behaviors.
 
-### The Analyzer Base Class
+## The Analyzer Base Class
 
 To implement an Analyzer we must inherit from the Analyzer
 [abstract base class](https://docs.python.org/3/library/abc.html).
@@ -30,7 +30,7 @@ class Analyzer(abc.ABC):
         pass
 ```
 
-###### Analyzer.build
+### Analyzer.build
 
 Returns an instance of your analyzer. This allows you to move dependency
 management out of your `__init__`.
@@ -44,7 +44,7 @@ def build(cls: Type[A], graph_client: GraphClient) -> A:
     return cls(dgraph_client)
 ```
 
-###### Analyzer.get_queries
+### Analyzer.get_queries
 
 `get_queries` is where you define any of your graph signatures, either one or
 multiple.
@@ -59,7 +59,7 @@ def get_queries(self) -> OneOrMany[Queryable]:
     pass
 ```
 
-###### Analyzer.on_response
+### Analyzer.on_response
 
 `on_response` is called if any of the sigantures from `get_queries` matched a
 graph.
@@ -79,7 +79,7 @@ def on_response(self, response: Viewable, output: Any):
     pass
 ```
 
-#### SuspiciousSvchost Example
+## SuspiciousSvchost Example
 
 Heres an example - we're going to write some logic to look for suspicious
 executions of `svchost`.
@@ -159,7 +159,7 @@ Our query is therefor read as: Any Process, with a process_name that exactly
 matches `invalid_parents`, with any child process, where the child process_name
 that exactly matches `svchost.exe`.
 
-#### Adding Context
+## Adding Context
 
 We may want to add some optional context to our query, without requiring that
 context for our Analyzer to match. We can do this easily in our `on_response`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,8 +44,7 @@ author = "Grapl Security"
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
-    # TODO: Upgrade to Myst parser; recommonmark is EOL
-    "recommonmark",
+    "myst_parser",
     "sphinx_rtd_theme",
 ]
 
@@ -82,17 +81,4 @@ autodoc_default_options = {
 
 
 def setup(app):
-    app.add_config_value(
-        "recommonmark_config",
-        {
-            "enable_auto_toc_tree": True,
-            #'auto_toc_tree_section': 'Contents',
-            #'enable_math': False,
-            #'enable_inline_math': False,
-            "enable_eval_rst": True,
-        },
-        True,
-    )
-    from recommonmark.transform import AutoStructify
-
-    app.add_transform(AutoStructify)
+    pass

--- a/docs/queryable.md
+++ b/docs/queryable.md
@@ -1,4 +1,4 @@
-## Queryables
+# Queryables
 
 Grapl provides powerful primitives for building graph based queries.
 
@@ -25,7 +25,7 @@ one_process = ProcessQuery().query_first(gclient)
 count = ProcessQuery().get_count(gclient)
 ```
 
-###### Queryable.query
+## Queryable.query
 
 Query the graph for all nodes that match.
 
@@ -46,7 +46,7 @@ Query the graph for all nodes that match.
         pass
 ```
 
-###### Queryable.query_first
+## Queryable.query_first
 
 Query the graph for the first node that matches.
 
@@ -64,7 +64,7 @@ Query the graph for the first node that matches.
         pass
 ```
 
-###### Queryable.get_count
+## Queryable.get_count
 
 Query the graph, counting all matches.
 
@@ -108,9 +108,9 @@ query.query_first(mclient, contains_node_key="node-key-to-query")
 In this case, if our signature matches such that any of the nodes A, B, C, have
 the node_key "node-key-to-query", we have a match - otherwise, no match.
 
-### And, Or, Not
+## Boolean Logic
 
-##### And
+### And
 
 For a single predicate constraint (with\_\* method) all constraints are
 considered And'd.
@@ -122,7 +122,7 @@ ProcessQuery()
 .with_process_name(contains=["foo", "bar"])
 ```
 
-##### Or
+### Or
 
 Multiple predicate constraints are considered Or'd.
 
@@ -134,7 +134,7 @@ ProcessQuery()
 .with_process_name(contains="bar")
 ```
 
-##### Not
+### Not
 
 Any constraint can be wrapped in a Not to negate the constraint.
 
@@ -145,7 +145,7 @@ ProcessQuery()
 .with_process_name(contains=Not("foo"))
 ```
 
-##### All Together
+### All Together
 
 This query matches a process with a process*name that either is \_not* 'foo' but
 ends with '.exe', _or_ it will match a process with a process containing "bar"
@@ -156,6 +156,8 @@ ProcessQuery()
 .with_process_name(contains=Not("foo"), ends_eith=".exe")
 .with_process_name(contains=["bar", baz])
 ```
+
+## Filters and functions
 
 ### with\_\* methods
 
@@ -181,7 +183,7 @@ def with_process_name(
 The `process_name` field is indexed such that we can constrain our query
 through:
 
-###### eq
+### eq
 
 Matches a node's `process_name` if it exactly matches `eq`
 
@@ -189,7 +191,7 @@ Matches a node's `process_name` if it exactly matches `eq`
 ProcessQuery().with_process_name(eq="svchost.exe")
 ```
 
-###### contains
+### contains
 
 Matches a node's `process_name` if it contains `contains`
 
@@ -197,7 +199,7 @@ Matches a node's `process_name` if it contains `contains`
 ProcessQuery().with_process_name(contains="svc")
 ```
 
-###### ends_with
+### ends_with
 
 Matches a node's `process_name` if it ends with `ends_with`
 
@@ -205,7 +207,7 @@ Matches a node's `process_name` if it ends with `ends_with`
 ProcessQuery().with_process_name(ends_with=".exe")
 ```
 
-###### starts_with
+### starts_with
 
 Matches a node's `process_name` if it starts with `starts_with`
 
@@ -213,7 +215,7 @@ Matches a node's `process_name` if it starts with `starts_with`
 ProcessQuery().with_process_name(starts_with="svchost")
 ```
 
-###### regexp
+### regexp
 
 Matches a node's `process_name` if it matches the regexp pattern `regexp`
 
@@ -221,7 +223,7 @@ Matches a node's `process_name` if it matches the regexp pattern `regexp`
 ProcessQuery().with_process_name(regexp="svc.*exe")
 ```
 
-###### distance
+### distance
 
 Matches a node's `process_name` if it has a string distance of less than the
 provided threshold
@@ -230,7 +232,7 @@ provided threshold
 ProcessQuery().with_process_name(distance=("svchost", 2))
 ```
 
-#### Example
+### Example
 
 Here's an example where we look for processes with a `process_name` that is
 _not_ equal to `svchost.exe`, but that has a very close string distance to it.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 ### Doc generation
-Sphinx==3.1.2
+Sphinx==4.2.0
 # markdown support for sphinx
-recommonmark
+myst-parser==0.15.2
 sphinx-rtd-theme==0.5.1
 
 ### General Python stuff


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/764

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Remove recommonmark
- Introduce myst-parser (the new recommended way to do markdown sphinx stuff)
- Fix some non-sequential headers (like #one to ###three)

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
![image](https://user-images.githubusercontent.com/69007229/138971890-f4b0cf54-5ace-47aa-aa55-54671a5daeb0.png)

all works fine after a `make build-docs`

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
