### PR TITLE
WITH_LOCAL_GRAPL_ENV overrides the TAG= specified in build_and_upload_containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ build-test-unit-js:
 
 .PHONY: build-test-integration
 build-test-integration: build
+	$(WITH_LOCAL_GRAPL_ENV)
 	$(DOCKER_BUILDX_BAKE) \
 		--file ./test/docker-compose.integration-tests.build.yml \
 		python-integration-tests rust-integration-tests
@@ -159,6 +160,7 @@ build-test-integration: build
 .PHONY: build-test-e2e
 build-test-e2e: build
 	./pants package ./src/python/e2e-test-runner/e2e_test_runner:pex
+	$(WITH_LOCAL_GRAPL_ENV)
 	$(DOCKER_BUILDX_BAKE) \
 		--file ./test/docker-compose.integration-tests.build.yml \
 		e2e-tests

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,6 @@ build-test-unit-js:
 
 .PHONY: build-test-integration
 build-test-integration: build
-	$(WITH_LOCAL_GRAPL_ENV)
 	$(DOCKER_BUILDX_BAKE) \
 		--file ./test/docker-compose.integration-tests.build.yml \
 		python-integration-tests rust-integration-tests
@@ -160,7 +159,6 @@ build-test-integration: build
 .PHONY: build-test-e2e
 build-test-e2e: build
 	./pants package ./src/python/e2e-test-runner/e2e_test_runner:pex
-	$(WITH_LOCAL_GRAPL_ENV)
 	$(DOCKER_BUILDX_BAKE) \
 		--file ./test/docker-compose.integration-tests.build.yml \
 		e2e-tests

--- a/local-grapl.env
+++ b/local-grapl.env
@@ -118,4 +118,4 @@ GRAPL_TEST_USER_NAME=${DEPLOYMENT_NAME}-grapl-test-user
 # Locally this should be empty so that Nomad picks up local images
 DOCKER_REGISTRY=""
 # Nomad won't pick up local images that are tagged with latest
-TAG=dev
+TAG="${TAG:-dev}"


### PR DESCRIPTION
well, this was annoying.

I've now *actually tested* this locally by commenting out the `docker push` in build_and_upload_containers; the tags now actually work.