### PR TITLE
Remove quotes to reduce diff noise when creating RCs

### DIFF
--- a/pulumi/grapl/Pulumi.testing.yaml
+++ b/pulumi/grapl/Pulumi.testing.yaml
@@ -1,7 +1,7 @@
 config:
   aws:region: us-east-1
   grapl:GRAPL_OPERATIONAL_ALARMS_EMAIL: operational-alarms@graplsecurity.com
-  grapl:container_repository: "docker.cloudsmith.io/grapl/testing"
+  grapl:container_repository: docker.cloudsmith.io/grapl/testing
   grapl:env_vars:
     analyzer-dispatcher:
       RUST_BACKTRACE: "1"

--- a/pulumi/integration_tests/Pulumi.testing.yaml
+++ b/pulumi/integration_tests/Pulumi.testing.yaml
@@ -1,3 +1,3 @@
 config:
   aws:region: us-east-1
-  integration-tests:container_repository: "docker.cloudsmith.io/grapl/testing"
+  integration-tests:container_repository: docker.cloudsmith.io/grapl/testing


### PR DESCRIPTION
After processing this file through `pulumi config`, the quotes around
string values are removed. This, in turn, introduces diff noise when
generating a release candidate with our `grapl-rc` plugin.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
