### PR TITLE
Propagate $TAG into Nomad

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,6 @@ build-test-unit-js:
 
 .PHONY: build-test-integration
 build-test-integration: build
-	$(WITH_LOCAL_GRAPL_ENV)
 	$(DOCKER_BUILDX_BAKE) \
 		--file ./test/docker-compose.integration-tests.build.yml \
 		python-integration-tests rust-integration-tests
@@ -160,7 +159,6 @@ build-test-integration: build
 .PHONY: build-test-e2e
 build-test-e2e: build
 	./pants package ./src/python/e2e-test-runner/e2e_test_runner:pex
-	$(WITH_LOCAL_GRAPL_ENV)
 	$(DOCKER_BUILDX_BAKE) \
 		--file ./test/docker-compose.integration-tests.build.yml \
 		e2e-tests

--- a/local-grapl.env
+++ b/local-grapl.env
@@ -117,7 +117,3 @@ GRAPL_TEST_USER_NAME=${DEPLOYMENT_NAME}-grapl-test-user
 
 # Locally this should be empty so that Nomad picks up local images
 DOCKER_REGISTRY=""
-
-# Locally this should be pinned to `dev`, and not read in ${TAG} or anything.
-# (Also, FYI, Nomad cannot pick up local images named `latest`.)
-TAG="${TAG:-dev}"

--- a/local-grapl.env
+++ b/local-grapl.env
@@ -117,5 +117,7 @@ GRAPL_TEST_USER_NAME=${DEPLOYMENT_NAME}-grapl-test-user
 
 # Locally this should be empty so that Nomad picks up local images
 DOCKER_REGISTRY=""
-# Nomad won't pick up local images that are tagged with latest
-TAG="${TAG:-dev}"
+
+# Locally this should be pinned to `dev`, and not read in ${TAG} or anything.
+# (Also, FYI, Nomad cannot pick up local images named `latest`.)
+TAG=dev

--- a/local-grapl.env
+++ b/local-grapl.env
@@ -120,4 +120,4 @@ DOCKER_REGISTRY=""
 
 # Locally this should be pinned to `dev`, and not read in ${TAG} or anything.
 # (Also, FYI, Nomad cannot pick up local images named `latest`.)
-TAG=dev
+TAG="${TAG:-dev}"

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -65,7 +65,6 @@ variable "analyzer_dispatcher_dead_letter_queue" {
 
 variable "analyzer_dispatcher_tag" {
   type        = string
-  default     = "dev"
   description = "The tagged version of the analyzer-dispatcher we should deploy."
 }
 
@@ -81,7 +80,6 @@ variable "analyzer_executor_queue" {
 
 variable "analyzer_executor_tag" {
   type        = string
-  default     = "dev"
   description = "The tagged version of the analyzer-executor we should deploy."
 }
 
@@ -107,7 +105,6 @@ variable "engagement_creator_queue" {
 
 variable "engagement_creator_tag" {
   type        = string
-  default     = "dev"
   description = "The tagged version of the engagement-creator we should deploy."
 }
 
@@ -145,7 +142,6 @@ variable "num_graph_mergers" {
 
 variable "graph_merger_tag" {
   type        = string
-  default     = "dev"
   description = "The tagged version of the graph_merger we should deploy."
 }
 
@@ -169,7 +165,6 @@ variable "model_plugins_bucket" {
 
 variable "model_plugin_deployer_tag" {
   type        = string
-  default     = "dev"
   description = "The tagged version of the model plugin deployer to deploy."
 }
 
@@ -187,7 +182,6 @@ variable "num_node_identifier_retries" {
 
 variable "node_identifier_tag" {
   type        = string
-  default     = "dev"
   description = "The tagged version of the node_identifier and the node_identifier_retry we should deploy."
 }
 
@@ -220,13 +214,11 @@ variable "subgraphs_generated_bucket" {
 
 variable "graphql_endpoint_tag" {
   type        = string
-  default     = "dev"
   description = "The image tag for the graphql endpoint docker image."
 }
 
 variable "web_ui_tag" {
   type        = string
-  default     = "dev"
   description = "The image tag for the Grapl web UI docker image."
 }
 
@@ -247,7 +239,6 @@ variable "user_session_table" {
 
 variable "sysmon_generator_tag" {
   type        = string
-  default     = "dev"
   description = "The image tag for the sysmon generator docker image."
 }
 
@@ -261,7 +252,6 @@ variable "sysmon_generator_dead_letter_queue" {
 
 variable "osquery_generator_tag" {
   type        = string
-  default     = "dev"
   description = "The image tag for the osquery generator docker image."
 }
 

--- a/nomad/grapl-provision.nomad
+++ b/nomad/grapl-provision.nomad
@@ -77,7 +77,6 @@ variable "rust_log" {
 
 variable "provisioner_tag" {
   type        = string
-  default     = "dev"
   description = "The tagged version of the provisioner we should deploy."
 }
 

--- a/nomad/local/e2e-tests.nomad
+++ b/nomad/local/e2e-tests.nomad
@@ -10,7 +10,6 @@ variable "container_registry" {
 
 variable "e2e_tests_tag" {
   type        = string
-  default     = "dev"
   description = "The tagged version of the e2e tests we should deploy."
 }
 

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -6,7 +6,6 @@ variable "container_registry" {
 
 variable "localstack_tag" {
   type        = string
-  default     = "dev"
   description = "The tagged version of localstack we should deploy."
 }
 

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -71,6 +71,16 @@ variable "grapl_root" {
   description = "Where to find the Grapl repo on the host OS (where Nomad runs)."
 }
 
+variable "python_integration_tests_tag" {
+  type        = string
+  description = "The tagged version of the python-integration-tests we should deploy."
+}
+
+variable "rust_integration_tests_tag" {
+  type        = string
+  description = "The tagged version of the rust-integration-tests we should deploy."
+}
+
 locals {
   log_level = "DEBUG"
 
@@ -145,7 +155,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}rust-integration-tests:dev"
+        image = "${var.container_registry}grapl/${var.container_repo}rust-integration-tests:${var.rust_integration_tests_tag}"
       }
 
       # This writes an env file that gets read by the task automatically
@@ -213,7 +223,7 @@ job "integration-tests" {
       user   = var.docker_user
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}python-integration-tests:dev"
+        image = "${var.container_registry}grapl/${var.container_repo}python-integration-tests:${var.python_integration_tests_tag}"
         # Pants caches requirements per-user. So when we run a Docker container
         # with the host's userns, this lets us reuse the pants cache.
         # (This descreases runtime on my personal laptop from 390s to 190s)

--- a/nomad/local/nomad_run_local_infra.sh
+++ b/nomad/local/nomad_run_local_infra.sh
@@ -13,6 +13,7 @@ declare -a NOMAD_VARS=(
     -var "ZOOKEEPER_PORT=${ZOOKEEPER_PORT}"
     -var "FAKE_AWS_ACCESS_KEY_ID=${FAKE_AWS_ACCESS_KEY_ID}"
     -var "FAKE_AWS_SECRET_ACCESS_KEY=${FAKE_AWS_SECRET_ACCESS_KEY}"
+    -var "localstack_tag=${TAG}"
 )
 
 # shellcheck source-path=SCRIPTDIR

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -223,18 +223,20 @@ def main() -> None:
 
         provision_vars = _get_subset(
             dict(
+                provisioner_tag=version_tag("provisioner", {}, require_artifact=False),
                 **grapl_core_job_vars_inputs,
                 **nomad_inputs,
             ),
             {
-                "_aws_endpoint",
                 "aws_access_key_id",
                 "aws_access_key_secret",
+                "_aws_endpoint",
                 "aws_region",
                 "deployment_name",
+                "provisioner_tag",
                 "rust_log",
-                "schema_table_name",
                 "schema_properties_table_name",
+                "schema_table_name",
                 "test_user_name",
                 "user_auth_table",
             },
@@ -339,7 +341,9 @@ def main() -> None:
                 container_repo="raw/",
                 # TODO: consider replacing with the previous per-service `configurable_envvars`
                 rust_log="DEBUG",
-                provisioner_tag=version_tag("provisioner", artifacts),
+                provisioner_tag=version_tag(
+                    "provisioner", artifacts, require_artifact=True
+                ),
                 **nomad_inputs,
             ),
             {

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from typing import Set
+from typing import Mapping, Set
 
 from typing_extensions import Final
 
@@ -22,6 +22,7 @@ from infra.autotag import register_auto_tags
 from infra.bucket import Bucket
 from infra.cache import Cache
 from infra.consul_intentions import ConsulIntentions
+from infra.docker_image_tag import version_tag
 from infra.get_hashicorp_provider_address import get_hashicorp_provider_address
 
 # TODO: temporarily disabled until we can reconnect the ApiGateway to the new
@@ -42,6 +43,27 @@ import pulumi
 
 def _get_subset(inputs: NomadVars, subset: Set[str]) -> NomadVars:
     return {k: inputs[k] for k in subset}
+
+
+def grapl_core_docker_image_tags(
+    artifacts: Mapping[str, str], require_artifact: bool = False
+) -> NomadVars:
+    # partial apply some repeated args
+    version_tag_alias = lambda key: version_tag(key, artifacts, require_artifact)
+
+    return dict(
+        analyzer_dispatcher_tag=version_tag_alias("analyzer-dispatcher"),
+        analyzer_executor_tag=version_tag_alias("analyzer-executor"),
+        dgraph_tag="latest",
+        engagement_creator_tag=version_tag_alias("engagement-creator"),
+        graph_merger_tag=version_tag_alias("graph-merger"),
+        graphql_endpoint_tag=version_tag_alias("graphql-endpoint"),
+        model_plugin_deployer_tag=version_tag_alias("model-plugin-deployer"),
+        node_identifier_tag=version_tag_alias("node-identifier"),
+        osquery_generator_tag=version_tag_alias("osquery-generator"),
+        sysmon_generator_tag=version_tag_alias("sysmon-generator"),
+        web_ui_tag=version_tag_alias("grapl-web-ui"),
+    )
 
 
 def main() -> None:
@@ -189,6 +211,7 @@ def main() -> None:
             vars=dict(
                 **grapl_core_job_vars_inputs,
                 **nomad_inputs,
+                **grapl_core_docker_image_tags({}),
             ),
         )
 
@@ -289,19 +312,9 @@ def main() -> None:
             container_repo="raw/",
             # TODO: consider replacing with the previous per-service `configurable_envvars`
             rust_log="DEBUG",
-            # Build Tags. We use per service tags so we can update services independently
-            analyzer_dispatcher_tag=artifacts["analyzer-dispatcher"],
-            analyzer_executor_tag=artifacts["analyzer-executor"],
-            dgraph_tag="latest",
-            engagement_creator_tag=artifacts["engagement-creator"],
-            graph_merger_tag=artifacts["graph-merger"],
-            graphql_endpoint_tag=artifacts["graphql-endpoint"],
-            model_plugin_deployer_tag=artifacts["model-plugin-deployer"],
-            node_identifier_tag=artifacts["node-identifier"],
-            osquery_generator_tag=artifacts["osquery-generator"],
-            sysmon_generator_tag=artifacts["sysmon-generator"],
-            web_ui_tag=artifacts["grapl-web-ui"],
             **nomad_inputs,
+            # Build Tags. We use per service tags so we can update services independently
+            **grapl_core_docker_image_tags(artifacts, require_artifact=True),
         )
 
         nomad_grapl_core = NomadJob(
@@ -326,7 +339,7 @@ def main() -> None:
                 container_repo="raw/",
                 # TODO: consider replacing with the previous per-service `configurable_envvars`
                 rust_log="DEBUG",
-                provisioner_tag=artifacts["provisioner"],
+                provisioner_tag=version_tag("provisioner", artifacts),
                 **nomad_inputs,
             ),
             {

--- a/pulumi/infra/docker_image_tag.py
+++ b/pulumi/infra/docker_image_tag.py
@@ -1,0 +1,35 @@
+import os
+from typing import Mapping
+
+from typing_extensions import Final
+
+# This default is chosen because Nomad cannot pull images called "latest"
+# from the local machine (it takes it as a directive to go to Dockerhub)
+# Originates at the `TAG ?= dev` at the top of the Makefile.
+_DEFAULT_TAG: Final[str] = "dev"
+
+
+def version_tag(
+    key: str,
+    artifacts: Mapping[str, str],
+    require_artifact: bool = False,
+) -> str:
+    """
+    First, try and get it from artifacts;
+        if no artifact and require_artifact, throw error
+    then fall back to $TAG;
+    then fall back to "dev"
+    """
+    artifact_version = artifacts.get(key)
+    if artifact_version:
+        return artifact_version
+    if not artifact_version and require_artifact:
+        raise KeyError(
+            "Expected to find an artifacts entry for {key} in Pulumi config file"
+        )
+
+    tag = os.getenv("TAG")
+    if tag:
+        return tag
+
+    return _DEFAULT_TAG

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -10,6 +10,7 @@ import pulumi_aws as aws
 import pulumi_nomad as nomad
 from infra import config
 from infra.autotag import register_auto_tags
+from infra.docker_image_tag import version_tag
 from infra.nomad_job import NomadJob, NomadVars
 from infra.quiet_docker_build_output import quiet_docker_output
 
@@ -21,8 +22,10 @@ def main() -> None:
     stack_name = pulumi.get_stack()
 
     pulumi_config = pulumi.Config()
-    artifacts = pulumi_config.get_object("artifacts")
-    e2e_tag = artifacts and artifacts.get("e2e-tests")
+    artifacts = pulumi_config.get_object("artifacts") or {}
+    version_tag_alias = lambda key: version_tag(
+        key, artifacts, require_output=config.LOCAL_GRAPL
+    )
 
     quiet_docker_output()
 
@@ -58,7 +61,7 @@ def main() -> None:
         "_aws_endpoint": grapl_stack.aws_endpoint,
         "aws_region": aws.get_region().name,
         "deployment_name": grapl_stack.deployment_name,
-        "e2e_tests_tag": e2e_tag,
+        "e2e_tests_tag": version_tag_alias("e2e-tests"),
         "schema_properties_table_name": grapl_stack.schema_properties_table_name,
         "sysmon_log_bucket": grapl_stack.sysmon_log_bucket,
         "schema_table_name": grapl_stack.schema_table_name,
@@ -86,7 +89,13 @@ def main() -> None:
             "docker_user": os.environ["DOCKER_USER"],
             "grapl_root": os.environ["GRAPL_ROOT"],
             "_kafka_endpoint": grapl_stack.kafka_endpoint,
+            "python_integration_tests_tag": version_tag_alias(
+                "python-integration-tests", artifacts
+            ),
             "_redis_endpoint": grapl_stack.redis_endpoint,
+            "rust_integration_tests_tag": version_tag_alias(
+                "rust-integration-tests", artifacts
+            ),
             "schema_properties_table_name": grapl_stack.schema_properties_table_name,
             "test_user_name": grapl_stack.test_user_name,
         }

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -24,7 +24,7 @@ def main() -> None:
     pulumi_config = pulumi.Config()
     artifacts = pulumi_config.get_object("artifacts") or {}
     version_tag_alias = lambda key: version_tag(
-        key, artifacts, require_output=config.LOCAL_GRAPL
+        key, artifacts, require_artifact=(not config.LOCAL_GRAPL)
     )
 
     quiet_docker_output()
@@ -90,12 +90,10 @@ def main() -> None:
             "grapl_root": os.environ["GRAPL_ROOT"],
             "_kafka_endpoint": grapl_stack.kafka_endpoint,
             "python_integration_tests_tag": version_tag_alias(
-                "python-integration-tests", artifacts
+                "python-integration-tests"
             ),
             "_redis_endpoint": grapl_stack.redis_endpoint,
-            "rust_integration_tests_tag": version_tag_alias(
-                "rust-integration-tests", artifacts
-            ),
+            "rust_integration_tests_tag": version_tag_alias("rust-integration-tests"),
             "schema_properties_table_name": grapl_stack.schema_properties_table_name,
             "test_user_name": grapl_stack.test_user_name,
         }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
ongoing attempt to solve grapl/merge

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

the current issue is that we'd build Docker images with a TAG of `ci-pipeline`, but Nomad assumed some things were still `:dev`.
- It never inspected `$TAG` at all
- e2e and integration tests were straight-up hardcoded to `dev`

This changes every place we consume a tag to use `def version_tag` (ctrl-f for it). 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
ran `make test-integration` and `make test-e2e` and also variants with `TAG=derp make test-integration`
seemed to work

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
