### PR TITLE
Destroy stateful resources one-by-one, and allow for failures.

### DIFF
--- a/.buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh
+++ b/.buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh
@@ -48,14 +48,26 @@ urns=$(pulumi stack output stateful-resource-urns --stack="${stack}")
 mapfile -t target_args < <(echo "${urns}" | jq -r '. | map("--target=" + .) | .[]')
 
 echo -e "--- :pulumi: Destroying stateful resources for ${stack}"
-pulumi destroy \
-    --cwd="${project_dir}" \
-    --stack="${stack}" \
-    --show-replacement-steps \
-    --non-interactive \
-    --diff \
-    --yes \
-    --refresh \
-    --message="Destroying stateful resources" \
-    --target-dependents \
-    "${target_args[@]}"
+
+# Attempt to destroy each target, one at a time.
+# This can be de-for-loop-ified after
+# https://github.com/pulumi/pulumi/issues/3304
+for target_arg in "${target_args[@]}"; do
+    (
+        # Allow errors; this is best-effort and should allow for failed
+        # destroys of targets that no longer exist.
+        set +e
+
+        pulumi destroy \
+            --cwd="${project_dir}" \
+            --stack="${stack}" \
+            --show-replacement-steps \
+            --non-interactive \
+            --diff \
+            --yes \
+            --refresh \
+            --message="Destroying stateful resources" \
+            --target-dependents \
+            "${target_arg}"
+    )
+done

--- a/.buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh
+++ b/.buildkite/scripts/grapl_testing_stack/destroy_stateful_resources.sh
@@ -53,21 +53,18 @@ echo -e "--- :pulumi: Destroying stateful resources for ${stack}"
 # This can be de-for-loop-ified after
 # https://github.com/pulumi/pulumi/issues/3304
 for target_arg in "${target_args[@]}"; do
-    (
-        # Allow errors; this is best-effort and should allow for failed
-        # destroys of targets that no longer exist.
-        set +e
-
-        pulumi destroy \
-            --cwd="${project_dir}" \
-            --stack="${stack}" \
-            --show-replacement-steps \
-            --non-interactive \
-            --diff \
-            --yes \
-            --refresh \
-            --message="Destroying stateful resources" \
-            --target-dependents \
-            "${target_arg}"
-    )
+    pulumi destroy \
+        --cwd="${project_dir}" \
+        --stack="${stack}" \
+        --show-replacement-steps \
+        --non-interactive \
+        --diff \
+        --yes \
+        --refresh \
+        --message="Destroying stateful resources" \
+        --target-dependents \
+        "${target_arg}" ||
+        true
+    # ^ Allow errors; each destroy is best-effort and should allow for
+    # failed destroys of targets that no longer exist.
 done


### PR DESCRIPTION

### What changes does this PR make to Grapl? Why?

I noticed an issue starting around https://buildkite.com/grapl/grapl-provision/builds/201

My suspicion of what happened:
- a previous `pulumi update` did not succeed in creating grapl-core
- now, running destroy_stateful_resources on target urns [resource1, resource2, grapl-core] fails because, well, grapl-core never even came up beforehand

As such, I am making destroy_stateful_resources *best effort*. This is a short term solution until we have multitenancy IDs anyway. 
