### PR TITLE
Revert revert "Merge pull request #1303 from grapl-security/reenableE2eTesting"

### DIFF
--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -34,19 +34,16 @@ steps:
 
   - wait
 
-  # https://github.com/grapl-security/issue-tracker/issues/793
-  # Uncomment once a successful `provision` created a pulumi output
-  # called 'stateful-resource-urns'
-  # - label: ":pulumi: Destroy stateful resources in Staging account"
-  #   plugins:
-  #     - grapl-security/vault-login#v0.1.0
-  #     - grapl-security/vault-env#v0.1.0:
-  #         secrets:
-  #           - PULUMI_ACCESS_TOKEN
-  #   command:
-  #     - .buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh grapl/grapl/testing
-  #   agents:
-  #     queue: "pulumi-staging"
+  - label: ":pulumi: Destroy stateful resources in Staging account"
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - PULUMI_ACCESS_TOKEN
+    command:
+      - .buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh grapl/grapl/testing
+    agents:
+      queue: "pulumi-staging"
 
   - wait
 

--- a/.buildkite/pipeline.testing.yml
+++ b/.buildkite/pipeline.testing.yml
@@ -17,8 +17,5 @@ steps:
             - PULUMI_ACCESS_TOKEN
     command:
       - .buildkite/scripts/grapl_testing_stack/run_parameterized_job.sh e2e-tests 6
-    # We don't believe the test is currently repeatable until we execute on
-    # https://github.com/grapl-security/issue-tracker/issues/793
-    # But we also don't want these failures blocking the pipeline.
-    # Remove this once 793 is complete.
-    soft_fail: true
+    artifact_paths:
+      - "test_artifacts/**/*"

--- a/.buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh
+++ b/.buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh
@@ -55,6 +55,7 @@ pulumi destroy \
     --non-interactive \
     --diff \
     --yes \
+    --refresh \
     --message="Destroying stateful resources" \
     --target-dependents \
     "${target_args[@]}"


### PR DESCRIPTION
Step 2 of the plan described in https://github.com/grapl-security/grapl/pull/1304

The plan here is:
remove the delete and then run an update and then re-add the delete

this is the re-add.
also I added a `--refresh` because thomas asked nicely.

# Don't merge this until `grapl/provision` runs successfully.