### PR TITLE
Pin mypy_boto3 versions

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -139,18 +139,17 @@ config = "src/python/mypy.ini"
 args = [ "--show-error-codes", "--namespace-packages" ] #, "--verbose" ]
 
 extra_type_stubs = [
-  # These could technically get specific versions, but, eh
-  "mypy_boto3_cloudwatch",
-  "mypy_boto3_dynamodb",
-  "mypy_boto3_ec2",
-  "mypy_boto3_lambda",
-  "mypy_boto3_route53",
-  "mypy_boto3_s3",
-  "mypy_boto3_sagemaker",
-  "mypy_boto3_secretsmanager",
-  "mypy_boto3_sns",
-  "mypy_boto3_sqs",
-  "mypy_boto3_ssm",
+  "mypy_boto3_cloudwatch==1.20.35.post1",
+  "mypy_boto3_dynamodb==1.20.35.post1",
+  "mypy_boto3_ec2==1.20.35.post1",
+  "mypy_boto3_lambda==1.20.35.post1",
+  "mypy_boto3_route53==1.20.35.post1",
+  "mypy_boto3_s3==1.20.35.post1",
+  "mypy_boto3_sagemaker==1.20.35.post1",
+  "mypy_boto3_secretsmanager==1.20.35.post1",
+  "mypy_boto3_sns==1.20.35.post1",
+  "mypy_boto3_sqs==1.20.35.post1",
+  "mypy_boto3_ssm==1.20.35.post1",
 
   "types-click==7.1.8",
   "types-protobuf==3.19.6",


### PR DESCRIPTION
Followup to https://github.com/grapl-security/grapl/pull/1427/files

```
extra_type_stubs = [
  # These could technically get specific versions, but, eh
  "mypy_boto3_cloudwatch",
  "mypy_boto3_dynamodb",
```
famous last words