### PR TITLE
Remove integration testing artifacts

### DIFF
--- a/pulumi/grapl/Pulumi.testing.yaml
+++ b/pulumi/grapl/Pulumi.testing.yaml
@@ -14,8 +14,6 @@ config:
     node-identifier-retry: 20211214215813-64ac5287
     osquery-generator: 20211214215813-64ac5287
     provisioner: 20211214215813-64ac5287
-    python-integration-tests: 20211203221111-6cab2487
-    rust-integration-tests: 20211203221111-6cab2487
     sysmon-generator: 20211214215813-64ac5287
   grapl:container_repository: docker.cloudsmith.io/grapl/testing
   grapl:env_vars:

--- a/pulumi/integration_tests/Pulumi.testing.yaml
+++ b/pulumi/integration_tests/Pulumi.testing.yaml
@@ -13,7 +13,5 @@ config:
     node-identifier-retry: 20211214215813-64ac5287
     osquery-generator: 20211214215813-64ac5287
     provisioner: 20211214215813-64ac5287
-    python-integration-tests: 20211203221111-6cab2487
-    rust-integration-tests: 20211203221111-6cab2487
     sysmon-generator: 20211214215813-64ac5287
   integration-tests:container_repository: docker.cloudsmith.io/grapl/testing


### PR DESCRIPTION
⚠️ THIS IS A PR AGAINST THE `rc` BRANCH, NOT `main`! :warning:

At one point we were uploading these artifacts to Cloudsmith and
adding them to Pulumi stack configuration files. However, these don't
actually need to be promoted through our pipeline. Their presence now
causes downstream promotions to fail (because these artifacts have
since been removed from Cloudsmith), so they must now be removed
manually.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>