### PR TITLE
Use Pants tags to declaratively maintain the list of service PEXes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,8 @@ help: ## Print this help
 ##@ Build 🔨
 
 .PHONY: build-service-pexs
-build-service-pexs:
-	./pants package \
-		./src/python/analyzer_executor/src \
-		./src/python/engagement-creator/engagement_creator:pex \
-		./src/python/provisioner/provisioner:pex
+build-service-pexs: ## Build all PEX files that are used by our service processes
+	./pants --tag="service-pex" package ::
 
 .PHONY: build-test-unit
 build-test-unit:

--- a/src/python/analyzer_executor/src/BUILD
+++ b/src/python/analyzer_executor/src/BUILD
@@ -9,4 +9,5 @@ python_sources(
 pex_binary(
     output_path="analyzer-executor.pex",
     entry_point="./run.py:run",
+    tags=["service-pex"],
 )

--- a/src/python/engagement-creator/engagement_creator/BUILD
+++ b/src/python/engagement-creator/engagement_creator/BUILD
@@ -4,4 +4,5 @@ pex_binary(
     name="pex",
     output_path="engagement-creator.pex",
     entry_point="./run.py:run",
+    tags=["service-pex"],
 )

--- a/src/python/provisioner/provisioner/BUILD
+++ b/src/python/provisioner/provisioner/BUILD
@@ -4,4 +4,5 @@ pex_binary(
     name="pex",
     output_path="provisioner.pex",
     entry_point="./app.py:provision",
+    tags=["service-pex"],
 )


### PR DESCRIPTION
Just a tiny quality-of-life improvement I spotted in the course of larger refactorings.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>