### PR TITLE
Feed fully qualified Docker Image URLs into the Nomad file instead of piecemeal tags and container_repos

### DIFF
--- a/etc/formatter/Dockerfile
+++ b/etc/formatter/Dockerfile
@@ -15,11 +15,12 @@ SHELL ["/bin/bash", "-c", "-o", "pipefail"]
 # Install npm, Prettier
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
 
-# Ignore this lint about deleteing the apt-get lists (we're caching!)
-# hadolint ignore=DL3009
+# Ignore DL3009 lint about deleteing the apt-get lists (we're caching!)
+# Ignore DL3008 lint about pinning NodeJS; it's complex: https://github.com/nodesource/distributions/issues/33
+# hadolint ignore=DL3009,DL3008
 RUN --mount=type=cache,target=/var/lib/apt/lists \
     apt-get update && \
-    apt-get install --yes --no-install-recommends nodejs=16.13.0-deb-1nodesource1 \
+    apt-get install --yes --no-install-recommends nodejs \
     && npm install -g prettier@2.2.1 \
     && npm install -g prettier-plugin-toml@0.3.1
 

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -18,14 +18,6 @@ variable "container_images" {
 EOF
 }
 
-# TODO delete
-variable "container_repository" {
-  type        = string
-  default     = ""
-  description = "The container registry in which we can find Grapl services. Requires a trailing / if not empty string"
-}
-
-
 variable "aws_access_key_id" {
   type        = string
   default     = "DUMMY_LOCAL_AWS_ACCESS_KEY_ID"
@@ -300,7 +292,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_images["dgraph"]}"
+        image = var.container_images["dgraph"]
         args = [
           "dgraph",
           "zero",
@@ -364,7 +356,7 @@ job "grapl-core" {
         driver = "docker"
 
         config {
-          image = "${var.container_images["dgraph"]}"
+          image = var.container_images["dgraph"]
           args = [
             "dgraph",
             "zero",
@@ -468,7 +460,7 @@ job "grapl-core" {
         driver = "docker"
 
         config {
-          image = "${var.container_images["dgraph"]}"
+          image = var.container_images["dgraph"]
           args = [
             "dgraph",
             "alpha",
@@ -581,7 +573,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_images["graph-merger"]}"
+        image = var.container_images["graph-merger"]
       }
 
       # This writes an env files that gets read by nomad automatically
@@ -637,7 +629,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_images["node-identifier"]}"
+        image = var.container_images["node-identifier"]
       }
 
       template {
@@ -677,7 +669,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_images["node-identifier-retry"]}"
+        image = var.container_images["node-identifier-retry"]
       }
 
       template {
@@ -712,7 +704,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_images["analyzer-dispatcher"]}"
+        image = var.container_images["analyzer-dispatcher"]
       }
 
       template {
@@ -751,7 +743,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_images["analyzer-executor"]}"
+        image = var.container_images["analyzer-executor"]
       }
 
       template {
@@ -810,7 +802,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_images["engagement-creator"]}"
+        image = var.container_images["engagement-creator"]
       }
 
       template {
@@ -863,7 +855,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_images["graphql-endpoint"]}"
+        image = var.container_images["graphql-endpoint"]
         ports = ["graphql-endpoint-port"]
       }
 
@@ -920,7 +912,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_images["model-plugin-deployer"]}"
+        image = var.container_images["model-plugin-deployer"]
         ports = ["model-plugin-deployer"]
       }
 
@@ -952,7 +944,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_images["web-ui"]}"
+        image = var.container_images["web-ui"]
         ports = ["web-ui-port"]
       }
 
@@ -1002,7 +994,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_images["sysmon-generator"]}"
+        image = var.container_images["sysmon-generator"]
       }
 
       template {
@@ -1032,7 +1024,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_images["osquery-generator"]}"
+        image = var.container_images["osquery-generator"]
       }
 
       template {

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -6,15 +6,8 @@ variable "rust_log" {
 variable "container_images" {
   type        = map(string)
   description = <<EOF
-  A map of $NAME_OF_TASK to the URL for that task's docker image.
-
-  The values can look like, for instance:
-    - a hardcoded value pulled from Dockerhub
-        "dgraph/dgraph:v21.0.3"
-    - an image pulled from the host's Docker daemon (no `:latest`!)
-        "model-plugin-deployer:dev"
-    - an image pulled from Cloudsmith
-        "docker.cloudsmith.io/grapl/raw/graph-merger:20211105192234-a86a8ad2"
+  A map of $NAME_OF_TASK to the URL for that task's docker image ID.
+  (See DockerImageId in Pulumi for further documentation.)
 EOF
 }
 

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -3,11 +3,28 @@ variable "rust_log" {
   description = "Controls the logging behavior of Rust-based services."
 }
 
+variable "container_images" {
+  type        = map(string)
+  description = <<EOF
+  A map of $NAME_OF_TASK to the URL for that task's docker image.
+
+  The values can look like, for instance:
+    - a hardcoded value pulled from Dockerhub
+        "dgraph/dgraph:v21.0.3"
+    - an image pulled from the host's Docker daemon (no `:latest`!)
+        "model-plugin-deployer:dev"
+    - an image pulled from Cloudsmith
+        "docker.cloudsmith.io/grapl/raw/graph-merger:20211105192234-a86a8ad2"
+EOF
+}
+
+# TODO delete
 variable "container_repository" {
   type        = string
   default     = ""
   description = "The container registry in which we can find Grapl services. Requires a trailing / if not empty string"
 }
+
 
 variable "aws_access_key_id" {
   type        = string
@@ -57,11 +74,6 @@ variable "analyzer_dispatcher_dead_letter_queue" {
   description = "Dead letter queue for the analyzer services"
 }
 
-variable "analyzer_dispatcher_tag" {
-  type        = string
-  description = "The tagged version of the analyzer-dispatcher we should deploy."
-}
-
 variable "analyzer_matched_subgraphs_bucket" {
   type        = string
   description = "The s3 bucket used for storing matches"
@@ -70,17 +82,6 @@ variable "analyzer_matched_subgraphs_bucket" {
 variable "analyzer_executor_queue" {
   type        = string
   description = "Main queue for the executor"
-}
-
-variable "analyzer_executor_tag" {
-  type        = string
-  description = "The tagged version of the analyzer-executor we should deploy."
-}
-
-variable "dgraph_tag" {
-  type        = string
-  default     = "v21.03.1"
-  description = "The tag we should use when pulling dgraph."
 }
 
 variable "dgraph_replicas" {
@@ -95,11 +96,6 @@ variable "dgraph_shards" {
 
 variable "engagement_creator_queue" {
   type = string
-}
-
-variable "engagement_creator_tag" {
-  type        = string
-  description = "The tagged version of the engagement-creator we should deploy."
 }
 
 variable "_redis_endpoint" {
@@ -134,11 +130,6 @@ variable "num_graph_mergers" {
   description = "The number of graph merger instances to run."
 }
 
-variable "graph_merger_tag" {
-  type        = string
-  description = "The tagged version of the graph_merger we should deploy."
-}
-
 variable "graph_merger_queue" {
   type = string
 }
@@ -157,11 +148,6 @@ variable "model_plugins_bucket" {
   description = "The s3 bucket used for storing plugins"
 }
 
-variable "model_plugin_deployer_tag" {
-  type        = string
-  description = "The tagged version of the model plugin deployer to deploy."
-}
-
 variable "num_node_identifiers" {
   type        = number
   default     = 1
@@ -172,11 +158,6 @@ variable "num_node_identifier_retries" {
   type        = number
   default     = 1
   description = "The number of node identifier retries to run."
-}
-
-variable "node_identifier_tag" {
-  type        = string
-  description = "The tagged version of the node_identifier and the node_identifier_retry we should deploy."
 }
 
 variable "node_identifier_queue" {
@@ -206,16 +187,6 @@ variable "subgraphs_generated_bucket" {
   description = "The destination bucket for generated subgraphs. Used by Node identifier."
 }
 
-variable "graphql_endpoint_tag" {
-  type        = string
-  description = "The image tag for the graphql endpoint docker image."
-}
-
-variable "web_ui_tag" {
-  type        = string
-  description = "The image tag for the Grapl web UI docker image."
-}
-
 variable "deployment_name" {
   type        = string
   description = "The deployment name"
@@ -231,22 +202,12 @@ variable "user_session_table" {
   description = "What is the name of the DynamoDB user session table?"
 }
 
-variable "sysmon_generator_tag" {
-  type        = string
-  description = "The image tag for the sysmon generator docker image."
-}
-
 variable "sysmon_generator_queue" {
   type = string
 }
 
 variable "sysmon_generator_dead_letter_queue" {
   type = string
-}
-
-variable "osquery_generator_tag" {
-  type        = string
-  description = "The image tag for the osquery generator docker image."
 }
 
 variable "osquery_generator_queue" {
@@ -339,7 +300,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "dgraph/dgraph:${var.dgraph_tag}"
+        image = "${var.container_images["dgraph"]}"
         args = [
           "dgraph",
           "zero",
@@ -403,7 +364,7 @@ job "grapl-core" {
         driver = "docker"
 
         config {
-          image = "dgraph/dgraph:${var.dgraph_tag}"
+          image = "${var.container_images["dgraph"]}"
           args = [
             "dgraph",
             "zero",
@@ -507,7 +468,7 @@ job "grapl-core" {
         driver = "docker"
 
         config {
-          image = "dgraph/dgraph:${var.dgraph_tag}"
+          image = "${var.container_images["dgraph"]}"
           args = [
             "dgraph",
             "alpha",
@@ -620,7 +581,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_repository}graph-merger:${var.graph_merger_tag}"
+        image = "${var.container_images["graph-merger"]}"
       }
 
       # This writes an env files that gets read by nomad automatically
@@ -676,7 +637,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_repository}node-identifier:${var.node_identifier_tag}"
+        image = "${var.container_images["node-identifier"]}"
       }
 
       template {
@@ -716,7 +677,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_repository}node-identifier-retry:${var.node_identifier_tag}"
+        image = "${var.container_images["node-identifier-retry"]}"
       }
 
       template {
@@ -751,7 +712,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_repository}analyzer-dispatcher:${var.analyzer_dispatcher_tag}"
+        image = "${var.container_images["analyzer-dispatcher"]}"
       }
 
       template {
@@ -790,7 +751,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_repository}analyzer-executor:${var.analyzer_executor_tag}"
+        image = "${var.container_images["analyzer-executor"]}"
       }
 
       template {
@@ -849,7 +810,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_repository}engagement-creator:${var.engagement_creator_tag}"
+        image = "${var.container_images["engagement-creator"]}"
       }
 
       template {
@@ -902,7 +863,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_repository}graphql-endpoint:${var.graphql_endpoint_tag}"
+        image = "${var.container_images["graphql-endpoint"]}"
         ports = ["graphql-endpoint-port"]
       }
 
@@ -959,7 +920,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_repository}model-plugin-deployer:${var.model_plugin_deployer_tag}"
+        image = "${var.container_images["model-plugin-deployer"]}"
         ports = ["model-plugin-deployer"]
       }
 
@@ -991,7 +952,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_repository}grapl-web-ui:${var.web_ui_tag}"
+        image = "${var.container_images["web-ui"]}"
         ports = ["web-ui-port"]
       }
 
@@ -1041,7 +1002,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_repository}sysmon-generator:${var.sysmon_generator_tag}"
+        image = "${var.container_images["sysmon-generator"]}"
       }
 
       template {
@@ -1071,7 +1032,7 @@ job "grapl-core" {
       driver = "docker"
 
       config {
-        image = "${var.container_repository}osquery-generator:${var.osquery_generator_tag}"
+        image = "${var.container_images["osquery-generator"]}"
       }
 
       template {

--- a/nomad/grapl-provision.nomad
+++ b/nomad/grapl-provision.nomad
@@ -22,10 +22,19 @@ variable "_aws_endpoint" {
 EOF
 }
 
-variable "container_repository" {
-  type        = string
-  default     = ""
-  description = "The container repository in which we can find Grapl services. Requires a trailing / if not empty string"
+variable "container_images" {
+  type        = map(string)
+  description = <<EOF
+  A map of $NAME_OF_TASK to the URL for that task's docker image.
+
+  The values can look like, for instance:
+    - a hardcoded value pulled from Dockerhub
+        "dgraph/dgraph:v21.0.3"
+    - an image pulled from the host's Docker daemon (no `:latest`!)
+        "model-plugin-deployer:dev"
+    - an image pulled from Cloudsmith
+        "docker.cloudsmith.io/grapl/raw/graph-merger:20211105192234-a86a8ad2"
+EOF
 }
 
 variable "aws_access_key_id" {
@@ -69,12 +78,6 @@ variable "rust_log" {
   description = "Controls the logging behavior of Rust-based services."
 }
 
-variable "provisioner_tag" {
-  type        = string
-  description = "The tagged version of the provisioner we should deploy."
-}
-
-
 locals {
   # Prefer these over their `var` equivalents.
   # The aws endpoint is in template env format
@@ -106,7 +109,7 @@ job "grapl-provision" {
       driver = "docker"
 
       config {
-        image = "${var.container_repository}provisioner:${var.provisioner_tag}"
+        image = var.container_images["provisioner"]
       }
 
       lifecycle {

--- a/nomad/grapl-provision.nomad
+++ b/nomad/grapl-provision.nomad
@@ -25,15 +25,8 @@ EOF
 variable "container_images" {
   type        = map(string)
   description = <<EOF
-  A map of $NAME_OF_TASK to the URL for that task's docker image.
-
-  The values can look like, for instance:
-    - a hardcoded value pulled from Dockerhub
-        "dgraph/dgraph:v21.0.3"
-    - an image pulled from the host's Docker daemon (no `:latest`!)
-        "model-plugin-deployer:dev"
-    - an image pulled from Cloudsmith
-        "docker.cloudsmith.io/grapl/raw/graph-merger:20211105192234-a86a8ad2"
+  A map of $NAME_OF_TASK to the URL for that task's docker image ID.
+  (See DockerImageId in Pulumi for further documentation.)
 EOF
 }
 

--- a/nomad/local/e2e-tests.nomad
+++ b/nomad/local/e2e-tests.nomad
@@ -5,15 +5,8 @@
 variable "container_images" {
   type        = map(string)
   description = <<EOF
-  A map of $NAME_OF_TASK to the URL for that task's docker image.
-
-  The values can look like, for instance:
-    - a hardcoded value pulled from Dockerhub
-        "dgraph/dgraph:v21.0.3"
-    - an image pulled from the host's Docker daemon (no `:latest`!)
-        "model-plugin-deployer:dev"
-    - an image pulled from Cloudsmith
-        "docker.cloudsmith.io/grapl/raw/graph-merger:20211105192234-a86a8ad2"
+  A map of $NAME_OF_TASK to the URL for that task's docker image ID.
+  (See DockerImageId in Pulumi for further documentation.)
 EOF
 }
 

--- a/nomad/local/e2e-tests.nomad
+++ b/nomad/local/e2e-tests.nomad
@@ -139,7 +139,7 @@ job "e2e-tests" {
       driver = "docker"
 
       config {
-        image      = "${var.container_repository}e2e-tests:${var.e2e_tests_tag}"
+        image      = var.container_images["e2e-tests"]
         entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
         command = trimspace(<<EOF
 graplctl upload analyzer --analyzer_main_py ./etc/local_grapl/suspicious_svchost/main.py
@@ -183,7 +183,7 @@ EOF
       driver = "docker"
 
       config {
-        image = var.container_images["e2e-integration-tests"]
+        image = var.container_images["e2e-tests"]
       }
 
       # This writes an env file that gets read by the task automatically

--- a/nomad/local/e2e-tests.nomad
+++ b/nomad/local/e2e-tests.nomad
@@ -2,15 +2,19 @@
 # https://discuss.hashicorp.com/t/best-practices-for-testing-against-services-in-nomad-consul-connect/29022
 # We'll submit integration tests to Nomad as 
 # 
-variable "container_repository" {
-  type        = string
-  default     = ""
-  description = "The container repository in which we can find Grapl services. Requires a trailing /"
-}
+variable "container_images" {
+  type        = map(string)
+  description = <<EOF
+  A map of $NAME_OF_TASK to the URL for that task's docker image.
 
-variable "e2e_tests_tag" {
-  type        = string
-  description = "The tagged version of the e2e tests we should deploy."
+  The values can look like, for instance:
+    - a hardcoded value pulled from Dockerhub
+        "dgraph/dgraph:v21.0.3"
+    - an image pulled from the host's Docker daemon (no `:latest`!)
+        "model-plugin-deployer:dev"
+    - an image pulled from Cloudsmith
+        "docker.cloudsmith.io/grapl/raw/graph-merger:20211105192234-a86a8ad2"
+EOF
 }
 
 variable "aws_region" {
@@ -179,7 +183,7 @@ EOF
       driver = "docker"
 
       config {
-        image = "${var.container_repository}e2e-tests:${var.e2e_tests_tag}"
+        image = var.container_images["e2e-integration-tests"]
       }
 
       # This writes an env file that gets read by the task automatically

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -5,15 +5,8 @@
 variable "container_images" {
   type        = map(string)
   description = <<EOF
-  A map of $NAME_OF_TASK to the URL for that task's docker image.
-
-  The values can look like, for instance:
-    - a hardcoded value pulled from Dockerhub
-        "dgraph/dgraph:v21.0.3"
-    - an image pulled from the host's Docker daemon (no `:latest`!)
-        "model-plugin-deployer:dev"
-    - an image pulled from Cloudsmith
-        "docker.cloudsmith.io/grapl/raw/graph-merger:20211105192234-a86a8ad2"
+  A map of $NAME_OF_TASK to the URL for that task's docker image ID.
+  (See DockerImageId in Pulumi for further documentation.)
 EOF
 }
 

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -74,16 +74,6 @@ variable "grapl_root" {
   description = "Where to find the Grapl repo on the host OS (where Nomad runs)."
 }
 
-variable "python_integration_tests_tag" {
-  type        = string
-  description = "The tagged version of the python-integration-tests we should deploy."
-}
-
-variable "rust_integration_tests_tag" {
-  type        = string
-  description = "The tagged version of the rust-integration-tests we should deploy."
-}
-
 locals {
   log_level = "DEBUG"
 

--- a/nomad/local/start_detach.sh
+++ b/nomad/local/start_detach.sh
@@ -19,7 +19,7 @@ ensure_cros_bridge_networking_workaround() {
         if ! grep -q "_/bridge.ko" "$module_filepath"; then
             echo "It looks like you're on ChromeOS, but haven't installed the Nomad bridge networking workaround."
             # shellcheck source-path=SCRIPTDIR
-            source "../../etc/chromeos/lib/installs.sh"
+            source "$(dirname "${BASH_SOURCE[0]}")/../../etc/chromeos/lib/installs.sh"
             install_nomad_chromeos_workaround
             echo "ChromeOS Nomad bridge networking workaround should now be installed. Continuing..."
         fi

--- a/nomad/local/start_detach.sh
+++ b/nomad/local/start_detach.sh
@@ -19,7 +19,7 @@ ensure_cros_bridge_networking_workaround() {
         if ! grep -q "_/bridge.ko" "$module_filepath"; then
             echo "It looks like you're on ChromeOS, but haven't installed the Nomad bridge networking workaround."
             # shellcheck source-path=SCRIPTDIR
-            source "$(dirname "${BASH_SOURCE[0]}")/../../etc/chromeos/lib/installs.sh"
+            source "../../etc/chromeos/lib/installs.sh"
             install_nomad_chromeos_workaround
             echo "ChromeOS Nomad bridge networking workaround should now be installed. Continuing..."
         fi

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -18,7 +18,7 @@ from infra.autotag import register_auto_tags
 from infra.bucket import Bucket
 from infra.cache import Cache
 from infra.consul_intentions import ConsulIntentions
-from infra.docker_images import DockerImageId, DockerImageIdBuilder, version_tag
+from infra.docker_images import DockerImageId, DockerImageIdBuilder
 from infra.get_hashicorp_provider_address import get_hashicorp_provider_address
 
 # TODO: temporarily disabled until we can reconnect the ApiGateway to the new
@@ -47,30 +47,26 @@ def _container_images(
     """
     Build a map of {task name -> docker image identifier}.
     """
-    img_id_builder = DockerImageIdBuilder(config.container_repository())
-
-    def build_img_id_with_tag(image_name: str) -> DockerImageId:
-        """
-        A shortcut to grab the version tag from the artifacts map and build a
-        DockerImageId out of it
-        """
-        tag = version_tag(image_name, artifacts, require_artifact)
-        return img_id_builder.build(image_name=image_name, tag=tag)
+    builder = DockerImageIdBuilder(
+        container_repository=config.container_repository(),
+        artifacts=artifacts,
+        require_artifact=require_artifact,
+    )
 
     return {
-        "analyzer-dispatcher": build_img_id_with_tag("analyzer-dispatcher"),
-        "analyzer-executor": build_img_id_with_tag("analyzer-executor"),
+        "analyzer-dispatcher": builder.build_with_tag("analyzer-dispatcher"),
+        "analyzer-executor": builder.build_with_tag("analyzer-executor"),
         "dgraph": DockerImageId("dgraph/dgraph:v21.03.1"),
-        "engagement-creator": build_img_id_with_tag("engagement-creator"),
-        "graph-merger": build_img_id_with_tag("graph-merger"),
-        "graphql-endpoint": build_img_id_with_tag("graphql-endpoint"),
-        "model-plugin-deployer": build_img_id_with_tag("model-plugin-deployer"),
-        "node-identifier": build_img_id_with_tag("node-identifier"),
-        "node-identifier-retry": build_img_id_with_tag("node-identifier-retry"),
-        "osquery-generator": build_img_id_with_tag("osquery-generator"),
-        "provisioner": build_img_id_with_tag("provisioner"),
-        "sysmon-generator": build_img_id_with_tag("sysmon-generator"),
-        "web-ui": build_img_id_with_tag("grapl-web-ui"),
+        "engagement-creator": builder.build_with_tag("engagement-creator"),
+        "graph-merger": builder.build_with_tag("graph-merger"),
+        "graphql-endpoint": builder.build_with_tag("graphql-endpoint"),
+        "model-plugin-deployer": builder.build_with_tag("model-plugin-deployer"),
+        "node-identifier": builder.build_with_tag("node-identifier"),
+        "node-identifier-retry": builder.build_with_tag("node-identifier-retry"),
+        "osquery-generator": builder.build_with_tag("osquery-generator"),
+        "provisioner": builder.build_with_tag("provisioner"),
+        "sysmon-generator": builder.build_with_tag("sysmon-generator"),
+        "web-ui": builder.build_with_tag("grapl-web-ui"),
     }
 
 

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -1,4 +1,3 @@
-import json
 import sys
 from pathlib import Path
 from typing import Mapping, Set
@@ -19,7 +18,7 @@ from infra.autotag import register_auto_tags
 from infra.bucket import Bucket
 from infra.cache import Cache
 from infra.consul_intentions import ConsulIntentions
-from infra.docker_images import DockerImageIdBuilder, version_tag
+from infra.docker_images import DockerImageId, DockerImageIdBuilder, version_tag
 from infra.get_hashicorp_provider_address import get_hashicorp_provider_address
 
 # TODO: temporarily disabled until we can reconnect the ApiGateway to the new
@@ -44,36 +43,35 @@ def _get_subset(inputs: NomadVars, subset: Set[str]) -> NomadVars:
 
 def _container_images(
     artifacts: Mapping[str, str], require_artifact: bool = False
-) -> str:
+) -> Mapping[str, DockerImageId]:
     """
-    Build a map of "task name -> docker image URL".
-    See the .nomad file's var `container_images` for further documentation.
+    Build a map of {task name -> docker image identifier}.
     """
     img_id_builder = DockerImageIdBuilder(config.container_repository())
 
-    def build_img_id_with_tag(image_name: str) -> str:
-        # A shortcut to grab the version tag from the artifacts map and build a
-        # Cloudsmith docker image url out of it.
+    def build_img_id_with_tag(image_name: str) -> DockerImageId:
+        """
+        A shortcut to grab the version tag from the artifacts map and build a
+        DockerImageId out of it
+        """
         tag = version_tag(image_name, artifacts, require_artifact)
         return img_id_builder.build(image_name=image_name, tag=tag)
 
-    return json.dumps(
-        {
-            "analyzer-dispatcher": build_img_id_with_tag("analyzer-dispatcher"),
-            "analyzer-executor": build_img_id_with_tag("analyzer-executor"),
-            "dgraph": "dgraph/dgraph:v21.03.1",
-            "engagement-creator": build_img_id_with_tag("engagement-creator"),
-            "graph-merger": build_img_id_with_tag("graph-merger"),
-            "graphql-endpoint": build_img_id_with_tag("graphql-endpoint"),
-            "model-plugin-deployer": build_img_id_with_tag("model-plugin-deployer"),
-            "node-identifier": build_img_id_with_tag("node-identifier"),
-            "node-identifier-retry": build_img_id_with_tag("node-identifier-retry"),
-            "osquery-generator": build_img_id_with_tag("osquery-generator"),
-            "provisioner": build_img_id_with_tag("provisioner"),
-            "sysmon-generator": build_img_id_with_tag("sysmon-generator"),
-            "web-ui": build_img_id_with_tag("grapl-web-ui"),
-        }
-    )
+    return {
+        "analyzer-dispatcher": build_img_id_with_tag("analyzer-dispatcher"),
+        "analyzer-executor": build_img_id_with_tag("analyzer-executor"),
+        "dgraph": DockerImageId("dgraph/dgraph:v21.03.1"),
+        "engagement-creator": build_img_id_with_tag("engagement-creator"),
+        "graph-merger": build_img_id_with_tag("graph-merger"),
+        "graphql-endpoint": build_img_id_with_tag("graphql-endpoint"),
+        "model-plugin-deployer": build_img_id_with_tag("model-plugin-deployer"),
+        "node-identifier": build_img_id_with_tag("node-identifier"),
+        "node-identifier-retry": build_img_id_with_tag("node-identifier-retry"),
+        "osquery-generator": build_img_id_with_tag("osquery-generator"),
+        "provisioner": build_img_id_with_tag("provisioner"),
+        "sysmon-generator": build_img_id_with_tag("sysmon-generator"),
+        "web-ui": build_img_id_with_tag("grapl-web-ui"),
+    }
 
 
 def main() -> None:

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -47,7 +47,7 @@ def _container_images(
 ) -> str:
     """
     Build a map of "task name -> docker image URL".
-    See `grapl-core.nomad` container_images for examples.
+    See the .nomad file's var `container_images` for further documentation.
     """
     cs_urls = CloudsmithImageUrl(config.container_repository())
 

--- a/pulumi/infra/docker_images.py
+++ b/pulumi/infra/docker_images.py
@@ -1,5 +1,5 @@
 import os
-from typing import Mapping
+from typing import Mapping, Optional
 
 from typing_extensions import Final
 
@@ -15,10 +15,12 @@ def version_tag(
     require_artifact: bool = False,
 ) -> str:
     """
-    First, try and get it from artifacts;
+    First, try and get the value from artifacts;
         if no artifact and require_artifact, throw error
     then fall back to $TAG;
     then fall back to "dev"
+
+    We generally set `require_artifact=True` for production deployments.
     """
     artifact_version = artifacts.get(key)
     if artifact_version:
@@ -33,3 +35,14 @@ def version_tag(
         return tag
 
     return _DEFAULT_TAG
+
+
+class CloudsmithImageUrl:
+    def __init__(self, container_repository: Optional[str]) -> None:
+        if container_repository is not None:
+            self.container_repository: str = f"{container_repository}/"
+        else:
+            self.container_repository = ""
+
+    def build(self, image_name: str, tag: str) -> str:
+        return f"{self.container_repository}{image_name}:{tag}"

--- a/pulumi/infra/docker_images.py
+++ b/pulumi/infra/docker_images.py
@@ -54,10 +54,10 @@ def _version_tag(
 
 class DockerImageIdBuilder:
     def __init__(
-        self, 
+        self,
         container_repository: Optional[str],
-        artifacts: Mapping[str, str], 
-        require_artifact: bool = False
+        artifacts: Mapping[str, str],
+        require_artifact: bool = False,
     ) -> None:
         self.container_repository = (
             f"{container_repository}/" if container_repository else ""
@@ -72,5 +72,7 @@ class DockerImageIdBuilder:
         """
         Automatically grabs the version tag from config's artifacts.
         """
-        tag = _version_tag(image_name, artifacts=self.artifacts, require_artifact=self.require_artifact)
+        tag = _version_tag(
+            image_name, artifacts=self.artifacts, require_artifact=self.require_artifact
+        )
         return self.build(image_name, tag)

--- a/pulumi/infra/docker_images.py
+++ b/pulumi/infra/docker_images.py
@@ -24,7 +24,7 @@ The values can look like, for instance:
 DockerImageId = NewType("DockerImageId", str)
 
 
-def version_tag(
+def _version_tag(
     key: str,
     artifacts: Mapping[str, str],
     require_artifact: bool = False,
@@ -53,10 +53,24 @@ def version_tag(
 
 
 class DockerImageIdBuilder:
-    def __init__(self, container_repository: Optional[str]) -> None:
+    def __init__(
+        self, 
+        container_repository: Optional[str],
+        artifacts: Mapping[str, str], 
+        require_artifact: bool = False
+    ) -> None:
         self.container_repository = (
             f"{container_repository}/" if container_repository else ""
         )
+        self.artifacts = artifacts
+        self.require_artifact = require_artifact
 
     def build(self, image_name: str, tag: str) -> DockerImageId:
         return DockerImageId(f"{self.container_repository}{image_name}:{tag}")
+
+    def build_with_tag(self, image_name: str) -> DockerImageId:
+        """
+        Automatically grabs the version tag from config's artifacts.
+        """
+        tag = _version_tag(image_name, artifacts=self.artifacts, require_artifact=self.require_artifact)
+        return self.build(image_name, tag)

--- a/pulumi/infra/docker_images.py
+++ b/pulumi/infra/docker_images.py
@@ -37,7 +37,7 @@ def version_tag(
     return _DEFAULT_TAG
 
 
-class CloudsmithImageUrl:
+class DockerImageIdBuilder:
     def __init__(self, container_repository: Optional[str]) -> None:
         if container_repository is not None:
             self.container_repository: str = f"{container_repository}/"
@@ -45,4 +45,9 @@ class CloudsmithImageUrl:
             self.container_repository = ""
 
     def build(self, image_name: str, tag: str) -> str:
+        """
+        Returns a Docker image identifier that can be consumed by the
+        Nomad Docker plugin `image` field.
+        https://www.nomadproject.io/docs/drivers/docker#image
+        """
         return f"{self.container_repository}{image_name}:{tag}"

--- a/pulumi/infra/nomad_job.py
+++ b/pulumi/infra/nomad_job.py
@@ -1,12 +1,13 @@
+import json
 from pathlib import Path
-from typing import Any, Mapping, Optional, Union
+from typing import Mapping, Optional, Union
 
 import pulumi_nomad as nomad
 from infra.config import DEPLOYMENT_NAME
 
 import pulumi
 
-_ValidNomadVarTypes = pulumi.Input[Union[str, bool, int]]
+_ValidNomadVarTypes = pulumi.Input[Union[str, bool, int, Mapping[str, str]]]
 NomadVars = Mapping[str, Optional[_ValidNomadVarTypes]]
 
 
@@ -19,6 +20,9 @@ class NomadJob(pulumi.ComponentResource):
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
         super().__init__("grapl:NomadJob", name, None, opts)
+
+        vars = self._fix_pulumi_preview(vars)
+        vars = self._json_dump_complex_types(vars)
 
         self.job = nomad.Job(
             resource_name=f"{DEPLOYMENT_NAME}-{name}-job",
@@ -37,7 +41,20 @@ class NomadJob(pulumi.ComponentResource):
             f.close()
             return jobspec
 
-    def _fix_pulumi_preview(self, vars: Mapping[str, Any]) -> Mapping[str, Any]:
+    def _json_dump_complex_types(self, vars: NomadVars) -> NomadVars:
+        """
+        Nomad accepts input of lists and maps, but the Nomad/Pulumi plugin doesn't
+        convert them correctly.
+        """
+        complex_types_dumped = {
+            k: json.dumps(v) for (k, v) in vars.items() if isinstance(v, (dict, list))
+        }
+        return dict(
+            **vars,
+            **complex_types_dumped,
+        )
+
+    def _fix_pulumi_preview(self, vars: NomadVars) -> NomadVars:
         """
         This is an ugly hack to deal with pulumi preview never resolving Outputs into a real string.
         Without this, the vars gets unset if there's a single key with an unresolved output

--- a/pulumi/infra/nomad_job.py
+++ b/pulumi/infra/nomad_job.py
@@ -46,13 +46,10 @@ class NomadJob(pulumi.ComponentResource):
         Nomad accepts input of lists and maps, but the Nomad/Pulumi plugin doesn't
         convert them correctly.
         """
-        complex_types_dumped = {
-            k: json.dumps(v) for (k, v) in vars.items() if isinstance(v, (dict, list))
+        return {
+            k: json.dumps(v) if isinstance(v, (dict, list)) else v
+            for (k, v) in vars.items()
         }
-        return dict(
-            **vars,
-            **complex_types_dumped,
-        )
 
     def _fix_pulumi_preview(self, vars: NomadVars) -> NomadVars:
         """

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -10,7 +10,7 @@ import pulumi_aws as aws
 import pulumi_nomad as nomad
 from infra import config
 from infra.autotag import register_auto_tags
-from infra.docker_images import DockerImageId, DockerImageIdBuilder, version_tag
+from infra.docker_images import DockerImageId, DockerImageIdBuilder
 from infra.nomad_job import NomadJob, NomadVars
 from infra.quiet_docker_build_output import quiet_docker_output
 
@@ -23,20 +23,16 @@ def _container_images(
     """
     Build a map of {task name -> docker image identifier}.
     """
-    img_id_builder = DockerImageIdBuilder(config.container_repository())
-
-    def build_img_id_with_tag(image_name: str) -> DockerImageId:
-        """
-        A shortcut to grab the version tag from the artifacts map and build a
-        DockerImageId out of it
-        """
-        tag = version_tag(image_name, artifacts, require_artifact)
-        return img_id_builder.build(image_name=image_name, tag=tag)
+    builder = DockerImageIdBuilder(
+        container_repository=config.container_repository(),
+        artifacts=artifacts,
+        require_artifact=require_artifact,
+    )
 
     return {
-        "e2e-tests": build_img_id_with_tag("e2e-tests"),
-        "python-integration-tests": build_img_id_with_tag("python-integration-tests"),
-        "rust-integration-tests": build_img_id_with_tag("rust-integration-tests"),
+        "e2e-tests": builder.build_with_tag("e2e-tests"),
+        "python-integration-tests": builder.build_with_tag("python-integration-tests"),
+        "rust-integration-tests": builder.build_with_tag("rust-integration-tests"),
     }
 
 

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -10,11 +10,39 @@ import pulumi_aws as aws
 import pulumi_nomad as nomad
 from infra import config
 from infra.autotag import register_auto_tags
-from infra.docker_images import version_tag
+from infra.docker_images import CloudsmithImageUrl, version_tag
 from infra.nomad_job import NomadJob, NomadVars
 from infra.quiet_docker_build_output import quiet_docker_output
 
 import pulumi
+
+
+def _container_images(
+    artifacts: Mapping[str, str], require_artifact: bool = False
+) -> str:
+    """
+    Build a map of "task name -> docker image URL".
+    See `grapl-core.nomad` container_images for examples.
+    """
+    cs_urls = CloudsmithImageUrl(config.container_repository())
+
+    def build_image_url_with_version_tag(image_name: str) -> str:
+        # A shortcut to grab the version tag from the artifacts map and build a
+        # Cloudsmith docker image url out of it.
+        tag = version_tag(image_name, artifacts, require_artifact)
+        return cs_urls.build(image_name=image_name, tag=tag)
+
+    return json.dumps(
+        {
+            "e2e-tests": build_image_url_with_version_tag("e2e-tests"),
+            "python-integration-tests": build_image_url_with_version_tag(
+                "python-integration-tests"
+            ),
+            "rust-integration-tests": build_image_url_with_version_tag(
+                "rust-integration-tests"
+            ),
+        }
+    )
 
 
 def main() -> None:
@@ -23,8 +51,8 @@ def main() -> None:
 
     pulumi_config = pulumi.Config()
     artifacts = pulumi_config.get_object("artifacts") or {}
-    version_tag_alias = lambda key: version_tag(
-        key, artifacts, require_artifact=(not config.LOCAL_GRAPL)
+    container_images = _container_images(
+        artifacts, require_artifact=(not config.LOCAL_GRAPL)
     )
 
     quiet_docker_output()
@@ -60,8 +88,8 @@ def main() -> None:
         "aws_access_key_secret": secret_key,
         "_aws_endpoint": grapl_stack.aws_endpoint,
         "aws_region": aws.get_region().name,
+        "container_images": container_images,
         "deployment_name": grapl_stack.deployment_name,
-        "e2e_tests_tag": version_tag_alias("e2e-tests"),
         "schema_properties_table_name": grapl_stack.schema_properties_table_name,
         "sysmon_log_bucket": grapl_stack.sysmon_log_bucket,
         "schema_table_name": grapl_stack.schema_table_name,
@@ -85,15 +113,12 @@ def main() -> None:
             "aws_access_key_secret": secret_key,
             "_aws_endpoint": grapl_stack.aws_endpoint,
             "aws_region": aws.get_region().name,
+            "container_images": container_images,
             "deployment_name": grapl_stack.deployment_name,
             "docker_user": os.environ["DOCKER_USER"],
             "grapl_root": os.environ["GRAPL_ROOT"],
             "_kafka_endpoint": grapl_stack.kafka_endpoint,
-            "python_integration_tests_tag": version_tag_alias(
-                "python-integration-tests"
-            ),
             "_redis_endpoint": grapl_stack.redis_endpoint,
-            "rust_integration_tests_tag": version_tag_alias("rust-integration-tests"),
             "schema_properties_table_name": grapl_stack.schema_properties_table_name,
             "test_user_name": grapl_stack.test_user_name,
         }

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -23,7 +23,7 @@ def _container_images(
 ) -> str:
     """
     Build a map of "task name -> docker image URL".
-    See `grapl-core.nomad` container_images for examples.
+    See the .nomad file's var `container_images` for further documentation.
     """
     cs_urls = CloudsmithImageUrl(config.container_repository())
 

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -1,10 +1,11 @@
+import json
 import os
 import sys
 from pathlib import Path
 
 sys.path.insert(0, "..")
 
-from typing import Optional, cast
+from typing import Mapping, Optional, cast
 
 import pulumi_aws as aws
 import pulumi_nomad as nomad

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -10,7 +10,7 @@ import pulumi_aws as aws
 import pulumi_nomad as nomad
 from infra import config
 from infra.autotag import register_auto_tags
-from infra.docker_image_tag import version_tag
+from infra.docker_images import version_tag
 from infra.nomad_job import NomadJob, NomadVars
 from infra.quiet_docker_build_output import quiet_docker_output
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/697

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Previously we'd feed a `container_repository` and `tag`s into the Nomad file and do some variable interpolation inside Nomad to build the Docker Image ID ("okay, where do we find the docker image?")

I'm lifting this work up to the Pulumi level per the attached issue.
Main motivation for picking this up now: we will soon potentially be in a situation where some images come from the `grapl/raw` cloudsmith repo, and some come from the `grapl/$USERNAME` repo (if I wanted to upload 1 image for testing). This is much easier to reason about at the Pulumi level. 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
against CI
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
