### PR TITLE
Make source of TAG values more obvious

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -1,7 +1,6 @@
 ---
 env:
   PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
-  TAG: ci-pipeline
   BUILDKITE_PLUGIN_VAULT_ENV_SECRET_PREFIX: "secret/data/buildkite/env"
   # TODO: Figure out a way for this to be sourced from our
   # rust-toolchain file

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -12,7 +12,7 @@ services:
   ########################################################################
 
   sysmon-generator:
-    image: sysmon-generator:${TAG:-latest}
+    image: sysmon-generator:${TAG}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -21,7 +21,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   osquery-generator:
-    image: osquery-generator:${TAG:-latest}
+    image: osquery-generator:${TAG}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -30,7 +30,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   node-identifier:
-    image: node-identifier:${TAG:-latest}
+    image: node-identifier:${TAG}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -39,7 +39,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   node-identifier-retry:
-    image: node-identifier-retry:${TAG:-latest}
+    image: node-identifier-retry:${TAG}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -48,7 +48,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   graph-merger:
-    image: graph-merger:${TAG:-latest}
+    image: graph-merger:${TAG}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -57,7 +57,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   analyzer-dispatcher:
-    image: analyzer-dispatcher:${TAG:-latest}
+    image: analyzer-dispatcher:${TAG}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -66,7 +66,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   model-plugin-deployer:
-    image: model-plugin-deployer:${TAG:-latest}
+    image: model-plugin-deployer:${TAG}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -75,7 +75,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   grapl-web-ui:
-    image: grapl-web-ui:${TAG:-latest}
+    image: grapl-web-ui:${TAG}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -84,7 +84,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   plugin-bootstrap:
-    image: plugin-bootstrap:${TAG:-latest}
+    image: plugin-bootstrap:${TAG}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -93,7 +93,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   plugin-registry:
-    image: plugin-registry:${TAG:-latest}
+    image: plugin-registry:${TAG}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -102,7 +102,7 @@ services:
         - RUST_BUILD=${RUST_BUILD:-debug}
 
   plugin-work-queue:
-    image: plugin-work-queue:${TAG:-latest}
+    image: plugin-work-queue:${TAG}
     build:
       context: src
       dockerfile: rust/Dockerfile
@@ -116,14 +116,14 @@ services:
 
   # should match `pulumi/infra/analyzer_executor.py`'s GraplDockerBuild
   analyzer-executor:
-    image: analyzer-executor:${TAG:-latest}
+    image: analyzer-executor:${TAG}
     build:
       context: .
       dockerfile: ./src/python/Dockerfile
       target: analyzer-executor
 
   engagement-creator:
-    image: engagement-creator:${TAG:-latest}
+    image: engagement-creator:${TAG}
     build:
       context: .
       dockerfile: ./src/python/Dockerfile
@@ -134,7 +134,7 @@ services:
   ########################################################################
 
   graphql-endpoint:
-    image: graphql-endpoint:${TAG:-latest}
+    image: graphql-endpoint:${TAG}
     build:
       context: src/js/graphql_endpoint
       dockerfile: Dockerfile
@@ -145,25 +145,25 @@ services:
   ########################################################################
 
   pulumi:
-    image: local-pulumi:${TAG:-latest}
+    image: local-pulumi:${TAG}
     build:
       context: .
       dockerfile: Dockerfile.pulumi
 
   localstack:
-    image: localstack-grapl-fork:${TAG:-latest}
+    image: localstack-grapl-fork:${TAG}
     build:
       context: localstack
       dockerfile: Dockerfile
 
   postgres:
-    image: postgres-ext:${TAG:-latest}
+    image: postgres-ext:${TAG}
     build:
       context: postgres
       dockerfile: Dockerfile
 
   provisioner:
-    image: provisioner:${TAG:-latest}
+    image: provisioner:${TAG}
     build:
       context: .
       dockerfile: ./src/python/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ volumes:
 
 services:
   pulumi:
-    image: local-pulumi:${TAG:-latest}
+    image: local-pulumi:${TAG}
     entrypoint: ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
     command:
       - |

--- a/test/docker-compose.integration-tests.build.yml
+++ b/test/docker-compose.integration-tests.build.yml
@@ -3,21 +3,21 @@ version: "3.8"
 
 services:
   rust-integration-tests:
-    image: rust-integration-tests:${TAG:-latest}
+    image: rust-integration-tests:${TAG}
     build:
       context: ${PWD}/src
       dockerfile: rust/Dockerfile
       target: integration-tests
 
   python-integration-tests:
-    image: python-integration-tests:${TAG:-latest}
+    image: python-integration-tests:${TAG}
     build:
       context: ${PWD}
       dockerfile: src/python/Dockerfile
       target: python-integration-tests
 
   e2e-tests:
-    image: e2e-tests:${TAG:-latest}
+    image: e2e-tests:${TAG}
     build:
       context: .
       dockerfile: ./src/python/Dockerfile

--- a/test/docker-compose.unit-tests-js.yml
+++ b/test/docker-compose.unit-tests-js.yml
@@ -11,7 +11,7 @@ x-common-variables:
 
 services:
   graphql-endpoint-test:
-    image: grapl/graphql-endpoint:${TAG:-latest}
+    image: grapl/graphql-endpoint:${TAG}
     build:
       context: ${PWD}/src/js/graphql_endpoint
       dockerfile: Dockerfile

--- a/test/docker-compose.unit-tests-rust.yml
+++ b/test/docker-compose.unit-tests-rust.yml
@@ -4,7 +4,7 @@ version: "3.8"
 
 services:
   rust-test:
-    image: grapl/rust-test-unit:${TAG:-latest}
+    image: grapl/rust-test-unit:${TAG}
     build:
       context: ${PWD}/src
       dockerfile: ./rust/Dockerfile


### PR DESCRIPTION
Another change made in service of ultimately revising our image build and management processes.

We had multiple places that could be injecting default or fallback values for our `TAG` environment variable, making it tricky to find any single source of truth for that information.

Now, all the fallback values are removed, with the exception of one in the `Makefile`. This will make things easier to reason about.