### PR TITLE
Update Vault address for CODECOV_TOKEN

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -61,7 +61,7 @@ steps:
       - grapl-security/vault-login#v0.1.2
       - grapl-security/vault-env#v0.1.0:
           secrets:
-            - CODECOV_TOKEN
+            - grapl/CODECOV_TOKEN
       - grapl-security/codecov#v0.1.2
     agents:
       queue: "beefy"
@@ -107,7 +107,7 @@ steps:
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - grapl/TOOLCHAIN_AUTH_TOKEN
-            - CODECOV_TOKEN
+            - grapl/CODECOV_TOKEN
       - grapl-security/codecov#v0.1.2
 
   - label: ":python::jeans: Typechecking"
@@ -127,7 +127,7 @@ steps:
       - grapl-security/vault-login#v0.1.2
       - grapl-security/vault-env#v0.1.0:
           secrets:
-            - CODECOV_TOKEN
+            - grapl/CODECOV_TOKEN
       - grapl-security/codecov#v0.1.2
 
   - label: ":typescript::yaml::lint-roller: Lint using Prettier"


### PR DESCRIPTION
I just discovered that Codecov tokens are per-repository, and not
per-organization. Previously, our `grapl` repository token was stored
in our secrets engine under simply `CODECOV_TOKEN`.

Now, we use a similar pattern to how we manage
`TOOLCHAIN_AUTH_TOKEN`s, by putting the `CODECOV_TOKEN` in a directory
that corresponds to its repository.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>