### PR TITLE
Reenable warnings on node-identifier and graph-merger

### DIFF
--- a/src/rust/graph-merger/src/lib.rs
+++ b/src/rust/graph-merger/src/lib.rs
@@ -1,6 +1,3 @@
-#![allow(unused)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
 pub mod reverse_resolver;
 pub mod service;
 pub mod upsert_util;

--- a/src/rust/graph-merger/src/main.rs
+++ b/src/rust/graph-merger/src/main.rs
@@ -1,18 +1,29 @@
-use rusoto_sqs::SqsClient;
-use tracing::info;
-
 use grapl_config::{
-    env_helpers::{s3_event_emitters_from_env, FromEnv},
+    env_helpers::{
+        s3_event_emitters_from_env,
+        FromEnv,
+    },
     event_caches,
 };
 use grapl_observe::metric_reporter::MetricReporter;
-use grapl_service::{decoder::ProtoDecoder, serialization::MergedGraphSerializer};
-use sqs_executor::{make_ten, s3_event_retriever::S3PayloadRetriever};
-
+use grapl_service::{
+    decoder::ProtoDecoder,
+    serialization::MergedGraphSerializer,
+};
 use rusoto_dynamodb::DynamoDbClient;
+use rusoto_sqs::SqsClient;
+use sqs_executor::{
+    make_ten,
+    s3_event_retriever::S3PayloadRetriever,
+};
+use tracing::info;
+
 use crate::{
     reverse_resolver::ReverseEdgeResolver,
-    service::{time_based_key_fn, GraphMerger},
+    service::{
+        time_based_key_fn,
+        GraphMerger,
+    },
 };
 
 pub mod reverse_resolver;

--- a/src/rust/graph-merger/src/reverse_resolver.rs
+++ b/src/rust/graph-merger/src/reverse_resolver.rs
@@ -105,13 +105,13 @@ impl ReverseEdgeResolver {
         }
         drop(cache);
 
-        self.metric_reporter.clone().counter(
+        let _ = self.metric_reporter.clone().counter(
             "reverse_resolver.cache.hit.count",
             cache_hit as f64,
             0.10,
             &[],
         );
-        self.metric_reporter.clone().counter(
+        let _ = self.metric_reporter.clone().counter(
             "reverse_resolver.cache.miss.count",
             cache_miss as f64,
             0.10,

--- a/src/rust/graph-merger/src/service.rs
+++ b/src/rust/graph-merger/src/service.rs
@@ -1,9 +1,7 @@
 use std::{
     fmt::Debug,
     io::Stdout,
-    sync::{
-        Arc,
-    },
+    sync::Arc,
     time::{
         SystemTime,
         UNIX_EPOCH,
@@ -11,27 +9,14 @@ use std::{
 };
 
 use async_trait::async_trait;
-use dgraph_tonic::{
-    Client as DgraphClient,
+use dgraph_tonic::Client as DgraphClient;
+use grapl_observe::metric_reporter::MetricReporter;
+use rust_proto::graph_descriptions::{
+    IdentifiedGraph,
+    MergedGraph,
 };
-
-use tracing::{
-    error,
-    info,
-    warn,
-};
-
-use grapl_observe::{
-    metric_reporter::{
-        MetricReporter,
-    },
-};
-
-
 use sqs_executor::{
-    cache::{
-        Cache,
-    },
+    cache::Cache,
     errors::{
         CheckedError,
         Recoverable,
@@ -39,14 +24,16 @@ use sqs_executor::{
     event_handler::{
         CompletedEvents,
         EventHandler,
-    }
+    },
 };
-use rust_proto::graph_descriptions::{IdentifiedGraph, MergedGraph};
+use tracing::{
+    error,
+    info,
+    warn,
+};
 
 use crate::{
-    reverse_resolver::{
-        ReverseEdgeResolver,
-    },
+    reverse_resolver::ReverseEdgeResolver,
     upserter,
 };
 

--- a/src/rust/graph-merger/src/service.rs
+++ b/src/rust/graph-merger/src/service.rs
@@ -1,13 +1,10 @@
 use std::{
-    collections::HashMap,
     fmt::Debug,
     io::Stdout,
     sync::{
         Arc,
-        Mutex,
     },
     time::{
-        Duration,
         SystemTime,
         UNIX_EPOCH,
     },
@@ -16,63 +13,24 @@ use std::{
 use async_trait::async_trait;
 use dgraph_tonic::{
     Client as DgraphClient,
-    Mutate,
-    Query,
 };
-use failure::{
-    bail,
-    Error,
+
+use tracing::{
+    error,
+    info,
+    warn,
 };
-use grapl_config::{
-    env_helpers::{
-        s3_event_emitters_from_env,
-        FromEnv,
-    },
-    event_caches,
-};
+
 use grapl_observe::{
-    dgraph_reporter::DgraphMetricReporter,
     metric_reporter::{
-        tag,
         MetricReporter,
     },
 };
-use grapl_service::{
-    decoder::ProtoDecoder,
-    serialization::MergedGraphSerializer,
-};
-use grapl_utils::{
-    future_ext::GraplFutureExt,
-    rusoto_ext::dynamodb::GraplDynamoDbClientExt,
-};
-use lazy_static::lazy_static;
-use rusoto_dynamodb::{
-    AttributeValue,
-    BatchGetItemInput,
-    DynamoDb,
-    DynamoDbClient,
-    GetItemInput,
-    KeysAndAttributes,
-};
-use rusoto_s3::S3Client;
-use rusoto_sqs::SqsClient;
-use rust_proto::graph_descriptions::{
-    Edge,
-    EdgeList,
-    IdentifiedGraph,
-    IdentifiedNode,
-    MergedGraph,
-    MergedNode,
-};
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use serde_json::Value;
+
+
 use sqs_executor::{
     cache::{
         Cache,
-        Cacheable,
     },
     errors::{
         CheckedError,
@@ -81,23 +39,14 @@ use sqs_executor::{
     event_handler::{
         CompletedEvents,
         EventHandler,
-    },
-    make_ten,
-    s3_event_retriever::S3PayloadRetriever,
+    }
 };
-use tracing::{
-    error,
-    info,
-    warn,
-};
+use rust_proto::graph_descriptions::{IdentifiedGraph, MergedGraph};
 
 use crate::{
-    reverse_resolver,
     reverse_resolver::{
-        get_r_edges_from_dynamodb,
         ReverseEdgeResolver,
     },
-    upsert_util,
     upserter,
 };
 

--- a/src/rust/graph-merger/src/upsert_util.rs
+++ b/src/rust/graph-merger/src/upsert_util.rs
@@ -1,18 +1,12 @@
 use std::collections::HashMap;
 
 use node_property::Property::{
-    DecrementOnlyInt as ProtoDecrementOnlyIntProp,
-    DecrementOnlyUint as ProtoDecrementOnlyUintProp,
-    ImmutableInt as ProtoImmutableIntProp,
-    ImmutableStr as ProtoImmutableStrProp,
-    ImmutableUint as ProtoImmutableUintProp,
-    IncrementOnlyInt as ProtoIncrementOnlyIntProp,
+    DecrementOnlyInt as ProtoDecrementOnlyIntProp, DecrementOnlyUint as ProtoDecrementOnlyUintProp,
+    ImmutableInt as ProtoImmutableIntProp, ImmutableStr as ProtoImmutableStrProp,
+    ImmutableUint as ProtoImmutableUintProp, IncrementOnlyInt as ProtoIncrementOnlyIntProp,
     IncrementOnlyUint as ProtoIncrementOnlyUintProp,
 };
-use rust_proto::{
-    graph_descriptions::*,
-    node_property::Property,
-};
+use rust_proto::graph_descriptions::*;
 
 pub struct Escaped(String);
 
@@ -82,7 +76,7 @@ pub(crate) fn build_upserts(
     mutations.push(creation_quad);
     inner_queries.push_str(&creation_query);
     inner_queries.push('\n');
-    for (predicate_param, (prop_name, prop)) in properties.iter().enumerate() {
+    for (prop_name, prop) in properties.iter() {
         if &prop_name == &"node_key" {
             continue;
         }
@@ -94,15 +88,8 @@ pub(crate) fn build_upserts(
             predicate_name=?prop_name,
         );
         let prop_value = escape_prop(prop);
-        let (next_query, muts) = gen_node_property_upsert_quads(
-            query_param,
-            predicate_param as u128,
-            &creation_var_name,
-            &node_key,
-            node_type,
-            prop_name,
-            &prop_value,
-        );
+        let (next_query, muts) =
+            gen_node_property_upsert_quads(&creation_var_name, prop_name, &prop_value);
         inner_queries.push_str(&next_query);
         inner_queries.push('\n');
         mutations.extend_from_slice(&muts[..]);
@@ -117,7 +104,6 @@ pub(crate) fn node_creation_quads(
     node_type: &str,
 ) -> (String, String, dgraph_tonic::Mutation) {
     let creation_var_name = format!("node_exists_{}", query_param);
-    let mut mu_0 = dgraph_tonic::Mutation::new();
     let escaped_node_key = node_key;
     let inner_query = format!(
         r#"
@@ -134,7 +120,7 @@ pub(crate) fn node_creation_quads(
 
     // If the node exists, do nothing, otherwise create it with its type
     let mut mu_1 = dgraph_tonic::Mutation::new();
-    let mut mu_1_n_quads = format!(
+    let mu_1_n_quads = format!(
         concat!(
             r#"_:{creation_var_name} <node_key> {node_key} ."#,
             "\n",
@@ -155,18 +141,14 @@ pub(crate) fn node_creation_quads(
 }
 
 pub(crate) fn gen_node_property_upsert_quads(
-    query_param: u128,
-    predicate_param: u128,
     creation_var_name: &str,
-    node_key: &Escaped,
-    node_type: &str,
     prop_name: &str,
     prop_value: &Escaped,
 ) -> (String, [dgraph_tonic::Mutation; 2]) {
     // let mut node_query_name = format!("pred_query_{}_{}_{}", prop_name, query_param, predicate_param);
     let mut mu_0 = dgraph_tonic::Mutation::new();
 
-    let mut inner_query = format!(
+    let inner_query = format!(
         r#"
             var(func: uid({creation_var_name}), first: 1)
     "#,
@@ -174,7 +156,7 @@ pub(crate) fn gen_node_property_upsert_quads(
     );
 
     // If the node exists, set the predicate. Currently 'last write wins'.
-    let mut mu_0_n_quads = format!(
+    let mu_0_n_quads = format!(
         r#"uid({creation_var_name}) <{prop_name}> {prop_value} ."#,
         creation_var_name = creation_var_name,
         prop_name = prop_name,
@@ -190,7 +172,7 @@ pub(crate) fn gen_node_property_upsert_quads(
     let mut mu_1 = dgraph_tonic::Mutation::new();
 
     // condition if the node does not exist
-    let mut mu_1_n_quads = format!(
+    let mu_1_n_quads = format!(
         concat!(r#"_:{creation_var_name} <{prop_name}> {prop_value} ."#,),
         creation_var_name = creation_var_name,
         prop_name = prop_name,

--- a/src/rust/graph-merger/src/upsert_util.rs
+++ b/src/rust/graph-merger/src/upsert_util.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
 
 use node_property::Property::{
-    DecrementOnlyInt as ProtoDecrementOnlyIntProp, DecrementOnlyUint as ProtoDecrementOnlyUintProp,
-    ImmutableInt as ProtoImmutableIntProp, ImmutableStr as ProtoImmutableStrProp,
-    ImmutableUint as ProtoImmutableUintProp, IncrementOnlyInt as ProtoIncrementOnlyIntProp,
+    DecrementOnlyInt as ProtoDecrementOnlyIntProp,
+    DecrementOnlyUint as ProtoDecrementOnlyUintProp,
+    ImmutableInt as ProtoImmutableIntProp,
+    ImmutableStr as ProtoImmutableStrProp,
+    ImmutableUint as ProtoImmutableUintProp,
+    IncrementOnlyInt as ProtoIncrementOnlyIntProp,
     IncrementOnlyUint as ProtoIncrementOnlyUintProp,
 };
 use rust_proto::graph_descriptions::*;

--- a/src/rust/graph-merger/src/upserter.rs
+++ b/src/rust/graph-merger/src/upserter.rs
@@ -9,7 +9,6 @@ use dgraph_query_lib::{
         ConditionValue,
     },
     mutation::{
-        Mutation,
         MutationBuilder,
         MutationPredicateValue,
         MutationUID,
@@ -25,17 +24,11 @@ use dgraph_query_lib::{
         QueryBlockBuilder,
         QueryBlockType,
     },
-    upsert::{
-        Upsert,
-        UpsertBlock,
-    },
     ToQueryString,
 };
 use dgraph_tonic::{
     Client as DgraphClient,
     Mutate,
-    Mutation as DgraphMutation,
-    MutationResponse,
     Query,
 };
 use futures::StreamExt;
@@ -55,7 +48,6 @@ pub use rust_proto::node_property::Property::{
 };
 use rust_proto::{
     graph_descriptions::*,
-    node_property::Property,
 };
 
 use crate::upsert_util;
@@ -126,7 +118,7 @@ impl GraphMergeHelper {
 
             let dgraph_client = dgraph_client.clone();
             Self::enforce_transaction(move || {
-                let mut txn = dgraph_client.new_mutated_txn();
+                let txn = dgraph_client.new_mutated_txn();
                 txn.upsert_and_commit_now(combined_query.clone(), all_mutations.clone())
             })
         })
@@ -211,7 +203,7 @@ impl GraphMergeHelper {
             .collect();
 
         let mut unresolved = vec![];
-        for (from_node_key, to_node_key, edge_name) in all_edges.iter() {
+        for (from_node_key, to_node_key, _edge_name) in all_edges.iter() {
             if !node_key_to_uid.contains_key(from_node_key) {
                 unresolved.push(from_node_key);
             }
@@ -272,7 +264,7 @@ impl GraphMergeHelper {
                         |e| tracing::error!(message="Failed to set json for mutation", error=?e),
                     );
 
-                    let mut txn = dgraph_client.new_mutated_txn();
+                    let txn = dgraph_client.new_mutated_txn();
                     txn.mutate_and_commit_now(dgraph_mutation.clone())
                 })
             })

--- a/src/rust/graph-merger/src/upserter.rs
+++ b/src/rust/graph-merger/src/upserter.rs
@@ -37,6 +37,7 @@ use futures_retry::{
     RetryPolicy,
 };
 use grapl_utils::iter_ext::GraplIterExt;
+use rust_proto::graph_descriptions::*;
 pub use rust_proto::node_property::Property::{
     DecrementOnlyInt as ProtoDecrementOnlyIntProp,
     DecrementOnlyUint as ProtoDecrementOnlyUintProp,
@@ -45,9 +46,6 @@ pub use rust_proto::node_property::Property::{
     ImmutableUint as ProtoImmutableUintProp,
     IncrementOnlyInt as ProtoIncrementOnlyIntProp,
     IncrementOnlyUint as ProtoIncrementOnlyUintProp,
-};
-use rust_proto::{
-    graph_descriptions::*,
 };
 
 use crate::upsert_util;

--- a/src/rust/node-identifier/src/sessions.rs
+++ b/src/rust/node-identifier/src/sessions.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code, unused_variables)]
 use std::{
     collections::HashMap,
     convert::TryFrom,


### PR DESCRIPTION
### Which issue does this PR correspond to?
None, this was just a quick win I Saw.

### What changes does this PR make to Grapl? Why?
Previously the graph-merger and node-identifier had `#![allow(dead_code, unused_imports)]` and I removed that and fixed any of the issues that caused.

### How were these changes tested?
No additional testing. This is primarily a cosmetic change, very little code has changed.