### PR TITLE
use venv instead of grapl-venv for the pyright config

### DIFF
--- a/build-support/editor_setup.py
+++ b/build-support/editor_setup.py
@@ -36,7 +36,7 @@ BASE_PYRIGHTCONFIG: PyrightConfig = {
     "pythonVersion": "3.7",
     "pythonPlatform": "Linux",
     "venvPath": "build-support",
-    "venv": "grapl-venv",
+    "venv": "venv",
     "verboseOutput": True,
     "reportMissingImports": True,
     "exclude": [


### PR DESCRIPTION

<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
NA
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
This PR fixes the editor setup script to emit a configuration which uses the `build-support/venv` instead of the defunct `build-support/grapl-venv`
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
```
. build-support/venv/bin/activate
./build-support/editor_setup.py generate
```
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
