### PR TITLE
Assorted Makefile cleanups and refactorings

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -141,6 +141,11 @@ steps:
   - label: ":hammer: Integration Tests"
     command:
       - make test-integration
+    plugins:
+      - grapl-security/vault-login#v0.1.2
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - grapl/TOOLCHAIN_AUTH_TOKEN
     env:
       GRAPL_LOG_LEVEL: "DEBUG"
     agents:
@@ -151,6 +156,11 @@ steps:
   - label: ":hammer: E2E Tests"
     command:
       - make test-e2e
+    plugins:
+      - grapl-security/vault-login#v0.1.2
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - grapl/TOOLCHAIN_AUTH_TOKEN
     env:
       GRAPL_LOG_LEVEL: "DEBUG"
       DUMP_ARTIFACTS: "True"

--- a/.buildkite/scripts/build_and_upload_containers.sh
+++ b/.buildkite/scripts/build_and_upload_containers.sh
@@ -49,7 +49,7 @@ cloudsmith_tag() {
 }
 
 echo "--- Building all ${TAG} images"
-make build-test-e2e
+make build-for-push
 
 for service in "${services[@]}"; do
     # Re-tag the container we just built so we can upload it to

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,10 @@ build-test-integration: build
 
 .PHONY: build-test-e2e
 build-test-e2e: build
-	./pants package ./src/python/e2e-test-runner/e2e_test_runner:pex
+# Any PEX tagged with `e2e-test-pex` is required for our image. This
+# seems like the most straightforward way of capturing these
+# dependencies at the moment.
+	./pants --tag="e2e-test-pex" package ::
 	$(DOCKER_BUILDX_BAKE) \
 		--file ./test/docker-compose.integration-tests.build.yml \
 		e2e-tests

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,8 @@ build-test-unit-js:
 build-test-integration: build
 	$(DOCKER_BUILDX_BAKE) \
 		--file ./test/docker-compose.integration-tests.build.yml \
-		python-integration-tests rust-integration-tests
+		python-integration-tests \
+		rust-integration-tests
 
 .PHONY: build-test-e2e
 build-test-e2e: build

--- a/nomad/bin/run_parameterized_job.sh
+++ b/nomad/bin/run_parameterized_job.sh
@@ -29,7 +29,7 @@ await_nomad_job_finish "grapl-provision" 60 "Grapl Provision"
 
 # Now we have to actually dispatch a job; Pulumi simply uploaded
 # the jobspec, since it's a Parameterized Batch Job.
-echo -e "\n+++ Dispatching Nomad job: ${job_to_dispatch}"
+echo -e "--- Dispatching Nomad job: ${job_to_dispatch}"
 
 job_id=$(nomad_dispatch "${job_to_dispatch}")
 echo "You can view job progress at $(url_to_nomad_job_in_ui "${job_id}")"

--- a/nomad/local/nomad_run_local_infra.sh
+++ b/nomad/local/nomad_run_local_infra.sh
@@ -21,7 +21,7 @@ declare -a NOMAD_VARS=(
 # shellcheck source-path=SCRIPTDIR
 source "${THIS_DIR}/../lib/nomad_cli_tools.sh"
 
-echo "--- Deploying Nomad local infrastructure."
+echo "Deploying Nomad local infrastructure"
 
 # Wait a short period of time before attempting to deploy infrastructure
 # shellcheck disable=SC2016
@@ -49,4 +49,4 @@ echo "Nomad Job Run complete, checking for task failures"
 
 check_for_task_failures_in_job "grapl-local-infra"
 
-echo "--- Nomad local-infra deployed!"
+echo "Nomad local-infra deployed!"

--- a/src/js/engagement_view/Makefile
+++ b/src/js/engagement_view/Makefile
@@ -32,11 +32,9 @@ build-env-image:
 
 # This will run every time, because all PHONYs (e.g. build-env-image) run every time.
 node_modules: build-env-image package.json yarn.lock
-	echo "--- Installing node_modules"
 	$(DOCKER_RUN) yarn install
 
 build: node_modules $(ASSET_DIRS) $(ASSET_FILES)
-	echo "--- Building engagement_view"
 	$(DOCKER_RUN) yarn build
 
 .PHONY: test

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -46,7 +46,7 @@ COPY --chown=grapl ./etc/sample_data/ etc/sample_data
 
 # Copy in `graplctl`, which does the actual uploading during e2e
 RUN mkdir -p /home/grapl/bin
-COPY --chown=grapl ./bin/graplctl /home/grapl/bin/graplctl
+COPY --chown=grapl dist/src.python.graplctl.graplctl/graplctl.pex /home/grapl/bin/graplctl
 
 COPY --chown=grapl ./dist/e2e-tests.pex .
 CMD ["./e2e-tests.pex"]

--- a/src/python/e2e-test-runner/e2e_test_runner/BUILD
+++ b/src/python/e2e-test-runner/e2e_test_runner/BUILD
@@ -7,4 +7,5 @@ pex_binary(
     # Explicit `dependencies` needed, because `pytest` picks up tests
     # dynamically, not by explicit imports
     dependencies=[":test_files"],
+    tags=["e2e-test-pex"],
 )

--- a/src/python/graplctl/graplctl/BUILD
+++ b/src/python/graplctl/graplctl/BUILD
@@ -4,4 +4,5 @@ python_sources(
 
 pex_binary(
     entry_point="cli.py:main",
+    tags=["e2e-test-pex"],
 )


### PR DESCRIPTION
In the course of reworking some Docker-related stuff, it became apparent that our existing Makefile targets were a bit more complicated than necessary. They have now been rearranged to better reflect the true underlying dependency structure.

I also added some additional logging output for the benefit of our Buildkite runs of our integration and e2e tests, as well as enabled our remote build cache for those tests, which should help speed things up a bit.

Read the individual commits for further details.