### PR TITLE
some pulumi fixes

### DIFF
--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -67,13 +67,13 @@ variable "PLUGIN_WORK_QUEUE_DB_PASSWORD" {
 
 
 variable "PLUGIN_REGISTRY_DB_PORT" {
-  type        = string
+  type        = int
   description = "The port for the plugin registry db"
 }
 
 
 variable "PLUGIN_WORK_QUEUE_DB_PORT" {
-  type        = string
+  type        = int
   description = "The port for the plugin work queue db"
 }
 

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -67,13 +67,13 @@ variable "PLUGIN_WORK_QUEUE_DB_PASSWORD" {
 
 
 variable "PLUGIN_REGISTRY_DB_PORT" {
-  type        = int
+  type        = string
   description = "The port for the plugin registry db"
 }
 
 
 variable "PLUGIN_WORK_QUEUE_DB_PORT" {
-  type        = int
+  type        = string
   description = "The port for the plugin work queue db"
 }
 

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -233,7 +233,7 @@ def main() -> None:
         )
 
         pulumi.export("plugin-work-queue-db-hostname", "LOCAL_GRAPL_REPLACE_IP")
-        pulumi.export("plugin-work-queue-db-port", plugin_work_queue_db.port)
+        pulumi.export("plugin-work-queue-db-port", str(plugin_work_queue_db.port))
         pulumi.export("plugin-work-queue-db-username", plugin_work_queue_db.username)
         pulumi.export("plugin-work-queue-db-password", plugin_work_queue_db.password)
 
@@ -259,11 +259,11 @@ def main() -> None:
             container_images=_container_images({}),
             rust_log=rust_log_levels,
             plugin_registry_db_hostname="LOCAL_GRAPL_REPLACE_IP",
-            plugin_registry_db_port=plugin_registry_db.port,
+            plugin_registry_db_port=str(plugin_registry_db.port),
             plugin_registry_db_username=plugin_registry_db.username,
             plugin_registry_db_password=plugin_registry_db.password,
             plugin_work_queue_db_hostname="LOCAL_GRAPL_REPLACE_IP",
-            plugin_work_queue_db_port=plugin_work_queue_db.port,
+            plugin_work_queue_db_port=str(plugin_work_queue_db.port),
             plugin_work_queue_db_username=plugin_work_queue_db.username,
             plugin_work_queue_db_password=plugin_work_queue_db.password,
             py_log_level=py_log_level,
@@ -396,7 +396,9 @@ def main() -> None:
         )
 
         pulumi.export("plugin-registry-db-hostname", plugin_registry_postgres.host())
-        pulumi.export("plugin-registry-db-port", plugin_registry_postgres.port())
+        pulumi.export(
+            "plugin-registry-db-port", plugin_registry_postgres.port().apply(str)
+        )
         pulumi.export(
             "plugin-registry-db-username", plugin_registry_postgres.username()
         )
@@ -407,7 +409,9 @@ def main() -> None:
         pulumi.export(
             "plugin-work-queue-db-hostname", plugin_work_queue_postgres.host()
         )
-        pulumi.export("plugin-work-queue-db-port", plugin_work_queue_postgres.port())
+        pulumi.export(
+            "plugin-work-queue-db-port", plugin_work_queue_postgres.port().apply(str)
+        )
         pulumi.export(
             "plugin-work-queue-db-username",
             plugin_work_queue_postgres.username(),

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -233,7 +233,7 @@ def main() -> None:
         )
 
         pulumi.export("plugin-work-queue-db-hostname", "LOCAL_GRAPL_REPLACE_IP")
-        pulumi.export("plugin-work-queue-db-port", str(plugin_work_queue_db.port))
+        pulumi.export("plugin-work-queue-db-port", plugin_work_queue_db.port)
         pulumi.export("plugin-work-queue-db-username", plugin_work_queue_db.username)
         pulumi.export("plugin-work-queue-db-password", plugin_work_queue_db.password)
 
@@ -259,11 +259,11 @@ def main() -> None:
             container_images=_container_images({}),
             rust_log=rust_log_levels,
             plugin_registry_db_hostname="LOCAL_GRAPL_REPLACE_IP",
-            plugin_registry_db_port=str(plugin_registry_db.port),
+            plugin_registry_db_port=plugin_registry_db.port,
             plugin_registry_db_username=plugin_registry_db.username,
             plugin_registry_db_password=plugin_registry_db.password,
             plugin_work_queue_db_hostname="LOCAL_GRAPL_REPLACE_IP",
-            plugin_work_queue_db_port=str(plugin_work_queue_db.port),
+            plugin_work_queue_db_port=plugin_work_queue_db.port,
             plugin_work_queue_db_username=plugin_work_queue_db.username,
             plugin_work_queue_db_password=plugin_work_queue_db.password,
             py_log_level=py_log_level,
@@ -395,32 +395,26 @@ def main() -> None:
             nomad_agent_security_group_id=nomad_agent_security_group_id,
         )
 
+        pulumi.export("plugin-registry-db-hostname", plugin_registry_postgres.host())
+        pulumi.export("plugin-registry-db-port", plugin_registry_postgres.port())
         pulumi.export(
-            "plugin-registry-db-hostname", plugin_registry_postgres.instance.address
+            "plugin-registry-db-username", plugin_registry_postgres.username()
         )
         pulumi.export(
-            "plugin-registry-db-port", str(plugin_registry_postgres.instance.port)
-        )
-        pulumi.export(
-            "plugin-registry-db-username", plugin_registry_postgres.instance.username
-        )
-        pulumi.export(
-            "plugin-registry-db-password", plugin_registry_postgres.instance.password
+            "plugin-registry-db-password", plugin_registry_postgres.password()
         )
 
         pulumi.export(
-            "plugin-work-queue-db-hostname", plugin_work_queue_postgres.instance.address
+            "plugin-work-queue-db-hostname", plugin_work_queue_postgres.host()
         )
-        pulumi.export(
-            "plugin-work-queue-db-port", str(plugin_work_queue_postgres.instance.port)
-        )
+        pulumi.export("plugin-work-queue-db-port", plugin_work_queue_postgres.port())
         pulumi.export(
             "plugin-work-queue-db-username",
-            plugin_work_queue_postgres.instance.username,
+            plugin_work_queue_postgres.username(),
         )
         pulumi.export(
             "plugin-work-queue-db-password",
-            plugin_work_queue_postgres.instance.password,
+            plugin_work_queue_postgres.password(),
         )
 
         pulumi.export("kafka-bootstrap-servers", kafka.bootstrap_servers())
@@ -449,16 +443,14 @@ def main() -> None:
             # instead of the var version.
             _redis_endpoint=cache.endpoint,
             container_images=_container_images(artifacts, require_artifact=True),
-            plugin_registry_db_hostname=plugin_registry_postgres.instance.address,
-            plugin_registry_db_port=plugin_registry_postgres.instance.port.apply(str),
-            plugin_registry_db_username=plugin_registry_postgres.instance.username,
-            plugin_registry_db_password=plugin_registry_postgres.instance.password,
-            plugin_work_queue_db_hostname=plugin_work_queue_postgres.instance.address,
-            plugin_work_queue_db_port=plugin_work_queue_postgres.instance.port.apply(
-                str
-            ),
-            plugin_work_queue_db_username=plugin_work_queue_postgres.instance.username,
-            plugin_work_queue_db_password=plugin_work_queue_postgres.instance.password,
+            plugin_registry_db_hostname=plugin_registry_postgres.host(),
+            plugin_registry_db_port=plugin_registry_postgres.port().apply(str),
+            plugin_registry_db_username=plugin_registry_postgres.username(),
+            plugin_registry_db_password=plugin_registry_postgres.password(),
+            plugin_work_queue_db_hostname=plugin_work_queue_postgres.host(),
+            plugin_work_queue_db_port=plugin_work_queue_postgres.port().apply(str),
+            plugin_work_queue_db_username=plugin_work_queue_postgres.username(),
+            plugin_work_queue_db_password=plugin_work_queue_postgres.password(),
             py_log_level=py_log_level,
             rust_log=rust_log_levels,
             **nomad_inputs,

--- a/pulumi/infra/postgres.py
+++ b/pulumi/infra/postgres.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, cast
 
 import pulumi_aws as aws
 import pulumi_random as random
@@ -164,13 +164,16 @@ class Postgres(pulumi.ComponentResource):
         )
 
     def host(self) -> pulumi.Output[str]:
-        return self._instance.address
+        # Cast needed due to https://github.com/pulumi/pulumi/issues/7679
+        return cast(pulumi.Output[str], self._instance.address)
 
     def port(self) -> pulumi.Output[int]:
-        return self._instance.port
+        # Cast needed due to https://github.com/pulumi/pulumi/issues/7679
+        return cast(pulumi.Output[int], self._instance.port)
 
     def username(self) -> pulumi.Output[str]:
-        return self._instance.username
+        # Cast needed due to https://github.com/pulumi/pulumi/issues/7679
+        return cast(pulumi.Output[str], self._instance.username)
 
     def password(self) -> pulumi.Output[str]:
         # just to be safe...

--- a/pulumi/infra/postgres.py
+++ b/pulumi/infra/postgres.py
@@ -137,7 +137,7 @@ class Postgres(pulumi.ComponentResource):
         ), "Database name must be alpha+alphanumeric"
 
         instance_name = f"{name}-instance"
-        self.instance = aws.rds.Instance(
+        self._instance = aws.rds.Instance(
             instance_name,
             identifier=instance_name,
             name=database_name,  # See above diatribe
@@ -162,3 +162,16 @@ class Postgres(pulumi.ComponentResource):
             port=postgres_port,
             opts=child_opts,
         )
+
+    def host(self) -> pulumi.Output[str]:
+        return self._instance.address
+
+    def port(self) -> pulumi.Output[int]:
+        return self._instance.port
+
+    def username(self) -> pulumi.Output[str]:
+        return self._instance.username
+
+    def password(self) -> pulumi.Output[str]:
+        # just to be safe...
+        return pulumi.Output.secret(self._instance.password)

--- a/src/js/engagement_view/src/components/dashboard/Dashboard.tsx
+++ b/src/js/engagement_view/src/components/dashboard/Dashboard.tsx
@@ -57,9 +57,7 @@ export default function Dashboard() {
                         {" "}
                         Upload Plugin{" "}
                     </Link>
-                    <Button
-                        className={classes.sagemaker}
-                    >
+                    <Button className={classes.sagemaker}>
                         {" "}
                         Engagement Notebook{" "}
                     </Button>


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
none
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
fixes pulumi code for abstracting over a postgres database, before it was emitting stuff like this in the grapl stack outputs:

```
"plugin-work-queue-db-port": "<pulumi.output.Output object at 0x7ebfe8beaf50>"
```

now it outputs a port instead:

```
Previewing update (grapl/jgrillo-sandbox)

View Live: https://app.pulumi.com/grapl/grapl/jgrillo-sandbox/previews/4b3fd2eb-c923-4a8e-b39c-a381d9cf72d4

     Type                   Name                                 Plan       Info
     pulumi:pulumi:Stack    grapl-jgrillo-sandbox                           
     ├─ grapl:NomadJob      grapl-core                                      
 ~   │  └─ nomad:index:Job  jgrillo-sandbox-grapl-core-job       update     [diff: 
     └─ grapl:NomadJob      grapl-provision                                 
 ~      └─ nomad:index:Job  jgrillo-sandbox-grapl-provision-job  update     [diff: ~h
 
Outputs:
  - kafka-e2e-consumer-group-name        : "[secret]"
  ~ plugin-registry-db-port              : "<pulumi.output.Output object at 0x7ebfe8c7db50>" => 5432
  ~ plugin-work-queue-db-port            : "<pulumi.output.Output object at 0x7ebfe8beaf50>" => 5432

Resources:
    ~ 2 to update
    156 unchanged

``` 
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
`pulumi preview`
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
