### PR TITLE
We should use opt-level 1 for all of dev

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -26,5 +26,5 @@ members = [
   "./sysmon",
 ]
 
-[profile.test]
+[profile.dev]
 opt-level = 1


### PR DESCRIPTION
### Which issue does this PR correspond to?
None.

### What changes does this PR make to Grapl? Why?
One line change. We should use opt-level=1 for all of dev profile, not just test. This way we avoid recompiling.

### How were these changes tested?
No additional testing.