### PR TITLE
Grapl Pulumi constructs an API Gateway route to `grapl-web-ui`

### DIFF
--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -402,7 +402,7 @@ def main() -> None:
             "grapl-api-gateway",
             nomad_agents_alb_security_group=nomad_agent_alb_security_group_id,
             nomad_agents_alb_listener_arn=nomad_agent_alb_listener_arn,
-            private_subnet_ids=nomad_agent_subnet_ids,
+            nomad_agents_private_subnet_ids=nomad_agent_subnet_ids,
             opts=pulumi.ResourceOptions(
                 depends_on=[nomad_grapl_ingress],
             ),

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -291,7 +291,9 @@ def main() -> None:
 
         vpc_id = networking_stack.require_output("grapl-vpc")
         subnet_ids = networking_stack.require_output("grapl-private-subnet-ids")
-        nomad_agent_security_group_id = nomad_agents_stack.require_output("security-group")
+        nomad_agent_security_group_id = nomad_agents_stack.require_output(
+            "security-group"
+        )
         nomad_agent_alb_security_group_id = nomad_agents_stack.require_output(
             "alb-security-group"
         )
@@ -306,7 +308,7 @@ def main() -> None:
             "main-cache",
             subnet_ids=subnet_ids,
             vpc_id=vpc_id,
-            nomad_agent_security_group_id=nomad_agent_security_group_id
+            nomad_agent_security_group_id=nomad_agent_security_group_id,
         )
         artifacts = pulumi_config.require_object("artifacts")
 

--- a/pulumi/infra/api_gateway.py
+++ b/pulumi/infra/api_gateway.py
@@ -84,14 +84,14 @@ class ApiGateway(pulumi.ComponentResource):
 
         # Use apigwv2's VpcLink for http integrations.
         vpc_link = aws.apigatewayv2.VpcLink(
-            "vpc-link-to-nomad-ingress",
+            "{name}-vpc-link-to-nomad-ingress",
             security_group_ids=[nomad_agents_alb_security_group],
             subnet_ids=nomad_agents_private_subnet_ids,
             opts=pulumi.ResourceOptions(parent=api),
         )
 
         integration = aws.apigatewayv2.Integration(
-            "vpc-link-integration",
+            f"{name}-vpc-link-integration",
             api_id=api.id,
             connection_id=vpc_link.id,
             connection_type="VPC_LINK",
@@ -103,7 +103,7 @@ class ApiGateway(pulumi.ComponentResource):
         )
 
         route = aws.apigatewayv2.Route(
-            "vpc-link-route",
+            f"{name}-vpc-link-route",
             api_id=api.id,
             route_key=_API_GATEWAY_DEFAULT_ROUTE_KEY,
             # For info on this weird transformation, see
@@ -120,7 +120,7 @@ class ApiGateway(pulumi.ComponentResource):
         )
 
         self.stage = aws.apigatewayv2.Stage(
-            "vpc-link-stage",
+            f"{name}-vpc-link-stage",
             name=_API_GATEWAY_DEFAULT_STAGE_NAME,
             api_id=api.id,
             auto_deploy=True,

--- a/pulumi/infra/api_gateway.py
+++ b/pulumi/infra/api_gateway.py
@@ -35,6 +35,21 @@ class ApiGateway(pulumi.ComponentResource):
         private_subnet_ids: pulumi.Input[List[str]],
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
+        """
+        Quick diatribe on how this is all hooked up:
+        Incoming request
+        --> API Gateway Route (snapshotted as a Stage)
+        --> API Gateway "integration"
+        --> VPCLink
+          (everything beyond here is defined in `platform-infrastructure`)
+        --> Nomad Agents ALB Listener (listen on :80, forward to ALB)
+        --> Nomad Agents ALB
+        --> ALB Target Group's :1234
+        --> a real Nomad Agent instance :1234
+          (everything beyond here is defined in Nomad job files)
+        --> Nomad ingress gateway (`grapl-ingress.nomad`)
+        --> `web-ui` service
+        """
         super().__init__("grapl:ApiGateway", name, None, opts)
 
         api = aws.apigatewayv2.Api(

--- a/pulumi/infra/api_gateway.py
+++ b/pulumi/infra/api_gateway.py
@@ -1,0 +1,96 @@
+import json
+from typing import List, Optional
+
+import pulumi_aws as aws
+
+import pulumi
+
+API_GATEWAY_LOGS_JSON_FORMAT = json.dumps(
+    {
+        # This is verbatim what you get from clicking the JSON button at
+        # https://console.aws.amazon.com/apigateway/main/monitor/logging/edit
+        "requestId": "$context.requestId",
+        "ip": "$context.identity.sourceIp",
+        "requestTime": "$context.requestTime",
+        "httpMethod": "$context.httpMethod",
+        "routeKey": "$context.routeKey",
+        "status": "$context.status",
+        "protocol": "$context.protocol",
+        "responseLength": "$context.responseLength",
+        # And some extra- integration-specific ones.
+        "integrationError": "$context.integration.error",
+        "integrationStatus": "$context.integration.status",
+        "responseType": "$context.error.responseType",
+        "message": "$context.error.message",
+    }
+)
+
+
+class ApiGateway(pulumi.ComponentResource):
+    def __init__(
+        self,
+        name: str,
+        nomad_agents_alb_security_group: pulumi.Input[str],
+        nomad_agents_alb_listener_arn: pulumi.Input[str],
+        private_subnet_ids: pulumi.Input[List[str]],
+        opts: Optional[pulumi.ResourceOptions] = None,
+    ) -> None:
+        super().__init__("grapl:ApiGateway", name, None, opts)
+
+        api = aws.apigatewayv2.Api(
+            "api",
+            protocol_type="HTTP",
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        # Use apigwv2's VpcLink for http integrations.
+        link = aws.apigatewayv2.VpcLink(
+            "vpc_link_to_ec2",
+            security_group_ids=[nomad_agents_alb_security_group],
+            subnet_ids=private_subnet_ids,
+            opts=pulumi.ResourceOptions(parent=api),
+        )
+
+        integration = aws.apigatewayv2.Integration(
+            "integration",
+            api_id=api.id,
+            connection_id=link.id,
+            connection_type="VPC_LINK",
+            integration_method="ANY",
+            integration_type="HTTP_PROXY",
+            integration_uri=nomad_agents_alb_listener_arn,
+            request_parameters={
+                # AWS calls this "Parameter Mapping."
+                # This one strips the `/stage-xyz` from incoming requests.
+                "overwrite:path": "$request.path",
+            },
+            opts=pulumi.ResourceOptions(parent=api),
+        )
+
+        default_route = aws.apigatewayv2.Route(
+            "default_route",
+            api_id=api.id,
+            route_key="$default",
+            target=integration.id.apply(lambda id: f"integrations/{id}"),
+            opts=pulumi.ResourceOptions(parent=api),
+        )
+
+        stage_logs = aws.cloudwatch.LogGroup(
+            f"{name}-log-group",
+            name=f"/{name}-apigw_stage_logs",
+            retention_in_days=7,
+            opts=pulumi.ResourceOptions(parent=api),
+        )
+
+        self.stage = aws.apigatewayv2.Stage(
+            "stage",
+            api_id=api.id,
+            auto_deploy=True,
+            access_log_settings=aws.apigatewayv2.StageAccessLogSettingsArgs(
+                destination_arn=stage_logs.arn,
+                format=API_GATEWAY_LOGS_JSON_FORMAT,
+            ),
+            opts=pulumi.ResourceOptions(parent=api),
+        )
+
+        self.register_outputs({})

--- a/pulumi/infra/api_gateway.py
+++ b/pulumi/infra/api_gateway.py
@@ -74,11 +74,6 @@ class ApiGateway(pulumi.ComponentResource):
             integration_method="ANY",
             integration_type="HTTP_PROXY",
             integration_uri=nomad_agents_alb_listener_arn,
-            request_parameters={
-                # AWS calls this "Parameter Mapping."
-                # This one strips the `/stage-xyz` from incoming requests.
-                "overwrite:path": "$request.path",
-            },
             opts=pulumi.ResourceOptions(parent=api),
         )
 
@@ -99,6 +94,12 @@ class ApiGateway(pulumi.ComponentResource):
 
         self.stage = aws.apigatewayv2.Stage(
             "stage",
+            # Naming it $default means that the stage is served from
+            # https://api-id.execute-api.us-east-1.amazonaws.com/
+            # instead of something like
+            # https://api-id.execute-api.us-east-1.amazonaws.com/stage-1a2b3c4
+            # this makes it much easier to reference stuff in e.g. `<domain>/static/`
+            name="$default",
             api_id=api.id,
             auto_deploy=True,
             access_log_settings=aws.apigatewayv2.StageAccessLogSettingsArgs(

--- a/pulumi/infra/api_gateway.py
+++ b/pulumi/infra/api_gateway.py
@@ -2,10 +2,11 @@ import json
 from typing import List, Optional
 
 import pulumi_aws as aws
+from typing_extensions import Final
 
 import pulumi
 
-API_GATEWAY_LOGS_JSON_FORMAT = json.dumps(
+API_GATEWAY_LOGS_JSON_FORMAT: Final[str] = json.dumps(
     {
         # This is verbatim what you get from clicking the JSON button at
         # https://console.aws.amazon.com/apigateway/main/monitor/logging/edit
@@ -25,14 +26,37 @@ API_GATEWAY_LOGS_JSON_FORMAT = json.dumps(
     }
 )
 
+# > The $default route catches requests that don't explicitly match other
+# > routes in your API.
+# https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-routes.html
+#
+# Since we want to send *all* routes to `web-ui`, this captures all routes.
+_API_GATEWAY_DEFAULT_ROUTE_KEY: Final[str] = "$default"
+
+# > You can create a $default stage that is served from the base of your API's
+# > URL—for example, https://{api_id}.execute-api.{region}.amazonaws.com/.
+# > You use this URL to invoke an API stage.
+# https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-stages.html
+#
+# Naming it $default means that the stage is served from
+# https://api-id.execute-api.us-east-1.amazonaws.com/
+# instead of something like
+# https://api-id.execute-api.us-east-1.amazonaws.com/stage-1a2b3c4
+# this makes it much easier to reference stuff in e.g. `<domain>/static/`
+_API_GATEWAY_DEFAULT_STAGE_NAME: Final[str] = "$default"
+
 
 class ApiGateway(pulumi.ComponentResource):
     def __init__(
         self,
         name: str,
+        # These 2 properties are exported from nomad_agents_stack and refer
+        # to the application load balancer on the autoscaling group.
         nomad_agents_alb_security_group: pulumi.Input[str],
         nomad_agents_alb_listener_arn: pulumi.Input[str],
-        private_subnet_ids: pulumi.Input[List[str]],
+        # This property is exported from networking_stack and defines the
+        # subnet the Nomad Agents Cluster runs on
+        nomad_agents_private_subnet_ids: pulumi.Input[List[str]],
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
         """
@@ -42,10 +66,10 @@ class ApiGateway(pulumi.ComponentResource):
         --> API Gateway "integration"
         --> VPCLink
           (everything beyond here is defined in `platform-infrastructure`)
-        --> Nomad Agents ALB Listener (listen on :80, forward to ALB)
+        --> Nomad Agents ALB Listener port
         --> Nomad Agents ALB
-        --> ALB Target Group's :1234
-        --> a real Nomad Agent instance :1234
+        --> ALB Target Group's port
+        --> a real Nomad Agent instance's port
           (everything beyond here is defined in Nomad job files)
         --> Nomad ingress gateway (`grapl-ingress.nomad`)
         --> `web-ui` service
@@ -53,7 +77,7 @@ class ApiGateway(pulumi.ComponentResource):
         super().__init__("grapl:ApiGateway", name, None, opts)
 
         api = aws.apigatewayv2.Api(
-            "api",
+            f"{name}-api",
             protocol_type="HTTP",
             opts=pulumi.ResourceOptions(parent=self),
         )
@@ -62,7 +86,7 @@ class ApiGateway(pulumi.ComponentResource):
         link = aws.apigatewayv2.VpcLink(
             "vpc_link_to_ec2",
             security_group_ids=[nomad_agents_alb_security_group],
-            subnet_ids=private_subnet_ids,
+            subnet_ids=nomad_agents_private_subnet_ids,
             opts=pulumi.ResourceOptions(parent=api),
         )
 
@@ -78,28 +102,26 @@ class ApiGateway(pulumi.ComponentResource):
         )
 
         default_route = aws.apigatewayv2.Route(
-            "default_route",
+            "default-route",
             api_id=api.id,
-            route_key="$default",
+            # This is an APIGWv2 magic value that picks up all traffic.
+            route_key=_API_GATEWAY_DEFAULT_ROUTE_KEY,
+            # For info on this weird transformation, see
+            # https://www.pulumi.com/registry/packages/aws/api-docs/apigatewayv2/route/#target_python
             target=integration.id.apply(lambda id: f"integrations/{id}"),
             opts=pulumi.ResourceOptions(parent=api),
         )
 
         stage_logs = aws.cloudwatch.LogGroup(
             f"{name}-log-group",
-            name=f"/{name}-apigw_stage_logs",
+            name=f"/{name}-apigw-stage-logs",
             retention_in_days=7,
             opts=pulumi.ResourceOptions(parent=api),
         )
 
         self.stage = aws.apigatewayv2.Stage(
             "stage",
-            # Naming it $default means that the stage is served from
-            # https://api-id.execute-api.us-east-1.amazonaws.com/
-            # instead of something like
-            # https://api-id.execute-api.us-east-1.amazonaws.com/stage-1a2b3c4
-            # this makes it much easier to reference stuff in e.g. `<domain>/static/`
-            name="$default",
+            name=_API_GATEWAY_DEFAULT_STAGE_NAME,
             api_id=api.id,
             auto_deploy=True,
             access_log_settings=aws.apigatewayv2.StageAccessLogSettingsArgs(

--- a/pulumi/infra/cache.py
+++ b/pulumi/infra/cache.py
@@ -14,9 +14,9 @@ class Cache(pulumi.ComponentResource):
     def __init__(
         self,
         name: str,
-        subnet_ids: pulumi.Output[List[str]],
-        vpc_id: pulumi.Output[str],
-        nomad_agent_security_group_id: str,
+        subnet_ids: pulumi.Input[List[str]],
+        vpc_id: pulumi.Input[str],
+        nomad_agent_security_group_id: pulumi.Input[str],
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
         super().__init__("grapl:Cache", name, None, opts)

--- a/pulumi/infra/cache.py
+++ b/pulumi/infra/cache.py
@@ -16,6 +16,7 @@ class Cache(pulumi.ComponentResource):
         name: str,
         subnet_ids: pulumi.Input[List[str]],
         vpc_id: pulumi.Input[str],
+        # We grab this security group from the Nomad Agents stack.
         nomad_agent_security_group_id: pulumi.Input[str],
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
@@ -40,7 +41,6 @@ class Cache(pulumi.ComponentResource):
 
         # Allow communication between nomad-agents and redis
         # These are in different VPCs with the peering done in the networking module
-        # We assume that the stack name for nomad-agents is the same as grapl's stack name
         aws.ec2.SecurityGroupRule(
             "nomad-agents-egress-to-redis",
             type="egress",


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/665

### What changes does this PR make to Grapl? Why?
This PR depends on https://github.com/grapl-security/platform-infrastructure/pull/43

We construct an API Gateway route that forwards HTTP traffic all the way to grapl-web-ui; documentation on this pipeline is
in the api_gateway.py file.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
![image](https://user-images.githubusercontent.com/69007229/140235589-0c2e312d-55e4-4fcb-9a6d-b56ad81634c5.png)
also checked graphql endpoint:
```
curl -I -X POST https://n87ev5n1dg.execute-api.us-east-1.amazonaws.com/graphQlEndpoint/
HTTP/2 401 
date: Wed, 03 Nov 2021 23:41:48 GMT
content-type: text/plain; charset=utf-8
content-length: 38
set-cookie: actix-session=CwUZ2zRRO8F3ByybXBzBUCbB9MRuoGL8QxQZfkSo; HttpOnly; Secure; Path=/
apigw-requestid: IQGpeiDOIAMEJ2g=
```
correctly gives me a 401 unauth