### PR TITLE
Nomad ingress on port 1234 has the correct upstream.

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -310,7 +310,6 @@ locals {
   redis_port     = local._redis[1]
 
   # Grapl services
-  web_ui_port           = 1234
   graphql_endpoint_port = 5000
 
   # enabled
@@ -1001,8 +1000,6 @@ job "grapl-core" {
       mode = "bridge"
 
       port "web-ui-port" {
-        static = local.web_ui_port
-        to     = local.web_ui_port
       }
     }
 

--- a/nomad/grapl-ingress.nomad
+++ b/nomad/grapl-ingress.nomad
@@ -28,7 +28,7 @@ job "grapl-ingress" {
               protocol = "tcp"
               service {
                 # the upstream service
-                name = "grapl-web-ui"
+                name = "web-ui"
               }
             }
           }


### PR DESCRIPTION
Okay, so let me preface this by saying: I'm not really sure how this worked before.

Previously the ingress gateway said its upstream (the service it serves) would be "grapl-web-ui"; that never actually existed, this service is called web-ui!

This also solves a mystery I had, where for some reason the `web-ui`'s ports had to be specified and exactly the same as the ingress.

Anyway - all the weirdness is removed, web-ui has a dynamicly assigned port now, and the ingress gateway correctly sends stuff to it.