### PR TITLE
Enable metrics for consul and nomad

### DIFF
--- a/nomad/local/consul-agent-conf.hcl
+++ b/nomad/local/consul-agent-conf.hcl
@@ -12,6 +12,7 @@ acl = {
 telemetry {
   # Enable metrics for consul
   # metrics path is /v1/agent/metrics?format=prometheus
-  disable_compat_1.9 = true
+  # compat disabled because hcl formatting breaks on the '.'. However this is what is used in AWS
+  # disable_compat_1.9 = true
   prometheus_retention_time = "30s"
 }

--- a/nomad/local/consul-agent-conf.hcl
+++ b/nomad/local/consul-agent-conf.hcl
@@ -8,3 +8,10 @@ acl = {
   # denied
   down_policy = "extend-cache"
 }
+
+telemetry {
+  # Enable metrics for consul
+  # metrics path is /v1/agent/metrics?format=prometheus
+  disable_compat_1.9 = true
+  prometheus_retention_time = "30s"
+}

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -221,7 +221,7 @@ job "grapl-local-infra" {
       driver = "docker"
 
       config {
-        image = "confluentinc/cp-kafka:6.2.2"
+        image = "confluentinc/cp-kafka:6.2.0"
         ports = ["kafka-for-other-nomad-tasks", "kafka-for-host-os"]
       }
 

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -221,7 +221,7 @@ job "grapl-local-infra" {
       driver = "docker"
 
       config {
-        image = "confluentinc/cp-kafka:6.2.0"
+        image = "confluentinc/cp-kafka:6.2.2"
         ports = ["kafka-for-other-nomad-tasks", "kafka-for-host-os"]
       }
 

--- a/nomad/local/nomad-agent-conf.nomad
+++ b/nomad/local/nomad-agent-conf.nomad
@@ -20,7 +20,7 @@ plugin "docker" {
 ####################
 telemetry {
   # enable metrics for nomad
-  # metrics path is /v1/metrics
+  # metrics path is /v1/metrics?format=prometheus
   collection_interval        = "1s"
   disable_hostname           = true
   prometheus_metrics         = true

--- a/nomad/local/nomad-agent-conf.nomad
+++ b/nomad/local/nomad-agent-conf.nomad
@@ -13,3 +13,17 @@ plugin "docker" {
     }
   }
 }
+
+
+####################
+# Telemetry configs
+####################
+telemetry {
+  # enable metrics for nomad
+  # metrics path is /v1/metrics
+  collection_interval        = "1s"
+  disable_hostname           = true
+  prometheus_metrics         = true
+  publish_allocation_metrics = true
+  publish_node_metrics       = true
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/811

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
This enables metric endpoints for consul and nomad in dev.
This is part of the setup for having observability in dev and will allow us to see any memory usage issues

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
make up
GET http://localhost:4646/v1/metrics?format=prometheus
GET http://localhost:8500/v1/agent/metrics?format=prometheus

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
