### PR TITLE
Pull Pulumi artifacts from testing repository

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -50,9 +50,10 @@ steps:
           # NOTE: this assumes that all artifacts mentioned in this
           # file are stored in Cloudsmith!
           download: all_artifacts.json
-      - grapl-security/cloudsmith#v0.1.0:
+      - grapl-security/cloudsmith#v0.1.1:
           promote:
             org: grapl
+            action: move
             from: raw
             to: testing
             packages_file: all_artifacts.json

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -6,6 +6,9 @@ env:
 steps:
   - label: ":docker: Build Docker Containers"
     command:
+      # Note: all these containers are uploaded to the `raw`
+      # repository. If they all get built successfully, then we'll
+      # promote them as a group later.
       - ".buildkite/scripts/build_and_upload_containers.sh"
     key: "docker-containers"
     plugins:
@@ -29,6 +32,32 @@ steps:
   - label: "Merge artifacts files"
     command:
       - .buildkite/scripts/merge_artifact_files.sh
+
+  - wait
+
+  # Promote all the artifacts
+  #
+  # We do this before the RC creation because that
+  # triggers a run of the provision pipeline, and we want to make sure
+  # all the artifacts are in place first.
+  - label: ":cloudsmith: Promote artifacts"
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - CLOUDSMITH_API_KEY
+      - artifacts#v1.4.0:
+          # NOTE: this assumes that all artifacts mentioned in this
+          # file are stored in Cloudsmith!
+          download: all_artifacts.json
+      - grapl-security/cloudsmith#v0.1.0:
+          promote:
+            org: grapl
+            from: raw
+            to: testing
+            packages_file: all_artifacts.json
+    agents:
+      queue: "artifact-uploaders"
 
   - wait
 

--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -2,11 +2,6 @@
 
 set -euo pipefail
 
-# TODO:
-# - Build Containers for Fargate services
-# - Upload them to Cloudsmith
-# - Record them as artifacts for subsequent processing
-
 # ISSUES:
 # - How to do this selectively? I only really want to do this if we've
 #   got real changes to build
@@ -20,7 +15,6 @@ source .buildkite/scripts/lib/version.sh
 TAG="$(timestamp_and_sha_version)"
 export TAG
 
-# TODO: This name may change
 readonly CLOUDSMITH_DOCKER_REGISTRY="docker.cloudsmith.io/grapl/raw"
 
 # These are defined in docker-compose.build.yml. There are other
@@ -61,14 +55,11 @@ for service in "${services[@]}"; do
     new_tag="$(cloudsmith_tag "${service}" "${TAG}")"
     echo "--- :docker: Retagging ${service} container to ${new_tag}"
     docker tag \
-        "grapl/${service}:${TAG}" \
+        "${service}:${TAG}" \
         "${new_tag}"
 
     echo "--- :docker: Push ${new_tag}"
     docker push "${new_tag}"
 done
 
-# TODO: Do we want to put the complete container image name in for
-# each service? Perhaps not, particularly if we're going to be
-# promoting containers across repositories
 artifact_json "${TAG}" "${services[@]}" > "$(artifacts_file_for containers)"

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -12,7 +12,7 @@ services:
   ########################################################################
 
   sysmon-generator:
-    image: grapl/sysmon-generator:${TAG:-latest}
+    image: sysmon-generator:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -21,7 +21,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   osquery-generator:
-    image: grapl/osquery-generator:${TAG:-latest}
+    image: osquery-generator:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -30,7 +30,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   node-identifier:
-    image: grapl/node-identifier:${TAG:-latest}
+    image: node-identifier:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -39,7 +39,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   node-identifier-retry:
-    image: grapl/node-identifier-retry:${TAG:-latest}
+    image: node-identifier-retry:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -48,7 +48,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   graph-merger:
-    image: grapl/graph-merger:${TAG:-latest}
+    image: graph-merger:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -57,7 +57,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   analyzer-dispatcher:
-    image: grapl/analyzer-dispatcher:${TAG:-latest}
+    image: analyzer-dispatcher:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -66,7 +66,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   model-plugin-deployer:
-    image: grapl/model-plugin-deployer:${TAG:-latest}
+    image: model-plugin-deployer:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -75,7 +75,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   grapl-web-ui:
-    image: grapl/grapl-web-ui:${TAG:-latest}
+    image: grapl-web-ui:${TAG:-latest}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -89,14 +89,14 @@ services:
 
   # should match `pulumi/infra/analyzer_executor.py`'s GraplDockerBuild
   analyzer-executor:
-    image: grapl/analyzer-executor:${TAG:-latest}
+    image: analyzer-executor:${TAG:-latest}
     build:
       context: .
       dockerfile: ./src/python/Dockerfile
       target: analyzer-executor
 
   engagement-creator:
-    image: grapl/engagement-creator:${TAG:-latest}
+    image: engagement-creator:${TAG:-latest}
     build:
       context: .
       dockerfile: ./src/python/Dockerfile
@@ -107,14 +107,14 @@ services:
   ########################################################################
 
   graphql-endpoint:
-    image: grapl/graphql-endpoint:${TAG:-latest}
+    image: graphql-endpoint:${TAG:-latest}
     build:
       context: src/js/graphql_endpoint
       dockerfile: Dockerfile
       target: graphql-endpoint-deploy
 
   notebook:
-    image: grapl/notebook:${TAG:-latest}
+    image: notebook:${TAG:-latest}
     build:
       context: .
       dockerfile: ./src/python/Dockerfile
@@ -125,19 +125,19 @@ services:
   ########################################################################
 
   pulumi:
-    image: grapl/local-pulumi:${TAG:-latest}
+    image: local-pulumi:${TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.pulumi
 
   localstack:
-    image: grapl/localstack:${TAG:-latest}
+    image: localstack-grapl-fork:${TAG:-latest}
     build:
       context: localstack
       dockerfile: Dockerfile
 
   provisioner:
-    image: grapl/provisioner:${TAG:-latest}
+    image: provisioner:${TAG:-latest}
     build:
       context: .
       dockerfile: ./src/python/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ volumes:
 
 services:
   pulumi:
-    image: grapl/local-pulumi:${TAG:-latest}
+    image: local-pulumi:${TAG:-latest}
     entrypoint: ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
     command:
       - |

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -3,16 +3,10 @@ variable "rust_log" {
   description = "Controls the logging behavior of Rust-based services."
 }
 
-variable "container_registry" {
+variable "container_repository" {
   type        = string
   default     = ""
   description = "The container registry in which we can find Grapl services. Requires a trailing / if not empty string"
-}
-
-variable "container_repo" {
-  type        = string
-  default     = ""
-  description = "The container repo inside the registry in which we can find Grapl services. Requires a trailing / if not empty string"
 }
 
 variable "aws_access_key_id" {
@@ -626,7 +620,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}graph-merger:${var.graph_merger_tag}"
+        image = "${var.container_repository}graph-merger:${var.graph_merger_tag}"
       }
 
       # This writes an env files that gets read by nomad automatically
@@ -682,7 +676,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}node-identifier:${var.node_identifier_tag}"
+        image = "${var.container_repository}node-identifier:${var.node_identifier_tag}"
       }
 
       template {
@@ -722,7 +716,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}node-identifier-retry:${var.node_identifier_tag}"
+        image = "${var.container_repository}node-identifier-retry:${var.node_identifier_tag}"
       }
 
       template {
@@ -757,7 +751,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}analyzer-dispatcher:${var.analyzer_dispatcher_tag}"
+        image = "${var.container_repository}analyzer-dispatcher:${var.analyzer_dispatcher_tag}"
       }
 
       template {
@@ -796,7 +790,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}analyzer-executor:${var.analyzer_executor_tag}"
+        image = "${var.container_repository}analyzer-executor:${var.analyzer_executor_tag}"
       }
 
       template {
@@ -855,7 +849,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}engagement-creator:${var.engagement_creator_tag}"
+        image = "${var.container_repository}engagement-creator:${var.engagement_creator_tag}"
       }
 
       template {
@@ -908,7 +902,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}graphql-endpoint:${var.graphql_endpoint_tag}"
+        image = "${var.container_repository}graphql-endpoint:${var.graphql_endpoint_tag}"
         ports = ["graphql-endpoint-port"]
       }
 
@@ -965,7 +959,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}model-plugin-deployer:${var.model_plugin_deployer_tag}"
+        image = "${var.container_repository}model-plugin-deployer:${var.model_plugin_deployer_tag}"
         ports = ["model-plugin-deployer"]
       }
 
@@ -997,7 +991,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}grapl-web-ui:${var.web_ui_tag}"
+        image = "${var.container_repository}grapl-web-ui:${var.web_ui_tag}"
         ports = ["web-ui-port"]
       }
 
@@ -1047,7 +1041,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}sysmon-generator:${var.sysmon_generator_tag}"
+        image = "${var.container_repository}sysmon-generator:${var.sysmon_generator_tag}"
       }
 
       template {
@@ -1077,7 +1071,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}osquery-generator:${var.osquery_generator_tag}"
+        image = "${var.container_repository}osquery-generator:${var.osquery_generator_tag}"
       }
 
       template {

--- a/nomad/grapl-provision.nomad
+++ b/nomad/grapl-provision.nomad
@@ -22,16 +22,10 @@ variable "_aws_endpoint" {
 EOF
 }
 
-variable "container_registry" {
+variable "container_repository" {
   type        = string
   default     = ""
-  description = "The container registry in which we can find Grapl services. Requires a trailing / if not empty string"
-}
-
-variable "container_repo" {
-  type        = string
-  default     = ""
-  description = "The container repo inside the registry in which we can find Grapl services. Requires a trailing / if not empty string"
+  description = "The container repository in which we can find Grapl services. Requires a trailing / if not empty string"
 }
 
 variable "aws_access_key_id" {
@@ -112,7 +106,7 @@ job "grapl-provision" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}provisioner:${var.provisioner_tag}"
+        image = "${var.container_repository}provisioner:${var.provisioner_tag}"
       }
 
       lifecycle {

--- a/nomad/local/e2e-tests.nomad
+++ b/nomad/local/e2e-tests.nomad
@@ -2,10 +2,10 @@
 # https://discuss.hashicorp.com/t/best-practices-for-testing-against-services-in-nomad-consul-connect/29022
 # We'll submit integration tests to Nomad as 
 # 
-variable "container_registry" {
+variable "container_repository" {
   type        = string
   default     = ""
-  description = "The container registry in which we can find Grapl services. Requires a trailing /"
+  description = "The container repository in which we can find Grapl services. Requires a trailing /"
 }
 
 variable "e2e_tests_tag" {
@@ -135,7 +135,7 @@ job "e2e-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_registry}grapl/e2e-tests:${var.e2e_tests_tag}"
+        image      = "${var.container_repository}e2e-tests:${var.e2e_tests_tag}"
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command = trimspace(<<EOF
 graplctl upload analyzer --analyzer_main_py ./etc/local_grapl/suspicious_svchost/main.py
@@ -179,7 +179,7 @@ EOF
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/e2e-tests:${var.e2e_tests_tag}"
+        image = "${var.container_repository}e2e-tests:${var.e2e_tests_tag}"
       }
 
       # This writes an env file that gets read by the task automatically

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -1,7 +1,7 @@
-variable "container_registry" {
+variable "container_repository" {
   type        = string
   default     = ""
-  description = "The container registry in which we can find Grapl services. Requires a trailing /"
+  description = "The container repository in which we can find Grapl services. Requires a trailing /"
 }
 
 variable "localstack_tag" {
@@ -127,7 +127,7 @@ job "grapl-local-infra" {
 
       config {
         # Once we move to Kafka, we can go back to the non-fork.
-        image = "${var.container_registry}grapl/localstack:${var.localstack_tag}"
+        image = "localstack-grapl-fork:${var.localstack_tag}"
         # Was running into this: https://github.com/localstack/localstack/issues/1349
         memory_hard_limit = 2048
         ports             = ["localstack"]

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -2,16 +2,10 @@
 # https://discuss.hashicorp.com/t/best-practices-for-testing-against-services-in-nomad-consul-connect/29022
 # We'll submit integration tests to Nomad as 
 # 
-variable "container_registry" {
+variable "container_repository" {
   type        = string
   default     = ""
-  description = "The container registry in which we can find Grapl services. Requires a trailing /"
-}
-
-variable "container_repo" {
-  type        = string
-  default     = ""
-  description = "The container repo inside the registry in which we can find Grapl services. Requires a trailing / if not empty string"
+  description = "The container repository in which we can find Grapl services. Requires a trailing /"
 }
 
 variable "aws_region" {
@@ -155,7 +149,7 @@ job "integration-tests" {
       driver = "docker"
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}rust-integration-tests:${var.rust_integration_tests_tag}"
+        image = "${var.container_repository}rust-integration-tests:${var.rust_integration_tests_tag}"
       }
 
       # This writes an env file that gets read by the task automatically
@@ -223,7 +217,7 @@ job "integration-tests" {
       user   = var.docker_user
 
       config {
-        image = "${var.container_registry}grapl/${var.container_repo}python-integration-tests:${var.python_integration_tests_tag}"
+        image = "${var.container_repository}python-integration-tests:${var.python_integration_tests_tag}"
         # Pants caches requirements per-user. So when we run a Docker container
         # with the host's userns, this lets us reuse the pants cache.
         # (This descreases runtime on my personal laptop from 390s to 190s)

--- a/pulumi/grapl/Pulumi.testing.yaml
+++ b/pulumi/grapl/Pulumi.testing.yaml
@@ -1,6 +1,7 @@
 config:
   aws:region: us-east-1
   grapl:GRAPL_OPERATIONAL_ALARMS_EMAIL: operational-alarms@graplsecurity.com
+  grapl:container_repository: "docker.cloudsmith.io/grapl/testing"
   grapl:env_vars:
     analyzer-dispatcher:
       RUST_BACKTRACE: "1"

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -306,8 +306,7 @@ def main() -> None:
             # The vars with a leading underscore indicate that the hcl local version of the variable should be used
             # instead of the var version.
             _redis_endpoint=cache.endpoint,
-            container_registry="docker.cloudsmith.io/",
-            container_repo="raw/",
+            container_repository=f"{config.container_repository()}/",
             # TODO: consider replacing with the previous per-service `configurable_envvars`
             rust_log="DEBUG",
             **nomad_inputs,
@@ -333,8 +332,7 @@ def main() -> None:
             dict(
                 # The vars with a leading underscore indicate that the hcl local version of the variable should be used
                 # instead of the var version.
-                container_registry="docker.cloudsmith.io/",
-                container_repo="raw/",
+                container_repository=f"{config.container_repository()}/",
                 # TODO: consider replacing with the previous per-service `configurable_envvars`
                 rust_log="DEBUG",
                 provisioner_tag=version_tag(
@@ -344,8 +342,7 @@ def main() -> None:
             ),
             {
                 "aws_region",
-                "container_registry",
-                "container_repo",
+                "container_repository",
                 "deployment_name",
                 "provisioner_tag",
                 "rust_log",

--- a/pulumi/infra/config.py
+++ b/pulumi/infra/config.py
@@ -211,3 +211,20 @@ def require_artifact(artifact_name: str) -> Any:
             "\nDon't forget to remove artifacts you don't need after running it!"
         )
     return artifact
+
+
+def container_repository() -> Optional[str]:
+    """The repository from which to pull container images from.
+
+    This will be different for different stacks; we promote packages
+    through a series of different registries that mirrors the progress
+    of code through our pipelines.
+
+    The value will be something like
+    `docker.cloudsmith.io/grapl/testing`; to target a specific image
+    in client code, you would append the image name and tag to the
+    return value of this function.
+
+    Not specifying a repository will result in local images being used.
+    """
+    return pulumi.Config().get("container_repository")

--- a/test/docker-compose.integration-tests.build.yml
+++ b/test/docker-compose.integration-tests.build.yml
@@ -3,7 +3,7 @@ version: "3.8"
 
 services:
   rust-integration-tests:
-    image: grapl/rust-integration-tests:${TAG:-latest}
+    image: rust-integration-tests:${TAG:-latest}
     build:
       context: ${PWD}/src
       dockerfile: rust/Dockerfile
@@ -12,14 +12,14 @@ services:
         - RUST_BUILD=test-integration
 
   python-integration-tests:
-    image: grapl/python-integration-tests:${TAG:-latest}
+    image: python-integration-tests:${TAG:-latest}
     build:
       context: ${PWD}
       dockerfile: src/python/Dockerfile
       target: python-integration-tests
 
   e2e-tests:
-    image: grapl/e2e-tests:${TAG:-latest}
+    image: e2e-tests:${TAG:-latest}
     build:
       context: .
       dockerfile: ./src/python/Dockerfile


### PR DESCRIPTION
First, we add a promotion step to our merge pipeline; if all our
containers build successfully, we'll use our new Cloudsmith Buildkite
plugin to promote the new artifacts out of the `raw` repository into
the `testing` one. Anything left in the `raw` repository will be
deleted over time, because anything that remains in there more than a
few minutes is by definition part of a failing commit.

Then, we parameterize our Pulumi stack with the value of this
repository, so we can instruct Nomad where to pull the containers
from. Previously, we specified this using a combination of "registry"
and "repo". However, because of how the naming in Cloudsmith works, we
always had to interject a `grapl/` into the resulting address. (That
is, `registry` was `docker.cloudsmith.io` and `repository` was `raw`,
with a resulting value of
`docker.cloudsmith.io/grapl/raw/<MY_IMAGE_NAME>:<TAG>`.

The fact that we specified a name of `grapl/<MY_IMAGE_NAME>` in our
Docker Compose build files complicated things. We did this to adhere
to Docker Hub conventions, even though we don't ever push these images
to Docker Hub. Therefore, we had to take special care to assemble the
correct name of an image, depending on whether we were deploying into
AWS or "local Grapl".

In an attempt to simplify things, we now just specify everything up to
the image name (so, e.g., `docker.cloudsmith.io/grapl/testing`) in a
Pulumi stack configuration variable, named
`container_repository`. Though it's technically a combination of a
registry and part of a repository, it does make things a bit easier to
reason about, and to configure.

Since we pin our artifacts in Pulumi using just the bare container
name and version, these will continue to work as before (because the
same names and versions will be present in the new container repository.

To make this work with local containers, we just remove the `grapl/`
prefix from the image name, making them the same as what we expect
elsewhere. This still works, and is actually a little bit safer
because now it will be impossible to accidentally push them to Docker
Hub. (I renamed our local `localstack` image to
`localstack-grapl-fork` to make it more obvious that we are using
something different than the "normal" localstack container.)

Signed-off-by: Christopher Maier <chris@graplsecurity.com>