### PR TITLE
Revert "Merge pull request #1303 from grapl-security/reenableE2eTesting"

### DIFF
--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -34,16 +34,19 @@ steps:
 
   - wait
 
-  - label: ":pulumi: Destroy stateful resources in Staging account"
-    plugins:
-      - grapl-security/vault-login#v0.1.0
-      - grapl-security/vault-env#v0.1.0:
-          secrets:
-            - PULUMI_ACCESS_TOKEN
-    command:
-      - .buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh grapl/grapl/testing
-    agents:
-      queue: "pulumi-staging"
+  # https://github.com/grapl-security/issue-tracker/issues/793
+  # Uncomment once a successful `provision` created a pulumi output
+  # called 'stateful-resource-urns'
+  # - label: ":pulumi: Destroy stateful resources in Staging account"
+  #   plugins:
+  #     - grapl-security/vault-login#v0.1.0
+  #     - grapl-security/vault-env#v0.1.0:
+  #         secrets:
+  #           - PULUMI_ACCESS_TOKEN
+  #   command:
+  #     - .buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh grapl/grapl/testing
+  #   agents:
+  #     queue: "pulumi-staging"
 
   - wait
 

--- a/.buildkite/pipeline.testing.yml
+++ b/.buildkite/pipeline.testing.yml
@@ -17,5 +17,8 @@ steps:
             - PULUMI_ACCESS_TOKEN
     command:
       - .buildkite/scripts/grapl_testing_stack/run_parameterized_job.sh e2e-tests 6
-    artifact_paths:
-      - "test_artifacts/**/*"
+    # We don't believe the test is currently repeatable until we execute on
+    # https://github.com/grapl-security/issue-tracker/issues/793
+    # But we also don't want these failures blocking the pipeline.
+    # Remove this once 793 is complete.
+    soft_fail: true


### PR DESCRIPTION
This reverts commit 016ac1f8ec5dba68e4117d10052107ef2213ef99, reversing
changes made to 8d7e612115787d2c699c3f7199f3f9c89079a2de.
Reverts https://github.com/grapl-security/grapl/pull/1303

The reasoning is due to the state described in this Pulumi ticket:
https://github.com/pulumi/pulumi/issues/8562

The plan here is:
remove the delete and then run an update and then re-add the delete

I'll get a successful `provision` run with this revert, and then revert-revert.