### PR TITLE
Issue 733 generator executor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,6 +61,7 @@ BUILD @christophermaier
 /src/rust/derive-dynamic-node/ @colin-grapl
 /src/rust/endpoint-plugin/ @inickles-grapl
 /src/rust/generators/ @inickles-grapl
+/src/rust/generator-executor/ @colin-grapl
 /src/rust/graph-merger/ @grapl-security/wg-data-infra
 /src/rust/grapl-config/ @inickles-grapl @wimax-grapl
 /src/rust/grapl-graphql-codegen/ @colin-grapl

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1581,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1591,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
@@ -1619,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-lite"
@@ -1640,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote 1.0.15",
@@ -1662,21 +1662,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1700,6 +1700,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator-executor"
+version = "0.1.0"
+dependencies = [
+ "async-stream",
+ "futures-util",
+ "generator-sdk",
+ "grapl-config",
+ "grapl-utils",
+ "plugin-work-queue",
+ "rust-proto",
+ "structopt",
+ "thiserror",
+ "tokio 1.16.1",
+ "tokio-stream",
+ "tonic",
+ "tonic-health",
+ "tracing",
+]
+
+[[package]]
 name = "generator-sdk"
 version = "0.1.0"
 dependencies = [
@@ -1713,7 +1733,7 @@ dependencies = [
  "tonic",
  "tonic-health",
  "tracing",
- "trust-dns-resolver 0.20.3",
+ "trust-dns-resolver 0.20.4",
  "uuid",
 ]
 
@@ -4968,9 +4988,9 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0d7f5db438199a6e2609debe3f69f808d074e0a2888ee0bccb45fe234d03f4"
+checksum = "ca94d4e9feb6a181c690c4040d7a24ef34018d8313ac5044a61d21222ae24e31"
 dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
@@ -5012,9 +5032,9 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad17b608a64bd0735e67bde16b0636f8aa8591f831a25d18443ed00a699770"
+checksum = "ecae383baad9995efaa34ce8e57d12c3f305e545887472a492b838f4b5cfb77a"
 dependencies = [
  "cfg-if 1.0.0",
  "futures-util",
@@ -5027,7 +5047,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tokio 1.16.1",
- "trust-dns-proto 0.20.3",
+ "trust-dns-proto 0.20.4",
 ]
 
 [[package]]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "./generators/graph-generator-lib",
   "./generators/osquery-generator",
   "./generators/sysmon-generator",
+  "./generator-executor",
   "./graph-merger",
   "./grapl",
   "./grapl-config",

--- a/src/rust/generator-executor/Cargo.toml
+++ b/src/rust/generator-executor/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "generator-executor"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+async-stream = "0.3.2"
+futures-util = "0.3.21"
+grapl-config = { path = "../grapl-config" }
+grapl-utils = { path = "../grapl-utils" }
+generator-sdk = { path = "../plugin-sdk/generator-sdk/", features = ["client"] }
+plugin-work-queue = { path = "../plugin-work-queue" }
+rust-proto = { path = "../rust-proto" }
+structopt = "0.3.25"
+thiserror = "1.0.30"
+tokio = { version = "1.14.0", features = ["full"] }
+tokio-stream = "0.1.8"
+tonic = "0.6.1"
+tonic-health = "0.5.0"
+tracing = "0.1.29"

--- a/src/rust/generator-executor/src/lib.rs
+++ b/src/rust/generator-executor/src/lib.rs
@@ -1,5 +1,3 @@
-
-
 use async_stream::stream;
 use futures_util::pin_mut;
 use generator_sdk::{
@@ -12,16 +10,12 @@ use generator_sdk::{
     ClientConfig as GeneratorClientConfig,
 };
 use grapl_utils::future_ext::GraplFutureExt;
-use plugin_work_queue::client::{
-    PluginWorkQueueServiceClient,
-};
-use rust_proto::{
-    plugin_work_queue::{
-        AcknowledgeGeneratorRequest,
-        ExecutionJob,
-        GetExecuteGeneratorRequest,
-        GetExecuteGeneratorResponse,
-    },
+use plugin_work_queue::client::PluginWorkQueueServiceClient;
+use rust_proto::plugin_work_queue::{
+    AcknowledgeGeneratorRequest,
+    ExecutionJob,
+    GetExecuteGeneratorRequest,
+    GetExecuteGeneratorResponse,
 };
 use structopt::StructOpt;
 use tokio::time::{

--- a/src/rust/generator-executor/src/lib.rs
+++ b/src/rust/generator-executor/src/lib.rs
@@ -1,15 +1,10 @@
-use std::{
-    future::Future,
-    net::SocketAddr,
-    pin::Pin,
-};
+
 
 use async_stream::stream;
 use futures_util::pin_mut;
 use generator_sdk::{
     client::{
         CacheBuilder,
-        ClientCache,
         GeneratorClient,
         GeneratorClientError,
         TokioAsyncResolver,
@@ -19,10 +14,8 @@ use generator_sdk::{
 use grapl_utils::future_ext::GraplFutureExt;
 use plugin_work_queue::client::{
     PluginWorkQueueServiceClient,
-    PluginWorkQueueServiceClientError,
 };
 use rust_proto::{
-    plugin_sdk::generators::RunGeneratorResponse,
     plugin_work_queue::{
         AcknowledgeGeneratorRequest,
         ExecutionJob,
@@ -123,7 +116,7 @@ pub async fn process_message_loop(
 
     while let Some((job, request_id)) = jobs.next().await {
         let ExecutionJob {
-            tenant_id,
+            tenant_id: _,
             plugin_id,
             data,
         } = job;

--- a/src/rust/generator-executor/src/lib.rs
+++ b/src/rust/generator-executor/src/lib.rs
@@ -1,0 +1,180 @@
+use std::{
+    future::Future,
+    net::SocketAddr,
+    pin::Pin,
+};
+
+use async_stream::stream;
+use futures_util::pin_mut;
+use generator_sdk::{
+    client::{
+        CacheBuilder,
+        ClientCache,
+        GeneratorClient,
+        GeneratorClientError,
+        TokioAsyncResolver,
+    },
+    ClientConfig as GeneratorClientConfig,
+};
+use grapl_utils::future_ext::GraplFutureExt;
+use plugin_work_queue::client::{
+    PluginWorkQueueServiceClient,
+    PluginWorkQueueServiceClientError,
+};
+use rust_proto::{
+    plugin_sdk::generators::RunGeneratorResponse,
+    plugin_work_queue::{
+        AcknowledgeGeneratorRequest,
+        ExecutionJob,
+        GetExecuteGeneratorRequest,
+        GetExecuteGeneratorResponse,
+    },
+};
+use structopt::StructOpt;
+use tokio::time::{
+    sleep,
+    Duration,
+};
+use tokio_stream::{
+    Stream,
+    StreamExt,
+};
+
+#[derive(StructOpt)]
+pub struct GeneratorExecutorConfig {
+    #[structopt(env)]
+    plugin_work_queue_address: String,
+    // Path to the certificate to be used when validating the generator plugin TLS sessions
+    #[structopt(env)]
+    generator_certificate_path: std::path::PathBuf,
+    #[structopt(flatten)]
+    generator_client_config: GeneratorClientConfig,
+}
+
+fn make_job_stream(
+    mut work_queue_client: PluginWorkQueueServiceClient<tonic::transport::Channel>,
+) -> impl Stream<Item = (ExecutionJob, i64)> {
+    stream! {
+        loop {
+            let message = match work_queue_client.get_execute_generator(GetExecuteGeneratorRequest {}).await {
+                Ok(message) => message,
+                Err(e) => {
+                    tracing::error!(message="Failed to retrieve generator job", error=?e);
+                    // check what kind of error it is and retry it accordingly
+                    sleep(Duration::from_secs(1)).await;
+                    continue
+                }
+            };
+            match message {
+                GetExecuteGeneratorResponse { execution_job: Some(job), request_id } => yield (job, request_id),
+                _ => {
+                    tracing::debug!(message="No available jobs");
+                    sleep(Duration::from_secs(1)).await;
+                }
+            };
+
+        }
+    }
+}
+
+// Attempts to ack the message. On failure, will retry in a background task
+async fn try_ack(
+    work_queue_client: &mut PluginWorkQueueServiceClient<tonic::transport::Channel>,
+    request_id: i64,
+    success: bool,
+) {
+    if let Err(e) = work_queue_client
+        .acknowledge_generator(AcknowledgeGeneratorRequest {
+            request_id,
+            success,
+        })
+        .timeout(Duration::from_secs(2))
+        .await
+    {
+        let mut work_queue_client = work_queue_client.clone();
+        tokio::spawn(async move {
+            tracing::error!(
+                message="Failed to acknowledge message after 2 seconds",
+                error=?e,
+            );
+            if let Err(e) = work_queue_client
+                .acknowledge_generator(AcknowledgeGeneratorRequest {
+                    request_id,
+                    success,
+                })
+                .timeout(Duration::from_secs(10))
+                .await
+            {
+                tracing::error!(
+                    message="Failed to acknowledge message after 10 seconds",
+                    error=?e,
+                )
+            }
+        });
+    };
+}
+
+pub async fn process_message_loop(
+    mut work_queue_client: PluginWorkQueueServiceClient<tonic::transport::Channel>,
+    mut generator_client: GeneratorClient,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let jobs = make_job_stream(work_queue_client.clone());
+    pin_mut!(jobs);
+
+    while let Some((job, request_id)) = jobs.next().await {
+        let ExecutionJob {
+            tenant_id,
+            plugin_id,
+            data,
+        } = job;
+
+        // based on the error, either retry later or ack as a failure
+        let response = generator_client
+            .run_generator(data, plugin_id.to_string())
+            .await;
+
+        match response {
+            Ok(_) => {
+                try_ack(&mut work_queue_client, request_id, true).await;
+            }
+            Err(ref e) => {
+                if !should_retry(e) {
+                    try_ack(&mut work_queue_client, request_id, false).await;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// Unless there's a reason to believe this error is persistent, we should always retry
+fn should_retry(client_error: &GeneratorClientError) -> bool {
+    match client_error {
+        GeneratorClientError::ConnectError(_) => true,
+        GeneratorClientError::EmptyResolution { .. } => true,
+        GeneratorClientError::ResolveError(_) => true,
+        GeneratorClientError::InvalidUri(_) => false,
+        GeneratorClientError::Status(_) => true,
+        GeneratorClientError::ProtocolError(_) => true,
+        GeneratorClientError::ProtoError(_) => false,
+    }
+}
+
+pub async fn execute_service(
+    config: GeneratorExecutorConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cert = std::fs::read(config.generator_certificate_path)?;
+    let cert = tonic::transport::Certificate::from_pem(cert);
+
+    let work_queue =
+        PluginWorkQueueServiceClient::connect(config.plugin_work_queue_address).await?;
+    let generator_client = GeneratorClient::new(
+        CacheBuilder::from(config.generator_client_config.client_cache_config).build(),
+        cert, // load certificate
+        TokioAsyncResolver::from(config.generator_client_config.client_dns_config),
+    );
+    process_message_loop(work_queue, generator_client).await?;
+
+    Ok(())
+}

--- a/src/rust/plugin-sdk/generator-sdk/src/client.rs
+++ b/src/rust/plugin-sdk/generator-sdk/src/client.rs
@@ -3,7 +3,7 @@ use std::{
     time::Duration,
 };
 
-use moka::future::{
+pub use moka::future::{
     Cache,
     CacheBuilder,
 };
@@ -21,6 +21,7 @@ use tonic::{
     },
     Code,
 };
+pub use trust_dns_resolver::TokioAsyncResolver;
 use trust_dns_resolver::{
     config::{
         NameServerConfigGroup,
@@ -33,7 +34,6 @@ use trust_dns_resolver::{
         rr::rdata::SRV,
     },
     Name,
-    TokioAsyncResolver,
 };
 
 use crate::{
@@ -59,7 +59,7 @@ pub enum GeneratorClientError {
     ProtoError(#[from] GeneratorsDeserializationError),
 }
 
-type ClientCache = Cache<String, GeneratorServiceClient<Channel>>;
+pub type ClientCache = Cache<String, GeneratorServiceClient<Channel>>;
 
 /// The GeneratorClient manages connections to arbitrary generators across arbitrary tenants
 #[derive(Clone)]

--- a/src/rust/plugin-work-queue/src/client.rs
+++ b/src/rust/plugin-work-queue/src/client.rs
@@ -25,6 +25,7 @@ use tonic::{
         Body,
         StdError,
     },
+    transport::Channel,
     Status,
 };
 
@@ -36,9 +37,17 @@ pub enum PluginWorkQueueServiceClientError {
     DeserializeError(#[from] PluginWorkQueueDeserializationError),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PluginWorkQueueServiceClient<T> {
     inner: _PluginWorkQueueServiceClient<T>,
+}
+
+impl PluginWorkQueueServiceClient<Channel> {
+    pub async fn connect(value: String) -> Result<Self, tonic::transport::Error> {
+        Ok(PluginWorkQueueServiceClient::new(
+            _PluginWorkQueueServiceClient::connect(value).await?,
+        ))
+    }
 }
 
 impl<T> PluginWorkQueueServiceClient<T>


### PR DESCRIPTION
### Which issue does this PR correspond to?
733

### What changes does this PR make to Grapl? Why?
This adds the business logic of the generator executor. The service polls the work queue for new generator work and dispatches that work over to the generator.

All of the mTLS is handled already in the generator client.

The next steps for this service would be to set up the nomad job and get it the cert it needs but in order to keep the PR small I figured I'd start here.

### How were these changes tested?
There's no additional testing at this point. As the rest of the plugin system comes together we can start building out more testing.