### PR TITLE
Introduce a new plugin-registry image to cloudsmith - but don't include it in nomad/pulumi just yet

### DIFF
--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -32,6 +32,7 @@ services=(
     node-identifier
     node-identifier-retry
     osquery-generator
+    plugin-registry
     provisioner
     # Heads up: Adding `rust-integration-tests` here? Reconsider!
     # It's 9GB and Cloudsmith space is pricy!

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -83,6 +83,15 @@ services:
       args:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
+  plugin-registry:
+    image: plugin-registry:${TAG:-latest}
+    build:
+      context: src
+      dockerfile: rust/Dockerfile
+      target: plugin-registry-deploy
+      args:
+        - RUST_BUILD=${RUST_BUILD:-debug}
+
   ########################################################################
   # Python Services
   ########################################################################

--- a/src/rust/plugin-registry/Cargo.toml
+++ b/src/rust/plugin-registry/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "plugin-registry-service"
+name = "plugin-registry"
 path = "src/main.rs"
 
 [lib]
@@ -19,3 +19,7 @@ tokio = { version = "1.14.0", features = ["full"] }
 tonic = "0.6.1"
 tonic-health = "0.5.0"
 tracing = "0.1.29"
+uuid = { version = "0.8.2", features = ["v4"] }
+
+[features]
+integration = []


### PR DESCRIPTION
Precursor work to https://github.com/grapl-security/grapl/pull/1312
but due to https://grapl-internal.slack.com/archives/C02J5JYS92S/p1639524803254000 we have to do this first