### PR TITLE
Invoke `curl` in a more secure way

### DIFF
--- a/nomad/lib/nomad_cli_tools.sh
+++ b/nomad/lib/nomad_cli_tools.sh
@@ -4,8 +4,13 @@ set -euo pipefail
 NOMAD_ADDRESS="${NOMAD_ADDRESS:-http://localhost:4646}"
 
 curl_quiet() {
-    # shellcheck disable=SC2068
-    curl --location --silent --show-error $@
+    if [[ ${NOMAD_ADDRESS} =~ ^https://.*$ ]]; then
+        # shellcheck disable=SC2068
+        curl --proto "=https" --tlsv1.2 --location --silent --show-error $@
+    else
+        # shellcheck disable=SC2068
+        curl --location --silent --show-error $@
+    fi
 }
 
 nomad_dispatch() {


### PR DESCRIPTION
Basically adds `--proto "=https" --tlsv1.2` to all the `curl`
invocations I could find.

Also translates short options to long options for readability.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
