### PR TITLE
Change a _ to a -

### DIFF
--- a/pulumi/integration_tests/Pulumi.testing.yaml
+++ b/pulumi/integration_tests/Pulumi.testing.yaml
@@ -1,3 +1,3 @@
 config:
   aws:region: us-east-1
-  integration-tests:container_repository: docker.cloudsmith.io/grapl/testing
+  integration-tests:container-repository: docker.cloudsmith.io/grapl/testing


### PR DESCRIPTION
Followup to https://github.com/grapl-security/grapl/issues/1396
I changed the reader for `container_repository()` to expect `-` not `_` 