### PR TITLE
Successfully create a Nomad namespace from new NomadClient in rust-integration-tests

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -13,4 +13,4 @@ pulls:
     contribution if it is still applicable.
   staleLabel: Stale
   exemptLabels:
-    - dependencies  # We don't want to automatically close Dependabot PRs
+    - dependencies # We don't want to automatically close Dependabot PRs

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ typecheck: ## Typecheck Python Code
 .PHONY: test-integration
 test-integration: export COMPOSE_PROJECT_NAME := $(COMPOSE_PROJECT_INTEGRATION_TESTS)
 test-integration: build-test-integration ## Build and run integration tests
-	$(WITH_LOCAL_GRAPL_ENV)
+	@$(WITH_LOCAL_GRAPL_ENV)
 	$(MAKE) test-with-env EXEC_TEST_COMMAND="nomad/bin/run_parameterized_job.sh integration-tests 9"
 
 .PHONY: test-grapl-template-generator
@@ -258,7 +258,7 @@ test-grapl-template-generator:  # Test that the Grapl Template Generator spits o
 .PHONY: test-e2e
 test-e2e: export COMPOSE_PROJECT_NAME := $(COMPOSE_PROJECT_E2E_TESTS)
 test-e2e: build-test-e2e ## Build and run e2e tests
-	$(WITH_LOCAL_GRAPL_ENV)
+	@$(WITH_LOCAL_GRAPL_ENV)
 	$(MAKE) test-with-env EXEC_TEST_COMMAND="nomad/bin/run_parameterized_job.sh e2e-tests 6"
 
 # This target is not intended to be used directly from the command line.
@@ -282,7 +282,7 @@ test-with-env: # (Do not include help text - not to be used directly)
 	# Ensure we call stop even after test failure, and return exit code from
 	# the test, not the stop command.
 	trap stopGrapl EXIT
-	$(WITH_LOCAL_GRAPL_ENV)
+	@$(WITH_LOCAL_GRAPL_ENV)
 	# Bring up the Grapl environment and detach
 	$(MAKE) up
 	# Run tests and check exit codes from each test container
@@ -370,7 +370,7 @@ up: build ## Bring up local Grapl and detach to return control to tty
 	# Primarily used for bringing up an environment for integration testing.
 	# For use with a project name consider setting COMPOSE_PROJECT_NAME env var
 	# Usage: `make up`
-	$(WITH_LOCAL_GRAPL_ENV)
+	@$(WITH_LOCAL_GRAPL_ENV)
 	# Start the Nomad agent
 	$(MAKE) stop-nomad-detach; $(MAKE) start-nomad-detach
 	# We use this target with COMPOSE_FILE being set pointing to other files.
@@ -390,19 +390,19 @@ up: build ## Bring up local Grapl and detach to return control to tty
 
 .PHONY: down
 down: ## docker-compose down - both stops and removes the containers
-	$(WITH_LOCAL_GRAPL_ENV)
+	@$(WITH_LOCAL_GRAPL_ENV)
 	# This is only for killing the lambda containers that Localstack
 	# spins up in our network, but that docker-compose doesn't know
 	# about. This must be the network that is used in Localstack's
 	# LAMBDA_DOCKER_NETWORK environment variable.
 	$(MAKE) stop-nomad-detach
 	docker-compose $(EVERY_COMPOSE_FILE) down --timeout=0
-	docker-compose $(EVERY_COMPOSE_FILE) --project-name $(COMPOSE_PROJECT_INTEGRATION_TESTS) down --timeout=0
-	docker-compose $(EVERY_COMPOSE_FILE) --project-name $(COMPOSE_PROJECT_E2E_TESTS) down --timeout=0
+	@docker-compose $(EVERY_COMPOSE_FILE) --project-name $(COMPOSE_PROJECT_INTEGRATION_TESTS) down --timeout=0
+	@docker-compose $(EVERY_COMPOSE_FILE) --project-name $(COMPOSE_PROJECT_E2E_TESTS) down --timeout=0
 
 .PHONY: stop
 stop: ## docker-compose stop - stops (but preserves) the containers
-	$(WITH_LOCAL_GRAPL_ENV)
+	@$(WITH_LOCAL_GRAPL_ENV)
 	docker-compose $(EVERY_COMPOSE_FILE) stop
 
 ##@ Utility ⚙
@@ -428,12 +428,12 @@ clean-artifacts: ## Remove all dumped artifacts from test runs (see dump_artifac
 .PHONY: local-pulumi
 local-pulumi: export COMPOSE_PROJECT_NAME="grapl"
 local-pulumi:  ## launch pulumi via docker-compose up
-	$(WITH_LOCAL_GRAPL_ENV)
+	@$(WITH_LOCAL_GRAPL_ENV)
 	docker-compose -f docker-compose.yml run pulumi
 
 .PHONY: start-nomad-detach
 start-nomad-detach:  ## Start the Nomad environment, detached
-	$(WITH_LOCAL_GRAPL_ENV)
+	@$(WITH_LOCAL_GRAPL_ENV)
 	nomad/local/start_detach.sh
 
 .PHONY: stop-nomad-detach
@@ -446,7 +446,7 @@ push: build-docker-images ## Push Grapl containers to supplied DOCKER_REGISTRY
 
 .PHONY: e2e-logs
 e2e-logs: ## All docker-compose logs
-	$(WITH_LOCAL_GRAPL_ENV)
+	@$(WITH_LOCAL_GRAPL_ENV)
 	docker-compose $(EVERY_COMPOSE_FILE) --project-name $(COMPOSE_PROJECT_E2E_TESTS) logs -f
 
 .PHONY: docker-kill-all

--- a/bin/generate_nomad_rust_client.sh
+++ b/bin/generate_nomad_rust_client.sh
@@ -46,7 +46,8 @@ docker run \
     --generator-name rust \
     --library reqwest \
     --additional-properties=packageName="${CRATE_NAME}" \
-    --additional-properties=packageVersion="${CRATE_VERSION}"
+    --additional-properties=packageVersion="${CRATE_VERSION}" \
+    --additional-properties=useSingleRequestParameter=true
 
 ################################################################################
 # Modify the generated code a bit

--- a/etc/ci_scripts/dump_artifacts/cli.py
+++ b/etc/ci_scripts/dump_artifacts/cli.py
@@ -54,7 +54,7 @@ def main() -> None:
     compose_project = args.compose_project
 
     cwd = os.getcwd()
-    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    timestamp = datetime.now().isoformat(timespec="seconds")
     artifacts_dir = Path(f"{cwd}/test_artifacts/{compose_project}_{timestamp}")
     os.makedirs(artifacts_dir, exist_ok=False)
 
@@ -74,7 +74,7 @@ def main() -> None:
     )
 
     nomad_artifacts.dump_all(artifacts_dir, dump_agent_logs=args.dump_agent_logs)
-    LOGGER.info(f"Dumped to {artifacts_dir}")
+    LOGGER.info(f"--- Artifacts dumped to {artifacts_dir}")
 
 
 if __name__ == "__main__":

--- a/etc/ci_scripts/dump_artifacts/cli.py
+++ b/etc/ci_scripts/dump_artifacts/cli.py
@@ -55,6 +55,7 @@ def main() -> None:
 
     cwd = os.getcwd()
     timestamp = datetime.now().isoformat(timespec="seconds")
+    timestamp = timestamp.replace(":", "-")  # colons in paths are bad
     artifacts_dir = Path(f"{cwd}/test_artifacts/{compose_project}_{timestamp}")
     os.makedirs(artifacts_dir, exist_ok=False)
 

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1116,7 +1116,16 @@ job "grapl-core" {
       name = "plugin-registry"
       port = "plugin-registry-port"
       connect {
-        sidecar_service {}
+        sidecar_service {
+          proxy {
+            upstreams {
+              # Yes, Nomad itself is registered as a Consul Connect service!
+              destination_name = "nomad"
+              # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
+              local_bind_port  = 1000
+            }
+          }
+        }
       }
     }
   }

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1099,6 +1099,7 @@ job "grapl-core" {
       }
 
       env {
+        NOMAD_SERVICE_ADDRESS = "${NOMAD_UPSTREAM_ADDR_nomad}"  # Nomad is, itself, a Consul service
         PLUGIN_REGISTRY_BIND_ADDRESS    = "0.0.0.0:${NOMAD_PORT_plugin-registry-port}"
         PLUGIN_REGISTRY_DB_HOSTNAME     = local.plugin_registry_db_hostname
         PLUGIN_REGISTRY_DB_PASSWORD     = var.plugin_registry_db_password

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1099,7 +1099,7 @@ job "grapl-core" {
       }
 
       env {
-        NOMAD_SERVICE_ADDRESS = "${NOMAD_UPSTREAM_ADDR_nomad}"  # Nomad is, itself, a Consul service
+        NOMAD_SERVICE_ADDRESS           = "${attr.unique.network.ip-address}:4646"
         PLUGIN_REGISTRY_BIND_ADDRESS    = "0.0.0.0:${NOMAD_PORT_plugin-registry-port}"
         PLUGIN_REGISTRY_DB_HOSTNAME     = local.plugin_registry_db_hostname
         PLUGIN_REGISTRY_DB_PASSWORD     = var.plugin_registry_db_password
@@ -1117,14 +1117,6 @@ job "grapl-core" {
       port = "plugin-registry-port"
       connect {
         sidecar_service {
-          proxy {
-            upstreams {
-              # Yes, Nomad itself is registered as a Consul Connect service!
-              destination_name = "nomad"
-              # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
-              local_bind_port  = 1000
-            }
-          }
         }
       }
     }

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -131,20 +131,13 @@ job "integration-tests" {
             upstreams {
               destination_name = "model-plugin-deployer"
               # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
-              local_bind_port  = 1000
+              local_bind_port = 1000
             }
 
             upstreams {
               destination_name = "plugin-registry"
               # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
-              local_bind_port  = 1001 
-            }
-
-            upstreams {
-              # Yes, Nomad itself is registered as a Consul Connect service!
-              destination_name = "nomad"
-              # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
-              local_bind_port  = 1002
+              local_bind_port = 1001
             }
           }
         }
@@ -182,7 +175,7 @@ job "integration-tests" {
 
         GRAPL_PLUGIN_REGISTRY_ADDRESS = "http://0.0.0.0:${NOMAD_UPSTREAM_PORT_plugin-registry}"
 
-        NOMAD_SERVICE_ADDRESS="${NOMAD_UPSTREAM_ADDR_nomad}"
+        NOMAD_SERVICE_ADDRESS = "${attr.unique.network.ip-address}:4646"
       }
 
       resources {

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -130,12 +130,21 @@ job "integration-tests" {
 
             upstreams {
               destination_name = "model-plugin-deployer"
-              local_bind_port  = 1000 # doesn't really matter
+              # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
+              local_bind_port  = 1000
             }
 
             upstreams {
               destination_name = "plugin-registry"
-              local_bind_port  = 1001 # doesn't really matter
+              # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
+              local_bind_port  = 1001 
+            }
+
+            upstreams {
+              # Yes, Nomad itself is registered as a Consul Connect service!
+              destination_name = "nomad"
+              # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
+              local_bind_port  = 1002
             }
           }
         }
@@ -172,6 +181,8 @@ job "integration-tests" {
         GRAPL_MODEL_PLUGIN_DEPLOYER_PORT = "${NOMAD_UPSTREAM_PORT_model-plugin-deployer}"
 
         GRAPL_PLUGIN_REGISTRY_ADDRESS = "http://0.0.0.0:${NOMAD_UPSTREAM_PORT_plugin-registry}"
+
+        NOMAD_SERVICE_ADDRESS="${NOMAD_UPSTREAM_ADDR_nomad}"
       }
 
       resources {

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -3028,6 +3028,7 @@ dependencies = [
  "futures",
  "grapl-config",
  "grapl-utils",
+ "nomad-client-gen",
  "rusoto_core",
  "rusoto_s3",
  "rust-proto",

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -152,8 +152,9 @@ EXIT_STATUS=0
 
 for test in $(find /tests -type f -executable -exec readlink -f {} \;)
 do
-    echo Executing "${test}"
-    "${test}"
+    echo "--- Executing ${test}"
+    # Redirect stderr so it's inline with stdout
+    "${test}" 2>&1
     exit_code=$?
     if [[ ${exit_code} -ne 0 ]]; then
         echo Test failed with exit code ${exit_code}

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -149,19 +149,26 @@ COPY --chmod=777 <<-"EOF" /run-tests.sh
 # will be zero.
 
 EXIT_STATUS=0
+declare -a FAILING_TESTS=()
 
 for test in $(find /tests -type f -executable -exec readlink -f {} \;)
 do
     echo "--- Executing ${test}"
     # Redirect stderr so it's inline with stdout
-    "${test}" 2>&1
+    "${test}"
     exit_code=$?
     if [[ ${exit_code} -ne 0 ]]; then
+        FAILING_TESTS+=("${test}")
         echo Test failed with exit code ${exit_code}
         EXIT_STATUS=${exit_code}
     fi
 done
 
+if [[ ${EXIT_STATUS} -ne 0 ]]; then
+  echo ""
+  echo ">>> FAILING TESTS: ${FAILING_TESTS[@]}"
+  echo "   See .stderr.txt (or the Nomad stderr tab) to see additional failure backtraces."
+fi
 exit ${EXIT_STATUS}
 
 EOF

--- a/src/rust/nomad-client-gen/src/apis/acl_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/acl_api.rs
@@ -16,6 +16,227 @@ use super::{
 };
 use crate::apis::ResponseContent;
 
+/// struct for passing parameters to the method [`delete_acl_policy`]
+#[derive(Clone, Debug, Default)]
+pub struct DeleteAclPolicyParams {
+    /// The ACL policy name.
+    pub policy_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`delete_acl_token`]
+#[derive(Clone, Debug, Default)]
+pub struct DeleteAclTokenParams {
+    /// The token accessor ID.
+    pub token_accessor: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_acl_policies`]
+#[derive(Clone, Debug, Default)]
+pub struct GetAclPoliciesParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_acl_policy`]
+#[derive(Clone, Debug, Default)]
+pub struct GetAclPolicyParams {
+    /// The ACL policy name.
+    pub policy_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_acl_token`]
+#[derive(Clone, Debug, Default)]
+pub struct GetAclTokenParams {
+    /// The token accessor ID.
+    pub token_accessor: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_acl_token_self`]
+#[derive(Clone, Debug, Default)]
+pub struct GetAclTokenSelfParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_acl_tokens`]
+#[derive(Clone, Debug, Default)]
+pub struct GetAclTokensParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_acl_bootstrap`]
+#[derive(Clone, Debug, Default)]
+pub struct PostAclBootstrapParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_acl_policy`]
+#[derive(Clone, Debug, Default)]
+pub struct PostAclPolicyParams {
+    /// The ACL policy name.
+    pub policy_name: String,
+    pub acl_policy: crate::models::AclPolicy,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_acl_token`]
+#[derive(Clone, Debug, Default)]
+pub struct PostAclTokenParams {
+    /// The token accessor ID.
+    pub token_accessor: String,
+    pub acl_token: crate::models::AclToken,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_acl_token_onetime`]
+#[derive(Clone, Debug, Default)]
+pub struct PostAclTokenOnetimeParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_acl_token_onetime_exchange`]
+#[derive(Clone, Debug, Default)]
+pub struct PostAclTokenOnetimeExchangeParams {
+    pub one_time_token_exchange_request: crate::models::OneTimeTokenExchangeRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
 /// struct for typed errors of method [`delete_acl_policy`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -150,13 +371,16 @@ pub enum PostAclTokenOnetimeExchangeError {
 
 pub async fn delete_acl_policy(
     configuration: &configuration::Configuration,
-    policy_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: DeleteAclPolicyParams,
 ) -> Result<(), Error<DeleteAclPolicyError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let policy_name = params.policy_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -219,13 +443,16 @@ pub async fn delete_acl_policy(
 
 pub async fn delete_acl_token(
     configuration: &configuration::Configuration,
-    token_accessor: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: DeleteAclTokenParams,
 ) -> Result<(), Error<DeleteAclTokenError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let token_accessor = params.token_accessor;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -288,17 +515,20 @@ pub async fn delete_acl_token(
 
 pub async fn get_acl_policies(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetAclPoliciesParams,
 ) -> Result<Vec<crate::models::AclPolicyListStub>, Error<GetAclPoliciesError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -377,18 +607,21 @@ pub async fn get_acl_policies(
 
 pub async fn get_acl_policy(
     configuration: &configuration::Configuration,
-    policy_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetAclPolicyParams,
 ) -> Result<crate::models::AclPolicy, Error<GetAclPolicyError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let policy_name = params.policy_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -471,18 +704,21 @@ pub async fn get_acl_policy(
 
 pub async fn get_acl_token(
     configuration: &configuration::Configuration,
-    token_accessor: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetAclTokenParams,
 ) -> Result<crate::models::AclToken, Error<GetAclTokenError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let token_accessor = params.token_accessor;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -565,17 +801,20 @@ pub async fn get_acl_token(
 
 pub async fn get_acl_token_self(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetAclTokenSelfParams,
 ) -> Result<crate::models::AclToken, Error<GetAclTokenSelfError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -654,17 +893,20 @@ pub async fn get_acl_token_self(
 
 pub async fn get_acl_tokens(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetAclTokensParams,
 ) -> Result<Vec<crate::models::AclTokenListStub>, Error<GetAclTokensError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -743,12 +985,15 @@ pub async fn get_acl_tokens(
 
 pub async fn post_acl_bootstrap(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostAclBootstrapParams,
 ) -> Result<Vec<crate::models::AclToken>, Error<PostAclBootstrapError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -807,14 +1052,17 @@ pub async fn post_acl_bootstrap(
 
 pub async fn post_acl_policy(
     configuration: &configuration::Configuration,
-    policy_name: &str,
-    acl_policy: crate::models::AclPolicy,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostAclPolicyParams,
 ) -> Result<(), Error<PostAclPolicyError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let policy_name = params.policy_name;
+    let acl_policy = params.acl_policy;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -878,14 +1126,17 @@ pub async fn post_acl_policy(
 
 pub async fn post_acl_token(
     configuration: &configuration::Configuration,
-    token_accessor: &str,
-    acl_token: crate::models::AclToken,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostAclTokenParams,
 ) -> Result<crate::models::AclToken, Error<PostAclTokenError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let token_accessor = params.token_accessor;
+    let acl_token = params.acl_token;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -949,12 +1200,15 @@ pub async fn post_acl_token(
 
 pub async fn post_acl_token_onetime(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostAclTokenOnetimeParams,
 ) -> Result<crate::models::OneTimeToken, Error<PostAclTokenOnetimeError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -1013,13 +1267,16 @@ pub async fn post_acl_token_onetime(
 
 pub async fn post_acl_token_onetime_exchange(
     configuration: &configuration::Configuration,
-    one_time_token_exchange_request: crate::models::OneTimeTokenExchangeRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostAclTokenOnetimeExchangeParams,
 ) -> Result<crate::models::AclToken, Error<PostAclTokenOnetimeExchangeError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let one_time_token_exchange_request = params.one_time_token_exchange_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 

--- a/src/rust/nomad-client-gen/src/apis/allocations_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/allocations_api.rs
@@ -16,6 +16,33 @@ use super::{
 };
 use crate::apis::ResponseContent;
 
+/// struct for passing parameters to the method [`get_allocations`]
+#[derive(Clone, Debug, Default)]
+pub struct GetAllocationsParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+    /// Flag indicating whether to include resources in response.
+    pub resources: Option<bool>,
+    /// Flag indicating whether to include task states in response.
+    pub task_states: Option<bool>,
+}
+
 /// struct for typed errors of method [`get_allocations`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -29,19 +56,22 @@ pub enum GetAllocationsError {
 
 pub async fn get_allocations(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
-    resources: Option<bool>,
-    task_states: Option<bool>,
+    params: GetAllocationsParams,
 ) -> Result<Vec<crate::models::AllocationListStub>, Error<GetAllocationsError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
+    let resources = params.resources;
+    let task_states = params.task_states;
 
     let local_var_client = &local_var_configuration.client;
 

--- a/src/rust/nomad-client-gen/src/apis/deployments_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/deployments_api.rs
@@ -16,6 +16,158 @@ use super::{
 };
 use crate::apis::ResponseContent;
 
+/// struct for passing parameters to the method [`get_deployment`]
+#[derive(Clone, Debug, Default)]
+pub struct GetDeploymentParams {
+    /// Deployment ID.
+    pub deployment_id: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_deployment_allocations`]
+#[derive(Clone, Debug, Default)]
+pub struct GetDeploymentAllocationsParams {
+    /// Deployment ID.
+    pub deployment_id: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_deployments`]
+#[derive(Clone, Debug, Default)]
+pub struct GetDeploymentsParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_deployment_allocation_health`]
+#[derive(Clone, Debug, Default)]
+pub struct PostDeploymentAllocationHealthParams {
+    /// Deployment ID.
+    pub deployment_id: String,
+    pub deployment_alloc_health_request: crate::models::DeploymentAllocHealthRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_deployment_fail`]
+#[derive(Clone, Debug, Default)]
+pub struct PostDeploymentFailParams {
+    /// Deployment ID.
+    pub deployment_id: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_deployment_pause`]
+#[derive(Clone, Debug, Default)]
+pub struct PostDeploymentPauseParams {
+    /// Deployment ID.
+    pub deployment_id: String,
+    pub deployment_pause_request: crate::models::DeploymentPauseRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_deployment_promote`]
+#[derive(Clone, Debug, Default)]
+pub struct PostDeploymentPromoteParams {
+    /// Deployment ID.
+    pub deployment_id: String,
+    pub deployment_promote_request: crate::models::DeploymentPromoteRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_deployment_unblock`]
+#[derive(Clone, Debug, Default)]
+pub struct PostDeploymentUnblockParams {
+    /// Deployment ID.
+    pub deployment_id: String,
+    pub deployment_unblock_request: crate::models::DeploymentUnblockRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
 /// struct for typed errors of method [`get_deployment`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -106,18 +258,21 @@ pub enum PostDeploymentUnblockError {
 
 pub async fn get_deployment(
     configuration: &configuration::Configuration,
-    deployment_id: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetDeploymentParams,
 ) -> Result<crate::models::Deployment, Error<GetDeploymentError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let deployment_id = params.deployment_id;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -200,18 +355,21 @@ pub async fn get_deployment(
 
 pub async fn get_deployment_allocations(
     configuration: &configuration::Configuration,
-    deployment_id: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetDeploymentAllocationsParams,
 ) -> Result<Vec<crate::models::AllocationListStub>, Error<GetDeploymentAllocationsError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let deployment_id = params.deployment_id;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -294,17 +452,20 @@ pub async fn get_deployment_allocations(
 
 pub async fn get_deployments(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetDeploymentsParams,
 ) -> Result<Vec<crate::models::Deployment>, Error<GetDeploymentsError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -383,14 +544,17 @@ pub async fn get_deployments(
 
 pub async fn post_deployment_allocation_health(
     configuration: &configuration::Configuration,
-    deployment_id: &str,
-    deployment_alloc_health_request: crate::models::DeploymentAllocHealthRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostDeploymentAllocationHealthParams,
 ) -> Result<crate::models::DeploymentUpdateResponse, Error<PostDeploymentAllocationHealthError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let deployment_id = params.deployment_id;
+    let deployment_alloc_health_request = params.deployment_alloc_health_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -454,13 +618,16 @@ pub async fn post_deployment_allocation_health(
 
 pub async fn post_deployment_fail(
     configuration: &configuration::Configuration,
-    deployment_id: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostDeploymentFailParams,
 ) -> Result<crate::models::DeploymentUpdateResponse, Error<PostDeploymentFailError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let deployment_id = params.deployment_id;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -523,14 +690,17 @@ pub async fn post_deployment_fail(
 
 pub async fn post_deployment_pause(
     configuration: &configuration::Configuration,
-    deployment_id: &str,
-    deployment_pause_request: crate::models::DeploymentPauseRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostDeploymentPauseParams,
 ) -> Result<crate::models::DeploymentUpdateResponse, Error<PostDeploymentPauseError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let deployment_id = params.deployment_id;
+    let deployment_pause_request = params.deployment_pause_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -594,14 +764,17 @@ pub async fn post_deployment_pause(
 
 pub async fn post_deployment_promote(
     configuration: &configuration::Configuration,
-    deployment_id: &str,
-    deployment_promote_request: crate::models::DeploymentPromoteRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostDeploymentPromoteParams,
 ) -> Result<crate::models::DeploymentUpdateResponse, Error<PostDeploymentPromoteError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let deployment_id = params.deployment_id;
+    let deployment_promote_request = params.deployment_promote_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -665,14 +838,17 @@ pub async fn post_deployment_promote(
 
 pub async fn post_deployment_unblock(
     configuration: &configuration::Configuration,
-    deployment_id: &str,
-    deployment_unblock_request: crate::models::DeploymentUnblockRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostDeploymentUnblockParams,
 ) -> Result<crate::models::DeploymentUpdateResponse, Error<PostDeploymentUnblockError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let deployment_id = params.deployment_id;
+    let deployment_unblock_request = params.deployment_unblock_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 

--- a/src/rust/nomad-client-gen/src/apis/enterprise_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/enterprise_api.rs
@@ -16,6 +16,99 @@ use super::{
 };
 use crate::apis::ResponseContent;
 
+/// struct for passing parameters to the method [`create_quota_spec`]
+#[derive(Clone, Debug, Default)]
+pub struct CreateQuotaSpecParams {
+    pub quota_spec: crate::models::QuotaSpec,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`delete_quota_spec`]
+#[derive(Clone, Debug, Default)]
+pub struct DeleteQuotaSpecParams {
+    /// The quota spec identifier.
+    pub spec_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_quota_spec`]
+#[derive(Clone, Debug, Default)]
+pub struct GetQuotaSpecParams {
+    /// The quota spec identifier.
+    pub spec_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_quotas`]
+#[derive(Clone, Debug, Default)]
+pub struct GetQuotasParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_quota_spec`]
+#[derive(Clone, Debug, Default)]
+pub struct PostQuotaSpecParams {
+    /// The quota spec identifier.
+    pub spec_name: String,
+    pub quota_spec: crate::models::QuotaSpec,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
 /// struct for typed errors of method [`create_quota_spec`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -73,13 +166,16 @@ pub enum PostQuotaSpecError {
 
 pub async fn create_quota_spec(
     configuration: &configuration::Configuration,
-    quota_spec: crate::models::QuotaSpec,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: CreateQuotaSpecParams,
 ) -> Result<(), Error<CreateQuotaSpecError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let quota_spec = params.quota_spec;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -139,13 +235,16 @@ pub async fn create_quota_spec(
 
 pub async fn delete_quota_spec(
     configuration: &configuration::Configuration,
-    spec_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: DeleteQuotaSpecParams,
 ) -> Result<(), Error<DeleteQuotaSpecError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let spec_name = params.spec_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -208,18 +307,21 @@ pub async fn delete_quota_spec(
 
 pub async fn get_quota_spec(
     configuration: &configuration::Configuration,
-    spec_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetQuotaSpecParams,
 ) -> Result<crate::models::QuotaSpec, Error<GetQuotaSpecError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let spec_name = params.spec_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -302,17 +404,20 @@ pub async fn get_quota_spec(
 
 pub async fn get_quotas(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetQuotasParams,
 ) -> Result<Vec<serde_json::Value>, Error<GetQuotasError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -391,14 +496,17 @@ pub async fn get_quotas(
 
 pub async fn post_quota_spec(
     configuration: &configuration::Configuration,
-    spec_name: &str,
-    quota_spec: crate::models::QuotaSpec,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostQuotaSpecParams,
 ) -> Result<(), Error<PostQuotaSpecError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let spec_name = params.spec_name;
+    let quota_spec = params.quota_spec;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 

--- a/src/rust/nomad-client-gen/src/apis/evaluations_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/evaluations_api.rs
@@ -16,6 +16,79 @@ use super::{
 };
 use crate::apis::ResponseContent;
 
+/// struct for passing parameters to the method [`get_evaluation`]
+#[derive(Clone, Debug, Default)]
+pub struct GetEvaluationParams {
+    /// Evaluation ID.
+    pub eval_id: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_evaluation_allocations`]
+#[derive(Clone, Debug, Default)]
+pub struct GetEvaluationAllocationsParams {
+    /// Evaluation ID.
+    pub eval_id: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_evaluations`]
+#[derive(Clone, Debug, Default)]
+pub struct GetEvaluationsParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
 /// struct for typed errors of method [`get_evaluation`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -51,18 +124,21 @@ pub enum GetEvaluationsError {
 
 pub async fn get_evaluation(
     configuration: &configuration::Configuration,
-    eval_id: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetEvaluationParams,
 ) -> Result<crate::models::Evaluation, Error<GetEvaluationError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let eval_id = params.eval_id;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -145,18 +221,21 @@ pub async fn get_evaluation(
 
 pub async fn get_evaluation_allocations(
     configuration: &configuration::Configuration,
-    eval_id: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetEvaluationAllocationsParams,
 ) -> Result<Vec<crate::models::AllocationListStub>, Error<GetEvaluationAllocationsError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let eval_id = params.eval_id;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -239,17 +318,20 @@ pub async fn get_evaluation_allocations(
 
 pub async fn get_evaluations(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetEvaluationsParams,
 ) -> Result<Vec<crate::models::Evaluation>, Error<GetEvaluationsError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 

--- a/src/rust/nomad-client-gen/src/apis/jobs_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/jobs_api.rs
@@ -16,6 +16,415 @@ use super::{
 };
 use crate::apis::ResponseContent;
 
+/// struct for passing parameters to the method [`delete_job`]
+#[derive(Clone, Debug, Default)]
+pub struct DeleteJobParams {
+    /// The job identifier.
+    pub job_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+    /// Boolean flag indicating whether to purge allocations of the job after deleting.
+    pub purge: Option<bool>,
+    /// Boolean flag indicating whether the operation should apply to all instances of the job globally.
+    pub global: Option<bool>,
+}
+
+/// struct for passing parameters to the method [`get_job`]
+#[derive(Clone, Debug, Default)]
+pub struct GetJobParams {
+    /// The job identifier.
+    pub job_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_job_allocations`]
+#[derive(Clone, Debug, Default)]
+pub struct GetJobAllocationsParams {
+    /// The job identifier.
+    pub job_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+    /// Specifies whether the list of allocations should include allocations from a previously registered job with the same ID. This is possible if the job is deregistered and reregistered.
+    pub all: Option<bool>,
+}
+
+/// struct for passing parameters to the method [`get_job_deployment`]
+#[derive(Clone, Debug, Default)]
+pub struct GetJobDeploymentParams {
+    /// The job identifier.
+    pub job_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_job_deployments`]
+#[derive(Clone, Debug, Default)]
+pub struct GetJobDeploymentsParams {
+    /// The job identifier.
+    pub job_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+    /// Flag indicating whether to constrain by job creation index or not.
+    pub all: Option<i32>,
+}
+
+/// struct for passing parameters to the method [`get_job_evaluations`]
+#[derive(Clone, Debug, Default)]
+pub struct GetJobEvaluationsParams {
+    /// The job identifier.
+    pub job_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_job_scale_status`]
+#[derive(Clone, Debug, Default)]
+pub struct GetJobScaleStatusParams {
+    /// The job identifier.
+    pub job_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_job_summary`]
+#[derive(Clone, Debug, Default)]
+pub struct GetJobSummaryParams {
+    /// The job identifier.
+    pub job_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_job_versions`]
+#[derive(Clone, Debug, Default)]
+pub struct GetJobVersionsParams {
+    /// The job identifier.
+    pub job_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+    /// Boolean flag indicating whether to compute job diffs.
+    pub diffs: Option<bool>,
+}
+
+/// struct for passing parameters to the method [`get_jobs`]
+#[derive(Clone, Debug, Default)]
+pub struct GetJobsParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_job`]
+#[derive(Clone, Debug, Default)]
+pub struct PostJobParams {
+    /// The job identifier.
+    pub job_name: String,
+    pub job_register_request: crate::models::JobRegisterRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_job_dispatch`]
+#[derive(Clone, Debug, Default)]
+pub struct PostJobDispatchParams {
+    /// The job identifier.
+    pub job_name: String,
+    pub job_dispatch_request: crate::models::JobDispatchRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_job_evaluate`]
+#[derive(Clone, Debug, Default)]
+pub struct PostJobEvaluateParams {
+    /// The job identifier.
+    pub job_name: String,
+    pub job_evaluate_request: crate::models::JobEvaluateRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_job_parse`]
+#[derive(Clone, Debug, Default)]
+pub struct PostJobParseParams {
+    pub jobs_parse_request: crate::models::JobsParseRequest,
+}
+
+/// struct for passing parameters to the method [`post_job_periodic_force`]
+#[derive(Clone, Debug, Default)]
+pub struct PostJobPeriodicForceParams {
+    /// The job identifier.
+    pub job_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_job_plan`]
+#[derive(Clone, Debug, Default)]
+pub struct PostJobPlanParams {
+    /// The job identifier.
+    pub job_name: String,
+    pub job_plan_request: crate::models::JobPlanRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_job_revert`]
+#[derive(Clone, Debug, Default)]
+pub struct PostJobRevertParams {
+    /// The job identifier.
+    pub job_name: String,
+    pub job_revert_request: crate::models::JobRevertRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_job_scaling_request`]
+#[derive(Clone, Debug, Default)]
+pub struct PostJobScalingRequestParams {
+    /// The job identifier.
+    pub job_name: String,
+    pub scaling_request: crate::models::ScalingRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_job_stability`]
+#[derive(Clone, Debug, Default)]
+pub struct PostJobStabilityParams {
+    /// The job identifier.
+    pub job_name: String,
+    pub job_stability_request: crate::models::JobStabilityRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_job_validate_request`]
+#[derive(Clone, Debug, Default)]
+pub struct PostJobValidateRequestParams {
+    pub job_validate_request: crate::models::JobValidateRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`register_job`]
+#[derive(Clone, Debug, Default)]
+pub struct RegisterJobParams {
+    pub job_register_request: crate::models::JobRegisterRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
 /// struct for typed errors of method [`delete_job`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -249,15 +658,18 @@ pub enum RegisterJobError {
 
 pub async fn delete_job(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
-    purge: Option<bool>,
-    global: Option<bool>,
+    params: DeleteJobParams,
 ) -> Result<crate::models::JobDeregisterResponse, Error<DeleteJobError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
+    let purge = params.purge;
+    let global = params.global;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -328,18 +740,21 @@ pub async fn delete_job(
 
 pub async fn get_job(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetJobParams,
 ) -> Result<crate::models::Job, Error<GetJobError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -421,19 +836,22 @@ pub async fn get_job(
 
 pub async fn get_job_allocations(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
-    all: Option<bool>,
+    params: GetJobAllocationsParams,
 ) -> Result<Vec<crate::models::AllocationListStub>, Error<GetJobAllocationsError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
+    let all = params.all;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -519,18 +937,21 @@ pub async fn get_job_allocations(
 
 pub async fn get_job_deployment(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetJobDeploymentParams,
 ) -> Result<crate::models::Deployment, Error<GetJobDeploymentError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -613,19 +1034,22 @@ pub async fn get_job_deployment(
 
 pub async fn get_job_deployments(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
-    all: Option<i32>,
+    params: GetJobDeploymentsParams,
 ) -> Result<Vec<crate::models::Deployment>, Error<GetJobDeploymentsError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
+    let all = params.all;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -711,18 +1135,21 @@ pub async fn get_job_deployments(
 
 pub async fn get_job_evaluations(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetJobEvaluationsParams,
 ) -> Result<Vec<crate::models::Evaluation>, Error<GetJobEvaluationsError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -805,18 +1232,21 @@ pub async fn get_job_evaluations(
 
 pub async fn get_job_scale_status(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetJobScaleStatusParams,
 ) -> Result<crate::models::JobScaleStatusResponse, Error<GetJobScaleStatusError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -899,18 +1329,21 @@ pub async fn get_job_scale_status(
 
 pub async fn get_job_summary(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetJobSummaryParams,
 ) -> Result<crate::models::JobSummary, Error<GetJobSummaryError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -993,19 +1426,22 @@ pub async fn get_job_summary(
 
 pub async fn get_job_versions(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
-    diffs: Option<bool>,
+    params: GetJobVersionsParams,
 ) -> Result<crate::models::JobVersionsResponse, Error<GetJobVersionsError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
+    let diffs = params.diffs;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -1092,17 +1528,20 @@ pub async fn get_job_versions(
 
 pub async fn get_jobs(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetJobsParams,
 ) -> Result<Vec<crate::models::JobListStub>, Error<GetJobsError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -1180,14 +1619,17 @@ pub async fn get_jobs(
 
 pub async fn post_job(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    job_register_request: crate::models::JobRegisterRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostJobParams,
 ) -> Result<crate::models::JobRegisterResponse, Error<PostJobError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let job_register_request = params.job_register_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -1250,14 +1692,17 @@ pub async fn post_job(
 
 pub async fn post_job_dispatch(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    job_dispatch_request: crate::models::JobDispatchRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostJobDispatchParams,
 ) -> Result<crate::models::JobDispatchResponse, Error<PostJobDispatchError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let job_dispatch_request = params.job_dispatch_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -1321,14 +1766,17 @@ pub async fn post_job_dispatch(
 
 pub async fn post_job_evaluate(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    job_evaluate_request: crate::models::JobEvaluateRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostJobEvaluateParams,
 ) -> Result<crate::models::JobRegisterResponse, Error<PostJobEvaluateError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let job_evaluate_request = params.job_evaluate_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -1392,9 +1840,12 @@ pub async fn post_job_evaluate(
 
 pub async fn post_job_parse(
     configuration: &configuration::Configuration,
-    jobs_parse_request: crate::models::JobsParseRequest,
+    params: PostJobParseParams,
 ) -> Result<crate::models::Job, Error<PostJobParseError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let jobs_parse_request = params.jobs_parse_request;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -1438,13 +1889,16 @@ pub async fn post_job_parse(
 
 pub async fn post_job_periodic_force(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostJobPeriodicForceParams,
 ) -> Result<crate::models::PeriodicForceResponse, Error<PostJobPeriodicForceError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -1507,14 +1961,17 @@ pub async fn post_job_periodic_force(
 
 pub async fn post_job_plan(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    job_plan_request: crate::models::JobPlanRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostJobPlanParams,
 ) -> Result<crate::models::JobPlanResponse, Error<PostJobPlanError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let job_plan_request = params.job_plan_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -1578,14 +2035,17 @@ pub async fn post_job_plan(
 
 pub async fn post_job_revert(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    job_revert_request: crate::models::JobRevertRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostJobRevertParams,
 ) -> Result<crate::models::JobRegisterResponse, Error<PostJobRevertError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let job_revert_request = params.job_revert_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -1649,14 +2109,17 @@ pub async fn post_job_revert(
 
 pub async fn post_job_scaling_request(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    scaling_request: crate::models::ScalingRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostJobScalingRequestParams,
 ) -> Result<crate::models::JobRegisterResponse, Error<PostJobScalingRequestError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let scaling_request = params.scaling_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -1720,14 +2183,17 @@ pub async fn post_job_scaling_request(
 
 pub async fn post_job_stability(
     configuration: &configuration::Configuration,
-    job_name: &str,
-    job_stability_request: crate::models::JobStabilityRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostJobStabilityParams,
 ) -> Result<crate::models::JobStabilityResponse, Error<PostJobStabilityError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_name = params.job_name;
+    let job_stability_request = params.job_stability_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -1791,13 +2257,16 @@ pub async fn post_job_stability(
 
 pub async fn post_job_validate_request(
     configuration: &configuration::Configuration,
-    job_validate_request: crate::models::JobValidateRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostJobValidateRequestParams,
 ) -> Result<crate::models::JobValidateResponse, Error<PostJobValidateRequestError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_validate_request = params.job_validate_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -1857,13 +2326,16 @@ pub async fn post_job_validate_request(
 
 pub async fn register_job(
     configuration: &configuration::Configuration,
-    job_register_request: crate::models::JobRegisterRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: RegisterJobParams,
 ) -> Result<crate::models::JobRegisterResponse, Error<RegisterJobError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let job_register_request = params.job_register_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 

--- a/src/rust/nomad-client-gen/src/apis/metrics_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/metrics_api.rs
@@ -16,6 +16,13 @@ use super::{
 };
 use crate::apis::ResponseContent;
 
+/// struct for passing parameters to the method [`get_metrics_summary`]
+#[derive(Clone, Debug, Default)]
+pub struct GetMetricsSummaryParams {
+    /// The format the user requested for the metrics summary (e.g. prometheus)
+    pub format: Option<String>,
+}
+
 /// struct for typed errors of method [`get_metrics_summary`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -29,9 +36,12 @@ pub enum GetMetricsSummaryError {
 
 pub async fn get_metrics_summary(
     configuration: &configuration::Configuration,
-    format: Option<&str>,
+    params: GetMetricsSummaryParams,
 ) -> Result<crate::models::MetricsSummary, Error<GetMetricsSummaryError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let format = params.format;
 
     let local_var_client = &local_var_configuration.client;
 

--- a/src/rust/nomad-client-gen/src/apis/namespaces_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/namespaces_api.rs
@@ -16,6 +16,98 @@ use super::{
 };
 use crate::apis::ResponseContent;
 
+/// struct for passing parameters to the method [`create_namespace`]
+#[derive(Clone, Debug, Default)]
+pub struct CreateNamespaceParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`delete_namespace`]
+#[derive(Clone, Debug, Default)]
+pub struct DeleteNamespaceParams {
+    /// The namespace identifier.
+    pub namespace_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_namespace`]
+#[derive(Clone, Debug, Default)]
+pub struct GetNamespaceParams {
+    /// The namespace identifier.
+    pub namespace_name: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_namespaces`]
+#[derive(Clone, Debug, Default)]
+pub struct GetNamespacesParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_namespace`]
+#[derive(Clone, Debug, Default)]
+pub struct PostNamespaceParams {
+    /// The namespace identifier.
+    pub namespace_name: String,
+    pub namespace2: crate::models::Namespace,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
 /// struct for typed errors of method [`create_namespace`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -73,12 +165,15 @@ pub enum PostNamespaceError {
 
 pub async fn create_namespace(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: CreateNamespaceParams,
 ) -> Result<(), Error<CreateNamespaceError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -137,13 +232,16 @@ pub async fn create_namespace(
 
 pub async fn delete_namespace(
     configuration: &configuration::Configuration,
-    namespace_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: DeleteNamespaceParams,
 ) -> Result<(), Error<DeleteNamespaceError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let namespace_name = params.namespace_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -206,18 +304,21 @@ pub async fn delete_namespace(
 
 pub async fn get_namespace(
     configuration: &configuration::Configuration,
-    namespace_name: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetNamespaceParams,
 ) -> Result<crate::models::Namespace, Error<GetNamespaceError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let namespace_name = params.namespace_name;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -300,17 +401,20 @@ pub async fn get_namespace(
 
 pub async fn get_namespaces(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetNamespacesParams,
 ) -> Result<Vec<crate::models::Namespace>, Error<GetNamespacesError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -389,14 +493,17 @@ pub async fn get_namespaces(
 
 pub async fn post_namespace(
     configuration: &configuration::Configuration,
-    namespace_name: &str,
-    namespace2: crate::models::Namespace,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostNamespaceParams,
 ) -> Result<(), Error<PostNamespaceError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let namespace_name = params.namespace_name;
+    let namespace2 = params.namespace2;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 

--- a/src/rust/nomad-client-gen/src/apis/nodes_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/nodes_api.rs
@@ -16,6 +16,158 @@ use super::{
 };
 use crate::apis::ResponseContent;
 
+/// struct for passing parameters to the method [`get_node`]
+#[derive(Clone, Debug, Default)]
+pub struct GetNodeParams {
+    /// The ID of the node.
+    pub node_id: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_node_allocations`]
+#[derive(Clone, Debug, Default)]
+pub struct GetNodeAllocationsParams {
+    /// The ID of the node.
+    pub node_id: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_nodes`]
+#[derive(Clone, Debug, Default)]
+pub struct GetNodesParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+    /// Whether or not to include the NodeResources and ReservedResources fields in the response.
+    pub resources: Option<bool>,
+}
+
+/// struct for passing parameters to the method [`update_node_drain`]
+#[derive(Clone, Debug, Default)]
+pub struct UpdateNodeDrainParams {
+    /// The ID of the node.
+    pub node_id: String,
+    pub node_update_drain_request: crate::models::NodeUpdateDrainRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`update_node_eligibility`]
+#[derive(Clone, Debug, Default)]
+pub struct UpdateNodeEligibilityParams {
+    /// The ID of the node.
+    pub node_id: String,
+    pub node_update_eligibility_request: crate::models::NodeUpdateEligibilityRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`update_node_purge`]
+#[derive(Clone, Debug, Default)]
+pub struct UpdateNodePurgeParams {
+    /// The ID of the node.
+    pub node_id: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
 /// struct for typed errors of method [`get_node`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -84,18 +236,21 @@ pub enum UpdateNodePurgeError {
 
 pub async fn get_node(
     configuration: &configuration::Configuration,
-    node_id: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetNodeParams,
 ) -> Result<crate::models::Node, Error<GetNodeError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let node_id = params.node_id;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -177,18 +332,21 @@ pub async fn get_node(
 
 pub async fn get_node_allocations(
     configuration: &configuration::Configuration,
-    node_id: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetNodeAllocationsParams,
 ) -> Result<Vec<crate::models::AllocationListStub>, Error<GetNodeAllocationsError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let node_id = params.node_id;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -271,18 +429,21 @@ pub async fn get_node_allocations(
 
 pub async fn get_nodes(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
-    resources: Option<bool>,
+    params: GetNodesParams,
 ) -> Result<Vec<crate::models::NodeListStub>, Error<GetNodesError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
+    let resources = params.resources;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -364,19 +525,22 @@ pub async fn get_nodes(
 
 pub async fn update_node_drain(
     configuration: &configuration::Configuration,
-    node_id: &str,
-    node_update_drain_request: crate::models::NodeUpdateDrainRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: UpdateNodeDrainParams,
 ) -> Result<crate::models::NodeDrainUpdateResponse, Error<UpdateNodeDrainError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let node_id = params.node_id;
+    let node_update_drain_request = params.node_update_drain_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -460,19 +624,22 @@ pub async fn update_node_drain(
 
 pub async fn update_node_eligibility(
     configuration: &configuration::Configuration,
-    node_id: &str,
-    node_update_eligibility_request: crate::models::NodeUpdateEligibilityRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: UpdateNodeEligibilityParams,
 ) -> Result<crate::models::NodeEligibilityUpdateResponse, Error<UpdateNodeEligibilityError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let node_id = params.node_id;
+    let node_update_eligibility_request = params.node_update_eligibility_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -556,18 +723,21 @@ pub async fn update_node_eligibility(
 
 pub async fn update_node_purge(
     configuration: &configuration::Configuration,
-    node_id: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: UpdateNodePurgeParams,
 ) -> Result<crate::models::NodePurgeResponse, Error<UpdateNodePurgeError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let node_id = params.node_id;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 

--- a/src/rust/nomad-client-gen/src/apis/plugins_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/plugins_api.rs
@@ -16,6 +16,54 @@ use super::{
 };
 use crate::apis::ResponseContent;
 
+/// struct for passing parameters to the method [`get_plugin_csi`]
+#[derive(Clone, Debug, Default)]
+pub struct GetPluginCsiParams {
+    /// The CSI plugin identifier.
+    pub plugin_id: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_plugins`]
+#[derive(Clone, Debug, Default)]
+pub struct GetPluginsParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
 /// struct for typed errors of method [`get_plugin_csi`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -40,18 +88,21 @@ pub enum GetPluginsError {
 
 pub async fn get_plugin_csi(
     configuration: &configuration::Configuration,
-    plugin_id: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetPluginCsiParams,
 ) -> Result<Vec<crate::models::CsiPlugin>, Error<GetPluginCsiError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let plugin_id = params.plugin_id;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -134,17 +185,20 @@ pub async fn get_plugin_csi(
 
 pub async fn get_plugins(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetPluginsParams,
 ) -> Result<Vec<crate::models::CsiPluginListStub>, Error<GetPluginsError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 

--- a/src/rust/nomad-client-gen/src/apis/regions_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/regions_api.rs
@@ -32,6 +32,8 @@ pub async fn get_regions(
 ) -> Result<Vec<String>, Error<GetRegionsError>> {
     let local_var_configuration = configuration;
 
+    // unbox the parameters
+
     let local_var_client = &local_var_configuration.client;
 
     let local_var_uri_str = format!("{}/regions", local_var_configuration.base_path);

--- a/src/rust/nomad-client-gen/src/apis/scaling_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/scaling_api.rs
@@ -16,6 +16,54 @@ use super::{
 };
 use crate::apis::ResponseContent;
 
+/// struct for passing parameters to the method [`get_scaling_policies`]
+#[derive(Clone, Debug, Default)]
+pub struct GetScalingPoliciesParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_scaling_policy`]
+#[derive(Clone, Debug, Default)]
+pub struct GetScalingPolicyParams {
+    /// The scaling policy identifier.
+    pub policy_id: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
 /// struct for typed errors of method [`get_scaling_policies`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -40,17 +88,20 @@ pub enum GetScalingPolicyError {
 
 pub async fn get_scaling_policies(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetScalingPoliciesParams,
 ) -> Result<Vec<crate::models::ScalingPolicyListStub>, Error<GetScalingPoliciesError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -129,18 +180,21 @@ pub async fn get_scaling_policies(
 
 pub async fn get_scaling_policy(
     configuration: &configuration::Configuration,
-    policy_id: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetScalingPolicyParams,
 ) -> Result<crate::models::ScalingPolicy, Error<GetScalingPolicyError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let policy_id = params.policy_id;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 

--- a/src/rust/nomad-client-gen/src/apis/search_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/search_api.rs
@@ -16,6 +16,54 @@ use super::{
 };
 use crate::apis::ResponseContent;
 
+/// struct for passing parameters to the method [`get_fuzzy_search`]
+#[derive(Clone, Debug, Default)]
+pub struct GetFuzzySearchParams {
+    pub fuzzy_search_request: crate::models::FuzzySearchRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_search`]
+#[derive(Clone, Debug, Default)]
+pub struct GetSearchParams {
+    pub search_request: crate::models::SearchRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
 /// struct for typed errors of method [`get_fuzzy_search`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -40,18 +88,21 @@ pub enum GetSearchError {
 
 pub async fn get_fuzzy_search(
     configuration: &configuration::Configuration,
-    fuzzy_search_request: crate::models::FuzzySearchRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetFuzzySearchParams,
 ) -> Result<crate::models::FuzzySearchResponse, Error<GetFuzzySearchError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let fuzzy_search_request = params.fuzzy_search_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -131,18 +182,21 @@ pub async fn get_fuzzy_search(
 
 pub async fn get_search(
     configuration: &configuration::Configuration,
-    search_request: crate::models::SearchRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetSearchParams,
 ) -> Result<crate::models::SearchResponse, Error<GetSearchError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let search_request = params.search_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 

--- a/src/rust/nomad-client-gen/src/apis/system_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/system_api.rs
@@ -16,6 +16,32 @@ use super::{
 };
 use crate::apis::ResponseContent;
 
+/// struct for passing parameters to the method [`put_system_gc`]
+#[derive(Clone, Debug, Default)]
+pub struct PutSystemGcParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`put_system_reconcile_summaries`]
+#[derive(Clone, Debug, Default)]
+pub struct PutSystemReconcileSummariesParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
 /// struct for typed errors of method [`put_system_gc`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -40,12 +66,15 @@ pub enum PutSystemReconcileSummariesError {
 
 pub async fn put_system_gc(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PutSystemGcParams,
 ) -> Result<(), Error<PutSystemGcError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -104,12 +133,15 @@ pub async fn put_system_gc(
 
 pub async fn put_system_reconcile_summaries(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PutSystemReconcileSummariesParams,
 ) -> Result<(), Error<PutSystemReconcileSummariesError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 

--- a/src/rust/nomad-client-gen/src/apis/volumes_api.rs
+++ b/src/rust/nomad-client-gen/src/apis/volumes_api.rs
@@ -16,6 +16,225 @@ use super::{
 };
 use crate::apis::ResponseContent;
 
+/// struct for passing parameters to the method [`create_volume`]
+#[derive(Clone, Debug, Default)]
+pub struct CreateVolumeParams {
+    /// Volume unique identifier.
+    pub volume_id: String,
+    /// The action to perform on the Volume (create, detach, delete).
+    pub action: String,
+    pub csi_volume_create_request: crate::models::CsiVolumeCreateRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`delete_snapshot`]
+#[derive(Clone, Debug, Default)]
+pub struct DeleteSnapshotParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+    /// Filters volume lists by plugin ID.
+    pub plugin_id: Option<String>,
+    /// The ID of the snapshot to target.
+    pub snapshot_id: Option<String>,
+}
+
+/// struct for passing parameters to the method [`delete_volume_registration`]
+#[derive(Clone, Debug, Default)]
+pub struct DeleteVolumeRegistrationParams {
+    /// Volume unique identifier.
+    pub volume_id: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+    /// Used to force the de-registration of a volume.
+    pub force: Option<String>,
+}
+
+/// struct for passing parameters to the method [`detach_or_delete_volume`]
+#[derive(Clone, Debug, Default)]
+pub struct DetachOrDeleteVolumeParams {
+    /// Volume unique identifier.
+    pub volume_id: String,
+    /// The action to perform on the Volume (create, detach, delete).
+    pub action: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+    /// Specifies node to target volume operation for.
+    pub node: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_external_volumes`]
+#[derive(Clone, Debug, Default)]
+pub struct GetExternalVolumesParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+    /// Filters volume lists by plugin ID.
+    pub plugin_id: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_snapshots`]
+#[derive(Clone, Debug, Default)]
+pub struct GetSnapshotsParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+    /// Filters volume lists by plugin ID.
+    pub plugin_id: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_volume`]
+#[derive(Clone, Debug, Default)]
+pub struct GetVolumeParams {
+    /// Volume unique identifier.
+    pub volume_id: String,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`get_volumes`]
+#[derive(Clone, Debug, Default)]
+pub struct GetVolumesParams {
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// If set, wait until query exceeds given index. Must be provided with WaitParam.
+    pub index: Option<i32>,
+    /// Provided with IndexParam to wait for change.
+    pub wait: Option<String>,
+    /// If present, results will include stale reads.
+    pub stale: Option<String>,
+    /// Constrains results to jobs that start with the defined prefix
+    pub prefix: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Maximum number of results to return.
+    pub per_page: Option<i32>,
+    /// Indicates where to start paging for queries that support pagination.
+    pub next_token: Option<String>,
+    /// Filters volume lists by node ID.
+    pub node_id: Option<String>,
+    /// Filters volume lists by plugin ID.
+    pub plugin_id: Option<String>,
+    /// Filters volume lists to a specific type.
+    pub _type: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_snapshot`]
+#[derive(Clone, Debug, Default)]
+pub struct PostSnapshotParams {
+    pub csi_snapshot_create_request: crate::models::CsiSnapshotCreateRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_volume`]
+#[derive(Clone, Debug, Default)]
+pub struct PostVolumeParams {
+    pub csi_volume_register_request: crate::models::CsiVolumeRegisterRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
+/// struct for passing parameters to the method [`post_volume_registration`]
+#[derive(Clone, Debug, Default)]
+pub struct PostVolumeRegistrationParams {
+    /// Volume unique identifier.
+    pub volume_id: String,
+    pub csi_volume_register_request: crate::models::CsiVolumeRegisterRequest,
+    /// Filters results based on the specified region.
+    pub region: Option<String>,
+    /// Filters results based on the specified namespace.
+    pub namespace: Option<String>,
+    /// A Nomad ACL token.
+    pub x_nomad_token: Option<String>,
+    /// Can be used to ensure operations are only run once.
+    pub idempotency_token: Option<String>,
+}
+
 /// struct for typed errors of method [`create_volume`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -139,15 +358,18 @@ pub enum PostVolumeRegistrationError {
 
 pub async fn create_volume(
     configuration: &configuration::Configuration,
-    volume_id: &str,
-    action: &str,
-    csi_volume_create_request: crate::models::CsiVolumeCreateRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: CreateVolumeParams,
 ) -> Result<(), Error<CreateVolumeError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let volume_id = params.volume_id;
+    let action = params.action;
+    let csi_volume_create_request = params.csi_volume_create_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -212,14 +434,17 @@ pub async fn create_volume(
 
 pub async fn delete_snapshot(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
-    plugin_id: Option<&str>,
-    snapshot_id: Option<&str>,
+    params: DeleteSnapshotParams,
 ) -> Result<(), Error<DeleteSnapshotError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
+    let plugin_id = params.plugin_id;
+    let snapshot_id = params.snapshot_id;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -286,14 +511,17 @@ pub async fn delete_snapshot(
 
 pub async fn delete_volume_registration(
     configuration: &configuration::Configuration,
-    volume_id: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
-    force: Option<&str>,
+    params: DeleteVolumeRegistrationParams,
 ) -> Result<(), Error<DeleteVolumeRegistrationError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let volume_id = params.volume_id;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
+    let force = params.force;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -360,15 +588,18 @@ pub async fn delete_volume_registration(
 
 pub async fn detach_or_delete_volume(
     configuration: &configuration::Configuration,
-    volume_id: &str,
-    action: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
-    node: Option<&str>,
+    params: DetachOrDeleteVolumeParams,
 ) -> Result<(), Error<DetachOrDeleteVolumeError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let volume_id = params.volume_id;
+    let action = params.action;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
+    let node = params.node;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -436,18 +667,21 @@ pub async fn detach_or_delete_volume(
 
 pub async fn get_external_volumes(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
-    plugin_id: Option<&str>,
+    params: GetExternalVolumesParams,
 ) -> Result<crate::models::CsiVolumeListExternalResponse, Error<GetExternalVolumesError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
+    let plugin_id = params.plugin_id;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -530,18 +764,21 @@ pub async fn get_external_volumes(
 
 pub async fn get_snapshots(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
-    plugin_id: Option<&str>,
+    params: GetSnapshotsParams,
 ) -> Result<crate::models::CsiSnapshotListResponse, Error<GetSnapshotsError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
+    let plugin_id = params.plugin_id;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -624,18 +861,21 @@ pub async fn get_snapshots(
 
 pub async fn get_volume(
     configuration: &configuration::Configuration,
-    volume_id: &str,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
+    params: GetVolumeParams,
 ) -> Result<crate::models::CsiVolume, Error<GetVolumeError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let volume_id = params.volume_id;
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -718,20 +958,23 @@ pub async fn get_volume(
 
 pub async fn get_volumes(
     configuration: &configuration::Configuration,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    index: Option<i32>,
-    wait: Option<&str>,
-    stale: Option<&str>,
-    prefix: Option<&str>,
-    x_nomad_token: Option<&str>,
-    per_page: Option<i32>,
-    next_token: Option<&str>,
-    node_id: Option<&str>,
-    plugin_id: Option<&str>,
-    _type: Option<&str>,
+    params: GetVolumesParams,
 ) -> Result<Vec<crate::models::CsiVolumeListStub>, Error<GetVolumesError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let region = params.region;
+    let namespace = params.namespace;
+    let index = params.index;
+    let wait = params.wait;
+    let stale = params.stale;
+    let prefix = params.prefix;
+    let x_nomad_token = params.x_nomad_token;
+    let per_page = params.per_page;
+    let next_token = params.next_token;
+    let node_id = params.node_id;
+    let plugin_id = params.plugin_id;
+    let _type = params._type;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -822,13 +1065,16 @@ pub async fn get_volumes(
 
 pub async fn post_snapshot(
     configuration: &configuration::Configuration,
-    csi_snapshot_create_request: crate::models::CsiSnapshotCreateRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostSnapshotParams,
 ) -> Result<crate::models::CsiSnapshotCreateResponse, Error<PostSnapshotError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let csi_snapshot_create_request = params.csi_snapshot_create_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -888,13 +1134,16 @@ pub async fn post_snapshot(
 
 pub async fn post_volume(
     configuration: &configuration::Configuration,
-    csi_volume_register_request: crate::models::CsiVolumeRegisterRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostVolumeParams,
 ) -> Result<(), Error<PostVolumeError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let csi_volume_register_request = params.csi_volume_register_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 
@@ -954,14 +1203,17 @@ pub async fn post_volume(
 
 pub async fn post_volume_registration(
     configuration: &configuration::Configuration,
-    volume_id: &str,
-    csi_volume_register_request: crate::models::CsiVolumeRegisterRequest,
-    region: Option<&str>,
-    namespace: Option<&str>,
-    x_nomad_token: Option<&str>,
-    idempotency_token: Option<&str>,
+    params: PostVolumeRegistrationParams,
 ) -> Result<(), Error<PostVolumeRegistrationError>> {
     let local_var_configuration = configuration;
+
+    // unbox the parameters
+    let volume_id = params.volume_id;
+    let csi_volume_register_request = params.csi_volume_register_request;
+    let region = params.region;
+    let namespace = params.namespace;
+    let x_nomad_token = params.x_nomad_token;
+    let idempotency_token = params.idempotency_token;
 
     let local_var_client = &local_var_configuration.client;
 

--- a/src/rust/plugin-registry/Cargo.toml
+++ b/src/rust/plugin-registry/Cargo.toml
@@ -15,6 +15,8 @@ async-trait = "0.1.51"
 grapl-config = { path = "../grapl-config" }
 grapl-utils = { path = "../grapl-utils" }
 rust-proto = { path = "../rust-proto" }
+nomad-client-gen = { path = "../nomad-client-gen" }
+
 sqlx = { version = "0.5.9", features = [
   "migrate",
   "postgres",

--- a/src/rust/plugin-registry/Cargo.toml
+++ b/src/rust/plugin-registry/Cargo.toml
@@ -16,7 +16,6 @@ grapl-config = { path = "../grapl-config" }
 grapl-utils = { path = "../grapl-utils" }
 rust-proto = { path = "../rust-proto" }
 nomad-client-gen = { path = "../nomad-client-gen" }
-
 sqlx = { version = "0.5.9", features = [
   "migrate",
   "postgres",

--- a/src/rust/plugin-registry/src/lib.rs
+++ b/src/rust/plugin-registry/src/lib.rs
@@ -3,8 +3,8 @@ use std::net::SocketAddr;
 use structopt::StructOpt;
 
 pub mod client;
-pub mod server;
 pub mod nomad_client;
+pub mod server;
 
 #[derive(StructOpt, Debug)]
 pub struct PluginRegistryServiceConfig {

--- a/src/rust/plugin-registry/src/lib.rs
+++ b/src/rust/plugin-registry/src/lib.rs
@@ -4,6 +4,7 @@ use structopt::StructOpt;
 
 pub mod client;
 pub mod server;
+pub mod nomad_client;
 
 #[derive(StructOpt, Debug)]
 pub struct PluginRegistryServiceConfig {

--- a/src/rust/plugin-registry/src/nomad_client.rs
+++ b/src/rust/plugin-registry/src/nomad_client.rs
@@ -1,7 +1,11 @@
-use nomad_client_gen::apis::configuration::Configuration as InternalConfig;
-use nomad_client_gen::apis::namespaces_api;
-use nomad_client_gen::models::Namespace;
-use nomad_client_gen::apis::Error;
+use nomad_client_gen::{
+    apis::{
+        configuration::Configuration as InternalConfig,
+        namespaces_api,
+        Error,
+    },
+    models::Namespace,
+};
 use structopt::StructOpt;
 
 /// Represents the environment variables needed to construct a NomadClient
@@ -30,10 +34,13 @@ impl NomadClient {
             ..Default::default()
         };
 
-        NomadClient { internal_config,}
+        NomadClient { internal_config }
     }
 
-    pub async fn create_namespace(&self, name: &str) -> Result<(), Error<namespaces_api::PostNamespaceError>> {
+    pub async fn create_namespace(
+        &self,
+        name: &str,
+    ) -> Result<(), Error<namespaces_api::PostNamespaceError>> {
         // Shockingly, not `create_namespace()`
         let new_namespace = Namespace {
             name: Some(name.to_owned()),
@@ -41,13 +48,14 @@ impl NomadClient {
             ..Default::default()
         };
         namespaces_api::post_namespace(
-            &self.internal_config, 
-            namespaces_api::PostNamespaceParams { 
+            &self.internal_config,
+            namespaces_api::PostNamespaceParams {
                 // It's odd to me that I have to specify the name twice...
                 namespace_name: name.to_owned(),
-                namespace2: new_namespace, 
-                ..Default::default() 
-            }
-        ).await
+                namespace2: new_namespace,
+                ..Default::default()
+            },
+        )
+        .await
     }
 }

--- a/src/rust/plugin-registry/src/nomad_client.rs
+++ b/src/rust/plugin-registry/src/nomad_client.rs
@@ -7,6 +7,7 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug)]
 pub struct NomadClientConfig {
     #[structopt(env)]
+    /// "${NOMAD_UPSTREAM_ADDR_nomad}"
     nomad_service_address: String,
 }
 
@@ -24,15 +25,15 @@ impl NomadClient {
 
     pub fn from_client_config(nomad_client_config: NomadClientConfig) -> Self {
         let internal_config = InternalConfig {
-            base_path: format!("https://{}/v1", nomad_client_config.nomad_service_address),
+            base_path: format!("http://{}/v1", nomad_client_config.nomad_service_address),
             ..Default::default()
         };
 
         NomadClient { internal_config,}
     }
 
-    pub async fn create_namespace(&self) -> Result<(), Error<namespaces_api::CreateNamespaceError>> {
-        namespaces_api::create_namespace(&self.internal_config, None, Some("im a namespace"),
+    pub async fn create_namespace(&self, name: &str) -> Result<(), Error<namespaces_api::CreateNamespaceError>> {
+        namespaces_api::create_namespace(&self.internal_config, None, Some(name),
             None, None).await
     }
 }

--- a/src/rust/plugin-registry/src/nomad_client.rs
+++ b/src/rust/plugin-registry/src/nomad_client.rs
@@ -7,7 +7,7 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug)]
 pub struct NomadClientConfig {
     #[structopt(env)]
-    /// "${NOMAD_UPSTREAM_ADDR_nomad}"
+    /// "${attr.unique.network.ip-address}:4646
     nomad_service_address: String,
 }
 

--- a/src/rust/plugin-registry/src/nomad_client.rs
+++ b/src/rust/plugin-registry/src/nomad_client.rs
@@ -41,13 +41,14 @@ impl NomadClient {
         &self,
         name: &str,
     ) -> Result<(), Error<namespaces_api::PostNamespaceError>> {
-        // Shockingly, not `create_namespace()`
         let new_namespace = Namespace {
             name: Some(name.to_owned()),
             description: Some("created by NomadClient::create_namespace".to_owned()),
             ..Default::default()
         };
+
         namespaces_api::post_namespace(
+            // Shockingly, not `create_namespace()`
             &self.internal_config,
             namespaces_api::PostNamespaceParams {
                 // It's odd to me that I have to specify the name twice...

--- a/src/rust/plugin-registry/src/nomad_client.rs
+++ b/src/rust/plugin-registry/src/nomad_client.rs
@@ -33,7 +33,8 @@ impl NomadClient {
     }
 
     pub async fn create_namespace(&self, name: &str) -> Result<(), Error<namespaces_api::CreateNamespaceError>> {
-        namespaces_api::create_namespace(&self.internal_config, None, Some(name),
+        // Shockingly, not `create_namespace()`
+        namespaces_api::post_namespace(&self.internal_config, None, Some(name),
             None, None).await
     }
 }

--- a/src/rust/plugin-registry/src/nomad_client.rs
+++ b/src/rust/plugin-registry/src/nomad_client.rs
@@ -1,0 +1,38 @@
+use nomad_client_gen::apis::configuration::Configuration as InternalConfig;
+use nomad_client_gen::apis::namespaces_api;
+use nomad_client_gen::apis::Error;
+use structopt::StructOpt;
+
+/// Represents the environment variables needed to construct a NomadClient
+#[derive(StructOpt, Debug)]
+pub struct NomadClientConfig {
+    #[structopt(env)]
+    nomad_service_address: String,
+}
+
+/// A thin wrapper around the nomad_client_gen
+pub struct NomadClient {
+    pub internal_config: InternalConfig,
+}
+
+#[allow(dead_code)]
+impl NomadClient {
+    /// Create a client from environment
+    pub fn from_env() -> Self {
+        Self::from_client_config(NomadClientConfig::from_args())
+    }
+
+    pub fn from_client_config(nomad_client_config: NomadClientConfig) -> Self {
+        let internal_config = InternalConfig {
+            base_path: format!("https://{}/v1", nomad_client_config.nomad_service_address),
+            ..Default::default()
+        };
+
+        NomadClient { internal_config,}
+    }
+
+    pub async fn create_namespace(&self) -> Result<(), Error<namespaces_api::CreateNamespaceError>> {
+        namespaces_api::create_namespace(&self.internal_config, None, Some("im a namespace"),
+            None, None).await
+    }
+}

--- a/src/rust/plugin-registry/tests/test_nomad_client.rs
+++ b/src/rust/plugin-registry/tests/test_nomad_client.rs
@@ -7,6 +7,6 @@ use plugin_registry::nomad_client;
 #[test_log::test(tokio::test)]
 async fn test_nomad_client() -> Result<(), Box<dyn std::error::Error>> {
     let client = nomad_client::NomadClient::from_env();
-    client.create_namespace().await?;
+    client.create_namespace("hello").await?;
     Ok(())
 }

--- a/src/rust/plugin-registry/tests/test_nomad_client.rs
+++ b/src/rust/plugin-registry/tests/test_nomad_client.rs
@@ -2,8 +2,6 @@
 
 use plugin_registry::nomad_client;
 
-/// For now, this is just a smoke test. This test can and should evolve as
-/// the service matures.
 #[test_log::test(tokio::test)]
 async fn test_nomad_client() -> Result<(), Box<dyn std::error::Error>> {
     let client = nomad_client::NomadClient::from_env();

--- a/src/rust/plugin-registry/tests/test_nomad_client.rs
+++ b/src/rust/plugin-registry/tests/test_nomad_client.rs
@@ -1,0 +1,12 @@
+#![cfg(feature = "integration")]
+
+use plugin_registry::nomad_client;
+
+/// For now, this is just a smoke test. This test can and should evolve as
+/// the service matures.
+#[test_log::test(tokio::test)]
+async fn test_nomad_client() -> Result<(), Box<dyn std::error::Error>> {
+    let client = nomad_client::NomadClient::from_env();
+    client.create_namespace().await?;
+    Ok(())
+}


### PR DESCRIPTION
For the DeployPlugin stuff [ https://github.com/grapl-security/issue-tracker/issues/722 ], we need to be able to interface with Nomad from one of our own Nomad services. 

This PR is a barebones proof of concept, where we prove we can create a new namespace (one of the steps required for deploying a plugin. see https://github.com/grapl-security/grapl-rfcs/blob/main/text/0000-plugins.md#deployplugin-details )

Also, just some general usability changes throughout, because I'm awful at doing standalone PRs. 
- We print out less junk during `make` (that's what the @s are)
- our test artifacts are slightly more readable
- rust-integration-tests prints out stdout and stderr inline (it's weird when it's split!!!)
---

How I tested:
1. well, I trusted in the power of "the rust test didn't fail when I made a request"
2. after running the test I checked namespaces: 
``` 
wimax@penguin:~/src/repos/grapl$ curl http://localhost:4646/v1/namespaces | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   333  100   333    0     0   162k      0 --:--:-- --:--:-- --:--:--  162k
[
  {
    "Name": "default",
    "Description": "Default shared namespace",
    "Quota": "",
    "Hash": "C7UbjDwBK0dK8wQq7Izg7SJIzaV+lIo2X7wRtzY3pSw=",
    "CreateIndex": 1,
    "ModifyIndex": 1
  },
  {
    "Name": "hello",
    "Description": "created by NomadClient::create_namespace",
    "Quota": "",
    "Hash": "W9kLonWHaoxTR7ZnW53WiBxZ5nQk9Eyz5OiG9A2v4rg=",
    "CreateIndex": 124,
    "ModifyIndex": 124
  }
]
```