### PR TITLE
Install Docker Compose v2 CLI plugin

### DIFF
--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -61,13 +61,24 @@ install_docker() {
         https://get.docker.com/ | sh
     sudo usermod -a -G docker "$USER"
 
-    echo_banner "Install docker-compose"
+    echo_banner "Install docker-compose (v1, old, Python)"
     sudo curl --proto "=https" \
         --tlsv1.2 \
         --location \
         --output /usr/local/bin/docker-compose \
-        "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)"
+        "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname --kernel-name)-$(uname --machine)"
     sudo chmod +x /usr/local/bin/docker-compose
+
+    echo_banner "Install docker compose (v2, new, Go) CLI plugin"
+    user_docker_cli_plugins_dir="${HOME}/.docker/cli-plugins"
+    mkdir --parents "${user_docker_cli_plugins_dir}"
+
+    curl --proto "=https" \
+        --tlsv1.2 \
+        --location \
+        --output "${user_docker_cli_plugins_dir}/docker-compose" \
+        "https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-$(uname --kernel-name | tr '[:upper:]' '[:lower:]')-$(uname --machine)"
+    chmod +x "${user_docker_cli_plugins_dir}/docker-compose"
 }
 
 install_rust_and_utilities() {


### PR DESCRIPTION
This ensures that both the old and new versions of Docker Compose are
present on our workstations.

We still use the old Docker Compose (invoked as `docker-compose`) in
our Makefiles, scripts, etc., but this will enable us to start
migrating over to the new Docker Compose (invoked as `docker compose`;
note the space).

Signed-off-by: Christopher Maier <chris@graplsecurity.com>