### PR TITLE
Update many of our Docker images from Buster to Bullseye (deb10 to deb11)

### DIFF
--- a/Dockerfile.pulumi
+++ b/Dockerfile.pulumi
@@ -1,10 +1,10 @@
-FROM python:3.7-slim-buster as grapl-local-pulumi
+FROM python:3.7-slim-bullseye as grapl-local-pulumi
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
-       build-essential=12.6 \
-       curl=7.64.0-4+deb10u2 \
-       unzip=6.0-23+deb10u2 \
+       build-essential=12.9 \
+       curl=7.74.0-1.3+deb11u1 \
+       unzip=6.0-26 \
     && rm -rf /var/lib/apt/lists/* \
     && adduser \
         --disabled-password \

--- a/etc/formatter/Dockerfile
+++ b/etc/formatter/Dockerfile
@@ -1,13 +1,13 @@
-FROM debian:buster-slim AS formatter
+FROM debian:bullseye-slim AS formatter
 
 # Ignore this lint about deleteing the apt-get lists (we're caching!)
 # hadolint ignore=DL3009
 RUN --mount=type=cache,target=/var/lib/apt/lists \
     apt-get update \
     && apt-get install --yes --no-install-recommends \
-        ca-certificates=20200601~deb10u2 \
-        curl=7.64.0-4+deb10u2 \
-        netbase=5.6
+        ca-certificates=20210119 \
+        curl=7.74.0-1.3+deb11u1 \
+        netbase=6.3
 
 # Because of the pipe below
 SHELL ["/bin/bash", "-c", "-o", "pipefail"]

--- a/src/js/engagement_view/build-env.Dockerfile
+++ b/src/js/engagement_view/build-env.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-buster-slim
+FROM node:16-bullseye-slim
 
 SHELL ["/bin/bash", "-c"]
 

--- a/src/js/graphql_endpoint/Dockerfile
+++ b/src/js/graphql_endpoint/Dockerfile
@@ -1,14 +1,14 @@
 # Don't forget to update the other `FROM node:` in this file.
 # Use the latest Node version here: https://docs.aws.amazon.com/lambda/latest/dg/lambda-nodejs.html
-FROM node:14.16-buster-slim AS graphql-endpoint-build
+FROM node:17.3-bullseye-slim AS graphql-endpoint-build
 
 RUN apt-get update \
     && apt-get --yes install --no-install-recommends \
-        build-essential=12.6 \
-        libffi-dev=3.2.1-9 \
-        libssl-dev=1.1.1d-0+deb10u7 \
-        python3=3.7.3-1 \
-        zip=3.0-11+b1 \
+        build-essential=12.9 \
+        libffi-dev=3.3-6 \
+        libssl-dev=1.1.1k-1+deb11u1 \
+        python3=3.9.2-3 \
+        zip=3.0-12 \
     && rm -rf /var/lib/apt/lists/* \
     && adduser \
         --disabled-password \
@@ -44,7 +44,7 @@ WORKDIR /home/grapl
 
 # Deploy image
 ################################################################################
-FROM node:14.16-buster-slim AS graphql-endpoint-deploy
+FROM node:17.3-bullseye-slim AS graphql-endpoint-deploy
 
 RUN adduser \
         --disabled-password \

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -1,11 +1,11 @@
 # grapl-python-base
 ################################################################################
-FROM python:3.7-slim-buster AS grapl-python-base
+FROM python:3.7-slim-bullseye AS grapl-python-base
 SHELL ["/bin/bash", "-c"]
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
-        bash=5.0-4 \
-        libstdc++6=8.3.0-6 \
+        bash=5.1-2+b3 \
+        libstdc++6=10.2.1-6 \
     && rm -rf /var/lib/apt/lists/* \
     && adduser \
         --disabled-password \
@@ -67,10 +67,10 @@ FROM grapl-python-base AS python-integration-tests
 USER root
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
-        build-essential=12.6 \
-        curl=7.64.0-4+deb10u2 \
-        protobuf-compiler=3.6.1.3-2 \
-        unzip=6.0-23+deb10u2 \
+        build-essential=12.9 \
+        curl=7.74.0-1.3+deb11u1 \
+        protobuf-compiler=3.12.4-1 \
+        unzip=6.0-26 \
     && rm -rf /var/lib/apt/lists/* \
     && adduser \
         --disabled-password \

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1-slim-buster AS base
+FROM rust:1-slim-bullseye AS base
 
 ARG RUST_BUILD=debug
 
@@ -11,10 +11,10 @@ SHELL ["/bin/bash", "-c"]
 RUN --mount=type=cache,target=/var/lib/apt/lists \
     apt-get update \
     && apt-get install -y --no-install-recommends \
-        build-essential=12.6 \
-        libssl-dev=1.1.1d-0+deb10u7 \
-        pkg-config=0.29-6 \
-        zlib1g-dev=1:1.2.11.dfsg-1
+        build-essential=12.9 \
+        libssl-dev=1.1.1k-1+deb11u1 \
+        pkg-config=0.29.2-1 \
+        zlib1g-dev=1:1.2.11.dfsg-2
 
 # Install rust toolchain before copying sources to avoid unecessarily
 # resinstalling on source file changes.


### PR DESCRIPTION
Also updates many of our `apt` dependencies. 

Tested with `make test-integration`. CI will exercise `make test-e2e`. 