### PR TITLE
Remove AWS Lambda backend for Pants

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -2,7 +2,6 @@
 pants_version = "2.8.0"
 backend_packages = [
   "grapl_setup_py",
-  "pants.backend.awslambda.python",
   "pants.backend.codegen.protobuf.python",
   "pants.backend.experimental.docker",
   "pants.backend.experimental.docker.lint.hadolint",


### PR DESCRIPTION
We no longer create lambdas, so there's no need for this.
