### PR TITLE
Hook Plugin Registry up to Nomad, and plumb through a very basic integration smoke-test.

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -925,6 +925,37 @@ job "grapl-core" {
     }
   }
 
+
+  group "plugin-registry" {
+    network {
+      mode = "bridge"
+      port "plugin-registry" {
+      }
+    }
+
+    task "plugin-registry" {
+      driver = "docker"
+
+      config {
+        image = var.container_images["plugin-registry"]
+        ports = ["plugin-registry"]
+      }
+
+      env {
+        RUST_LOG       = var.rust_log
+        RUST_BACKTRACE = local.rust_backtrace
+      }
+    }
+
+    service {
+      name = "plugin-registry"
+      port = "plugin-registry"
+      connect {
+        sidecar_service {}
+      }
+    }
+  }
+
   group "web-ui" {
     network {
       mode = "bridge"

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -942,8 +942,9 @@ job "grapl-core" {
       }
 
       env {
-        RUST_LOG       = var.rust_log
-        RUST_BACKTRACE = local.rust_backtrace
+        RUST_LOG                   = var.rust_log
+        RUST_BACKTRACE             = local.rust_backtrace
+        GRAPL_PLUGIN_REGISTRY_PORT = "${NOMAD_PORT_plugin-registry}"
       }
     }
 

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -214,8 +214,7 @@ job "grapl-local-infra" {
       }
 
       resources {
-        cpu    = 500
-        memory = 1024
+        memory = 500
       }
 
       env {

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -132,6 +132,11 @@ job "integration-tests" {
               destination_name = "model-plugin-deployer"
               local_bind_port  = 1000 # doesn't really matter
             }
+
+            upstreams {
+              destination_name = "plugin-registry"
+              local_bind_port  = 1001 # doesn't really matter
+            }
           }
         }
       }
@@ -165,6 +170,9 @@ job "integration-tests" {
 
         GRAPL_MODEL_PLUGIN_DEPLOYER_HOST = "0.0.0.0"
         GRAPL_MODEL_PLUGIN_DEPLOYER_PORT = "${NOMAD_UPSTREAM_PORT_model-plugin-deployer}"
+
+        GRAPL_PLUGIN_REGISTRY_HOST = "0.0.0.0"
+        GRAPL_PLUGIN_REGISTRY_PORT = "${NOMAD_UPSTREAM_PORT_plugin-registry}"
       }
 
       # Because Cargo does some... compiling... for some reason.... maybe.....

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -177,7 +177,7 @@ job "integration-tests" {
 
       # Because Cargo does some... compiling... for some reason.... maybe.....
       resources {
-        memory = 8192
+        memory = 6000
       }
     }
   }
@@ -278,7 +278,7 @@ job "integration-tests" {
       }
 
       resources {
-        memory = 2048
+        memory = 1024
       }
     }
   }

--- a/nomad/local/nomad_run_local_infra.sh
+++ b/nomad/local/nomad_run_local_infra.sh
@@ -25,6 +25,9 @@ echo "--- Deploying Nomad local infrastructure."
 # shellcheck disable=SC2016
 timeout 60 bash -c -- 'while [[ -z $(nomad node status 2>&1 | grep ready) ]]; do printf "Waiting for nomad-agent\n";sleep 1;done'
 
+# Do a Validate before a Plan. Helps end-users catch errors.
+nomad job validate "${NOMAD_VARS[@]}" "${NOMAD_FILE}"
+
 # Okay, now the Nomad agent is up, but it might not be ready to accept jobs.
 # Just loop on `nomad job plan` until it can.
 attemptPlan() {

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -64,6 +64,7 @@ def _container_images(
         "node-identifier": builder.build_with_tag("node-identifier"),
         "node-identifier-retry": builder.build_with_tag("node-identifier-retry"),
         "osquery-generator": builder.build_with_tag("osquery-generator"),
+        "plugin-registry": builder.build_with_tag("plugin-registry"),
         "provisioner": builder.build_with_tag("provisioner"),
         "sysmon-generator": builder.build_with_tag("sysmon-generator"),
         "web-ui": builder.build_with_tag("grapl-web-ui"),

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2905,6 +2905,7 @@ dependencies = [
  "tonic 0.6.1",
  "tonic-health",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -67,7 +67,7 @@ RUN --mount=type=cache,target=/grapl/rust/target,sharing=locked \
 ################################################################################
 FROM base AS build-test
 
-ENV RUST_INTEGRATION_TEST_FEATURES="node-identifier/integration,sqs-executor/integration,kafka-metrics-exporter/integration,model-plugin-deployer/integration"
+ENV RUST_INTEGRATION_TEST_FEATURES="node-identifier/integration,sqs-executor/integration,kafka-metrics-exporter/integration,model-plugin-deployer/integration,plugin-registry/integration"
 
 # For test coverage reports
 RUN --mount=type=cache,target=/usr/local/cargo/registry \

--- a/src/rust/plugin-registry/src/client.rs
+++ b/src/rust/plugin-registry/src/client.rs
@@ -129,8 +129,8 @@ where
         self.inner
             .get_generators_for_event_source(GetGeneratorsForEventSourceRequestProto::from(request))
             .await
-            .expect("todo");
-        todo!()
+            .map(|resp| resp.into_inner().try_into().expect("proto to rs"))
+            .map_err(|_status| PluginRegistryServiceError::TodoImplementThisEnumError())
     }
     /// Given information about a tenant, return all analyzers for that tenant
     pub async fn get_analyzers_for_tenant(

--- a/src/rust/plugin-registry/src/lib.rs
+++ b/src/rust/plugin-registry/src/lib.rs
@@ -1,11 +1,11 @@
 pub mod client;
 pub mod server;
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
+pub mod plugin_registry {
+    const PORT_ENV_VAR: &'static str = "GRAPL_PLUGIN_REGISTRY_PORT";
+
+    pub fn get_socket_addr() -> Result<std::net::SocketAddr, std::net::AddrParseError> {
+        let port = std::env::var(PORT_ENV_VAR).expect(PORT_ENV_VAR);
+        return format!("0.0.0.0:{}", port).parse();
     }
 }

--- a/src/rust/plugin-registry/src/main.rs
+++ b/src/rust/plugin-registry/src/main.rs
@@ -1,8 +1,12 @@
-use plugin_registry::server::exec_service;
+use plugin_registry::{
+    plugin_registry::get_socket_addr,
+    server::exec_service,
+};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (_env, _guard) = grapl_config::init_grapl_env!();
-    exec_service().await?;
+    let socket_addr = get_socket_addr()?;
+    exec_service(socket_addr).await?;
     Ok(())
 }

--- a/src/rust/plugin-registry/src/server.rs
+++ b/src/rust/plugin-registry/src/server.rs
@@ -38,7 +38,10 @@ use tonic::{
 };
 
 #[derive(Debug, thiserror::Error)]
-pub enum PluginRegistryServiceError {}
+pub enum PluginRegistryServiceError {
+    #[error("TODO implement this enum with real error types")]
+    TodoImplementThisEnumError(),
+}
 
 pub struct PluginRegistry {}
 
@@ -126,7 +129,12 @@ impl PluginRegistryService for PluginRegistry {
         &self,
         _request: Request<GetGeneratorsForEventSourceRequestProto>,
     ) -> Result<Response<GetGeneratorsForEventSourceResponseProto>, Status> {
-        todo!()
+        // Stub implementation, for integration test smoke-test purposes.
+        // Replace with a real implementation soon!
+        let message = _request.into_inner();
+        Ok(Response::new(GetGeneratorsForEventSourceResponseProto {
+            plugin_ids: [message.event_source_id].into_iter().flatten().collect(),
+        }))
     }
 
     async fn get_analyzers_for_tenant(

--- a/src/rust/plugin-registry/tests/test_smoketest.rs
+++ b/src/rust/plugin-registry/tests/test_smoketest.rs
@@ -1,0 +1,12 @@
+#![cfg(feature = "integration")]
+
+use plugin_registry::client::PluginRegistryServiceClient;
+use tonic::Code;
+
+/// For now, this is just a smoke test. This test can and should evolve as
+/// the service matures.
+#[tokio::test]
+async fn test_smoke_test_create_client() -> Result<(), Box<dyn std::error::Error>> {
+    let mut client = PluginRegistryServiceClient::from_env().await?;
+    Ok(())
+}

--- a/src/rust/plugin-registry/tests/test_smoketest.rs
+++ b/src/rust/plugin-registry/tests/test_smoketest.rs
@@ -1,12 +1,16 @@
 #![cfg(feature = "integration")]
 
 use plugin_registry::client::PluginRegistryServiceClient;
-use tonic::Code;
+use rust_proto::plugin_registry::GetGeneratorsForEventSourceRequest;
 
 /// For now, this is just a smoke test. This test can and should evolve as
 /// the service matures.
 #[tokio::test]
 async fn test_smoke_test_create_client() -> Result<(), Box<dyn std::error::Error>> {
     let mut client = PluginRegistryServiceClient::from_env().await?;
+    let request = GetGeneratorsForEventSourceRequest {
+        event_source_id: uuid::Uuid::new_v4(),
+    };
+    client.get_generators_for_event_source(request).await?;
     Ok(())
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
This is precursor work for https://app.zenhub.com/workspace/o/grapl-security/issue-tracker/issues/719
Just a very basic skeleton of a test framework, so that people can add real, valuable tests later.

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Add a `nomad job validate` that would have unblocked an issue Colin had.
- Build plugin-registry with make build
- add plugin-registry as a service to nomad
- add a smoketest integration test for plugin-registry
- add a fake implementation of GetGeneratorsForEventSourceRequest so that we can run this integration test against something. 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
make test-integration

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
