### PR TITLE
Remove pulumi-prep and update some documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,16 +163,13 @@ build-test-e2e: build
 		--file ./test/docker-compose.integration-tests.build.yml \
 		e2e-tests
 
-.PHONY: build-dist-artifacts
-build-dist-artifacts: build-service-pexs ## Generate all artifacts for dist/
-
 .PHONY: build-docker-images
 build-docker-images: graplctl build-ux
 	echo "--- Building Docker images"
 	$(DOCKER_BUILDX_BAKE) --file docker-compose.build.yml
 
 .PHONY: build
-build: build-dist-artifacts build-docker-images ## Build Grapl services
+build: build-service-pexs build-docker-images ## Build Grapl services
 
 .PHONY: build-formatter
 build-formatter:
@@ -471,9 +468,6 @@ populate-venv: ## Set up a Python virtualenv (you'll have to activate manually!)
 .PHONY: repl
 repl: ## Run an interactive ipython repl that can import from grapl-common etc
 	./pants --no-pantsd repl --shell=ipython src/python/repl
-
-.PHONY: pulumi-prep
-pulumi-prep: graplctl build-dist-artifacts ux-tarball ## Prepare some artifacts in advance of running a Pulumi update (does not run Pulumi!)
 
 .PHONY: update-buildkite-shared
 update-buildkite-shared: ## Pull in changes from grapl-security/buildkite-common

--- a/docs/setup/aws.md
+++ b/docs/setup/aws.md
@@ -56,25 +56,16 @@ The remaining steps assume your working directory is the Grapl repository.
 
 ### Build deployment artifacts
 
-Deployment artifacts are build via `make lambdas`.
-
-If environmental variable `TAG` is set, it will be a custom name for the build.
-If it is unset, it will default to "latest".
-
-```bash
-# build with 'latest' TAG:
-make pulumi-prep
-
-# build with a one-off custom TAG:
-$ TAG=my_grapl_test make pulumi-prep
-
-# or set a fixed custom TAG in .env:
-$ cat .env
-TAG="my_grapl_test"
-$ make pulumi-prep
-```
+Previously we supported uploading deployment artifacts (Docker images) directly
+from your dev machine, but the current state of Grapl requires that the Docker
+images be downloaded from Dockerhub or Cloudsmith. If you truly wish to upload
+an image to Cloudsmith, try `bin/upload_image_to_cloudsmith.sh`
 
 ## Spin up infrastructure with Pulumi
+
+(This section is actively under development, and as of Dec 2021 requires
+infrastructure defined in the private repository
+https://github.com/grapl-security/platform-infrastructure )
 
 See
 [pulumi/README.md](https://github.com/grapl-security/grapl/blob/main/pulumi/README.md)
@@ -121,36 +112,6 @@ and then use the `./bin/graplctl-pulumi.sh` wrapper _instead_ of invoking
 
 For further details, please read the documentation in that script.
 
-### How to spin up DGraph
-
-_Warning: these commands spin up infrastructure in your AWS account. Running
-these commands will incur charges._
-
-To spin up DGraph with `graplctl`, execute the following from the Grapl root:
-
-```bash
-./bin/graplctl dgraph create --instance-type i3.large
-```
-
-Note that we've selected `i3.large` instances for our DGraph database. If you'd
-like to choose a different instance class, you may see the available options by
-running:
-
-```bash
-bin/graplctl aws deploy --help
-```
-
-### Provision Grapl
-
-After we deploy to AWS successfully, we need to provision Grapl by executing the
-following from the root of the Grapl repository checkout:
-
-```bash
-./bin/graplctl aws provision
-```
-
-which will invoke the provisioner lambda.
-
 ## Testing
 
 Follow the instructions in this section to deploy analyzers, upload test data,
@@ -183,13 +144,11 @@ kick off the Grapl data pipeline.
 
 ### Execute the end-to-end tests
 
-To execute the end-to-end tests, run the following `graplctl` command:
+To deploy end-to-end tests to a Nomad cluster running on AWS, see
+[pulumi/integration_tests/README.md].
 
-```bash
-./bin/graplctl aws test
-```
-
-This will execute the `e2e-test-runner` lambda in AWS.
+Then, using the Nomad UI at `localhost:4646` (courtesy of SSM Port Forwarding),
+kick off the `e2e-tests` parameterized batch job.
 
 ### Logging in to the Grapl UI with the test user
 


### PR DESCRIPTION
this is a holdover from the days when Pulumi would upload local Docker images and lambda zips to AWS