### PR TITLE
Update dump_artifacts to account for multiple Nomad namespaces (plugins)

### DIFF
--- a/src/rust/plugin-registry/src/static_files/plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/plugin.nomad
@@ -54,6 +54,10 @@ job "grapl-plugin" {
       port "plugin_grpc_receiver" {}
     }
 
+    restart {
+      attempts = 1
+    }
+
     count = var.plugin_count
 
     task "tenant-plugin-execution-sidecar" {

--- a/src/rust/plugin-registry/tests/test_create_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_create_plugin.rs
@@ -12,7 +12,7 @@ use rust_proto::plugin_registry::{
 /// For now, this is just a smoke test. This test can and should evolve as
 /// the service matures.
 #[test_log::test(tokio::test)]
-async fn test_smoke_test_create_client() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_create_plugin() -> Result<(), Box<dyn std::error::Error>> {
     tracing::debug!(
         env=?std::env::args(),
     );

--- a/src/rust/plugin-registry/tests/test_nomad_client.rs
+++ b/src/rust/plugin-registry/tests/test_nomad_client.rs
@@ -6,7 +6,7 @@ use plugin_registry::nomad_client;
 async fn test_nomad_client_create_namespace() -> Result<(), Box<dyn std::error::Error>> {
     let client = nomad_client::NomadClient::from_env();
     client
-        .create_namespace("test_nomad_client_create_namespace")
+        .create_namespace("test-nomad-client-create-namespace")
         .await?;
     Ok(())
 }

--- a/src/rust/plugin-registry/tests/test_nomad_client.rs
+++ b/src/rust/plugin-registry/tests/test_nomad_client.rs
@@ -3,8 +3,10 @@
 use plugin_registry::nomad_client;
 
 #[test_log::test(tokio::test)]
-async fn test_nomad_client() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_nomad_client_create_namespace() -> Result<(), Box<dyn std::error::Error>> {
     let client = nomad_client::NomadClient::from_env();
-    client.create_namespace("hello").await?;
+    client
+        .create_namespace("test_nomad_client_create_namespace")
+        .await?;
     Ok(())
 }


### PR DESCRIPTION
Relates to grapl-security/issue-tracker#722

Previously we only dumped artifacts in the "default" namespace. Now we do every namespace!