### PR TITLE
opt-level=1 for dev

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -25,3 +25,6 @@ members = [
   "./sqs-executor",
   "./sysmon",
 ]
+
+[profile.test]
+opt-level = 1


### PR DESCRIPTION
### Which issue does this PR correspond to?
None, just a quick experiment.

### What changes does this PR make to Grapl? Why?
Sets the opt level for dev to 1, which is a minimal optimization level that barely increases compilation time but can significantly increase test performance.

### How were these changes tested?
`time make test-integration`

My experiments show that opt-level=1 is twice as fast overall for make test-integration.