### PR TITLE
Also simplify the aws-local-only-env-vars

### DIFF
--- a/nomad/grapl-provision.nomad
+++ b/nomad/grapl-provision.nomad
@@ -10,7 +10,7 @@ variable "deployment_name" {
   description = "The deployment name"
 }
 
-variable "aws_env_vars_for_locaaws_env_vars_for_locall" {
+variable "aws_env_vars_for_local" {
   type        = string
   description = <<EOF
 With local-grapl, we have to inject:

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -80,7 +80,7 @@ def _get_aws_env_vars_for_local() -> str:
 
     # This uses the weird Mustache {{}} tags because this interpolation eventually
     # gets passed in to a template{} stanza.
-    aws_endpoint = 'http://{{ env "attr.unique.network-ip-address" }}:4566'
+    aws_endpoint = 'http://{{ env "attr.unique.network.ip-address" }}:4566'
 
     return f"""
         GRAPL_AWS_ENDPOINT          = {aws_endpoint}

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -316,7 +316,7 @@ def main() -> None:
         provision_vars = _get_subset(
             local_grapl_core_job_vars,
             {
-                "local_only_aws_env_vars",
+                "aws_env_vars_for_local",
                 "aws_region",
                 "container_images",
                 "deployment_name",

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -73,15 +73,9 @@ def main() -> None:
     ##### Business Logic
     grapl_stack = GraplStack(stack_name)
 
-    aws_config = cast(aws.config.vars._ExportableConfig, aws.config)
-    access_key = aws_config.access_key
-    secret_key = aws_config.secret_key
-
     e2e_test_job_vars: NomadVars = {
         "analyzer_bucket": grapl_stack.analyzer_bucket,
-        "aws_access_key_id": access_key,
-        "aws_access_key_secret": secret_key,
-        "_aws_endpoint": grapl_stack.aws_endpoint,
+        "aws_env_vars_for_local": grapl_stack.aws_env_vars_for_local,
         "aws_region": aws.get_region().name,
         "container_images": _e2e_container_images(
             artifacts, require_artifact=(not config.LOCAL_GRAPL)
@@ -111,9 +105,7 @@ def main() -> None:
         # Grapl repo.
 
         integration_test_job_vars: NomadVars = {
-            "aws_access_key_id": access_key,
-            "aws_access_key_secret": secret_key,
-            "_aws_endpoint": grapl_stack.aws_endpoint,
+            "aws_env_vars_for_local": grapl_stack.aws_env_vars_for_local,
             "aws_region": aws.get_region().name,
             "container_images": _integration_container_images(
                 artifacts, require_artifact=(not config.LOCAL_GRAPL)
@@ -149,9 +141,7 @@ class GraplStack:
         def require_str(key: str) -> str:
             return cast(str, ref.require_output(key))
 
-        # Only specified if LOCAL_GRAPL
-        self.aws_endpoint = cast(Optional[str], ref.get_output("aws-endpoint"))
-
+        self.aws_env_vars_for_local = require_str("aws-env-vars-for-local")
         self.analyzer_bucket = require_str("analyzers-bucket")
         self.deployment_name = require_str("deployment-name")
         self.redis_endpoint = require_str("redis-endpoint")


### PR DESCRIPTION
Some simplifications:
- Unify the 3 environment variables as one; previously we had this weird behavior of "uh yeah if 1 of them exists we use all 3"
- As such, I moved the template string up to the Pulumi level
- Export the fully templated variable so other stacks can use it (i.e. pulumi/integration_tests)
- Remove any defaults from Nomad, and pull them up to Pulumi (this makes exporting it easier)