### PR TITLE
Upload [the currently unused in prod testing] integration-test containers to Cloudsmith

### DIFF
--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -33,6 +33,8 @@ services=(
     node-identifier-retry
     osquery-generator
     provisioner
+    python-integration-tests
+    rust-integration-tests
     sysmon-generator
 )
 
@@ -43,7 +45,7 @@ cloudsmith_tag() {
 }
 
 echo "--- Building all ${TAG} images"
-make build build-test-e2e
+make build build-test-e2e build-test-integration
 
 for service in "${services[@]}"; do
     # Re-tag the container we just built so we can upload it to


### PR DESCRIPTION
wimax  3:57 PM
Ah, shoot, looks like my PR failed
https://buildkite.com/grapl/grapl-provision/builds/175#a5604b6b-b156-4fc3-a932-ce337e2100a1
because we don't currently upload the python-integration-tests image to dockerhub; let me get on that
the good news is, it does correctly insert the artifacts in origin/rc!
https://github.com/grapl-security/grapl/blob/rc/pulumi/integration_tests/Pulumi.testing.yaml

```
File "../infra/docker_images.py", line 76, in build_with_tag
  | image_name, artifacts=self.artifacts, require_artifact=self.require_artifact
  | File "../infra/docker_images.py", line 45, in _version_tag
  | f"Expected to find an artifacts entry for {key} in Pulumi config file"
  | KeyError: 'Expected to find an artifacts entry for python-integration-tests in Pulumi config file'
```

we'll eventually want to run these integration tests against prod, so it seems fine for now to upload these to Cloudsmith even if nobody currently consumes them. 