### PR TITLE
Use new RC logic

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -68,7 +68,7 @@ steps:
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - PULUMI_ACCESS_TOKEN
-      - grapl-security/grapl-rc#85d098d:
+      - grapl-security/grapl-rc#4742c0f:
           artifact_file: all_artifacts.json
           stacks:
             - grapl/grapl/testing


### PR DESCRIPTION
This picks up the changes from
https://github.com/grapl-security/grapl-rc-buildkite-plugin/pull/9,
which should be a more robust fix. Once proven, we'll use a release
tag instead.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
