### PR TITLE
Only promote artifacts if they're not in the destination already

### DIFF
--- a/.buildkite/pipeline.merge.promote.yml
+++ b/.buildkite/pipeline.merge.promote.yml
@@ -1,0 +1,30 @@
+---
+env:
+  PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
+  BUILDKITE_PLUGIN_VAULT_ENV_SECRET_PREFIX: "secret/data/buildkite/env"
+
+steps:
+  # Promote all the artifacts
+  #
+  # We do this before the RC creation because that
+  # triggers a run of the provision pipeline, and we want to make sure
+  # all the artifacts are in place first.
+  - label: ":cloudsmith: Promote artifacts"
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - CLOUDSMITH_API_KEY
+      - artifacts#v1.4.0:
+          # NOTE: this assumes that all artifacts mentioned in this
+          # file are stored in Cloudsmith!
+          download: all_artifacts.json
+      - grapl-security/cloudsmith#v0.1.4:
+          promote:
+            org: grapl
+            action: move
+            from: raw
+            to: testing
+            packages_file: all_artifacts.json
+    agents:
+      queue: "docker"

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -35,30 +35,15 @@ steps:
 
   - wait
 
-  # Promote all the artifacts
-  #
-  # We do this before the RC creation because that
-  # triggers a run of the provision pipeline, and we want to make sure
-  # all the artifacts are in place first.
-  - label: ":cloudsmith: Promote artifacts"
+  # If we have some artifacts to promote in Cloudsmith, then upload
+  # the promotion step. If we have nothing, then the promotion step
+  # will fail.
+  - label: ":thinking_face: Anything to promote?"
     plugins:
-      - grapl-security/vault-login#v0.1.0
-      - grapl-security/vault-env#v0.1.0:
-          secrets:
-            - CLOUDSMITH_API_KEY
       - artifacts#v1.4.0:
-          # NOTE: this assumes that all artifacts mentioned in this
-          # file are stored in Cloudsmith!
           download: all_artifacts.json
-      - grapl-security/cloudsmith#v0.1.4:
-          promote:
-            org: grapl
-            action: move
-            from: raw
-            to: testing
-            packages_file: all_artifacts.json
-    agents:
-      queue: "docker"
+    command:
+      - .buildkite/scripts/upload_promotion_step_if_needed.sh
 
   - wait
 

--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -68,4 +68,78 @@ for service in "${services[@]}"; do
     docker push "${new_tag}"
 done
 
-artifact_json "${TAG}" "${services[@]}" > "$(artifacts_file_for containers)"
+########################################################################
+# Determine whether or not this image is "new"
+#
+# Cloudsmith apparently has a bug that affects promotions when an
+# artifact already exists in the destination repository. It seems to
+# detect that the artifact is present and doesn't overwrite it, but it
+# also doesn't carry tags / labels over. Thus, when we have services
+# that don't change, we end up losing them in Cloudsmith.
+#
+# Until we can inspect the source of our Rust services to determine if
+# they need a new image, we will build the images, but then query the
+# upstream registry to see if that content exists there already or
+# not.
+#
+# This does require us to build the images first (which wastes a bit
+# of time). It also requires us to push the images to our `raw`
+# repository first in order to obtain the image's sha256 checksum
+# (there doesn't appear to be a way to do this purely locally,
+# amazingly enough!). It also requires this script to be aware that
+# we'll ultimately be promoting to our `testing` repository. These are
+# all unfortunate, but it does allow us to sidestep this Cloudsmith
+# bug. More importantly, it should make deployments quicker and more
+# responsive, since services should churn less (they'll only restart
+# when a new image is available, rather than for every single
+# deployment). As such, we should keep this general logic even after
+# the Cloudsmith bug is fixed.
+
+# This is the list of services that actually have different images.
+new_services=()
+
+# This is where our images will ultimately be promoted to. It is the
+# registry we'll need to query to see if an image with the same
+# content already exists.
+readonly UPSTREAM_REGISTRY="docker.cloudsmith.io/grapl/testing"
+
+# It seems you can only get the sha256 sum of an image after pushing
+# it to a registry. Fun.
+#
+# Returns a string like `sha256:deadbeef....`
+sha256_of_image() {
+    docker manifest inspect --verbose "${1}" | jq --raw-output '.Descriptor.digest'
+}
+
+# Returns 0 if it is present; 1 if not.
+#
+# We'll go ahead and allow the output to go to our logs; that will
+# help debugging.
+image_present_upstream() {
+    docker manifest inspect "${1}"
+}
+
+echo "--- :cloudsmith::sleuth_or_spy: Checking upstream repository to determine what to promote"
+
+for service in "${services[@]}"; do
+    echo "--- :cloudsmith: Checking '${service}:${TAG}' in 'grapl/testing'"
+    raw_repository_tag="$(cloudsmith_tag "${service}" "${TAG}")"
+    sha256="$(sha256_of_image "${raw_repository_tag}")"
+    echo "${raw_repository_tag} has identifier '${sha256}'"
+    upstream_sha256_identifier="${UPSTREAM_REGISTRY}/${service}@${sha256}"
+
+    echo "Checking the existence of '${upstream_sha256_identifier}'"
+    if ! image_present_upstream "${upstream_sha256_identifier}"; then
+        echo "Image not present upstream; adding '${service}' to the list of images to promote"
+        new_services+=("${service}")
+    else
+        echo "Image already found upstream; nothing else to be done"
+    fi
+done
+
+# Now that we've filtered out things that already exist upstream, we
+# only need to care about the new stuff.
+#
+# NOTE: The awkward array handling is because we currently have Bash
+# 4.2 on our CI/CD machines... once we upgrade, we can ditch this.
+artifact_json "${TAG}" "${new_services[@]+${new_services[@]}}" > "$(artifacts_file_for containers)"

--- a/.buildkite/scripts/lib/artifacts.sh
+++ b/.buildkite/scripts/lib/artifacts.sh
@@ -29,7 +29,7 @@ artifact_json() {
     shift
     local -ra artifacts=("${@}")
 
-    for artifact in "${artifacts[@]}"; do
+    for artifact in "${artifacts[@]+"${artifacts[@]}"}"; do
         jq --null-input \
             --arg key "${artifact}" \
             --arg value "${version}" \

--- a/.buildkite/scripts/upload_promotion_step_if_needed.sh
+++ b/.buildkite/scripts/upload_promotion_step_if_needed.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$(jq 'length' all_artifacts.json)" == "0" ]; then
+    echo "No artifacts to promote!"
+else
+    echo "We have at least one artifact to promote"
+    buildkite-agent pipeline upload .buildkite/pipeline.merge.promote.yml
+fi


### PR DESCRIPTION
Due to what appears to be a Cloudsmith bug, we seem to be losing
images (tags, really) when we promote containers from our `raw`
repository to the `testing` repository. Cloudsmith detects that the
bytes of the image exist in the destination and thinks its job is
done; it doesn't seem to carry tags over, however. This manifests by
us not being able to find images in the `testing` repository, even
though it looks like Cloudsmith promoted them.

What we'll do now is add an additional check to help us assemble our
final list of artifacts to be promoted. We'll query the `testing`
repository to see if an image with the same sha256 sum as the one we
just built already exists there. If it does, then we must be dealing
with a service that hasn't changed since it was last pushed. In this
case, we'll just ignore it, and continue to use what's in the
`testing` repository. If no such image exists, then what we just built
must be new, so we will add it to our list of things to promote.

We have to add this logic here, rather than, say, in our Cloudsmith
plugin, because this list of services is also folded into our Pulumi
stack configuration files. Additionally, at some future time, we may
be able to simply inspect our code to see what changed, rather than
having to build images and push them first. All this argues for
putting the logic here, rather than any place else.

(We could use Pants to ask whether any of our Python images need to be
built, but the logic in this PR works regardless of what language the
services are written in. Were we to use Pants for this now, we would
also need to make changes to how we build the images; that's not
something we necessarily need to dig into right now.)

Signed-off-by: Christopher Maier <chris@graplsecurity.com>