### PR TITLE
Pull some variables and resources out of pulumi/grapl's `if local {} else prod {}`, further unifying these two cases. 

### DIFF
--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -114,6 +114,10 @@ def main() -> None:
     if not config.LOCAL_GRAPL:
         upstream_stacks = UpstreamStacks()
         nomad_provider = get_nomad_provider_address(upstream_stacks.nomad_server)
+        # Using get_output instead of require_output so that preview passes.
+        consul_master_token_secret_id = upstream_stacks.consul.get_output(
+            "consul-master-token-secret-id"
+        )
         consul_provider = get_consul_provider_address(
             upstream_stacks.consul, {"token": consul_master_token_secret_id}
         )
@@ -368,10 +372,6 @@ def main() -> None:
         vpc_id = upstream_stacks.networking.require_output("grapl-vpc")
         subnet_ids = upstream_stacks.networking.require_output(
             "grapl-private-subnet-ids"
-        )
-        # Using get_output instead of require_output so that preview passes.
-        consul_master_token_secret_id = upstream_stacks.consul.get_output(
-            "consul-master-token-secret-id"
         )
         nomad_agent_security_group_id = upstream_stacks.nomad_agents.require_output(
             "security-group"

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -118,7 +118,6 @@ def main() -> None:
             upstream_stacks.consul, {"token": consul_master_token_secret_id}
         )
 
-
     pulumi.export("test-user-name", config.GRAPL_TEST_USER_NAME)
 
     # TODO: temporarily disabled until we can reconnect the ApiGateway to the new
@@ -365,9 +364,11 @@ def main() -> None:
         # We use stack outputs from internally developed projects
         # We assume that the stack names will match the grapl stack name
         assert upstream_stacks, "Upstream stacks previously initialized"
-        
+
         vpc_id = upstream_stacks.networking.require_output("grapl-vpc")
-        subnet_ids = upstream_stacks.networking.require_output("grapl-private-subnet-ids")
+        subnet_ids = upstream_stacks.networking.require_output(
+            "grapl-private-subnet-ids"
+        )
         # Using get_output instead of require_output so that preview passes.
         consul_master_token_secret_id = upstream_stacks.consul.get_output(
             "consul-master-token-secret-id"

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -1,7 +1,5 @@
 import sys
 
-from infra.upstream_stacks import UpstreamStacks
-
 sys.path.insert(0, "..")
 
 from typing import List, Mapping, Optional, Set, cast
@@ -32,6 +30,7 @@ from infra.postgres import Postgres
 # from infra.secret import JWTSecret, TestUserPassword
 from infra.secret import TestUserPassword
 from infra.service_queue import ServiceQueue
+from infra.upstream_stacks import UpstreamStacks
 from pulumi.resource import CustomTimeouts, ResourceOptions
 from typing_extensions import Final
 

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -184,6 +184,20 @@ def main() -> None:
         ),
     )
 
+    # To learn more about this syntax, see
+    # https://docs.rs/env_logger/0.9.0/env_logger/#enabling-logging
+    rust_log_levels = ",".join(
+        [
+            "DEBUG",
+            "h2::codec=WARN",
+            "hyper=WARN",
+            "rusoto_core=WARN",
+            "rustls=WARN",
+            "serde_xml_rs=WARN",
+        ]
+    )
+    py_log_level = "DEBUG"
+
     # These are shared across both local and prod deployments.
     nomad_inputs: Final[NomadVars] = dict(
         analyzer_bucket=analyzers_bucket.bucket,
@@ -193,6 +207,7 @@ def main() -> None:
         analyzer_matched_subgraphs_bucket=analyzer_matched_emitter.bucket_name,
         analyzer_dispatcher_dead_letter_queue=analyzer_dispatcher_queue.dead_letter_queue_url,
         aws_region=aws.get_region().name,
+        container_images=_container_images(artifacts),
         engagement_creator_queue=engagement_creator_queue.main_queue_url,
         graph_merger_queue=graph_merger_queue.main_queue_url,
         graph_merger_dead_letter_queue=graph_merger_queue.dead_letter_queue_url,
@@ -202,6 +217,8 @@ def main() -> None:
         node_identifier_retry_queue=node_identifier_queue.retry_queue_url,
         osquery_generator_queue=osquery_generator_queue.main_queue_url,
         osquery_generator_dead_letter_queue=osquery_generator_queue.dead_letter_queue_url,
+        py_log_level=py_log_level,
+        rust_log=rust_log_levels,
         schema_properties_table_name=dynamodb_tables.schema_properties_table.name,
         schema_table_name=dynamodb_tables.schema_table.name,
         session_table_name=dynamodb_tables.dynamic_session_table.name,
@@ -217,20 +234,6 @@ def main() -> None:
         plugin_s3_bucket_aws_account_id=config.AWS_ACCOUNT_ID,
         plugin_s3_bucket_name=plugins_bucket.bucket,
     )
-
-    # To learn more about this syntax, see
-    # https://docs.rs/env_logger/0.9.0/env_logger/#enabling-logging
-    rust_log_levels = ",".join(
-        [
-            "DEBUG",
-            "h2::codec=WARN",
-            "hyper=WARN",
-            "rusoto_core=WARN",
-            "rustls=WARN",
-            "serde_xml_rs=WARN",
-        ]
-    )
-    py_log_level = "DEBUG"
 
     nomad_grapl_core_timeout = "5m"
 
@@ -280,18 +283,15 @@ def main() -> None:
 
         local_grapl_core_vars: Final[NomadVars] = dict(
             aws_env_vars_for_local=aws_env_vars_for_local,
-            container_images=_container_images(artifacts),
+            redis_endpoint=redis_endpoint,
             plugin_registry_db_hostname=plugin_registry_db.hostname,
-            plugin_registry_db_password=plugin_registry_db.password,
             plugin_registry_db_port=str(plugin_registry_db.port),
             plugin_registry_db_username=plugin_registry_db.username,
+            plugin_registry_db_password=plugin_registry_db.password,
             plugin_work_queue_db_hostname=plugin_work_queue_db.hostname,
-            plugin_work_queue_db_password=plugin_work_queue_db.password,
             plugin_work_queue_db_port=str(plugin_work_queue_db.port),
             plugin_work_queue_db_username=plugin_work_queue_db.username,
-            py_log_level=py_log_level,
-            redis_endpoint=redis_endpoint,
-            rust_log=rust_log_levels,
+            plugin_work_queue_db_password=plugin_work_queue_db.password,
             **nomad_inputs,
         )
 
@@ -469,7 +469,7 @@ def main() -> None:
             # The vars with a leading underscore indicate that the hcl local version of the variable should be used
             # instead of the var version.
             aws_env_vars_for_local=aws_env_vars_for_local,
-            container_images=_container_images(artifacts),
+            redis_endpoint=cache.endpoint,
             plugin_registry_db_hostname=plugin_registry_postgres.host(),
             plugin_registry_db_port=plugin_registry_postgres.port().apply(str),
             plugin_registry_db_username=plugin_registry_postgres.username(),
@@ -478,9 +478,6 @@ def main() -> None:
             plugin_work_queue_db_port=plugin_work_queue_postgres.port().apply(str),
             plugin_work_queue_db_username=plugin_work_queue_postgres.username(),
             plugin_work_queue_db_password=plugin_work_queue_postgres.password(),
-            py_log_level=py_log_level,
-            redis_endpoint=cache.endpoint,
-            rust_log=rust_log_levels,
             **nomad_inputs,
         )
 

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -295,7 +295,7 @@ def main() -> None:
     )
 
     ConsulIntentions(
-        "grapl-core",
+        "consul-intentions",
         # consul-intentions are stored in the nomad directory so that engineers remember to create/update intentions
         # when they update nomad configs
         intention_directory=path_from_root("nomad/consul-intentions").resolve(),

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -114,6 +114,7 @@ def main() -> None:
         upstream_stacks = UpstreamStacks()
         nomad_provider = get_nomad_provider_address(upstream_stacks.nomad_server)
         # Using get_output instead of require_output so that preview passes.
+        # NOTE wimax Feb 2022: Not sure the above is still the case
         consul_master_token_secret_id = upstream_stacks.consul.get_output(
             "consul-master-token-secret-id"
         )
@@ -387,6 +388,7 @@ def main() -> None:
         nomad_agent_role = aws.iam.Role.get(
             "nomad-agent-role",
             id=upstream_stacks.nomad_agents.require_output("iam-role"),
+            # NOTE: It's somewhat odd to set a StackReference as a parent
             opts=pulumi.ResourceOptions(parent=upstream_stacks.nomad_agents),
         )
 

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -426,17 +426,6 @@ def main() -> None:
             nomad_agent_security_group_id=nomad_agent_security_group_id,
         )
 
-        pulumi.export("plugin-registry-db-hostname", plugin_registry_postgres.host())
-        pulumi.export(
-            "plugin-registry-db-port", plugin_registry_postgres.port().apply(str)
-        )
-        pulumi.export(
-            "plugin-registry-db-username", plugin_registry_postgres.username()
-        )
-        pulumi.export(
-            "plugin-registry-db-password", plugin_registry_postgres.password()
-        )
-
         pulumi.export(
             "plugin-work-queue-db-hostname", plugin_work_queue_postgres.host()
         )

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -1,5 +1,7 @@
 import sys
 
+from pulumi.infra.upstream_stacks import UpstreamStacks
+
 sys.path.insert(0, "..")
 
 from typing import List, Mapping, Optional, Set, cast
@@ -106,10 +108,11 @@ def main() -> None:
         {"pulumi:project": pulumi.get_project(), "pulumi:stack": config.STACK_NAME}
     )
 
+    upstream_stacks: Optional[UpstreamStacks] = None
     nomad_provider: Optional[pulumi.ProviderResource] = None
     if not config.LOCAL_GRAPL:
-        nomad_server_stack = pulumi.StackReference(f"grapl/nomad/{config.STACK_NAME}")
-        nomad_provider = get_nomad_provider_address(nomad_server_stack)
+        upstream_stacks = UpstreamStacks()
+        nomad_provider = get_nomad_provider_address(upstream_stacks.nomad_server_stack)
 
     pulumi.export("test-user-name", config.GRAPL_TEST_USER_NAME)
 
@@ -358,13 +361,7 @@ def main() -> None:
         ###################################
         # We use stack outputs from internally developed projects
         # We assume that the stack names will match the grapl stack name
-        consul_stack = pulumi.StackReference(f"grapl/consul/{config.STACK_NAME}")
-        networking_stack = pulumi.StackReference(
-            f"grapl/networking/{config.STACK_NAME}"
-        )
-        nomad_agents_stack = pulumi.StackReference(
-            f"grapl/nomad-agents/{config.STACK_NAME}"
-        )
+
 
         vpc_id = networking_stack.require_output("grapl-vpc")
         subnet_ids = networking_stack.require_output("grapl-private-subnet-ids")

--- a/pulumi/infra/hashicorp_provider.py
+++ b/pulumi/infra/hashicorp_provider.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping
 
 import pulumi_consul as consul
 import pulumi_nomad as nomad

--- a/pulumi/infra/hashicorp_provider.py
+++ b/pulumi/infra/hashicorp_provider.py
@@ -1,4 +1,7 @@
-from typing import Any
+from typing import Any, Mapping, Optional
+
+import pulumi_consul as consul
+import pulumi_nomad as nomad
 
 import pulumi
 
@@ -9,7 +12,7 @@ def get_hashicorp_provider_address(
     pulumi_class: Any,
     provider_type: str,
     stack: pulumi.StackReference,
-    additional_configs: dict = {},
+    additional_configs: Mapping[str, Any] = {},
 ) -> Any:
     """
     This supports getting a Provider object with an explicit address set.
@@ -22,3 +25,27 @@ def get_hashicorp_provider_address(
     override_address = pulumi.Config(provider_type).get("address")
     address = override_address or stack.require_output("address")
     return pulumi_class.Provider(provider_type, address=address, **additional_configs)
+
+
+def get_nomad_provider_address(
+    stack: pulumi.StackReference,
+    additional_configs: Mapping[str, Any] = {},
+) -> nomad.Provider:
+    return get_hashicorp_provider_address(
+        pulumi_class=nomad,
+        provider_type="nomad",
+        stack=stack,
+        additional_configs=additional_configs,
+    )
+
+
+def get_consul_provider_address(
+    stack: pulumi.StackReference,
+    additional_configs: Mapping[str, Any] = {},
+) -> nomad.Provider:
+    return get_hashicorp_provider_address(
+        pulumi_class=consul,
+        provider_type="consul",
+        stack=stack,
+        additional_configs=additional_configs,
+    )

--- a/pulumi/infra/hashicorp_provider.py
+++ b/pulumi/infra/hashicorp_provider.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping
+from typing import Any, Mapping, cast
 
 import pulumi_consul as consul
 import pulumi_nomad as nomad
@@ -31,21 +31,27 @@ def get_nomad_provider_address(
     stack: pulumi.StackReference,
     additional_configs: Mapping[str, Any] = {},
 ) -> nomad.Provider:
-    return get_hashicorp_provider_address(
-        pulumi_class=nomad,
-        provider_type="nomad",
-        stack=stack,
-        additional_configs=additional_configs,
+    return cast(
+        nomad.Provider,
+        get_hashicorp_provider_address(
+            pulumi_class=nomad,
+            provider_type="nomad",
+            stack=stack,
+            additional_configs=additional_configs,
+        ),
     )
 
 
 def get_consul_provider_address(
     stack: pulumi.StackReference,
     additional_configs: Mapping[str, Any] = {},
-) -> nomad.Provider:
-    return get_hashicorp_provider_address(
-        pulumi_class=consul,
-        provider_type="consul",
-        stack=stack,
-        additional_configs=additional_configs,
+) -> consul.Provider:
+    return cast(
+        consul.Provider,
+        get_hashicorp_provider_address(
+            pulumi_class=consul,
+            provider_type="consul",
+            stack=stack,
+            additional_configs=additional_configs,
+        ),
     )

--- a/pulumi/infra/upstream_stacks.py
+++ b/pulumi/infra/upstream_stacks.py
@@ -1,0 +1,13 @@
+import pulumi
+from infra import config
+
+class UpstreamStacks:
+    def __init__(self) -> None:
+        self.consul_stack = pulumi.StackReference(f"grapl/consul/{config.STACK_NAME}")
+        self.nomad_server_stack = pulumi.StackReference(f"grapl/nomad/{config.STACK_NAME}")
+        self.networking_stack = pulumi.StackReference(
+            f"grapl/networking/{config.STACK_NAME}"
+        )
+        self.nomad_agents_stack = pulumi.StackReference(
+            f"grapl/nomad-agents/{config.STACK_NAME}"
+        )

--- a/pulumi/infra/upstream_stacks.py
+++ b/pulumi/infra/upstream_stacks.py
@@ -3,11 +3,11 @@ from infra import config
 
 class UpstreamStacks:
     def __init__(self) -> None:
-        self.consul_stack = pulumi.StackReference(f"grapl/consul/{config.STACK_NAME}")
-        self.nomad_server_stack = pulumi.StackReference(f"grapl/nomad/{config.STACK_NAME}")
-        self.networking_stack = pulumi.StackReference(
+        self.consul = pulumi.StackReference(f"grapl/consul/{config.STACK_NAME}")
+        self.nomad_server = pulumi.StackReference(f"grapl/nomad/{config.STACK_NAME}")
+        self.networking = pulumi.StackReference(
             f"grapl/networking/{config.STACK_NAME}"
         )
-        self.nomad_agents_stack = pulumi.StackReference(
+        self.nomad_agents = pulumi.StackReference(
             f"grapl/nomad-agents/{config.STACK_NAME}"
         )

--- a/pulumi/infra/upstream_stacks.py
+++ b/pulumi/infra/upstream_stacks.py
@@ -1,13 +1,13 @@
-import pulumi
 from infra import config
+
+import pulumi
+
 
 class UpstreamStacks:
     def __init__(self) -> None:
         self.consul = pulumi.StackReference(f"grapl/consul/{config.STACK_NAME}")
         self.nomad_server = pulumi.StackReference(f"grapl/nomad/{config.STACK_NAME}")
-        self.networking = pulumi.StackReference(
-            f"grapl/networking/{config.STACK_NAME}"
-        )
+        self.networking = pulumi.StackReference(f"grapl/networking/{config.STACK_NAME}")
         self.nomad_agents = pulumi.StackReference(
             f"grapl/nomad-agents/{config.STACK_NAME}"
         )

--- a/pulumi/infra/upstream_stacks.py
+++ b/pulumi/infra/upstream_stacks.py
@@ -3,6 +3,9 @@ from infra import config
 import pulumi
 
 
+# Not sure if this is an issue yet, but we may need to eventually look into
+# making this class a singleton. Pulumi gets cranky if you try to create
+# multiple stack references to the same stack in a single run.
 class UpstreamStacks:
     def __init__(self) -> None:
         self.consul = pulumi.StackReference(f"grapl/consul/{config.STACK_NAME}")

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -10,7 +10,7 @@ from infra import config
 from infra.artifacts import ArtifactGetter
 from infra.autotag import register_auto_tags
 from infra.docker_images import DockerImageId, DockerImageIdBuilder
-from infra.get_hashicorp_provider_address import get_nomad_provider_address
+from infra.hashicorp_provider import get_nomad_provider_address
 from infra.nomad_job import NomadJob, NomadVars
 from infra.path import path_from_root
 

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -6,12 +6,11 @@ import os
 from typing import Mapping, Optional, cast
 
 import pulumi_aws as aws
-import pulumi_nomad as nomad
 from infra import config
 from infra.artifacts import ArtifactGetter
 from infra.autotag import register_auto_tags
 from infra.docker_images import DockerImageId, DockerImageIdBuilder
-from infra.get_hashicorp_provider_address import get_hashicorp_provider_address
+from infra.get_hashicorp_provider_address import get_nomad_provider_address
 from infra.nomad_job import NomadJob, NomadVars
 from infra.path import path_from_root
 
@@ -67,9 +66,7 @@ def main() -> None:
     nomad_provider: Optional[pulumi.ProviderResource] = None
     if not config.LOCAL_GRAPL:
         nomad_server_stack = pulumi.StackReference(f"grapl/nomad/{stack_name}")
-        nomad_provider = get_hashicorp_provider_address(
-            nomad, "nomad", nomad_server_stack
-        )
+        nomad_provider = get_nomad_provider_address(nomad_server_stack)
 
     ##### Business Logic
     grapl_stack = GraplStack(stack_name)


### PR DESCRIPTION

This further reduces chance of https://github.com/grapl-security/grapl/pull/1486 type whifs by unifying the if-else branch for local and prod

you'll likely want to go through it commit-by-commit cm style
