### PR TITLE
Plumb the plugin-bootstrap/plugin-execution container images from `grapl-core.nomad` container_images= into `plugin.nomad`

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1119,17 +1119,18 @@ job "grapl-core" {
       }
 
       env {
-        AWS_REGION                      = var.aws_region
-        NOMAD_SERVICE_ADDRESS           = "${attr.unique.network.ip-address}:4646"
-        PLUGIN_REGISTRY_BIND_ADDRESS    = "0.0.0.0:${NOMAD_PORT_plugin-registry-port}"
-        PLUGIN_REGISTRY_DB_HOSTNAME     = local.plugin_registry_db_hostname
-        PLUGIN_REGISTRY_DB_PASSWORD     = var.plugin_registry_db_password
-        PLUGIN_REGISTRY_DB_PORT         = var.plugin_registry_db_port
-        PLUGIN_REGISTRY_DB_USERNAME     = var.plugin_registry_db_username
-        PLUGIN_S3_BUCKET_AWS_ACCOUNT_ID = var.plugin_s3_bucket_aws_account_id
-        PLUGIN_S3_BUCKET_NAME           = var.plugin_s3_bucket_name
-        RUST_BACKTRACE                  = local.rust_backtrace
-        RUST_LOG                        = var.rust_log
+        AWS_REGION                       = var.aws_region
+        NOMAD_SERVICE_ADDRESS            = "${attr.unique.network.ip-address}:4646"
+        PLUGIN_REGISTRY_BIND_ADDRESS     = "0.0.0.0:${NOMAD_PORT_plugin-registry-port}"
+        PLUGIN_REGISTRY_DB_HOSTNAME      = local.plugin_registry_db_hostname
+        PLUGIN_REGISTRY_DB_PASSWORD      = var.plugin_registry_db_password
+        PLUGIN_REGISTRY_DB_PORT          = var.plugin_registry_db_port
+        PLUGIN_REGISTRY_DB_USERNAME      = var.plugin_registry_db_username
+        PLUGIN_BOOTSTRAP_CONTAINER_IMAGE = var.container_images["plugin-bootstrap"]
+        PLUGIN_S3_BUCKET_AWS_ACCOUNT_ID  = var.plugin_s3_bucket_aws_account_id
+        PLUGIN_S3_BUCKET_NAME            = var.plugin_s3_bucket_name
+        RUST_BACKTRACE                   = local.rust_backtrace
+        RUST_LOG                         = var.rust_log
       }
     }
 

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1127,6 +1127,7 @@ job "grapl-core" {
         PLUGIN_REGISTRY_DB_PORT          = var.plugin_registry_db_port
         PLUGIN_REGISTRY_DB_USERNAME      = var.plugin_registry_db_username
         PLUGIN_BOOTSTRAP_CONTAINER_IMAGE = var.container_images["plugin-bootstrap"]
+        PLUGIN_EXECUTION_CONTAINER_IMAGE = "grapl/plugin-execution-sidecar-TODO" 
         PLUGIN_S3_BUCKET_AWS_ACCOUNT_ID  = var.plugin_s3_bucket_aws_account_id
         PLUGIN_S3_BUCKET_NAME            = var.plugin_s3_bucket_name
         RUST_BACKTRACE                   = local.rust_backtrace

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1127,6 +1127,7 @@ job "grapl-core" {
         PLUGIN_REGISTRY_DB_PORT          = var.plugin_registry_db_port
         PLUGIN_REGISTRY_DB_USERNAME      = var.plugin_registry_db_username
         PLUGIN_BOOTSTRAP_CONTAINER_IMAGE = var.container_images["plugin-bootstrap"]
+        # Plugin Execution code/image doesn't exist yet; change this once it does!
         PLUGIN_EXECUTION_CONTAINER_IMAGE = "grapl/plugin-execution-sidecar-TODO"
         PLUGIN_S3_BUCKET_AWS_ACCOUNT_ID  = var.plugin_s3_bucket_aws_account_id
         PLUGIN_S3_BUCKET_NAME            = var.plugin_s3_bucket_name

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1127,7 +1127,7 @@ job "grapl-core" {
         PLUGIN_REGISTRY_DB_PORT          = var.plugin_registry_db_port
         PLUGIN_REGISTRY_DB_USERNAME      = var.plugin_registry_db_username
         PLUGIN_BOOTSTRAP_CONTAINER_IMAGE = var.container_images["plugin-bootstrap"]
-        PLUGIN_EXECUTION_CONTAINER_IMAGE = "grapl/plugin-execution-sidecar-TODO" 
+        PLUGIN_EXECUTION_CONTAINER_IMAGE = "grapl/plugin-execution-sidecar-TODO"
         PLUGIN_S3_BUCKET_AWS_ACCOUNT_ID  = var.plugin_s3_bucket_aws_account_id
         PLUGIN_S3_BUCKET_NAME            = var.plugin_s3_bucket_name
         RUST_BACKTRACE                   = local.rust_backtrace

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -61,6 +61,7 @@ def _container_images(
         "node-identifier": builder.build_with_tag("node-identifier"),
         "node-identifier-retry": builder.build_with_tag("node-identifier-retry"),
         "osquery-generator": builder.build_with_tag("osquery-generator"),
+        "plugin-bootstrap": builder.build_with_tag("plugin-bootstrap"),
         "plugin-registry": builder.build_with_tag("plugin-registry"),
         "plugin-work-queue": builder.build_with_tag("plugin-work-queue"),
         "provisioner": builder.build_with_tag("provisioner"),

--- a/src/rust/plugin-registry/src/nomad/cli.rs
+++ b/src/rust/plugin-registry/src/nomad/cli.rs
@@ -15,7 +15,7 @@ pub enum NomadCliError {
     DeserializeJsonError(#[from] serde_json::Error),
 }
 
-pub type NomadVars = HashMap<String, String>;
+pub type NomadVars = HashMap<&'static str, String>;
 
 #[derive(Default)]
 pub struct NomadCli {}

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -34,6 +34,7 @@ pub async fn deploy_plugin(
     plugin_bucket_owner_id: &str,
     plugin_bucket_name: &str,
     plugin_bootstrap_container_image: &str,
+    plugin_execution_container_image: &str,
 ) -> Result<(), PluginRegistryServiceError> {
     // --- Convert HCL to JSON Job model
     let job_name = "grapl-plugin"; // Matches what's in `plugin.nomad`
@@ -52,11 +53,15 @@ pub async fn deploy_plugin(
         let job_file_vars: NomadVars = HashMap::from([
             ("aws_account_id", plugin_bucket_owner_id.to_string()),
             ("kernel_artifact_url", kernel_artifact_url),
+            ("plugin_artifact_url", plugin.artifact_s3_key),
             (
                 "plugin_bootstrap_container_image",
                 plugin_bootstrap_container_image.to_owned(),
             ),
-            ("plugin_artifact_url", plugin.artifact_s3_key),
+            (
+                "plugin_execution_container_image",
+                plugin_execution_container_image.to_owned(),
+            ),
             ("plugin_id", plugin.plugin_id.to_string()),
             ("rootfs_artifact_url", rootfs_artifact_url),
             ("tenant_id", plugin.tenant_id.to_string()),

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -44,18 +44,15 @@ pub async fn deploy_plugin(
             plugin_bucket_name
         );
         let job_file_vars: NomadVars = HashMap::from([
+            ("aws_account_id", plugin_bucket_owner_id.to_string()),
+            ("kernel_artifact_url", kernel_artifact_url),
             (
-                "aws_account_id".to_owned(),
-                plugin_bucket_owner_id.to_string(),
-            ),
-            ("kernel_artifact_url".to_owned(), kernel_artifact_url),
-            (
-                "plugin_bootstrap_container_image".to_owned(),
+                "plugin_bootstrap_container_image",
                 plugin_bootstrap_container_image.to_owned(),
             ),
-            ("plugin_artifact_url".to_owned(), plugin.artifact_s3_key),
-            ("plugin_id".to_owned(), plugin.plugin_id.to_string()),
-            ("tenant_id".to_owned(), plugin.tenant_id.to_string()),
+            ("plugin_artifact_url", plugin.artifact_s3_key),
+            ("plugin_id", plugin.plugin_id.to_string()),
+            ("tenant_id", plugin.tenant_id.to_string()),
         ]);
         cli.parse_hcl2(job_file_hcl, job_file_vars)?
     };

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -32,6 +32,7 @@ pub async fn deploy_plugin(
     db_client: &PluginRegistryDbClient,
     plugin: PluginRow,
     plugin_bucket_owner_id: &str,
+    plugin_bootstrap_container_image: &str,
 ) -> Result<(), PluginRegistryServiceError> {
     // --- Convert HCL to JSON Job model
     let job_name = "grapl-plugin"; // Matches what's in `plugin.nomad`

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -32,20 +32,30 @@ pub async fn deploy_plugin(
     db_client: &PluginRegistryDbClient,
     plugin: PluginRow,
     plugin_bucket_owner_id: &str,
+    plugin_bucket_name: &str,
     plugin_bootstrap_container_image: &str,
 ) -> Result<(), PluginRegistryServiceError> {
     // --- Convert HCL to JSON Job model
     let job_name = "grapl-plugin"; // Matches what's in `plugin.nomad`
     let job = {
         let job_file_hcl = static_files::PLUGIN_JOB;
+        let kernel_artifact_url = format!(
+            "https://{}.s3.amazonaws.com/kernel/v0.tar.gz",
+            plugin_bucket_name
+        );
         let job_file_vars: NomadVars = HashMap::from([
-            ("plugin_id".to_owned(), plugin.plugin_id.to_string()),
-            ("tenant_id".to_owned(), plugin.tenant_id.to_string()),
-            ("plugin_artifact_url".to_owned(), plugin.artifact_s3_key),
             (
                 "aws_account_id".to_owned(),
                 plugin_bucket_owner_id.to_string(),
             ),
+            ("kernel_artifact_url".to_owned(), kernel_artifact_url),
+            (
+                "plugin_bootstrap_container_image".to_owned(),
+                plugin_bootstrap_container_image.to_owned(),
+            ),
+            ("plugin_artifact_url".to_owned(), plugin.artifact_s3_key),
+            ("plugin_id".to_owned(), plugin.plugin_id.to_string()),
+            ("tenant_id".to_owned(), plugin.tenant_id.to_string()),
         ]);
         cli.parse_hcl2(job_file_hcl, job_file_vars)?
     };

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -40,8 +40,14 @@ pub async fn deploy_plugin(
     let job = {
         let job_file_hcl = static_files::PLUGIN_JOB;
         let kernel_artifact_url = format!(
-            "https://{}.s3.amazonaws.com/kernel/v0.tar.gz",
-            plugin_bucket_name
+            "https://{bucket}.s3.amazonaws.com/{key}",
+            bucket = plugin_bucket_name,
+            key = "kernel/v0.tar.gz",
+        );
+        let rootfs_artifact_url = format!(
+            "https://{bucket}.s3.amazonaws.com/{key}",
+            bucket = plugin_bucket_name,
+            key = "rootfs/v0.rootfs.tar.gz",
         );
         let job_file_vars: NomadVars = HashMap::from([
             ("aws_account_id", plugin_bucket_owner_id.to_string()),
@@ -52,6 +58,7 @@ pub async fn deploy_plugin(
             ),
             ("plugin_artifact_url", plugin.artifact_s3_key),
             ("plugin_id", plugin.plugin_id.to_string()),
+            ("rootfs_artifact_url", rootfs_artifact_url),
             ("tenant_id", plugin.tenant_id.to_string()),
         ]);
         cli.parse_hcl2(job_file_hcl, job_file_vars)?

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -127,6 +127,7 @@ pub struct PluginRegistry {
     plugin_bucket_name: String,
     plugin_bucket_owner_id: String,
     plugin_bootstrap_container_image: String,
+    plugin_execution_container_image: String,
 }
 
 impl PluginRegistry {
@@ -216,6 +217,8 @@ impl PluginRegistry {
         let plugin_id = request.plugin_id;
         let plugin_row = self.db_client.get_plugin(&plugin_id).await?;
 
+        // TODO: Given how many fields I'm forwarding here, it may just
+        // make sense to pass `deploy_plugin` &self verbatim...
         deploy_plugin::deploy_plugin(
             &self.nomad_client,
             &self.nomad_cli,
@@ -224,6 +227,7 @@ impl PluginRegistry {
             &self.plugin_bucket_owner_id,
             &self.plugin_bucket_name,
             &self.plugin_bootstrap_container_image,
+            &self.plugin_execution_container_image,
         )
         .await
         .map_err(PluginRegistryServiceError::from)?;
@@ -354,6 +358,7 @@ pub async fn exec_service(
         plugin_bucket_name: service_config.plugin_s3_bucket_name,
         plugin_bucket_owner_id: service_config.plugin_s3_bucket_aws_account_id,
         plugin_bootstrap_container_image: service_config.plugin_bootstrap_container_image,
+        plugin_execution_container_image: service_config.plugin_execution_container_image,
     };
 
     let addr = service_config.plugin_registry_bind_address;

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -115,6 +115,8 @@ pub struct PluginRegistryServiceConfig {
     plugin_registry_db_password: String,
     #[structopt(env)]
     plugin_bootstrap_container_image: String,
+    #[structopt(env)]
+    plugin_execution_container_image: String,
 }
 
 pub struct PluginRegistry {

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -220,6 +220,7 @@ impl PluginRegistry {
             &self.db_client,
             plugin_row,
             &self.plugin_bucket_owner_id,
+            &self.plugin_bucket_name,
             &self.plugin_bootstrap_container_image,
         )
         .await

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -113,6 +113,8 @@ pub struct PluginRegistryServiceConfig {
     plugin_registry_db_username: String,
     #[structopt(env)]
     plugin_registry_db_password: String,
+    #[structopt(env)]
+    plugin_bootstrap_container_image: String,
 }
 
 pub struct PluginRegistry {
@@ -122,6 +124,7 @@ pub struct PluginRegistry {
     s3: S3Client,
     plugin_bucket_name: String,
     plugin_bucket_owner_id: String,
+    plugin_bootstrap_container_image: String,
 }
 
 impl PluginRegistry {
@@ -217,6 +220,7 @@ impl PluginRegistry {
             &self.db_client,
             plugin_row,
             &self.plugin_bucket_owner_id,
+            &self.plugin_bootstrap_container_image,
         )
         .await
         .map_err(PluginRegistryServiceError::from)?;
@@ -346,6 +350,7 @@ pub async fn exec_service(
         s3: S3Client::from_env(),
         plugin_bucket_name: service_config.plugin_s3_bucket_name,
         plugin_bucket_owner_id: service_config.plugin_s3_bucket_aws_account_id,
+        plugin_bootstrap_container_image: service_config.plugin_bootstrap_container_image,
     };
 
     let addr = service_config.plugin_registry_bind_address;

--- a/src/rust/plugin-registry/src/static_files/plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/plugin.nomad
@@ -15,12 +15,12 @@ variable "plugin_artifact_url" {
 
 variable "kernel_artifact_url" {
   type        = string
-  description = "URL specifying the kernel in S3."
+  description = "S3 URL specifying the kernel for the Firecracker VM."
 }
 
 variable "rootfs_artifact_url" {
   type        = string
-  description = "URL specifying the RootFS in S3."
+  description = "S3 URL specifying the RootFS for the Firecracker VM."
 }
 
 variable "plugin_count" {

--- a/src/rust/plugin-registry/src/static_files/plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/plugin.nomad
@@ -13,6 +13,11 @@ variable "plugin_artifact_url" {
   description = "The url that specifies which binary to run as the plugin."
 }
 
+variable "kernel_artifact_url" {
+  type        = string
+  description = "The url that specifies where to find the kernel in S3."
+}
+
 variable "plugin_count" {
   type        = number
   default     = 1
@@ -135,7 +140,7 @@ job "grapl-plugin" {
       }
 
       artifact {
-        source      = "https://grapl-firecracker.s3.amazonaws.com/kernel/v0.tar.gz"
+        source      = var.kernel_artifact_url
         destination = "local/vmlinux"
         headers {
           x-amz-expected-bucket-owner = var.aws_account_id

--- a/src/rust/plugin-registry/src/static_files/plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/plugin.nomad
@@ -1,9 +1,3 @@
-variable "container_registry" {
-  type        = string
-  default     = "localhost:5000"
-  description = "The container registry in which we can find Grapl services."
-}
-
 variable "plugin_id" {
   type        = string
   description = "The ID for this plugin."
@@ -28,6 +22,11 @@ variable "plugin_count" {
 variable "aws_account_id" {
   type        = string
   description = "The account ID of the aws account that holds onto the plugin binaries."
+}
+
+variable "plugin_bootstrap_container_image" {
+  type        = string
+  description = "The plugin-bootstrap task's DockerImageId."
 }
 
 # Temporarily dropping the shared_key stuff and picking it up later, per
@@ -108,7 +107,7 @@ job "grapl-plugin" {
       }
 
       config {
-        image = "grapl/plugin-bootstrap-sidecar"
+        image = var.plugin_bootstrap_container_image
         ports = [
         "plugin_bootstrap_grpc_receiver"]
       }

--- a/src/rust/plugin-registry/src/static_files/plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/plugin.nomad
@@ -15,7 +15,12 @@ variable "plugin_artifact_url" {
 
 variable "kernel_artifact_url" {
   type        = string
-  description = "The url that specifies where to find the kernel in S3."
+  description = "URL specifying the kernel in S3."
+}
+
+variable "rootfs_artifact_url" {
+  type        = string
+  description = "URL specifying the RootFS in S3."
 }
 
 variable "plugin_count" {
@@ -31,7 +36,12 @@ variable "aws_account_id" {
 
 variable "plugin_bootstrap_container_image" {
   type        = string
-  description = "The plugin-bootstrap task's DockerImageId."
+  description = "The tenant-plugin-bootstrap-sidecar task's DockerImageId."
+}
+
+variable "plugin_execution_container_image" {
+  type        = string
+  description = "The tenant-plugin-execution-sidecar task's DockerImageId."
 }
 
 # Temporarily dropping the shared_key stuff and picking it up later, per
@@ -81,7 +91,7 @@ job "grapl-plugin" {
       }
 
       config {
-        image = "grapl/plugin-execution-sidecar"
+        image = var.plugin_execution_container_image
         ports = [
         "plugin_sidecar_grpc_receiver"]
       }

--- a/src/rust/plugin-registry/src/static_files/plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/plugin.nomad
@@ -149,7 +149,7 @@ job "grapl-plugin" {
       }
 
       artifact {
-        source      = "https://grapl-firecracker.s3.amazonaws.com/rootfs/v0.rootfs.tar.gz"
+        source      = var.rootfs_artifact_url
         destination = "local/rootfs.ext4"
         headers {
           x-amz-expected-bucket-owner = var.aws_account_id


### PR DESCRIPTION
Previously we had a static image `grapl/plugin-execution-sidecar` image, this now plumbs it in from

Pulumi => grapl-core.nomad => plugin registry env vars => `plugin.nomad` 