### PR TITLE
Add the 8m timeout to aws grapl-core as well

### DIFF
--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -205,6 +205,9 @@ def main() -> None:
     )
     py_log_level = "DEBUG"
 
+    # We've seen some potentially false failures from the default 5m timeout.
+    nomad_grapl_core_timeout = "8m"
+
     if config.LOCAL_GRAPL:
         ###################################
         # Local Grapl
@@ -254,8 +257,6 @@ def main() -> None:
             intention_directory=Path("../../nomad/consul-intentions").resolve(),
         )
 
-        # We've seen some potentially false failures from the default 5m timeout.
-        nomad_grapl_core_timeout = "8m"
         nomad_grapl_core = NomadJob(
             "grapl-core",
             jobspec=Path("../../nomad/grapl-core.nomad").resolve(),
@@ -387,7 +388,12 @@ def main() -> None:
             "grapl-core",
             jobspec=Path("../../nomad/grapl-core.nomad").resolve(),
             vars=prod_grapl_core_job_vars,
-            opts=pulumi.ResourceOptions(provider=nomad_provider),
+            opts=pulumi.ResourceOptions(
+                provider=nomad_provider,
+                custom_timeouts=CustomTimeouts(
+                    create=nomad_grapl_core_timeout, update=nomad_grapl_core_timeout
+                ),
+            ),
         )
 
         nomad_grapl_ingress = NomadJob(


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
Porting something I did for local to aws
https://github.com/grapl-security/grapl/pull/1326
```

cm  6:15 PM
:thinking_face: This keeps failing :point_up: but can be fixed by a retry. The failure is:
creating urn:pulumi:testing::grapl::grapl:NomadJob$nomad:index/job:Job::testing-grapl-core-job: error waiting for job 'grapl-core' to schedule/deploy successfully: error waiting for evaluation: timeout while waiting for state to become 'deployment_successful' (last state: 'monitoring_deployment', timeout: 5m0s)
Have you run into this before @wimax?

wimax  6:16 PM
Let me see if I can debug

cm  6:17 PM
(I manually retried it and it completed successfully)
```
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
they will be tested in CI after landing 🙄 