### PR TITLE
Add a script to destroy/recreate stateful resources during grapl/provision (currently disabled)

### DIFF
--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -34,9 +34,21 @@ steps:
 
   - wait
 
-  # TODO (wimax Dec 2021): Consider a selective `pulumi destroy` here that
-  # cleans up dgraph/dynamodb state ahead of e2e tests.
   # https://github.com/grapl-security/issue-tracker/issues/793
+  # Uncomment once a successful `provision` created a pulumi output
+  # called 'stateful-resource-urns'
+  # - label: ":pulumi: Destroy stateful resources in Staging account"
+  #   plugins:
+  #     - grapl-security/vault-login#v0.1.0
+  #     - grapl-security/vault-env#v0.1.0:
+  #         secrets:
+  #           - PULUMI_ACCESS_TOKEN
+  #   command:
+  #     - .buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh grapl/grapl/testing
+  #   agents:
+  #     queue: "pulumi-staging"
+
+  - wait
 
   - label: ":pulumi: Update grapl/testing environment in Staging account"
     plugins:

--- a/.buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh
+++ b/.buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh
@@ -2,7 +2,7 @@
 
 ################################################################################
 # https://github.com/grapl-security/issue-tracker/issues/793
-# This script is a stop-grap measure while we await organization IDs.
+# This script is a stop-gap measure while we await organization IDs.
 # It will destroy dgraph and dynamodb state in an AWS Grapl sandbox.
 # (You'll likely want to `pulumi update` immediately afterwards!)
 ################################################################################
@@ -43,7 +43,7 @@ pulumi config set \
     --cwd="${project_dir}" \
     --stack="${stack}"
 
-# turn '["a", "b"]' into '--target=a --target=b'
+# turn '["a", "b"]' into bash-array (--target=a --target=b)
 urns=$(pulumi stack output stateful-resource-urns --stack="${stack}")
 target_args=($(echo "${urns}" | jq -r '. | map("--target=" + .) | .[]'))
 

--- a/.buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh
+++ b/.buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+################################################################################
+# https://github.com/grapl-security/issue-tracker/issues/793
+# This script is a stop-grap measure while we await organization IDs.
+# It will destroy dgraph and dynamodb state in an AWS Grapl sandbox.
+# (You'll likely want to `pulumi update` immediately afterwards!)
+################################################################################
+
+set -euo pipefail
+
+########################################################################
+# This logic is mostly stolen from pulumi-buildkite-plugin, and sets up
+# a `pulumi` on PATH.
+if [[ -z "${SKIP_VENV:-}" ]]; then
+    echo -e "--- :python: Installing dependencies"
+    build-support/manage_virtualenv.sh populate
+    export VIRTUAL_ENV=build-support/venv
+    PATH="$(pwd)/${VIRTUAL_ENV}/bin":${PATH}
+    export PATH
+fi
+########################################################################
+
+project_dir="pulumi/grapl"
+stack="${1}"
+
+echo -e "--- :pulumi: Log in"
+pulumi login
+
+# The default for this is `true`, which was set to reduce unnecessary
+# network calls, but is actually useful to have in AWS! This lets us
+# get credentials from the IMDS.
+#
+# While it *technically* means that our configuration is not precisely
+# what is in version control, it's a configuration that doesn't
+# actually have any impact on the infrastructure being created.
+#
+# For further background, see:
+# https://github.com/pulumi/pulumi-aws/pull/1288
+# https://github.com/pulumi/pulumi-aws/issues/1636
+pulumi config set \
+    aws:skipMetadataApiCheck false \
+    --cwd="${project_dir}" \
+    --stack="${stack}"
+
+# turn '["a", "b"]' into '--target=a --target=b'
+urns=$(pulumi stack output stateful-resource-urns --stack="${stack}")
+target_args=($(echo "${urns}" | jq -r '. | map("--target=" + .) | .[]'))
+
+echo -e "--- :pulumi: Destroying stateful resources for ${stack}"
+pulumi destroy \
+    --cwd="${project_dir}" \
+    --stack="${stack}" \
+    --show-replacement-steps \
+    --non-interactive \
+    --diff \
+    --yes \
+    --message="Destroying stateful resources" \
+    --target-dependents \
+    "${target_args[@]}"

--- a/.buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh
+++ b/.buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh
@@ -45,7 +45,7 @@ pulumi config set \
 
 # turn '["a", "b"]' into bash-array (--target=a --target=b)
 urns=$(pulumi stack output stateful-resource-urns --stack="${stack}")
-target_args=($(echo "${urns}" | jq -r '. | map("--target=" + .) | .[]'))
+mapfile -t target_args < <(echo "${urns}" | jq -r '. | map("--target=" + .) | .[]')
 
 echo -e "--- :pulumi: Destroying stateful resources for ${stack}"
 pulumi destroy \

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -378,7 +378,11 @@ def main() -> None:
             jobspec=Path("../../nomad/grapl-provision.nomad").resolve(),
             vars=grapl_provision_job_vars,
             opts=pulumi.ResourceOptions(
-                depends_on=[nomad_grapl_core.job], provider=nomad_provider
+                depends_on=[
+                    nomad_grapl_core.job,
+                    dynamodb_tables,
+                ],
+                provider=nomad_provider,
             ),
         )
 
@@ -392,6 +396,19 @@ def main() -> None:
             ),
         )
         pulumi.export("stage-url", api_gateway.stage.invoke_url)
+
+        # Describes resources that should be destroyed/updated between
+        # E2E-in-AWS runs.
+        pulumi.export(
+            "stateful-resource-urns",
+            [
+                # grapl-core contains our dgraph instances
+                nomad_grapl_core.urn,
+                # We need to re-provision after we start a new dgraph
+                nomad_grapl_provision.urn,
+                dynamodb_tables.urn,
+            ],
+        )
 
     OpsAlarms(name="ops-alarms")
 


### PR DESCRIPTION


<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/793
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Between e2e tests runs, we want to clean up state.
This script, when enabled, will destroy grapl-provision, grapl-core, and dynamodb tables. 
a `pulumi update` will re-add them (and, yes, reprovision them!)

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I did this on my personal sandbox.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
