### PR TITLE
Use Rust image for formatting and linting in CI

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -3,6 +3,9 @@ env:
   PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
   TAG: ci-pipeline
   BUILDKITE_PLUGIN_VAULT_ENV_SECRET_PREFIX: "secret/data/buildkite/env"
+  # TODO: Figure out a way for this to be sourced from our
+  # rust-toolchain file
+  RUST_VERSION: 1.58.1
 
 # TODO: Cache for JS, Rust deps
 
@@ -38,11 +41,17 @@ steps:
       - cd src/rust
       - rustup set profile default
       - bin/format --check
+    plugins:
+      - docker#v3.8.0:
+          image: "rust:${RUST_VERSION}"
 
   - label: ":rust: Linting"
     command:
       - cd src/rust
       - bin/lint
+    plugins:
+      - docker#v3.8.0:
+          image: "rust:${RUST_VERSION}"
     agents:
       queue: "beefy"
 


### PR DESCRIPTION
I think with this, we could actually remove Rust from our CI builder
nodes, since the rest of our Rust interactions in CI occur in
containers already.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
