### PR TITLE
Remove brotli compression from grapl-web-ui

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -71,14 +71,12 @@ dependencies = [
  "actix-utils",
  "base64",
  "bitflags",
- "brotli2",
  "bytes 0.5.6",
  "cookie",
  "copyless",
  "derive_more",
  "either",
  "encoding_rs",
- "flate2",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -664,26 +662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "brotli-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "brotli2"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
-dependencies = [
- "brotli-sys",
- "libc",
 ]
 
 [[package]]
@@ -1525,18 +1503,6 @@ name = "fixedbitset"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
-
-[[package]]
-name = "flate2"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
-dependencies = [
- "cfg-if 1.0.0",
- "crc32fast",
- "libc",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2371,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c748cfe47cb8da225c37595b3108bea1c198c84aaae8ea0ba76d01dda9fc803"
+checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
 dependencies = [
  "hashbrown",
 ]

--- a/src/rust/grapl-web-ui/Cargo.toml
+++ b/src/rust/grapl-web-ui/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 grapl-config = { path = "../grapl-config" }
-actix-web = "3.3.2"
+actix-web = { version = "3.3.2", default_features = false }
 actix-files = "0.5.0"
 actix-session = "0.4.1"
 thiserror = "1.0.30"

--- a/src/rust/grapl-web-ui/src/main.rs
+++ b/src/rust/grapl-web-ui/src/main.rs
@@ -31,7 +31,8 @@ async fn main() -> Result<(), GraplUiError> {
     HttpServer::new(move || {
         App::new()
             .wrap(actix_web::middleware::Logger::default())
-            .wrap(actix_web::middleware::Compress::default())
+            // grapl-security/issue-tracker#803
+            // .wrap(actix_web::middleware::Compress::default())  // todo: Reenable compression when brotli isn't vulnerable
             .wrap(
                 CookieSession::private(&config.session_key)
                     .path("/")


### PR DESCRIPTION
### Which issue does this PR correspond to?
None, this is a hotfix for a CVE.

### What changes does this PR make to Grapl? Why?
Disables our usage of compression in grapl-web-ui, which removes our dependency on the vulnerable brotli2 crate.

I'm also slipping in a patch update for the lru crate, which has a UAF (that we are not impacted by, I don't believe).

### How were these changes tested?
No tests.