### PR TITLE
Simplify invocation to build all images in CI

### DIFF
--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -49,7 +49,7 @@ cloudsmith_tag() {
 }
 
 echo "--- Building all ${TAG} images"
-make build build-test-e2e
+make build-test-e2e
 
 for service in "${services[@]}"; do
     # Re-tag the container we just built so we can upload it to


### PR DESCRIPTION
We only need to run `make build-test-e2e`, since `build` is already
declared as a prerequisite of that target.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
