### PR TITLE
Loosen failure threshold for Codecov reporting

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -17,6 +17,9 @@ steps:
           image: "node"
           entrypoint: "bash"
 
+  - label: ":codecov: Validate codecov.yml"
+    command: curl --data-binary @codecov.yml https://codecov.io/validate
+
   - label: ":large_blue_square::lint-roller: Lint Protobuf"
     command:
       - make lint-proto

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@ BUILD @christophermaier
 /build-support/ @christophermaier
 /CHORES.md @christophermaier
 /CODE_OF_CONDUCT.md @christophermaier
+/codecov.yml @christophermaier
 /CONTRIBUTING.md @christophermaier
 /debugger/ @christophermaier
 /docker-compose*.yml @christophermaier

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+---
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
We've noticed a little flapping in our code coverage statistics around
our Rust protobuf generation, where unrelated changes appear to reduce
coverage. With the default settings, _any_ decrease in coverage
results in a "failure" in Github. We don't gate PR merges on coverage
changes at this point, so these "failures" end up being noise.

Until we sort out this flapping, we'll make the code coverage
reporting more advisory by losening the failure threshold to 1%. This
should reduce spurious failure statuses in Github.

A linting step has also been added in CI.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>