### PR TITLE
Remove unused GLOBAL_LAMBDA_ZIP_TAG

### DIFF
--- a/pulumi/infra/config.py
+++ b/pulumi/infra/config.py
@@ -73,20 +73,6 @@ REAL_DEPLOYMENT = DEPLOYMENT_NAME in ("testing")
 # that includes the AWS account ID.
 AWS_ACCOUNT_ID = "000000000000" if LOCAL_GRAPL else aws.get_caller_identity().account_id
 
-GLOBAL_LAMBDA_ZIP_TAG = os.getenv("TAG", "latest")
-"""Filename tag for all lambda function ZIP files.
-
-All our lambda function ZIP files currently have a name like:
-
-    <LAMBDA_NAME>-<TAG>.zip
-
-Since all the lambdas share the same tag, we can specify this globally.
-
-Use the environment variable `TAG` to specify a tag, or
-leave it unset to use the default value of `latest`.
-
-"""
-
 
 SERVICE_LOG_RETENTION_DAYS: Final[int] = 30
 


### PR DESCRIPTION
No more lambdas, no more lambda tags.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
