### PR TITLE
Coerce --dump-agent-logs from str to bool, woops

### DIFF
--- a/.buildkite/scripts/grapl_testing_stack/run_parameterized_job.sh
+++ b/.buildkite/scripts/grapl_testing_stack/run_parameterized_job.sh
@@ -23,7 +23,7 @@ dump_artifacts() {
         cd "${REPOSITORY_ROOT}"
         NOMAD_ADDRESS="${_NOMAD_ADDRESS}" ./pants run \
             ./etc/ci_scripts/dump_artifacts -- \
-            --dump-agent-logs=False
+            --no-dump-agent-logs
     )
 }
 trap dump_artifacts EXIT

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ grapl-template-generator: ## Build the Grapl Template Generator and install it t
 dump-artifacts-local:  # Run the script that dumps Nomad/Docker logs after test runs
 	./pants run ./etc/ci_scripts/dump_artifacts -- \
 		--compose-project="${COMPOSE_PROJECT_NAME}" \
-		--dump-agent-logs=True
+		--dump-agent-logs
 
 .PHONY: build-ux
 build-ux: ## Build website assets

--- a/etc/ci_scripts/dump_artifacts/cli.py
+++ b/etc/ci_scripts/dump_artifacts/cli.py
@@ -6,7 +6,7 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 # Odd path is due to the `/etc` root pattern in pants.toml, fyi
 from ci_scripts.dump_artifacts import docker_artifacts, nomad_artifacts

--- a/etc/ci_scripts/dump_artifacts/cli.py
+++ b/etc/ci_scripts/dump_artifacts/cli.py
@@ -10,7 +10,6 @@ from typing import Optional
 
 # Odd path is due to the `/etc` root pattern in pants.toml, fyi
 from ci_scripts.dump_artifacts import docker_artifacts, nomad_artifacts
-from grapl_common.utils.primitive_convertors import to_bool
 
 # need minimum 3.7 for capture_output=True
 assert sys.version_info >= (
@@ -35,8 +34,15 @@ class Args:
             default=None,
             help="Docker Compose project. Do not specify if Docker-Compose is not involved (e.g. running against prod)",
         )
-        parser.add_argument('--dump-agent-logs', dest='dump_agent_logs', action='store_true', help="Dump the logs for Nomad/Consul agents (useful if running locally)")
-        parser.add_argument('--no-dump-agent-logs', dest='dump_agent_logs', action='store_false')
+        parser.add_argument(
+            "--dump-agent-logs",
+            dest="dump_agent_logs",
+            action="store_true",
+            help="Dump the logs for Nomad/Consul agents (useful if running locally)",
+        )
+        parser.add_argument(
+            "--no-dump-agent-logs", dest="dump_agent_logs", action="store_false"
+        )
         parser.set_defaults(dump_agent_logs=False)
         args = parser.parse_args()
         self.compose_project: Optional[str] = args.compose_project

--- a/etc/ci_scripts/dump_artifacts/cli.py
+++ b/etc/ci_scripts/dump_artifacts/cli.py
@@ -35,17 +35,12 @@ class Args:
             default=None,
             help="Docker Compose project. Do not specify if Docker-Compose is not involved (e.g. running against prod)",
         )
-        parser.add_argument(
-            "--dump-agent-logs",
-            dest="dump_agent_logs",
-            required=False,
-            default=False,
-            help="Dump the logs for Nomad/Consul agents (e.g. running locally). [True / False]",
-        )
+        parser.add_argument('--dump-agent-logs', dest='dump_agent_logs', action='store_true', help="Dump the logs for Nomad/Consul agents (useful if running locally)")
+        parser.add_argument('--no-dump-agent-logs', dest='dump_agent_logs', action='store_false')
+        parser.set_defaults(dump_agent_logs=False)
         args = parser.parse_args()
         self.compose_project: Optional[str] = args.compose_project
-        # coerce from str -> Optional[bool] -> bool
-        self.dump_agent_logs = bool(to_bool(args.dump_agent_logs))
+        self.dump_agent_logs: bool = args.dump_agent_logs
 
 
 def main() -> None:

--- a/etc/ci_scripts/dump_artifacts/cli.py
+++ b/etc/ci_scripts/dump_artifacts/cli.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import logging
 import os
 import sys
@@ -9,6 +10,7 @@ from typing import Any, Optional
 
 # Odd path is due to the `/etc` root pattern in pants.toml, fyi
 from ci_scripts.dump_artifacts import docker_artifacts, nomad_artifacts
+from grapl_common.utils.primitive_convertors import to_bool
 
 # need minimum 3.7 for capture_output=True
 assert sys.version_info >= (
@@ -21,33 +23,34 @@ LOGGER.setLevel(logging.INFO)
 LOGGER.addHandler(logging.StreamHandler(stream=sys.stdout))
 
 
-def parse_args() -> Any:
-    import argparse
-
-    parser = argparse.ArgumentParser(
-        description="Dump all Docker logs for a given docker-compose project"
-    )
-    parser.add_argument(
-        "--compose-project",
-        dest="compose_project",
-        required=False,
-        default=None,
-        help="Docker Compose project. Do not specify if Docker-Compose is not involved (e.g. running against prod)",
-    )
-    parser.add_argument(
-        "--dump-agent-logs",
-        dest="dump_agent_logs",
-        required=False,
-        default=False,
-        help="Dump the logs for Nomad/Consul agents (e.g. running locally)",
-    )
-    return parser.parse_args()
+class Args:
+    def __init__(self) -> None:
+        parser = argparse.ArgumentParser(
+            description="Dump all Docker logs for a given docker-compose project"
+        )
+        parser.add_argument(
+            "--compose-project",
+            dest="compose_project",
+            required=False,
+            default=None,
+            help="Docker Compose project. Do not specify if Docker-Compose is not involved (e.g. running against prod)",
+        )
+        parser.add_argument(
+            "--dump-agent-logs",
+            dest="dump_agent_logs",
+            required=False,
+            default=False,
+            help="Dump the logs for Nomad/Consul agents (e.g. running locally). [True / False]",
+        )
+        args = parser.parse_args()
+        self.compose_project: Optional[str] = args.compose_project
+        # coerce from str -> Optional[bool] -> bool
+        self.dump_agent_logs = bool(to_bool(args.dump_agent_logs))
 
 
 def main() -> None:
-    args = parse_args()
-    compose_project: Optional[str] = args.compose_project
-    dump_agent_logs: bool = args.dump_agent_logs
+    args = Args()
+    compose_project = args.compose_project
 
     cwd = os.getcwd()
     timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
@@ -69,7 +72,7 @@ def main() -> None:
         compose_project=None, volume_name="dynamodb_dump", artifacts_dir=artifacts_dir
     )
 
-    nomad_artifacts.dump_all(artifacts_dir, dump_agent_logs=dump_agent_logs)
+    nomad_artifacts.dump_all(artifacts_dir, dump_agent_logs=args.dump_agent_logs)
     LOGGER.info(f"Dumped to {artifacts_dir}")
 
 


### PR DESCRIPTION
Relates to https://github.com/grapl-security/issue-tracker/issues/770

e2e tests worked fine, but dump_artifacts still tried to download agent logs. Turns out I was literally feeding in a string "False".
