### PR TITLE
Switch from artifact-uploaders queue to docker for promotions

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -58,7 +58,7 @@ steps:
             to: testing
             packages_file: all_artifacts.json
     agents:
-      queue: "artifact-uploaders"
+      queue: "docker"
 
   - wait
 

--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -133,7 +133,7 @@ steps:
             to: validated
             packages_file: current_artifacts.json
     agents:
-      queue: "artifact-uploaders"
+      queue: "docker"
 
   - wait
 


### PR DESCRIPTION
We recently retired the artifact-uploaders queue, since it was used
for uploading lambda zip files to Cloudsmith, and we no longer use
lambda functions.

However, they were also being used for promoting artifacts from one
repository to another. For that, we can just use the `docker` queue,
which also has access to the Cloudsmith API key, which is the main
thing we care about here.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
