### PR TITLE
Unset AWS credentials before trying to upload artifacts file

### DIFF
--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -55,6 +55,12 @@ steps:
     command:
       - "pulumi login"
       - "pulumi config get artifacts --cwd=pulumi/grapl --stack=grapl/testing --json | jq '.objectValue' > current_artifacts.json"
+      # We have to unset the AWS credentials injected by the
+      # asume-role plugin if we're going to subsequently upload the
+      # file to our bucket :(
+      - "unset AWS_ACCESS_KEY_ID"
+      - "unset AWS_SECRET_ACCESS_KEY"
+      - "unset AWS_SESSION_TOKEN"
     plugins:
       - grapl-security/vault-login#v0.1.0
       - grapl-security/vault-env#v0.1.0:


### PR DESCRIPTION
This is a wretchedly ugly hack but is currently the most
straightforward way to upload the resulting file to our artifacts
bucket.

The problem comes from our use of the assume-role plugin to inject AWS
credentials that have access to the staging account; this then gets in
the way of access to our artifacts S3 bucket, which resides in our CD
account.

(The irony is that we don't even need to interact with AWS for this at
all, but we need access to Pulumi in order to extract data from the
stack. I'll continue looking into better solutions, but for now, this
ought to work.)

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
