### PR TITLE
updates to make the kafka e2e tests run in aws

### DIFF
--- a/nomad/e2e-tests.nomad
+++ b/nomad/e2e-tests.nomad
@@ -225,9 +225,9 @@ EOF
         RUST_BACKTRACE = 1
         RUST_LOG       = local.log_level
 
-        KAFKA_BOOTSTRAP_SERVERS = local.kafka_bootstrap_servers
-        KAFKA_SASL_USERNAME     = var.kafka_sasl_username
-        KAFKA_SASL_PASSWORD     = var.kafka_sasl_password
+        KAFKA_BOOTSTRAP_SERVERS   = local.kafka_bootstrap_servers
+        KAFKA_SASL_USERNAME       = var.kafka_sasl_username
+        KAFKA_SASL_PASSWORD       = var.kafka_sasl_password
         KAFKA_CONSUMER_GROUP_NAME = var.kafka_consumer_group_name
       }
     }

--- a/nomad/e2e-tests.nomad
+++ b/nomad/e2e-tests.nomad
@@ -77,6 +77,11 @@ variable "kafka_sasl_password" {
   description = "The Confluent Cloud API secret to configure producers and consumers with."
 }
 
+variable "kafka_consumer_group_name" {
+  type        = string
+  description = "The name of the consumer group the e2e test consumers will join."
+}
+
 variable "test_user_name" {
   type        = string
   description = "The name of the test user"
@@ -223,6 +228,7 @@ EOF
         KAFKA_BOOTSTRAP_SERVERS = local.kafka_bootstrap_servers
         KAFKA_SASL_USERNAME     = var.kafka_sasl_username
         KAFKA_SASL_PASSWORD     = var.kafka_sasl_password
+        KAFKA_CONSUMER_GROUP_NAME = var.kafka_consumer_group_name
       }
     }
   }

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -216,7 +216,9 @@ def main() -> None:
     pulumi.export(
         "kafka-e2e-sasl-password", e2e_service_credentials.apply(lambda c: c.api_secret)
     )
-    pulumi.export("kafka-e2e-consumer-group-name", kafka.consumer_group("e2e-test-runner"))
+    pulumi.export(
+        "kafka-e2e-consumer-group-name", kafka.consumer_group("e2e-test-runner")
+    )
 
     if config.LOCAL_GRAPL:
         ###################################

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -216,6 +216,7 @@ def main() -> None:
     pulumi.export(
         "kafka-e2e-sasl-password", e2e_service_credentials.apply(lambda c: c.api_secret)
     )
+    pulumi.export("kafka-e2e-consumer-group-name", kafka.consumer_group("e2e-test-runner"))
 
     if config.LOCAL_GRAPL:
         ###################################

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -90,6 +90,7 @@ def main() -> None:
         "_kafka_bootstrap_servers": grapl_stack.kafka_bootstrap_servers,
         "kafka_sasl_username": grapl_stack.kafka_e2e_sasl_username,
         "kafka_sasl_password": grapl_stack.kafka_e2e_sasl_password,
+        "kafka_consumer_group_name": grapl_stack.kafka_e2e_consumer_group_name,
         "schema_properties_table_name": grapl_stack.schema_properties_table_name,
         "sysmon_log_bucket": grapl_stack.sysmon_log_bucket,
         "schema_table_name": grapl_stack.schema_table_name,
@@ -174,6 +175,7 @@ class GraplStack:
         self.kafka_bootstrap_servers = require_str("kafka-bootstrap-servers")
         self.kafka_e2e_sasl_username = require_str("kafka-e2e-sasl-username")
         self.kafka_e2e_sasl_password = require_str("kafka-e2e-sasl-password")
+        self.kafka_e2e_consumer_group_name = require_str("kafka-e2e-consumer-group-name")
 
 
 if __name__ == "__main__":

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -175,7 +175,9 @@ class GraplStack:
         self.kafka_bootstrap_servers = require_str("kafka-bootstrap-servers")
         self.kafka_e2e_sasl_username = require_str("kafka-e2e-sasl-username")
         self.kafka_e2e_sasl_password = require_str("kafka-e2e-sasl-password")
-        self.kafka_e2e_consumer_group_name = require_str("kafka-e2e-consumer-group-name")
+        self.kafka_e2e_consumer_group_name = require_str(
+            "kafka-e2e-consumer-group-name"
+        )
 
 
 if __name__ == "__main__":

--- a/src/python/e2e-test-runner/e2e_test_runner/test_kafka.py
+++ b/src/python/e2e-test-runner/e2e_test_runner/test_kafka.py
@@ -72,7 +72,7 @@ def test_can_write_metrics(kafka_producer: Producer) -> None:
             topic="metrics",
             key=f"e2e-test|{msg_id}",  # TODO: write valid metrics instead
             value=f"e2e-test|{msg_id}",
-            on_delivery=_producer_callback
+            on_delivery=_producer_callback,
         )
 
     kafka_producer.flush()
@@ -93,7 +93,7 @@ def test_can_write_logs(kafka_producer: Producer) -> None:
             topic="logs",
             key=f"e2e-test|{msg_id}",
             value=f"e2e-test|{msg_id}",
-            on_delivery=_producer_callback
+            on_delivery=_producer_callback,
         )
 
     kafka_producer.flush()


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/824
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

These changes update the kafka e2e tests to be a little more robust in a scenario where we have more than one writer to the logs and metrics topics (expected), multiple partitions (expected), and consumer groups (expected). Additionally, I've updated the e2e testing and confluent cloud infrastructure to work with kafka running in confluent cloud when the e2e tests are run in aws.

Corresponding confluent cloud infrastructure changes are here: https://github.com/grapl-security/confluent-cloud-infrastructure/pull/2

### How were these changes tested?

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
Ran e2e tests locally and in my aws sandbox.