### PR TITLE
Remove old pinned artifacts

### DIFF
--- a/pulumi/grapl/Pulumi.testing.yaml
+++ b/pulumi/grapl/Pulumi.testing.yaml
@@ -4,34 +4,18 @@ config:
   grapl:artifacts:
     analyzer-dispatcher: 20211116183615-cd97685c
     analyzer-executor: 20211116183615-cd97685c
-    dgraph-ttl: 20210923181707-96db1d59
     e2e-test-runner: 20210923181707-96db1d59
     e2e-tests: 20211116183615-cd97685c
     engagement-creator: 20211116183615-cd97685c
-    engagement-edge: 20210920154305-c6d7c551
     graph-merger: 20211116183615-cd97685c
     graphql-endpoint: 20211116183615-cd97685c
-    grapl-nomad-consul-client:
-      us-east-1: ami-0bc207803b7202acd
-      us-east-2: ami-0d2c737f1b938e0ce
-      us-west-1: ami-080046f2292f8cf50
-      us-west-2: ami-0b6dc43af1ec3f004
-    grapl-nomad-consul-server:
-      us-east-1: ami-008a9904d6bade13d
-      us-east-2: ami-0c4b98b8713fedab6
-      us-west-1: ami-013553b759c5d0a94
-      us-west-2: ami-019b4c6d43e6e9d6b
-    grapl-ux: 20210817165740-7e067a8d
     grapl-web-ui: 20211116183615-cd97685c
-    metric-forwarder: 20210706192702-6001e5a3
     model-plugin-deployer: 20211116183615-cd97685c
     node-identifier: 20211116183615-cd97685c
     node-identifier-retry: 20211116183615-cd97685c
-    node-identifier-retry-handler: 20210706190216-95cec5cb
     osquery-generator: 20211116183615-cd97685c
     provisioner: 20211116183615-cd97685c
     sysmon-generator: 20211116183615-cd97685c
-    ux-router: 20210920154305-c6d7c551
   grapl:env_vars:
     analyzer-dispatcher:
       RUST_BACKTRACE: "1"


### PR DESCRIPTION
⚠️ NOTE: THIS PR IS AGAINST THE `rc` BRANCH, *NOT* `main` ⚠️ 

We don't currently have an automated way to *remove* unused artifacts
from our Pulumi stack. With all the internal revisions that have
occurred lately, we were left with quite a number of obsolete
packages.

Once this is merged into the `rc` branch, this will trigger a new run
of the `grapl/provision` pipeline.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>