### PR TITLE
Unset AWS creds for artifact upload after prod aws-e2e-tests

### DIFF
--- a/.buildkite/pipeline.testing.yml
+++ b/.buildkite/pipeline.testing.yml
@@ -17,5 +17,6 @@ steps:
             - PULUMI_ACCESS_TOKEN
     command:
       - .buildkite/scripts/grapl_testing_stack/run_parameterized_job.sh e2e-tests 6
+      - .buildkite/scripts/unset_aws_creds_for_artifact_upload.sh
     artifact_paths:
-      - "test_artifacts/**/*"
+      - "test_artifacts/**/*" # Requires `unset_aws_creds_for_artifact_upload.sh`

--- a/.buildkite/scripts/extract_artifacts.sh
+++ b/.buildkite/scripts/extract_artifacts.sh
@@ -11,6 +11,7 @@ pulumi config get artifacts \
     --json |
     jq '.objectValue' > current_artifacts.json
 
-.buildkite/scripts/unset_aws_creds_for_artifact_upload.sh
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/unset_aws_creds_for_artifact_upload.sh"
 
 buildkite-agent artifact upload current_artifacts.json

--- a/.buildkite/scripts/extract_artifacts.sh
+++ b/.buildkite/scripts/extract_artifacts.sh
@@ -11,11 +11,6 @@ pulumi config get artifacts \
     --json |
     jq '.objectValue' > current_artifacts.json
 
-# We have to unset the AWS credentials injected by the
-# asume-role plugin if we're going to subsequently upload the
-# file to our bucket :(
-unset AWS_ACCESS_KEY_ID
-unset AWS_SECRET_ACCESS_KEY
-unset AWS_SESSION_TOKEN
+.buildkite/scripts/unset_aws_creds_for_artifact_upload.sh
 
 buildkite-agent artifact upload current_artifacts.json

--- a/.buildkite/scripts/unset_aws_creds_for_artifact_upload.sh
+++ b/.buildkite/scripts/unset_aws_creds_for_artifact_upload.sh
@@ -1,0 +1,9 @@
+# We have to unset the AWS credentials injected by the
+# assume-role plugin if we're going to subsequently upload the
+# file to our bucket :(
+
+# More info at https://github.com/grapl-security/grapl/pull/1277
+
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+unset AWS_SESSION_TOKEN

--- a/.buildkite/scripts/unset_aws_creds_for_artifact_upload.sh
+++ b/.buildkite/scripts/unset_aws_creds_for_artifact_upload.sh
@@ -1,8 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+################################################################################
 # We have to unset the AWS credentials injected by the
 # assume-role plugin if we're going to subsequently upload the
 # file to our bucket :(
-
 # More info at https://github.com/grapl-security/grapl/pull/1277
+################################################################################
 
 unset AWS_ACCESS_KEY_ID
 unset AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/770

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Continue using a hack around AWS creds for artifacts, until it's solved more holistically.
See https://grapl-internal.slack.com/archives/C02JCBKS97V/p1639004522015500 for further discussion

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
they weren't :) :) 

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
