### PR TITLE
Refactor PluginRegistry SQL queries into a DbClient. DeployPlugin now consumes DbClient.

### DIFF
--- a/src/rust/plugin-registry/src/db_client.rs
+++ b/src/rust/plugin-registry/src/db_client.rs
@@ -4,14 +4,10 @@ use rust_proto::plugin_registry::CreatePluginRequest;
 #[derive(sqlx::FromRow)]
 pub struct GetPluginRow {
     pub plugin_id: uuid::Uuid,
+    pub tenant_id: uuid::Uuid,
     pub display_name: String,
     pub plugin_type: String,
     pub artifact_s3_key: String,
-}
-
-pub struct CreatePluginResponse {
-    /// The identity of the plugin that was created
-    pub plugin_id: uuid::Uuid,
 }
 
 pub struct PluginRegistryDbClient {
@@ -24,9 +20,10 @@ impl PluginRegistryDbClient {
             r"
         SELECT
         plugin_id,
+        tenant_id,
         display_name,
         plugin_type,
-        artifact_s2_key
+        artifact_s3_key
         FROM plugins
         WHERE plugin_id = $0
             ",
@@ -61,8 +58,8 @@ impl PluginRegistryDbClient {
         .bind(&request.tenant_id)
         .bind(s3_key)
         .execute(&self.pool)
-        .await;
-        Ok(())
+        .await
+        .map(|_| ())
     }
 
     pub async fn new(postgres_address: &str) -> Result<Self, Box<dyn std::error::Error>> {

--- a/src/rust/plugin-registry/src/db_client.rs
+++ b/src/rust/plugin-registry/src/db_client.rs
@@ -1,0 +1,79 @@
+use grapl_utils::future_ext::GraplFutureExt;
+use rust_proto::plugin_registry::CreatePluginRequest;
+
+#[derive(sqlx::FromRow)]
+pub struct GetPluginRow {
+    pub plugin_id: uuid::Uuid,
+    pub display_name: String,
+    pub plugin_type: String,
+    pub artifact_s3_key: String,
+}
+
+pub struct CreatePluginResponse {
+    /// The identity of the plugin that was created
+    pub plugin_id: uuid::Uuid,
+}
+
+pub struct PluginRegistryDbClient {
+    pool: sqlx::PgPool,
+}
+
+impl PluginRegistryDbClient {
+    pub async fn get_plugin(&self, plugin_id: &uuid::Uuid) -> Result<GetPluginRow, sqlx::Error> {
+        sqlx::query_as(
+            r"
+        SELECT
+        plugin_id,
+        display_name,
+        plugin_type,
+        artifact_s2_key
+        FROM plugins
+        WHERE plugin_id = $0
+            ",
+        )
+        .bind(&plugin_id)
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    pub async fn create_plugin(
+        &self,
+        plugin_id: &uuid::Uuid,
+        request: &CreatePluginRequest,
+        s3_key: &str,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            r"
+            INSERT INTO plugins (
+                plugin_id,
+                plugin_type,
+                display_name,
+                tenant_id,
+                artifact_s3_key
+            )
+            VALUES ($1::uuid, $2, $3, $4::uuid, $5)
+            ON CONFLICT DO NOTHING;
+            ",
+        )
+        .bind(plugin_id)
+        .bind(&request.plugin_type.type_name())
+        .bind(&request.display_name)
+        .bind(&request.tenant_id)
+        .bind(s3_key)
+        .execute(&self.pool)
+        .await;
+        Ok(())
+    }
+
+    pub async fn new(postgres_address: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let client = Self {
+            pool: sqlx::PgPool::connect(&postgres_address)
+                .timeout(std::time::Duration::from_secs(5))
+                .await??,
+        };
+
+        sqlx::migrate!().run(&client.pool).await?;
+
+        Ok(client)
+    }
+}

--- a/src/rust/plugin-registry/src/db_client.rs
+++ b/src/rust/plugin-registry/src/db_client.rs
@@ -64,7 +64,7 @@ impl PluginRegistryDbClient {
 
     pub async fn new(postgres_address: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let client = Self {
-            pool: sqlx::PgPool::connect(&postgres_address)
+            pool: sqlx::PgPool::connect(postgres_address)
                 .timeout(std::time::Duration::from_secs(5))
                 .await??,
         };

--- a/src/rust/plugin-registry/src/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/deploy_plugin.rs
@@ -30,7 +30,7 @@ pub async fn deploy_plugin(
     // TODO: "nomad job plan" to make sure we have enough memory/cpu for the task
 
     // --- Deploy namespace
-    let namespace_name = "todo-fill-this-in-with-real-plugin-name";
+    let namespace_name = &plugin.display_name; // TODO: Do we need to regex enforce display names?
     client.create_namespace(namespace_name).await?;
     // TODO: What if the namespace already exists?
 

--- a/src/rust/plugin-registry/src/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/deploy_plugin.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
 use crate::{
+    db_client::GetPluginRow,
     error::PluginRegistryServiceError,
     nomad_cli,
     nomad_client,
-    static_files, db_client::GetPluginRow,
+    static_files,
 };
 
 /// https://github.com/grapl-security/grapl-rfcs/blob/main/text/0000-plugins.md#deployplugin-details
@@ -22,7 +23,10 @@ pub async fn deploy_plugin(
             ("plugin_id".to_owned(), plugin.plugin_id.to_string()),
             ("tenant_id".to_owned(), plugin.tenant_id.to_string()),
             ("plugin_artifact_url".to_owned(), plugin.artifact_s3_key),
-            ("aws_account_id".to_owned(), plugin_bucket_owner_id.to_string()),
+            (
+                "aws_account_id".to_owned(),
+                plugin_bucket_owner_id.to_string(),
+            ),
         ]);
         cli.parse_hcl2(job_file_hcl, job_file_vars)?
     };

--- a/src/rust/plugin-registry/src/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/deploy_plugin.rs
@@ -4,24 +4,25 @@ use crate::{
     error::PluginRegistryServiceError,
     nomad_cli,
     nomad_client,
-    static_files,
+    static_files, db_client::GetPluginRow,
 };
 
 /// https://github.com/grapl-security/grapl-rfcs/blob/main/text/0000-plugins.md#deployplugin-details
-#[tracing::instrument(skip(client, cli, plugin_id), err)]
+#[tracing::instrument(skip(client, cli, plugin), err)]
 pub async fn deploy_plugin(
     client: nomad_client::NomadClient,
     cli: nomad_cli::NomadCli,
-    plugin_id: uuid::Uuid,
+    plugin: GetPluginRow,
+    plugin_bucket_owner_id: &str,
 ) -> Result<(), PluginRegistryServiceError> {
     // --- Convert HCL to JSON Job model
     let job = {
         let job_file_hcl = static_files::PLUGIN_JOB;
         let job_file_vars: nomad_cli::NomadVars = HashMap::from([
-            ("plugin_id".to_owned(), plugin_id.to_string()),
-            ("tenant_id".to_owned(), "TODO".to_owned()),
-            ("plugin_artifact_url".to_owned(), "TODO".to_owned()),
-            ("aws_account_id".to_owned(), "TODO".to_owned()),
+            ("plugin_id".to_owned(), plugin.plugin_id.to_string()),
+            ("tenant_id".to_owned(), plugin.tenant_id.to_string()),
+            ("plugin_artifact_url".to_owned(), plugin.artifact_s3_key),
+            ("aws_account_id".to_owned(), plugin_bucket_owner_id.to_string()),
         ]);
         cli.parse_hcl2(job_file_hcl, job_file_vars)?
     };

--- a/src/rust/plugin-registry/src/lib.rs
+++ b/src/rust/plugin-registry/src/lib.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 use structopt::StructOpt;
 
 pub mod client;
+mod db_client;
 mod deploy_plugin;
 pub mod error;
 pub mod nomad_cli;

--- a/src/rust/plugin-registry/src/server.rs
+++ b/src/rust/plugin-registry/src/server.rs
@@ -135,7 +135,7 @@ impl PluginRegistry {
             plugin_type,
             plugin_id,
             display_name,
-            tenant_id: _
+            tenant_id: _,
         } = self.db_client.get_plugin(&request.plugin_id).await?;
 
         let s3_key: String = artifact_s3_key;
@@ -185,9 +185,14 @@ impl PluginRegistry {
         let plugin_id = request.plugin_id;
         let plugin_row = self.db_client.get_plugin(&plugin_id).await?;
 
-        deploy_plugin::deploy_plugin(nomad_client, nomad_cli, plugin_row, &self.plugin_bucket_owner_id)
-            .await
-            .map_err(PluginRegistryServiceError::from)?;
+        deploy_plugin::deploy_plugin(
+            nomad_client,
+            nomad_cli,
+            plugin_row,
+            &self.plugin_bucket_owner_id,
+        )
+        .await
+        .map_err(PluginRegistryServiceError::from)?;
 
         Ok(DeployPluginResponse {})
     }

--- a/src/rust/plugin-registry/src/server.rs
+++ b/src/rust/plugin-registry/src/server.rs
@@ -182,8 +182,9 @@ impl PluginRegistry {
         let nomad_client = nomad_client::NomadClient::from_env();
         let nomad_cli = nomad_cli::NomadCli {};
         let plugin_id = request.plugin_id;
+        let plugin_row = self.db_client.get_plugin(&plugin_id).await?;
 
-        deploy_plugin::deploy_plugin(nomad_client, nomad_cli, plugin_id)
+        deploy_plugin::deploy_plugin(nomad_client, nomad_cli, plugin_row, &self.plugin_bucket_owner_id)
             .await
             .map_err(PluginRegistryServiceError::from)?;
 

--- a/src/rust/plugin-registry/src/server.rs
+++ b/src/rust/plugin-registry/src/server.rs
@@ -135,6 +135,7 @@ impl PluginRegistry {
             plugin_type,
             plugin_id,
             display_name,
+            tenant_id: _
         } = self.db_client.get_plugin(&request.plugin_id).await?;
 
         let s3_key: String = artifact_s3_key;

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -8,7 +8,24 @@ use rust_proto::plugin_registry::DeployPluginRequest;
 async fn test_deploy_plugin() -> Result<(), Box<dyn std::error::Error>> {
     let mut client = PluginRegistryServiceClient::from_env().await?;
 
-    let plugin_id = uuid::Uuid::new_v4();
+    let tenant_id = uuid::Uuid::new_v4();
+
+    let create_response = {
+        let display_name = uuid::Uuid::new_v4().to_string();
+        let request = CreatePluginRequest {
+            plugin_artifact: b"dummy vec for now".to_vec(),
+            tenant_id: tenant_id.clone(),
+            display_name: display_name.clone(),
+            plugin_type: PluginType::Generator,
+        };
+
+        client
+            .create_plugin(request)
+            .timeout(std::time::Duration::from_secs(5))
+            .await??
+    };
+
+    let plugin_id = create_response.plugin_id;
 
     let request = DeployPluginRequest { plugin_id };
 

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -2,7 +2,11 @@
 
 use grapl_utils::future_ext::GraplFutureExt;
 use plugin_registry::client::PluginRegistryServiceClient;
-use rust_proto::plugin_registry::DeployPluginRequest;
+use rust_proto::plugin_registry::{
+    CreatePluginRequest,
+    DeployPluginRequest,
+    PluginType,
+};
 
 #[test_log::test(tokio::test)]
 async fn test_deploy_plugin() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
Followup to grapl-security/issue-tracker#722

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Previously, the Plugin Registry postgres queries were baked into the main controller `server.rs`; this has now been refactored out to a `PluginRegistryDbClient` so that other pieces of the PluginRegistry can reuse it.

Previously, DeployPlugin was just deploying a job with garbage standin data.
Now, it consumes the PluginRegistryDbClient to populate a job with real data from a previous CreatePlugin call.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Integration tests!!!

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
