### PR TITLE
setup_chromeos: fix nvm and pyenv installs on base chromeos; enable -euo pipefail

### DIFF
--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -34,6 +34,9 @@ install_docker() {
     echo "Install docker"
     curl -sSL https://get.docker.com/ | sh
     sudo usermod -a -G docker "$USER"
+
+    echo "Install docker-compose"
+    pip3 install docker-compose
 }
 
 install_rust_and_utilities() {
@@ -67,7 +70,7 @@ install_pyenv() {
 
     curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
 
-    # This function is stolen from the 
+    # This function is stolen from the
     # "If your ~/.profile sources ~/.bashrc (Debian, Ubuntu, Mint)"
     # section of https://github.com/pyenv/pyenv/blob/master/README.md
     setup_pyenv_on_path() {
@@ -80,7 +83,7 @@ install_pyenv() {
         a \
         ' -e ':a' -e '$!{n;ba};}' ~/.profile
         source ~/.profile
-        echo 'eval "$(pyenv init --path)"' >>~/.profile
+        echo 'eval "$(pyenv init --path)"' >> ~/.profile
         echo 'eval "$(pyenv init -)"' >> ~/.bashrc
     }
     setup_pyenv_on_path
@@ -97,8 +100,8 @@ install_nvm() {
 
     # Make nvm usable ASAP
     export NVM_DIR="$HOME/.config/nvm"
-    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"                   # This loads nvm
+    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" # This loads nvm bash_completion
 
     nvm install node
 }
@@ -126,7 +129,7 @@ install_utilities() {
 install_hashicorp_tools() {
     echo "Installing hashicorp tools: consul nomad packer"
     curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-    sudo apt-get install -y lsb-release software-properties-common  # for `lsb_release` and `apt-add-repository``
+    sudo apt-get install -y lsb-release software-properties-common # for `lsb_release` and `apt-add-repository``
     sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
     sudo apt-get update
     sudo apt-get install -y consul nomad packer

--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -6,6 +6,12 @@ set -euo pipefail
 PYENV_PYTHON_VERSION="3.7.10"
 
 ## helper functions
+source_profile() {
+    # Shellcheck can't follow $HOME or other vars like $USER so we disable the check here
+    # shellcheck disable=SC1091
+    source "$HOME/.profile"
+}
+
 get_latest_release() {
     curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
         grep '"tag_name":' |                                          # Get tag line
@@ -76,14 +82,18 @@ install_pyenv() {
     setup_pyenv_on_path() {
         # the sed invocation inserts the lines at the start of the file
         # after any initial comment lines
+        # shellcheck disable=0-9999
         sed -Ei -e '/^([^#]|$)/ {a \
         export PYENV_ROOT="$HOME/.pyenv"
         a \
         export PATH="$PYENV_ROOT/bin:$PATH"
         a \
         ' -e ':a' -e '$!{n;ba};}' ~/.profile
-        source ~/.profile
+
+        source_profile
+        # shellcheck disable=SC2016
         echo 'eval "$(pyenv init --path)"' >> ~/.profile
+        # shellcheck disable=SC2016
         echo 'eval "$(pyenv init -)"' >> ~/.bashrc
     }
     setup_pyenv_on_path
@@ -94,14 +104,14 @@ install_pyenv() {
 install_nvm() {
     echo "Installing nvm"
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-    # Shellcheck can't follow $HOME or other vars like $USER so we disable the check here
-    # shellcheck disable=SC1091
-    source "$HOME/.profile"
+    source_profile
 
     # Make nvm usable ASAP
-    export NVM_DIR="$HOME/.config/nvm"
-    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"                   # This loads nvm
-    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" # This loads nvm bash_completion
+    export NVM_DIR="${HOME}/.config/nvm"
+    # shellcheck disable=SC1091
+    [ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh" # This loads nvm
+    # shellcheck disable=SC1091
+    [ -s "${NVM_DIR}/bash_completion" ] && \. "${NVM_DIR}/bash_completion" # This loads nvm bash_completion
 
     nvm install node
 }

--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -168,7 +168,7 @@ install_cni_plugins() {
     cd /opt/cni/bin || exit 2
     VERSION=$(get_latest_release containernetworking/plugins)
     TGZ_NAME="cni-plugins-linux-amd64-${VERSION}.tgz"
-    sudo wget "https://github.com/containernetworking/plugins/releases/download/$VERSION/${TGZ_NAME}"
+    sudo wget "https://github.com/containernetworking/plugins/releases/download/${VERSION}/${TGZ_NAME}"
     sudo tar -xf "${TGZ_NAME}"
     sudo rm "${TGZ_NAME}"
 }

--- a/etc/chromeos/setup_chromeos.sh
+++ b/etc/chromeos/setup_chromeos.sh
@@ -20,4 +20,4 @@ install_hashicorp_tools
 install_cni_plugins
 install_nomad_chromeos_workaround
 install_git_hooks
-install_docker  # Do this last since it's not idempotent
+install_docker # Do this last since it's not idempotent

--- a/etc/chromeos/setup_chromeos.sh
+++ b/etc/chromeos/setup_chromeos.sh
@@ -2,13 +2,14 @@
 # This is a WIP set up script for chromeOS. Some commands may break by the time the script is next used
 # TODO ensure idempotency
 
+set -euo pipefail
+
 source etc/chromeos/lib/installs.sh
 
 echo "Starting ChromeOS automated setup"
 update_linux
 fix_shell_completion
 install_build_tooling
-install_docker
 install_rust_and_utilities
 install_pyenv
 install_nvm
@@ -19,3 +20,4 @@ install_hashicorp_tools
 install_cni_plugins
 install_nomad_chromeos_workaround
 install_git_hooks
+install_docker  # Do this last since it's not idempotent


### PR DESCRIPTION
I'm fixing some issues I discovered with a fresh ChromeOS install. 

- Number one is that issues silently fail due to lack of -euo pipefail.
- nvm didn't install correctly
- pyenv didn't install correctly
- added a docker-compose install via pip