### PR TITLE
A few steps closer to e2e tests in AWS

### DIFF
--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -29,6 +29,7 @@ readonly CLOUDSMITH_DOCKER_REGISTRY="docker.cloudsmith.io/grapl/raw"
 services=(
     analyzer-dispatcher
     analyzer-executor
+    e2e-tests
     engagement-creator
     graph-merger
     graphql-endpoint
@@ -58,6 +59,7 @@ for service in "${services[@]}"; do
     echo "--- :docker: Building ${service}:${TAG} container"
     docker buildx bake \
         --file=docker-compose.build.yml \
+        --file=test/docker-compose.integration-tests.build.yml \
         "${service}"
 
     # Re-tag the container we just built so we can upload it to

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,7 @@ export
 export EVERY_COMPOSE_FILE=--file docker-compose.yml \
 	--file ./test/docker-compose.unit-tests-rust.yml \
 	--file ./test/docker-compose.unit-tests-js.yml \
-	--file ./test/docker-compose.integration-tests.build.yml \
-	--file ./test/docker-compose.e2e-tests.build.yml \
+	--file ./test/docker-compose.integration-tests.build.yml
 
 DOCKER_BUILDX_BAKE := docker buildx bake $(DOCKER_BUILDX_BAKE_OPTS)
 
@@ -153,14 +152,18 @@ build-test-unit-js:
 
 .PHONY: build-test-integration
 build-test-integration: build
-	$(WITH_LOCAL_GRAPL_ENV) \
-	$(DOCKER_BUILDX_BAKE) --file ./test/docker-compose.integration-tests.build.yml
+	$(WITH_LOCAL_GRAPL_ENV)
+	$(DOCKER_BUILDX_BAKE) \
+		--file ./test/docker-compose.integration-tests.build.yml \
+		python-integration-tests rust-integration-tests
 
 .PHONY: build-test-e2e
 build-test-e2e: build
 	./pants package ./src/python/e2e-test-runner/e2e_test_runner:pex
-	$(WITH_LOCAL_GRAPL_ENV) \
-	$(DOCKER_BUILDX_BAKE) --file ./test/docker-compose.e2e-tests.build.yml
+	$(WITH_LOCAL_GRAPL_ENV)
+	$(DOCKER_BUILDX_BAKE) \
+		--file ./test/docker-compose.integration-tests.build.yml \
+		e2e-tests
 
 .PHONY: build-dist-artifacts
 build-dist-artifacts: build-service-pexs ## Generate all artifacts for dist/

--- a/nomad/local/e2e-tests.nomad
+++ b/nomad/local/e2e-tests.nomad
@@ -180,7 +180,7 @@ EOF
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}grapl/e2e-tests:${var.e2e_tests_tag}"
+        image = "${var.container_registry}grapl/e2e-tests:${var.e2e_tests_tag}"
       }
 
       # This writes an env file that gets read by the task automatically

--- a/nomad/local/e2e-tests.nomad
+++ b/nomad/local/e2e-tests.nomad
@@ -8,6 +8,12 @@ variable "container_registry" {
   description = "The container registry in which we can find Grapl services. Requires a trailing /"
 }
 
+variable "e2e_tests_tag" {
+  type        = string
+  default     = "dev"
+  description = "The tagged version of the e2e tests we should deploy."
+}
+
 variable "aws_region" {
   type = string
 }
@@ -130,7 +136,7 @@ job "e2e-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}grapl/e2e-tests:dev"
+        image      = "${var.container_registry}grapl/e2e-tests:${var.e2e_tests_tag}"
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command = trimspace(<<EOF
 graplctl upload analyzer --analyzer_main_py ./etc/local_grapl/suspicious_svchost/main.py
@@ -174,7 +180,7 @@ EOF
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/e2e-tests:dev"
+        image      = "${var.container_registry}grapl/e2e-tests:${var.e2e_tests_tag}"
       }
 
       # This writes an env file that gets read by the task automatically

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -261,6 +261,10 @@ def main() -> None:
             vpc_id=vpc_id,
             nomad_agent_security_group_id=nomad_agent_security_group_id,
         )
+
+        pulumi.export("kafka-endpoint", "dummy_value_while_we_wait_for_kafka")
+        pulumi.export("redis-endpoint", cache.endpoint)
+
         artifacts = pulumi_config.require_object("artifacts")
 
         # Set custom provider with the address set

--- a/pulumi/infra/nomad_job.py
+++ b/pulumi/infra/nomad_job.py
@@ -7,7 +7,7 @@ from infra.config import DEPLOYMENT_NAME
 import pulumi
 
 _ValidNomadVarTypes = pulumi.Input[Union[str, bool, int]]
-NomadVars = Mapping[str, _ValidNomadVarTypes]
+NomadVars = Mapping[str, Optional[_ValidNomadVarTypes]]
 
 
 class NomadJob(pulumi.ComponentResource):

--- a/pulumi/integration_tests/README.md
+++ b/pulumi/integration_tests/README.md
@@ -3,3 +3,11 @@
 Despite the name of this project, it contains both the e2e and the integration
 tests. This is because the two concepts will be merged into one in the semi-near
 future.
+
+# Initialization
+
+```
+pulumi stack init "grapl/integration-tests/${STACK_NAME}"
+pulumi config set aws:region "${REGION}"
+pulumi config set nomad:address "http://localhost:4646"
+```

--- a/pulumi/integration_tests/README.md
+++ b/pulumi/integration_tests/README.md
@@ -5,6 +5,7 @@ tests. This is because the two concepts will be merged into one in the semi-near
 future.
 
 # Initialization
+
 Do the following to set up an Integration Tests stack against a real AWS
 sandbox.
 

--- a/pulumi/integration_tests/README.md
+++ b/pulumi/integration_tests/README.md
@@ -5,9 +5,17 @@ tests. This is because the two concepts will be merged into one in the semi-near
 future.
 
 # Initialization
+Do the following to set up an Integration Tests stack against a real AWS
+sandbox.
 
 ```
+set -u
+STACK_NAME=# <fill in - same name as your grapl repo>
+REGION=# <fill in>
+E2E_TESTS_TAG=# <fill in - you'll find it in origin/rc branch>
+
 pulumi stack init "grapl/integration-tests/${STACK_NAME}"
 pulumi config set aws:region "${REGION}"
 pulumi config set nomad:address "http://localhost:4646"
+pulumi config set --path "artifacts.e2e-tests" "${E2E_TESTS_TAG}"
 ```

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 sys.path.insert(0, "..")
 
+from typing import Optional, cast
+
 import pulumi_aws as aws
 import pulumi_nomad as nomad
 from infra import config
@@ -16,7 +18,6 @@ import pulumi
 
 def main() -> None:
     ##### Preamble
-
     stack_name = pulumi.get_stack()
 
     quiet_docker_output()
@@ -43,14 +44,13 @@ def main() -> None:
 
     grapl_stack = GraplStack(stack_name)
 
-    # TODO Wimax Nov 2021: This logic will change this week, doesn't work against prod
-    assert aws.config.access_key, "Appease typechecker"
-    assert aws.config.secret_key, "Appease typechecker"
+    access_key = aws.config.access_key
+    secret_key = aws.config.secret_key
 
     e2e_test_job_vars: NomadVars = {
         "analyzer_bucket": grapl_stack.analyzer_bucket,
-        "aws_access_key_id": aws.config.access_key,
-        "aws_access_key_secret": aws.config.secret_key,
+        "aws_access_key_id": access_key,
+        "aws_access_key_secret": secret_key,
         "_aws_endpoint": grapl_stack.aws_endpoint,
         "aws_region": aws.get_region().name,
         "deployment_name": grapl_stack.deployment_name,
@@ -67,43 +67,52 @@ def main() -> None:
         vars=e2e_test_job_vars,
     )
 
-    integration_test_job_vars: NomadVars = {
-        "aws_access_key_id": aws.config.access_key,
-        "aws_access_key_secret": aws.config.secret_key,
-        "_aws_endpoint": grapl_stack.aws_endpoint,
-        "aws_region": aws.get_region().name,
-        "deployment_name": grapl_stack.deployment_name,
-        "docker_user": os.environ["DOCKER_USER"],
-        "grapl_root": os.environ["GRAPL_ROOT"],
-        "_kafka_endpoint": grapl_stack.kafka_endpoint,
-        "_redis_endpoint": grapl_stack.redis_endpoint,
-        "schema_properties_table_name": grapl_stack.schema_properties_table_name,
-        "test_user_name": grapl_stack.test_user_name,
-    }
+    if config.LOCAL_GRAPL:
+        # We don't do integration tests in AWS yet, mostly because the current
+        # Python Pants integration test setup is funky and requires an on-disk
+        # Grapl repo.
 
-    integration_tests = NomadJob(
-        "integration-tests",
-        jobspec=Path("../../nomad/local/integration-tests.nomad").resolve(),
-        vars=integration_test_job_vars,
-    )
+        integration_test_job_vars: NomadVars = {
+            "aws_access_key_id": access_key,
+            "aws_access_key_secret": secret_key,
+            "_aws_endpoint": grapl_stack.aws_endpoint,
+            "aws_region": aws.get_region().name,
+            "deployment_name": grapl_stack.deployment_name,
+            "docker_user": os.environ["DOCKER_USER"],
+            "grapl_root": os.environ["GRAPL_ROOT"],
+            "_kafka_endpoint": grapl_stack.kafka_endpoint,
+            "_redis_endpoint": grapl_stack.redis_endpoint,
+            "schema_properties_table_name": grapl_stack.schema_properties_table_name,
+            "test_user_name": grapl_stack.test_user_name,
+        }
+
+        integration_tests = NomadJob(
+            "integration-tests",
+            jobspec=Path("../../nomad/local/integration-tests.nomad").resolve(),
+            vars=integration_test_job_vars,
+        )
 
 
 class GraplStack:
     def __init__(self, stack_name: str) -> None:
         ref_name = "local-grapl" if config.LOCAL_GRAPL else f"grapl/grapl/{stack_name}"
         ref = pulumi.StackReference(ref_name)
-        output = ref.require_output  # just an alias
 
-        self.analyzer_bucket = output("analyzers-bucket")
-        self.aws_endpoint = output("aws-endpoint")
-        self.deployment_name = output("deployment-name")
-        self.kafka_endpoint = output("kafka-endpoint")
-        self.redis_endpoint = output("redis-endpoint")
-        self.schema_properties_table_name = output("schema-properties-table")
-        self.schema_table_name = output("schema-table")
-        self.sysmon_generator_queue = output("sysmon-generator-queue")
-        self.sysmon_log_bucket = output("sysmon-log-bucket")
-        self.test_user_name = output("test-user-name")
+        def req_str(key: str) -> str:
+            return cast(str, ref.require_output(key))
+
+        # Only specified if LOCAL_GRAPL
+        self.aws_endpoint = cast(Optional[str], ref.get_output("aws-endpoint"))
+
+        self.analyzer_bucket = require_str("analyzers-bucket")
+        self.deployment_name = require_str("deployment-name")
+        self.kafka_endpoint = require_str("kafka-endpoint")
+        self.redis_endpoint = require_str("redis-endpoint")
+        self.schema_properties_table_name = require_str("schema-properties-table")
+        self.schema_table_name = require_str("schema-table")
+        self.sysmon_generator_queue = require_str("sysmon-generator-queue")
+        self.sysmon_log_bucket = require_str("sysmon-log-bucket")
+        self.test_user_name = require_str("test-user-name")
 
 
 if __name__ == "__main__":

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -20,6 +20,10 @@ def main() -> None:
     ##### Preamble
     stack_name = pulumi.get_stack()
 
+    pulumi_config = pulumi.Config()
+    artifacts = pulumi_config.get_object("artifacts")
+    e2e_tag = artifacts and artifacts.get("e2e-tests")
+
     quiet_docker_output()
 
     # These tags will be added to all provisioned infrastructure
@@ -54,6 +58,7 @@ def main() -> None:
         "_aws_endpoint": grapl_stack.aws_endpoint,
         "aws_region": aws.get_region().name,
         "deployment_name": grapl_stack.deployment_name,
+        "e2e_tests_tag": e2e_tag,
         "schema_properties_table_name": grapl_stack.schema_properties_table_name,
         "sysmon_log_bucket": grapl_stack.sysmon_log_bucket,
         "schema_table_name": grapl_stack.schema_table_name,
@@ -98,7 +103,7 @@ class GraplStack:
         ref_name = "local-grapl" if config.LOCAL_GRAPL else f"grapl/grapl/{stack_name}"
         ref = pulumi.StackReference(ref_name)
 
-        def req_str(key: str) -> str:
+        def require_str(key: str) -> str:
             return cast(str, ref.require_output(key))
 
         # Only specified if LOCAL_GRAPL

--- a/test/docker-compose.e2e-tests.build.yml
+++ b/test/docker-compose.e2e-tests.build.yml
@@ -1,9 +1,0 @@
-version: "3.8"
-
-services:
-  e2e-tests:
-    image: grapl/e2e-tests:${TAG:-latest}
-    build:
-      context: .
-      dockerfile: ./src/python/Dockerfile
-      target: e2e-tests

--- a/test/docker-compose.integration-tests.build.yml
+++ b/test/docker-compose.integration-tests.build.yml
@@ -18,6 +18,13 @@ services:
       dockerfile: src/python/Dockerfile
       target: python-integration-tests
 
+  e2e-tests:
+    image: grapl/e2e-tests:${TAG:-latest}
+    build:
+      context: .
+      dockerfile: ./src/python/Dockerfile
+      target: e2e-tests
+
   # No Docker image for python integration tests - we run them against the Host OS!
 
   # TODO: Re-enable these tests after the following issues are resolved:


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
grapl-security/issue-tracker#770

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Introduce the "optional-ness" of aws_endpoint / access_key / secret_key, which we already do in `grapl-core.nomad`
- Introduce artifacts tags.
- Disable integration tests against AWS for now - it needs some work.
- Publish E2E tests to Cloudsmith
- Sunset e2e-tests.build, add that to integration-tests.build 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
locally:
make test-e2e
make test-integration

against my sandbox:
followed my initialization steps
pulumi up
manually run a `dispatch job`, upon which it fails because it doesn't know how to grab e2e tests with that `dev` tag (obviously)

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
