### PR TITLE
Precommit will ignore files that are not pants-managed

### DIFF
--- a/etc/hooks/pre-commit.sh
+++ b/etc/hooks/pre-commit.sh
@@ -5,7 +5,8 @@ FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
 [ -z "$FILES" ] && exit 0
 
 # Prettify all selected files
-echo "$FILES" | xargs ./pants fmt
+# (--owners-not-found-behavior=ignore will skip changed files that are not Pants-managed)
+echo "$FILES" | xargs ./pants --owners-not-found-behavior=ignore fmt
 
 # Add back the modified files to staging
 echo "$FILES" | xargs git add

--- a/etc/hooks/pre-commit.sh
+++ b/etc/hooks/pre-commit.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 
 # The sed here is to deal with any files with spaces in the names
-FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
+FILES=$(./pants list --changed-since=HEAD)
 [ -z "$FILES" ] && exit 0
 
 # Prettify all selected files
-# (--owners-not-found-behavior=ignore will skip changed files that are not Pants-managed)
-echo "$FILES" | xargs ./pants --owners-not-found-behavior=ignore fmt
+echo "$FILES" | xargs ./pants fmt
 
 # Add back the modified files to staging
 echo "$FILES" | xargs git add

--- a/etc/hooks/pre-commit.sh
+++ b/etc/hooks/pre-commit.sh
@@ -1,16 +1,9 @@
 #!/usr/bin/env bash
 
-# The sed here is to deal with any files with spaces in the names
-FILES=$(./pants list --changed-since=HEAD)
-[ -z "$FILES" ] && exit 0
-
-# Prettify all selected files
-echo "$FILES" | xargs ./pants fmt
+# Prettify all changed files managed by Pants
+./pants fmt --changed-since=HEAD
 
 # Add back the modified files to staging
-echo "$FILES" | xargs git add
+git add --update
 
 exit 0
-
-# This runs pants formatting and adds it to the commit
-#./pants --changed-since=HEAD fmt


### PR DESCRIPTION
`./pants fmt <a file with no BUILD>` would previously spit out something like
```
wimax@penguin:~/src/repos/grapl$ git commit -m "Add a wraper around the generated nomad client"
11:38:41.91 [INFO] Starting: Resolving plugins: toolchain.pants.plugin==0.17.0
11:38:44.31 [INFO] Completed: Resolving plugins: toolchain.pants.plugin==0.17.0
11:38:44.41 [WARN] Error loading access token: AuthError('Failed to load auth token (no default file or environment variable). Run `./pants auth-acquire` to set up authentication.')
11:38:44.48 [WARN] Error loading access token: AuthError('Failed to load auth token (no default file or environment variable). Run `./pants auth-acquire` to set up authentication.')
11:38:44.48 [WARN] Auth failed - BuildSense plugin is disabled.
11:38:44.54 [ERROR] 1 Exception encountered:

  ResolveError: No owning targets could be found for the file `nomad/grapl-core.nomad`.

Please check that there is a BUILD file in the parent directory nomad with a target whose `sources` field includes the file. See https://www.pantsbuild.org/v2.8/docs/targets for more information on target definitions.

You may want to run `./pants tailor` to autogenerate your BUILD files. See https://www.pantsbuild.org/v2.8/docs/create-initial-build-files.

If you would like to ignore un-owned files, please pass `--owners-not-found-behavior=ignore`.
```