### PR TITLE
Increase grapl-core nomad job timeout conservatively for aws-deploys

### DIFF
--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 from typing import Mapping, Set
 
+from pulumi.resource import CustomTimeouts, ResourceOptions
 from typing_extensions import Final
 
 sys.path.insert(0, "..")
@@ -240,10 +241,17 @@ def main() -> None:
             intention_directory=Path("../../nomad/consul-intentions").resolve(),
         )
 
+        # We've seen some potentially false failures from the default 5m timeout.
+        nomad_grapl_core_timeout = "8m"
         nomad_grapl_core = NomadJob(
             "grapl-core",
             jobspec=Path("../../nomad/grapl-core.nomad").resolve(),
             vars=local_grapl_core_job_vars,
+            opts=ResourceOptions(
+                custom_timeouts=CustomTimeouts(
+                    create=nomad_grapl_core_timeout, update=nomad_grapl_core_timeout
+                )
+            ),
         )
 
         nomad_grapl_ingress = NomadJob(

--- a/pulumi/infra/nomad_job.py
+++ b/pulumi/infra/nomad_job.py
@@ -32,8 +32,8 @@ class NomadJob(pulumi.ComponentResource):
             detach=False,
             # Purge job from Nomad servers after a `pulumi destroy`
             purge_on_destroy=True,
-            opts=pulumi.ResourceOptions(
-                parent=self, custom_timeouts=opts.custom_timeouts if opts else None
+            opts=pulumi.ResourceOptions.merge(
+                opts, pulumi.ResourceOptions(parent=self)
             ),
         )
 

--- a/pulumi/infra/nomad_job.py
+++ b/pulumi/infra/nomad_job.py
@@ -28,11 +28,13 @@ class NomadJob(pulumi.ComponentResource):
             resource_name=f"{DEPLOYMENT_NAME}-{name}-job",
             jobspec=self._file_contents(str(jobspec)),
             hcl2=nomad.JobHcl2Args(enabled=True, vars=self._fix_pulumi_preview(vars)),
-            opts=pulumi.ResourceOptions(parent=self),
             # Wait for all services to become healthy
             detach=False,
             # Purge job from Nomad servers after a `pulumi destroy`
             purge_on_destroy=True,
+            opts=pulumi.ResourceOptions(
+                parent=self, custom_timeouts=opts.custom_timeouts if opts else None
+            ),
         )
 
         self.register_outputs({})


### PR DESCRIPTION
The default is 5m.
Sometimes, the update step in pipeline.provision.yml fails, e.g. https://grapl-internal.slack.com/archives/C024C7TMJ2J/p1640036760073400

Unfortunately we don't really have the setup right now to debug why it's failing.
- the `pulumi update` happens in the Buildkite plugin
- This makes it difficult to do a "finally" step after the `pulumi update` - in this case, the finally step would be to run a "for dump artifacts" step like .buildkite/scripts/grapl_testing_stack/run_parameterized_job.sh does
- there's some talk about this here https://github.com/buildkite/feedback/issues/133

I'm taking a conservative step by bumping it to 8m for now