### PR TITLE
Disable the `codecov/patch` status check

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -25,7 +25,7 @@ steps:
       - .buildkite/scripts/ensure_regenerated_constraints.sh
 
   - label: ":codecov: Validate codecov.yml"
-    command: curl --proto "=https" --tlsv1.2 --verbose --data-binary @codecov.yml https://codecov.io/validate
+    command: curl --proto "=https" --tlsv1.2 --fail-with-body --verbose --data-binary @codecov.yml https://codecov.io/validate
 
   - label: ":large_blue_square::lint-roller: Lint Protobuf"
     command:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,7 @@
 ---
 coverage:
   status:
-    patch: "off"
+    patch: false
     project:
       default:
         target: auto

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 ---
 coverage:
   status:
+    patch: "off"
     project:
       default:
         target: auto


### PR DESCRIPTION
The annotates lines of a PR that are introduced but not covered by
tests. Currently, this causes a lot noise, particularly for Pulumi
code.

I don't see a way to keep `codecov/patch` enabled, but for it to
ignore everything under `pulumi`; if we could sort that out, it may be
a preferable solution. For the time being, however, we'll just stop
doing the patch status checks.

It would be good to re-enable them in the future, however. Time for
more research!

Signed-off-by: Christopher Maier <chris@graplsecurity.com>