### PR TITLE
Remove Bash 4.x-ism processing arrays

### DIFF
--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -139,7 +139,4 @@ done
 
 # Now that we've filtered out things that already exist upstream, we
 # only need to care about the new stuff.
-#
-# NOTE: The awkward array handling is because we currently have Bash
-# 4.2 on our CI/CD machines... once we upgrade, we can ditch this.
-artifact_json "${TAG}" "${new_services[@]+${new_services[@]}}" > "$(artifacts_file_for containers)"
+artifact_json "${TAG}" "${new_services[@]}" > "$(artifacts_file_for containers)"

--- a/.buildkite/scripts/lib/artifacts.sh
+++ b/.buildkite/scripts/lib/artifacts.sh
@@ -29,7 +29,7 @@ artifact_json() {
     shift
     local -ra artifacts=("${@}")
 
-    for artifact in "${artifacts[@]+"${artifacts[@]}"}"; do
+    for artifact in "${artifacts[@]}"; do
         jq --null-input \
             --arg key "${artifact}" \
             --arg value "${version}" \

--- a/.buildkite/scripts/lib/artifacts_test.sh
+++ b/.buildkite/scripts/lib/artifacts_test.sh
@@ -4,6 +4,17 @@ oneTimeSetUp() {
     source .buildkite/scripts/lib/artifacts.sh
 }
 
+test_artifact_json_no_artifacts() {
+    actual="$(artifact_json "1.0.0")"
+    assertEquals "{}" "${actual}"
+}
+
+test_artifact_json_empty_array() {
+    services=()
+    actual="$(artifact_json "1.0.0" "${services[@]}")"
+    assertEquals "{}" "${actual}"
+}
+
 test_artifact_json_small() {
     actual="$(artifact_json "1.0.0" "artifact_one")"
     expected=$(


### PR DESCRIPTION
We've now got Bash 5 in CI, so we don't need to jump through these
awkward hoops for possibly-empty arrays anymore.

This is a follow-on to https://github.com/grapl-security/issue-tracker/issues/773

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
