### PR TITLE
Tweak the grapl-rc version yet again.

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -68,7 +68,7 @@ steps:
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - PULUMI_ACCESS_TOKEN
-      - grapl-security/grapl-rc#v0.1.4:
+      - grapl-security/grapl-rc#f7f9da2:
           artifact_file: all_artifacts.json
           stacks:
             - grapl/grapl/testing


### PR DESCRIPTION
This picks up
https://github.com/grapl-security/grapl-rc-buildkite-plugin/pull/13,
which we hope fixes a hanging issue.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
