### PR TITLE
Move build_and_upload_containers.sh to just use make commands, not pure docker buildx bake

### DIFF
--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -48,19 +48,8 @@ cloudsmith_tag() {
     echo "${CLOUDSMITH_DOCKER_REGISTRY}/${service}:${tag}"
 }
 
-# These are then consumed by src/python/Dockerfile
-echo "--- :python: Building pex binaries"
-make build-service-pexs
-echo "--- :typescript: Building front-end"
-make build-ux
-echo "--- Building graplctl"
-make graplctl
-
-echo "--- :docker: Building all ${TAG} images"
-docker buildx bake \
-    --file=docker-compose.build.yml \
-    --file=test/docker-compose.integration-tests.build.yml \
-    "${services[@]}"
+echo "--- Building all ${TAG} images"
+make build build-test-e2e
 
 for service in "${services[@]}"; do
     # Re-tag the container we just built so we can upload it to


### PR DESCRIPTION
pretty self explanatory

this has bitten me twice today:

```
> [e2e-tests e2e-tests 1/7] COPY ./dist/e2e-tests.pex /home/grapl/:
  | ------
  | error: failed to solve: rpc error: code = Unknown desc = failed to compute cache key: "/dist/e2e-tests.pex" not found: not found
```
https://buildkite.com/grapl/grapl-merge/builds/286#b315e182-e379-41fa-807e-9e7f41345e4b

and
```
  | ------
  | > [e2e-tests 7/7] COPY --chown=grapl ./bin/graplctl /home/grapl/bin/graplctl:
  | ------
  | error: failed to solve: rpc error: code = Unknown desc = failed to compute cache key: "/bin/graplctl" not found: not found
  | 🚨 Error: The command exited with status 1
```
https://buildkite.com/grapl/grapl-merge/builds/285#196019be-5d12-41de-a1b7-3ad5cc2618fc

so, enough is enough, I'm ripping this bandaid off.

The negative: previously it was very explicit which exact targets were being built