### PR TITLE
Update rc plugin to work with shallow clones

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -68,7 +68,7 @@ steps:
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - PULUMI_ACCESS_TOKEN
-      - grapl-security/grapl-rc#v0.1.2:
+      - grapl-security/grapl-rc#85d098d:
           artifact_file: all_artifacts.json
           stacks:
             - grapl/grapl/testing


### PR DESCRIPTION
I'm using an unmerged PR for the grapl-rc plugin for the time being,
just to help thoroughly test it. Once we're satisfied it's working as
expected, we'll use a proper release tag.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>