### PR TITLE
Update to grapl-rc plugin v0.1.2

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -68,7 +68,7 @@ steps:
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - PULUMI_ACCESS_TOKEN
-      - grapl-security/grapl-rc#v0.1.1:
+      - grapl-security/grapl-rc#v0.1.2:
           artifact_file: all_artifacts.json
           stacks:
             - grapl/grapl/testing

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -176,8 +176,11 @@ steps:
             - PULUMI_ACCESS_TOKEN
       - improbable-eng/metahook#v0.4.1:
           pre-command: |
-            # This is slightly hacky, but means we don't need to build packages locally first
-            git fetch origin rc
+            # This is slightly hacky, but means we don't need to build
+            # packages locally first. The `set-branches` and
+            # `--depth=1` are to account for us using shallow clones
+            git remote set-branches --add origin rc
+            git fetch --depth=1 origin rc
             git show origin/rc:pulumi/grapl/Pulumi.testing.yaml > pulumi/grapl/Pulumi.testing.yaml
       - grapl-security/pulumi#v0.1.2:
           command: preview


### PR DESCRIPTION
This will once again allow us to create release candidates after we
switched CI over to using shallow git clones.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>