### PR TITLE
Update grapl-security/grapl-rc Buildkite plugin version to v0.1.5

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -68,7 +68,7 @@ steps:
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - PULUMI_ACCESS_TOKEN
-      - grapl-security/grapl-rc#v0.1.4:
+      - grapl-security/grapl-rc#v0.1.5:
           artifact_file: all_artifacts.json
           stacks:
             - grapl/grapl/testing


### PR DESCRIPTION
Signed-off-by: Christopher Maier <chris@graplsecurity.com>
