### PR TITLE
Add a `plugin_deployment` table. Register DeployPlugin success/fail in the table. 

### DIFF
--- a/src/rust/plugin-registry/Cargo.toml
+++ b/src/rust/plugin-registry/Cargo.toml
@@ -18,6 +18,7 @@ rust-proto = { path = "../rust-proto" }
 nomad-client-gen = { path = "../nomad-client-gen" }
 serde_json = "1.0.72"
 sqlx = { version = "0.5.9", features = [
+  "chrono",
   "migrate",
   "offline",
   "postgres",

--- a/src/rust/plugin-registry/migrations/20220202225101_create_plugin_deployment_table.sql
+++ b/src/rust/plugin-registry/migrations/20220202225101_create_plugin_deployment_table.sql
@@ -8,9 +8,11 @@ DO $$ BEGIN
 END $$;
 
 
+-- This table is append-only - so you'll see multiple entries for `plugin_id`
+-- and the latest state will be the last entry.
 CREATE TABLE IF NOT EXISTS plugin_deployment
 (
-    id               SERIAL                    PRIMARY KEY,
+    id               BIGSERIAL                 PRIMARY KEY,
     plugin_id        uuid                      NOT NULL,
     deploy_time      timestamptz               NOT NULL DEFAULT CURRENT_TIMESTAMP,
     status           plugin_deployment_status  NOT NULL

--- a/src/rust/plugin-registry/migrations/20220202225101_create_plugin_deployment_table.sql
+++ b/src/rust/plugin-registry/migrations/20220202225101_create_plugin_deployment_table.sql
@@ -1,0 +1,19 @@
+-- Satisfies the "If success, mark plugin as being deployed in plugins table"
+-- requirement of RFC 0000 DeployPlugin.
+
+DO $$ BEGIN
+    IF to_regtype('plugin_deployment_status') IS NULL THEN
+        CREATE TYPE plugin_deployment_status AS ENUM ('fail', 'success');
+    END IF;
+END $$;
+
+
+CREATE TABLE IF NOT EXISTS plugin_deployment
+(
+    id               SERIAL                    PRIMARY KEY,
+    plugin_id        uuid                      NOT NULL,
+    deploy_time      timestamptz               NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    status           plugin_deployment_status  NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS plugin_key_ix ON plugin_deployment (plugin_id);

--- a/src/rust/plugin-registry/sqlx-data.json
+++ b/src/rust/plugin-registry/sqlx-data.json
@@ -1,5 +1,28 @@
 {
   "db": "PostgreSQL",
+  "59991d338dfedafd140ece1f94cec67df8734490a5ccca581ae9c1d0507f003d": {
+    "query": "\n            INSERT INTO plugin_deployment (\n                plugin_id,\n                status\n            )\n            VALUES ($1::uuid, $2);\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          {
+            "Custom": {
+              "name": "plugin_deployment_status",
+              "kind": {
+                "Enum": [
+                  "fail",
+                  "success"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "nullable": []
+    }
+  },
   "c57567e93fa4914365fffaf15b1a6937f28b5ee1e8ed28d569ee66035926cd0e": {
     "query": "\n            INSERT INTO plugins (\n                plugin_id,\n                plugin_type,\n                display_name,\n                tenant_id,\n                artifact_s3_key\n            )\n            VALUES ($1::uuid, $2, $3, $4::uuid, $5)\n            ON CONFLICT DO NOTHING;\n            ",
     "describe": {

--- a/src/rust/plugin-registry/sqlx-data.json
+++ b/src/rust/plugin-registry/sqlx-data.json
@@ -23,6 +23,54 @@
       "nullable": []
     }
   },
+  "5a1b633a47279ec559e797b2d76abb94d85ebf1853cb7b7e9fa4d3b6f633d5f8": {
+    "query": "\n            SELECT\n                id,\n                plugin_id,\n                deploy_time,\n                status AS \"status: PluginDeploymentStatus\"\n            FROM plugin_deployment\n            WHERE plugin_id = $1\n            ORDER BY id desc limit 1;\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "plugin_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 2,
+          "name": "deploy_time",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 3,
+          "name": "status: PluginDeploymentStatus",
+          "type_info": {
+            "Custom": {
+              "name": "plugin_deployment_status",
+              "kind": {
+                "Enum": [
+                  "fail",
+                  "success"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "c57567e93fa4914365fffaf15b1a6937f28b5ee1e8ed28d569ee66035926cd0e": {
     "query": "\n            INSERT INTO plugins (\n                plugin_id,\n                plugin_type,\n                display_name,\n                tenant_id,\n                artifact_s3_key\n            )\n            VALUES ($1::uuid, $2, $3, $4::uuid, $5)\n            ON CONFLICT DO NOTHING;\n            ",
     "describe": {

--- a/src/rust/plugin-registry/src/db/client.rs
+++ b/src/rust/plugin-registry/src/db/client.rs
@@ -2,7 +2,7 @@ use grapl_utils::future_ext::GraplFutureExt;
 use rust_proto::plugin_registry::CreatePluginRequest;
 
 #[derive(sqlx::FromRow)]
-pub struct GetPluginRow {
+pub struct PluginRow {
     pub plugin_id: uuid::Uuid,
     pub tenant_id: uuid::Uuid,
     pub display_name: String,
@@ -16,9 +16,9 @@ pub struct PluginRegistryDbClient {
 
 impl PluginRegistryDbClient {
     #[tracing::instrument(skip(self), err)]
-    pub async fn get_plugin(&self, plugin_id: &uuid::Uuid) -> Result<GetPluginRow, sqlx::Error> {
+    pub async fn get_plugin(&self, plugin_id: &uuid::Uuid) -> Result<PluginRow, sqlx::Error> {
         sqlx::query_as!(
-            GetPluginRow,
+            PluginRow,
             r"
             SELECT
             plugin_id,

--- a/src/rust/plugin-registry/src/db/client.rs
+++ b/src/rust/plugin-registry/src/db/client.rs
@@ -1,42 +1,11 @@
 use grapl_utils::future_ext::GraplFutureExt;
 use rust_proto::plugin_registry::CreatePluginRequest;
-use sqlx::types::chrono::{
-    DateTime,
-    Utc,
+
+use super::models::{
+    PluginDeploymentRow,
+    PluginDeploymentStatus,
+    PluginRow,
 };
-
-#[derive(sqlx::FromRow)]
-pub struct PluginRow {
-    pub plugin_id: uuid::Uuid,
-    pub tenant_id: uuid::Uuid,
-    pub display_name: String,
-    pub plugin_type: String,
-    pub artifact_s3_key: String,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, sqlx::Type)]
-#[sqlx(type_name = "plugin_deployment_status", rename_all = "lowercase")]
-pub enum PluginDeploymentStatus {
-    Fail,
-    Success,
-}
-
-impl<T, E> From<&Result<T, E>> for PluginDeploymentStatus {
-    fn from(res: &Result<T, E>) -> Self {
-        match res.as_ref() {
-            Ok(_) => PluginDeploymentStatus::Success,
-            Err(_) => PluginDeploymentStatus::Fail,
-        }
-    }
-}
-
-#[derive(sqlx::FromRow)]
-pub struct PluginDeploymentRow {
-    pub id: i32,
-    pub plugin_id: uuid::Uuid,
-    pub deploy_time: DateTime<Utc>,
-    pub status: PluginDeploymentStatus,
-}
 
 pub struct PluginRegistryDbClient {
     pool: sqlx::PgPool,

--- a/src/rust/plugin-registry/src/db/mod.rs
+++ b/src/rust/plugin-registry/src/db/mod.rs
@@ -1,1 +1,2 @@
 pub mod client;
+pub mod models;

--- a/src/rust/plugin-registry/src/db/models.rs
+++ b/src/rust/plugin-registry/src/db/models.rs
@@ -1,0 +1,39 @@
+use sqlx::types::chrono::{
+    DateTime,
+    Utc,
+};
+
+#[derive(sqlx::FromRow)]
+pub struct PluginRow {
+    pub plugin_id: uuid::Uuid,
+    pub tenant_id: uuid::Uuid,
+    pub display_name: String,
+    pub plugin_type: String,
+    pub artifact_s3_key: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, sqlx::Type)]
+#[sqlx(type_name = "plugin_deployment_status", rename_all = "lowercase")]
+pub enum PluginDeploymentStatus {
+    Fail,
+    Success,
+}
+
+impl<T, E> From<&Result<T, E>> for PluginDeploymentStatus {
+    fn from(res: &Result<T, E>) -> Self {
+        match res.as_ref() {
+            Ok(_) => PluginDeploymentStatus::Success,
+            Err(_) => PluginDeploymentStatus::Fail,
+        }
+    }
+}
+
+/// The whole PluginDeployment table is currently just appended to, not
+/// consumed anywhere.
+#[derive(sqlx::FromRow)]
+pub struct PluginDeploymentRow {
+    pub id: i32,
+    pub plugin_id: uuid::Uuid,
+    pub deploy_time: DateTime<Utc>,
+    pub status: PluginDeploymentStatus,
+}

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -3,7 +3,11 @@ use std::collections::HashMap;
 use nomad_client_gen::models;
 
 use crate::{
-    db::client::PluginRow,
+    db::client::{
+        PluginDeploymentStatus,
+        PluginRegistryDbClient,
+        PluginRow,
+    },
     error::PluginRegistryServiceError,
     nomad::{
         cli::{
@@ -19,10 +23,11 @@ use crate::{
 };
 
 /// https://github.com/grapl-security/grapl-rfcs/blob/main/text/0000-plugins.md#deployplugin-details
-#[tracing::instrument(skip(client, cli, plugin), err)]
+#[tracing::instrument(skip(client, cli, db_client, plugin), err)]
 pub async fn deploy_plugin(
     client: &NomadClient,
     cli: &NomadCli,
+    db_client: &PluginRegistryDbClient,
     plugin: PluginRow,
     plugin_bucket_owner_id: &str,
 ) -> Result<(), PluginRegistryServiceError> {
@@ -62,12 +67,18 @@ pub async fn deploy_plugin(
         .map_err(|_| PluginRegistryServiceError::NomadJobAllocationError)?;
 
     // --- Start the job
-    let _job = client
+    let job_result = client
         .create_job(&job, job_name, Some(namespace_name.clone()))
-        .await?;
+        .await;
     // There's no guarantee that the job is *healthy*, just that it's been deployed.
 
     // --- If success, mark plugin as being deployed in `plugins` table
+    let status = PluginDeploymentStatus::from(&job_result);
+    db_client
+        .create_plugin_deployment(&plugin.plugin_id, status)
+        .await?;
+
+    job_result?;
 
     // TODO next CR. Right now all the plugins table interop is in the main
     //      server controller, gross!

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -3,10 +3,12 @@ use std::collections::HashMap;
 use nomad_client_gen::models;
 
 use crate::{
-    db::client::{
-        PluginDeploymentStatus,
-        PluginRegistryDbClient,
-        PluginRow,
+    db::{
+        client::PluginRegistryDbClient,
+        models::{
+            PluginDeploymentStatus,
+            PluginRow,
+        },
     },
     error::PluginRegistryServiceError,
     nomad::{

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use nomad_client_gen::models;
 
 use crate::{
-    db::client::GetPluginRow,
+    db::client::PluginRow,
     error::PluginRegistryServiceError,
     nomad::{
         cli::{
@@ -23,7 +23,7 @@ use crate::{
 pub async fn deploy_plugin(
     client: &NomadClient,
     cli: &NomadCli,
-    plugin: GetPluginRow,
+    plugin: PluginRow,
     plugin_bucket_owner_id: &str,
 ) -> Result<(), PluginRegistryServiceError> {
     // --- Convert HCL to JSON Job model

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -47,8 +47,8 @@ use tonic::{
 
 use crate::{
     db::client::{
-        PluginRow,
         PluginRegistryDbClient,
+        PluginRow,
     },
     error::PluginRegistryServiceError,
     nomad::{
@@ -214,6 +214,7 @@ impl PluginRegistry {
         deploy_plugin::deploy_plugin(
             &self.nomad_client,
             &self.nomad_cli,
+            &self.db_client,
             plugin_row,
             &self.plugin_bucket_owner_id,
         )

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -47,7 +47,7 @@ use tonic::{
 
 use crate::{
     db::client::{
-        GetPluginRow,
+        PluginRow,
         PluginRegistryDbClient,
     },
     error::PluginRegistryServiceError,
@@ -158,7 +158,7 @@ impl PluginRegistry {
         &self,
         request: GetPluginRequest,
     ) -> Result<GetPluginResponse, PluginRegistryServiceError> {
-        let GetPluginRow {
+        let PluginRow {
             artifact_s3_key,
             plugin_type,
             plugin_id,

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -46,9 +46,9 @@ use tonic::{
 };
 
 use crate::{
-    db::client::{
-        PluginRegistryDbClient,
-        PluginRow,
+    db::{
+        client::PluginRegistryDbClient,
+        models::PluginRow,
     },
     error::PluginRegistryServiceError,
     nomad::{

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -40,6 +40,7 @@ async fn test_deploy_plugin() -> Result<(), Box<dyn std::error::Error>> {
         .deploy_plugin(request)
         .timeout(std::time::Duration::from_secs(5))
         .await??;
+
     Ok(())
 }
 

--- a/src/rust/plugin-registry/tests/test_nomad_client.rs
+++ b/src/rust/plugin-registry/tests/test_nomad_client.rs
@@ -72,7 +72,7 @@ async fn test_plan_job_with_too_much_memory() -> Result<(), Box<dyn std::error::
 }
 
 #[async_trait]
-trait TestFunctions {
+trait NomadClientTestFunctions {
     async fn get_namespace(
         &self,
         namespace_name: &str,
@@ -80,7 +80,7 @@ trait TestFunctions {
 }
 
 #[async_trait]
-impl TestFunctions for NomadClient {
+impl NomadClientTestFunctions for NomadClient {
     async fn get_namespace(
         &self,
         namespace_name: &str,


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/722

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Satisfies the "[If success, mark plugin as being deployed in plugins table" ](https://github.com/grapl-security/grapl-rfcs/blob/main/text/0000-plugins.md#nomad-job) requirement.

I'm not really that convinced that this is _useful_, since we just track that a deployment was successfully attempted - not that it is healthy - but I can see it being useful as an audit-log.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
