### PR TITLE
pipeline.testing.yml: log in to Vault

### DIFF
--- a/.buildkite/pipeline.testing.yml
+++ b/.buildkite/pipeline.testing.yml
@@ -8,6 +8,11 @@ env:
 
 steps:
   - label: ":aws: E2E tests in AWS"
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - PULUMI_ACCESS_TOKEN
     command:
       - .buildkite/scripts/grapl_testing_stack/run_parameterized_job.sh e2e-tests 6
     # We don't believe the test is currently repeatable until we execute on

--- a/.buildkite/pipeline.testing.yml
+++ b/.buildkite/pipeline.testing.yml
@@ -8,6 +8,8 @@ env:
 
 steps:
   - label: ":aws: E2E tests in AWS"
+    agents:
+      queue: "pulumi-staging"
     plugins:
       - grapl-security/vault-login#v0.1.0
       - grapl-security/vault-env#v0.1.0:


### PR DESCRIPTION
Solves the following
```
Running commands | 8s
-- | --
  | $ trap 'kill -- $' INT TERM QUIT; .buildkite/scripts/grapl_testing_stack/run_parameterized_job.sh e2e-tests 6
  | warning: A new version of Pulumi is available. To upgrade from version '3.18.1' to '3.19.0', visit https://pulumi.com/docs/reference/install/ for manual instructions and release notes.
  | error: PULUMI_ACCESS_TOKEN must be set for login during non-interactive CLI sessions
  | 🚨 Error: The command exited with status 255
  | user command error: exit status 255
```

at 
https://buildkite.com/grapl/grapl-testing/builds/97#2bcd7730-538b-48f0-963a-75d6f546d64d