### PR TITLE
Enable the stateful resources destroy step in E2E-in-AWS

### DIFF
--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -34,19 +34,16 @@ steps:
 
   - wait
 
-  # https://github.com/grapl-security/issue-tracker/issues/793
-  # Uncomment once a successful `provision` created a pulumi output
-  # called 'stateful-resource-urns'
-  # - label: ":pulumi: Destroy stateful resources in Staging account"
-  #   plugins:
-  #     - grapl-security/vault-login#v0.1.0
-  #     - grapl-security/vault-env#v0.1.0:
-  #         secrets:
-  #           - PULUMI_ACCESS_TOKEN
-  #   command:
-  #     - .buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh grapl/grapl/testing
-  #   agents:
-  #     queue: "pulumi-staging"
+  - label: ":pulumi: Destroy stateful resources in Staging account"
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - PULUMI_ACCESS_TOKEN
+    command:
+      - .buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh grapl/grapl/testing
+    agents:
+      queue: "pulumi-staging"
 
   - wait
 

--- a/.buildkite/pipeline.testing.yml
+++ b/.buildkite/pipeline.testing.yml
@@ -17,8 +17,5 @@ steps:
             - PULUMI_ACCESS_TOKEN
     command:
       - .buildkite/scripts/grapl_testing_stack/run_parameterized_job.sh e2e-tests 6
-    # We don't believe the test is currently repeatable until we execute on
-    # https://github.com/grapl-security/issue-tracker/issues/793
-    # But we also don't want these failures blocking the pipeline.
-    # Remove this once 793 is complete.
-    soft_fail: true
+    artifact_paths:
+      - "test_artifacts/**/*"


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
Satisfies and closes out https://github.com/grapl-security/issue-tracker/issues/793
In doing so, may also close out https://github.com/grapl-security/issue-tracker/issues/770

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Uncomment the "stateful resources destroy" buildkite step, now that its precursor has been fulfilled (a certain pulumi output exists)
- (oops, forgot to add a thing about artifacts)

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
they weren't

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
