### PR TITLE
Don't require Integration Test artifacts if we're just running e2e

### DIFF
--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -33,8 +33,6 @@ services=(
     node-identifier-retry
     osquery-generator
     provisioner
-    python-integration-tests
-    rust-integration-tests
     sysmon-generator
 )
 
@@ -45,7 +43,7 @@ cloudsmith_tag() {
 }
 
 echo "--- Building all ${TAG} images"
-make build build-test-e2e build-test-integration
+make build build-test-e2e
 
 for service in "${services[@]}"; do
     # Re-tag the container we just built so we can upload it to


### PR DESCRIPTION
Cloudsmith charges by storage, and for some reason our rust=integration-test image is like 9GB.

Reverts https://github.com/grapl-security/grapl/pull/1295
Related to https://github.com/grapl-security/issue-tracker/issues/770

