### PR TITLE
Add TOOLCHAIN_AUTH_TOKEN when building images

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -16,6 +16,7 @@ steps:
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - CLOUDSMITH_API_KEY
+            - grapl/TOOLCHAIN_AUTH_TOKEN
       - docker-login#v2.0.1:
           username: grapl-cicd
           password-env: CLOUDSMITH_API_KEY


### PR DESCRIPTION
We build several PEXes for our Python containers; we may as well take
advantage of the remote cache to improve the overall speed of our
builds.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>