### PR TITLE
Adding a debug container to nomad

### DIFF
--- a/debugger/attach.sh
+++ b/debugger/attach.sh
@@ -15,4 +15,4 @@ docker run \
     --cap-add sys_ptrace \
     --volume="$(pwd):/from-host" \
     --workdir="/from-host" \
-    grapl/debugger
+    debugger:dev

--- a/debugger/attach_to_nomad_container.sh
+++ b/debugger/attach_to_nomad_container.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+########################################################################
+# See `grapl-local-infra.nomad` `debugger` section to understand usecase.
+########################################################################
+
+DEBUGGER_CONTAINER=$(docker ps --filter ancestor=debugger:dev --format="{{.Names}}")
+
+docker exec --interactive --tty "${DEBUGGER_CONTAINER}" /bin/bash

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -151,3 +151,9 @@ services:
       context: .
       dockerfile: ./src/python/Dockerfile
       target: provisioner
+
+  debugger:
+    image: debugger:${TAG:-debug}
+    build:
+      context: debugger
+      dockerfile: Dockerfile

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -334,9 +334,9 @@ job "grapl-local-infra" {
     # This container can help us, among other things, with debugging services
     # within Nomad/Consul. 
     # Sample use case: "Can I curl against <some-service>?"
-    #   1. Manually change the upstream in env{}
-    #   2. Manually change the upsteam in proxy{}
-    #   3. debugger/attach_to_nomad_container.sh
+    #   1. Manually change the upsteam in proxy{}
+    #   2. debugger/attach_to_nomad_container.sh
+    #   3. run `env | grep NOMAD_UPSTREAM` to see your upstreams
     #   4. curl away to your heart's content
     network {
       mode = "bridge"
@@ -354,10 +354,6 @@ job "grapl-local-infra" {
           "while true; do sleep 600; done",
         ]
       }
-    }
-
-    env {
-      UPSTREAM_BEING_INVESTIGATED = "${NOMAD_UPSTREAM_ADDR_graphql-endpoint}"
     }
 
     service {


### PR DESCRIPTION
We previously had a `debugger` container that I'm co-opting for "a Nomad service that connects to arbitrary upstreams for debug purposes." 

Basically, I'm trying to debug why an upstream `nomad` doesn't work, and we didn't really have a good container to do that in. I've run in to this "I want an arbitrary container to run `curl`s against" desire anyway.

See https://discuss.hashicorp.com/t/can-i-use-consul-connect-to-proxy-into-the-nomad-service-itself-as-an-upstream/34105 for more context.