### PR TITLE
Remove e2e-test-runner from testing stack

### DIFF
--- a/pulumi/grapl/Pulumi.testing.yaml
+++ b/pulumi/grapl/Pulumi.testing.yaml
@@ -4,7 +4,6 @@ config:
   grapl:artifacts:
     analyzer-dispatcher: 20211123004320-24e16e1b
     analyzer-executor: 20211123004320-24e16e1b
-    e2e-test-runner: 20210923181707-96db1d59
     e2e-tests: 20211123004320-24e16e1b
     engagement-creator: 20211123004320-24e16e1b
     graph-merger: 20211123004320-24e16e1b


### PR DESCRIPTION
⚠️ NOTE: THIS PR IS AGAINST THE rc BRANCH, NOT main ⚠️

This was an old dependency that no longer exists. This was caught when
trying to promote all the packages from the release candidate to the
new `validated` repository.

See https://github.com/grapl-security/grapl/pull/1271 for additional context.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
