### PR TITLE
Grapl Testing Stack dump_artifacts is now a Metahook post-command. Enabled on "pulumi update" in provision.

### DIFF
--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -53,12 +53,17 @@ steps:
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - PULUMI_ACCESS_TOKEN
+      - improbable-eng/metahook#v0.4.1:
+          post-command: |
+            .buildkite/scripts/grapl_testing_stack/dump_artifacts.sh
       - grapl-security/pulumi#v0.1.2:
           command: update
           project_dir: pulumi/grapl
           stack: grapl/testing
     agents:
       queue: "pulumi-staging"
+    artifact_paths:
+      - "test_artifacts/**/*"
 
   - wait
 

--- a/.buildkite/pipeline.testing.yml
+++ b/.buildkite/pipeline.testing.yml
@@ -15,6 +15,9 @@ steps:
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - PULUMI_ACCESS_TOKEN
+      - improbable-eng/metahook#v0.4.1:
+          post-command: |
+            .buildkite/scripts/grapl_testing_stack/dump_artifacts.sh
     command:
       - .buildkite/scripts/grapl_testing_stack/run_parameterized_job.sh e2e-tests 6
     artifact_paths:

--- a/.buildkite/scripts/grapl_testing_stack/dump_artifacts.sh
+++ b/.buildkite/scripts/grapl_testing_stack/dump_artifacts.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+##########
+# Wrapper around `dump_artifacts` that binds it to
+# the `grapl/nomad/testing` stack.
+#
+# Best used with Metahook post-command. Don't forget to set `artifact_paths:`!
+##########
+set -euo pipefail
+
+REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
+readonly REPOSITORY_ROOT
+
+readonly STACK="grapl/nomad/testing"
+_NOMAD_ADDRESS=$(pulumi stack output address --stack="${STACK}")
+readonly _NOMAD_ADDRESS
+
+cd "${REPOSITORY_ROOT}"
+NOMAD_ADDRESS="${_NOMAD_ADDRESS}" ./pants run \
+    ./etc/ci_scripts/dump_artifacts -- \
+    --no-dump-agent-logs

--- a/.buildkite/scripts/grapl_testing_stack/run_parameterized_job.sh
+++ b/.buildkite/scripts/grapl_testing_stack/run_parameterized_job.sh
@@ -3,8 +3,6 @@
 ##########
 # Wrapper around `nomad/bin/run_parameterized_job.sh` that binds it to
 # the `grapl/nomad/testing` stack.
-
-# Automatically run `dumpArtifacts` afterwards.
 ##########
 set -euo pipefail
 
@@ -15,18 +13,6 @@ readonly REPOSITORY_ROOT
 
 _NOMAD_ADDRESS=$(pulumi stack output address --stack="${STACK}")
 readonly _NOMAD_ADDRESS
-
-# Ensure we call dumpArtifacts even after test failure, and return exit code from
-# the test, not the stop command.
-dump_artifacts() {
-    (
-        cd "${REPOSITORY_ROOT}"
-        NOMAD_ADDRESS="${_NOMAD_ADDRESS}" ./pants run \
-            ./etc/ci_scripts/dump_artifacts -- \
-            --no-dump-agent-logs
-    )
-}
-trap dump_artifacts EXIT
 
 NOMAD_ADDRESS="${_NOMAD_ADDRESS}" \
     "${REPOSITORY_ROOT}/nomad/bin/run_parameterized_job.sh" "${@}"


### PR DESCRIPTION
For some reason, the pulumi update in `pipeline.provision.yml` times out beyond 8m. Moreover, we have zero visibility into _why_ this happens. We previously tried fixing this by bumping from 5 to 8 minutes in https://github.com/grapl-security/grapl/pull/1326

Now, thanks to metahook, we can execute a cleanup command  - `dump_artifacts` - after the command. Hooray!  We'll now be able to see which task within `grapl-core` may be slowing us down.