### PR TITLE
remove redundant .clone() in Rust Files from deleting --allow clippy:…

### DIFF
--- a/src/rust/bin/lint
+++ b/src/rust/bin/lint
@@ -90,7 +90,6 @@ if ! cargo clippy \
     --allow clippy::op_ref \
     --allow clippy::option_as_ref_deref \
     --allow clippy::or_fun_call \
-    --allow clippy::redundant_clone \
     --allow clippy::redundant_closure \
     --allow clippy::redundant_field_names \
     --allow clippy::redundant_pattern_matching \

--- a/src/rust/graph-merger/src/upsert_util.rs
+++ b/src/rust/graph-merger/src/upsert_util.rs
@@ -74,7 +74,7 @@ pub(crate) fn build_upserts(
 
     let (creation_var_name, creation_query, creation_quad) =
         node_creation_quads(query_param, &node_key, node_type);
-    key_query_map.insert(_node_key.clone(), creation_var_name.clone());
+    key_query_map.insert(_node_key, creation_var_name.clone());
 
     mutations.push(creation_quad);
     inner_queries.push_str(&creation_query);

--- a/src/rust/grapl-graphql-codegen/src/edge.rs
+++ b/src/rust/grapl-graphql-codegen/src/edge.rs
@@ -148,8 +148,7 @@ impl<'a> TryFrom<(String, &Field<'a, &'a str>)> for Edge {
         let reverse_edge_name = field
             .directives
             .iter()
-            .map(|directive| &directive.arguments)
-            .flatten()
+            .flat_map(|directive| &directive.arguments)
             .find_map(|(argument_name, argument)| {
                 if *argument_name == "reverse" {
                     if let graphql_parser::schema::Value::String(argument) = argument {

--- a/src/rust/model-plugin-deployer/src/client.rs
+++ b/src/rust/model-plugin-deployer/src/client.rs
@@ -38,6 +38,6 @@ impl RpcClient<Channel> {
             .timeout(Duration::from_secs(5))
             .concurrency_limit(30);
         let channel = endpoint.connect().await?;
-        Ok(RpcClient::new(channel.clone()))
+        Ok(RpcClient::new(channel))
     }
 }

--- a/src/rust/plugin-registry/src/client.rs
+++ b/src/rust/plugin-registry/src/client.rs
@@ -62,9 +62,7 @@ impl PluginRegistryServiceClient<tonic::transport::Channel> {
             .timeout(Duration::from_secs(5))
             .concurrency_limit(30);
         let channel = endpoint.connect().await?;
-        Ok(Self::new(_PluginRegistryServiceClient::new(
-            channel.clone(),
-        )))
+        Ok(Self::new(_PluginRegistryServiceClient::new(channel)))
     }
 }
 


### PR DESCRIPTION
…:redundant_clone from src/rust/bin/lint

<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/853

### What changes does this PR make to Grapl? Why?

This specific issue is pertaining to errors that manifest as a result of removing --allow clippy::redundant_clone from src/rust/bin/lint. This effort was straightforward, consisting of removing redundant `.clone()` when running `make lint-rust`. 

### How were these changes tested?

`make up` && `make test-e2e`

These are not functional changes and should not effect behavior. 
