### PR TITLE
Exclude some modules from rust log debug

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -277,6 +277,8 @@ locals {
   # enabled
   rust_backtrace = 1
 
+  py_grapl_log_level = "DEBUG"
+
   # This is used to conditionally submit env variables via template stanzas.
   local_only_env_vars = <<EOH
 GRAPL_AWS_ENDPOINT          = ${local.aws_endpoint}
@@ -781,7 +783,7 @@ job "grapl-core" {
         # AWS vars
         AWS_DEFAULT_REGION = var.aws_region
         # python vars
-        GRAPL_LOG_LEVEL = "INFO"
+        GRAPL_LOG_LEVEL = local.py_grapl_log_level
         # dgraph vars
         MG_ALPHAS = local.alpha_grpc_connect_str
         # service vars
@@ -840,7 +842,7 @@ job "grapl-core" {
         # AWS vars
         AWS_DEFAULT_REGION = var.aws_region
         # python vars
-        GRAPL_LOG_LEVEL = var.rust_log
+        GRAPL_LOG_LEVEL = local.py_grapl_log_level
         # dgraph vars
         MG_ALPHAS = local.alpha_grpc_connect_str
 

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -3,6 +3,11 @@ variable "rust_log" {
   description = "Controls the logging behavior of Rust-based services."
 }
 
+variable "py_log_level" {
+  type        = string
+  description = "Controls the logging behavior of Python-based services."
+}
+
 variable "container_images" {
   type        = map(string)
   description = <<EOF
@@ -276,8 +281,6 @@ locals {
 
   # enabled
   rust_backtrace = 1
-
-  py_grapl_log_level = "DEBUG"
 
   # This is used to conditionally submit env variables via template stanzas.
   local_only_env_vars = <<EOH
@@ -783,7 +786,7 @@ job "grapl-core" {
         # AWS vars
         AWS_DEFAULT_REGION = var.aws_region
         # python vars
-        GRAPL_LOG_LEVEL = local.py_grapl_log_level
+        GRAPL_LOG_LEVEL = var.py_log_level
         # dgraph vars
         MG_ALPHAS = local.alpha_grpc_connect_str
         # service vars
@@ -842,7 +845,7 @@ job "grapl-core" {
         # AWS vars
         AWS_DEFAULT_REGION = var.aws_region
         # python vars
-        GRAPL_LOG_LEVEL = local.py_grapl_log_level
+        GRAPL_LOG_LEVEL = var.py_log_level
         # dgraph vars
         MG_ALPHAS = local.alpha_grpc_connect_str
 

--- a/nomad/grapl-provision.nomad
+++ b/nomad/grapl-provision.nomad
@@ -66,9 +66,9 @@ variable "test_user_name" {
   description = "The name of the test user"
 }
 
-variable "rust_log" {
+variable "py_log_level" {
   type        = string
-  description = "Controls the logging behavior of Rust-based services."
+  description = "Controls the logging behavior of Python-based services."
 }
 
 locals {
@@ -129,7 +129,7 @@ job "grapl-provision" {
         GRAPL_SCHEMA_PROPERTIES_TABLE = var.schema_properties_table_name
         GRAPL_USER_AUTH_TABLE         = var.user_auth_table
         GRAPL_TEST_USER_NAME          = var.test_user_name
-        GRAPL_LOG_LEVEL               = var.rust_log # TODO: revisit
+        GRAPL_LOG_LEVEL               = var.py_log_level
       }
     }
 

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -271,7 +271,7 @@ job "integration-tests" {
         IS_RETRY          = "False"
 
         DEPLOYMENT_NAME = "${var.deployment_name}"
-        GRAPL_LOG_LEVEL = "${local.log_level}"
+        GRAPL_LOG_LEVEL = local.log_level
         MG_ALPHAS       = "localhost:9080"
 
       }

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -203,6 +203,7 @@ def main() -> None:
             "rustls=WARN",
         ]
     )
+    py_log_level = "DEBUG"
 
     if config.LOCAL_GRAPL:
         ###################################
@@ -240,6 +241,7 @@ def main() -> None:
             plugin_registry_db_port=str(plugin_registry_db.port),
             plugin_registry_db_username=plugin_registry_db.username,
             plugin_registry_db_password=plugin_registry_db.password,
+            py_log_level=py_log_level,
             **nomad_inputs,
         )
 
@@ -280,7 +282,7 @@ def main() -> None:
                 "aws_region",
                 "container_images",
                 "deployment_name",
-                "rust_log",
+                "py_log_level",
                 "schema_properties_table_name",
                 "schema_table_name",
                 "test_user_name",
@@ -370,13 +372,14 @@ def main() -> None:
             # The vars with a leading underscore indicate that the hcl local version of the variable should be used
             # instead of the var version.
             _redis_endpoint=cache.endpoint,
-            rust_log=rust_log_levels,
             container_images=_container_images(artifacts, require_artifact=True),
             # TODO When we get RDS set up replace these values
             plugin_registry_db_hostname="TODO",
             plugin_registry_db_port=str(5432),
             plugin_registry_db_username="postgres",
             plugin_registry_db_password="postgres",
+            py_log_level=py_log_level,
+            rust_log=rust_log_levels,
             **nomad_inputs,
         )
 
@@ -400,7 +403,7 @@ def main() -> None:
                 "aws_region",
                 "container_images",
                 "deployment_name",
-                "rust_log",
+                "py_log_level",
                 "schema_table_name",
                 "schema_properties_table_name",
                 "test_user_name",

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -192,13 +192,15 @@ def main() -> None:
         plugin_s3_bucket_name=plugins_bucket.bucket,
     )
 
+    # To learn more about this syntax, see
+    # https://docs.rs/env_logger/0.9.0/env_logger/#enabling-logging
     rust_log_levels = ",".join(
         [
             "DEBUG",
-            "serde_xml_rs::de=WARN",
-            "hyper::client=WARN",
-            "rusoto_core::request=WARN",
-            "rustls::anchors=WARN",
+            "serde_xml_rs=WARN",
+            "hyper=WARN",
+            "rusoto_core=WARN",
+            "rustls=WARN",
         ]
     )
 

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -192,6 +192,16 @@ def main() -> None:
         plugin_s3_bucket_name=plugins_bucket.bucket,
     )
 
+    rust_log_levels = ",".join(
+        [
+            "DEBUG",
+            "serde_xml_rs::de=WARN",
+            "hyper::client=WARN",
+            "rusoto_core::request=WARN",
+            "rustls::anchors=WARN",
+        ]
+    )
+
     if config.LOCAL_GRAPL:
         ###################################
         # Local Grapl
@@ -223,8 +233,7 @@ def main() -> None:
             aws_access_key_id=aws.config.access_key,
             aws_access_key_secret=aws.config.secret_key,
             container_images=_container_images({}),
-            # TODO: consider replacing rust_log= with the previous per-service `configurable_envvars`
-            rust_log="DEBUG",
+            rust_log=rust_log_levels,
             plugin_registry_db_hostname="LOCAL_GRAPL_REPLACE_IP",
             plugin_registry_db_port=str(plugin_registry_db.port),
             plugin_registry_db_username=plugin_registry_db.username,
@@ -359,8 +368,7 @@ def main() -> None:
             # The vars with a leading underscore indicate that the hcl local version of the variable should be used
             # instead of the var version.
             _redis_endpoint=cache.endpoint,
-            # TODO: consider replacing rust_log= with the previous per-service `configurable_envvars`
-            rust_log="DEBUG",
+            rust_log=rust_log_levels,
             container_images=_container_images(artifacts, require_artifact=True),
             # TODO When we get RDS set up replace these values
             plugin_registry_db_hostname="TODO",


### PR DESCRIPTION
I went through some of our logs and found some loud modules I wanted to keep quiet.