### PR TITLE
Use the shorter, 36-line E2E test input

### DIFF
--- a/nomad/e2e-tests.nomad
+++ b/nomad/e2e-tests.nomad
@@ -137,7 +137,7 @@ job "e2e-tests" {
         command = trimspace(<<EOF
 graplctl upload analyzer --analyzer_main_py ./etc/local_grapl/suspicious_svchost/main.py
 graplctl upload analyzer --analyzer_main_py ./etc/local_grapl/unique_cmd_parent/main.py
-graplctl upload sysmon --logfile ./etc/sample_data/eventlog.xml
+graplctl upload sysmon --logfile ./etc/sample_data/36_eventlog.xml
 EOF
         )
       }

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -38,16 +38,19 @@ CMD ["./provisioner.pex"]
 # e2e tests
 ################################################################################
 FROM grapl-python-base AS e2e-tests
-COPY --chown=grapl ./dist/e2e-tests.pex .
-CMD ["./e2e-tests.pex"]
+
 # Copy in the contents of `etc` in order to upload them during e2e tests
 RUN mkdir -p /home/grapl/etc
 COPY --chown=grapl ./etc/local_grapl etc/local_grapl
-RUN mkdir -p /home/grapl/etc/sample_data
-COPY --chown=grapl ./etc/sample_data/eventlog.xml etc/sample_data/eventlog.xml
+COPY --chown=grapl ./etc/sample_data/ etc/sample_data
+
 # Copy in `graplctl`, which does the actual uploading during e2e
 RUN mkdir -p /home/grapl/bin
 COPY --chown=grapl ./bin/graplctl /home/grapl/bin/graplctl
+
+COPY --chown=grapl ./dist/e2e-tests.pex .
+CMD ["./e2e-tests.pex"]
+
 ENV PATH=/home/grapl/bin:$PATH
 
 # grapl-notebook


### PR DESCRIPTION
At some point I asked for a shortened E2E input and I totally forgot to integrate it into the e2e tests. 
Seems to run in less time but double checking against CI