### PR TITLE
Promote packages to the "validated" repository in Cloudsmith

### DIFF
--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -45,6 +45,53 @@ steps:
 
   - wait
 
+  # This makes use of the Pulumi binary installed on our agents, and
+  # uses it *only* to extract information from the Pulumi YAML stack
+  # file.
+  #
+  # This is in a separate step because nothing has access to both the
+  # PULUMI_ACCESS_TOKEN and CLOUDSMITH_API_KEY secrets.
+  - label: ":pulumi: Extract current artifacts from stack"
+    command:
+      - "pulumi login"
+      - "pulumi config get artifacts --cwd=pulumi/grapl --stack=grapl/testing --json | jq '.objectValue' > current_artifacts.json"
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - PULUMI_ACCESS_TOKEN
+    artifact_paths:
+      - "current_artifacts.json"
+    agents:
+      queue: "pulumi-staging"
+
+  - wait
+
+  # Take the stack artifacts we just extracted and use it to drive
+  # promotions in Cloudsmith.
+  #
+  # We must use copy, rather than move, because we don't want to
+  # remove packages that future runs of this pipeline might need.
+  - label: ":cloudsmith: Promote validated packages"
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - CLOUDSMITH_API_KEY
+      - artifacts#v1.4.0:
+          download: current_artifacts.json
+      - grapl-security/cloudsmith#v0.1.1:
+          promote:
+            org: grapl
+            action: copy
+            from: testing
+            to: validated
+            packages_file: current_artifacts.json
+    agents:
+      queue: "artifact-uploaders"
+
+  - wait
+
   - label: ":writing_hand: Record successful build"
     command:
       - .buildkite/shared/steps/record_successful_pipeline_run.sh


### PR DESCRIPTION
Once packages make it through the testing pipeline, we can copy them
into the "validated" repository, which will be a holding place for
packages that can plausibly be released to production.

This repository has retention rules set up (out of band; not in this
PR) so that we only keep the 5 most recent versions of each package.

Additionally, we promote the packages via copy and not move because
once we're able to selectively build based on "what changed", we'll be
introducing subsets of new packages. If we were to move them all out,
then nothing would be available for the next run-through of the
pipelines.

In the future, we may be able to incorporate the "extract the current
artifacts from the Pulumi stack" logic into the Pulumi plugin, or
probably the artifacts plugin; for now, though, we'll just add it to
the pipeline directly as we work out the best patterns.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>