### PR TITLE
Don't close Dependabot PRs as stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,3 +12,5 @@ pulls:
     inactivity. Please feel free to reopen / resubmit your
     contribution if it is still applicable.
   staleLabel: Stale
+  exemptLabels:
+    - dependencies  # We don't want to automatically close Dependabot PRs


### PR DESCRIPTION
We didn't like that this could allow Dependabot PRs to "disappear",
particularly over long holidays like Christmas.

While we should ensure proper assignment of such PRs to individuals,
this is an easy step we can take to ensure nothing falls through the
cracks.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
