### PR TITLE
Remove automatic retries for e2e tests

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -150,9 +150,6 @@ steps:
       queue: "beefy"
     artifact_paths:
       - "test_artifacts/**/*"
-    retry:
-      automatic:
-        limit: 5
 
   - label: ":lint-roller::nomad: Lint HCL files"
     command:


### PR DESCRIPTION
It's been a while since these tests were experiencing transient
failures. If they pop up again, we can revisit this.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
