### PR TITLE
Update Rust Version

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -4,7 +4,7 @@ env:
   BUILDKITE_PLUGIN_VAULT_ENV_SECRET_PREFIX: "secret/data/buildkite/env"
   # TODO: Figure out a way for this to be sourced from our
   # rust-toolchain file
-  RUST_VERSION: 1.58.1
+  RUST_VERSION: 1.59.0
 
 # TODO: Cache for JS, Rust deps
 

--- a/src/rust/analyzer-dispatcher/src/dispatch_event.rs
+++ b/src/rust/analyzer-dispatcher/src/dispatch_event.rs
@@ -71,11 +71,7 @@ impl CompletionEventSerializer for AnalyzerDispatchSerializer {
         &mut self,
         completed_events: &[Self::CompletedEvent],
     ) -> Result<Vec<Self::Output>, Self::Error> {
-        let unique_events: Vec<_> = completed_events
-            .iter()
-            .map(|e| &e.events)
-            .flatten()
-            .collect();
+        let unique_events: Vec<_> = completed_events.iter().flat_map(|e| &e.events).collect();
 
         let mut final_subgraph = MergedGraph::new();
 

--- a/src/rust/bin/format
+++ b/src/rust/bin/format
@@ -14,7 +14,7 @@ set -euo pipefail
 # Note that you will need your Rustup profile set to something higher
 # than "minimal" (e.g., "default"), since `rustup` isn't included in
 # "minimal".
-export RUSTUP_TOOLCHAIN="nightly-2022-01-30"
+export RUSTUP_TOOLCHAIN="nightly-2022-02-24"
 
 # Default to checking formatting in the absence of any options.
 mode="check"

--- a/src/rust/generators/sysmon-generator/src/models/process/create.rs
+++ b/src/rust/generators/sysmon-generator/src/models/process/create.rs
@@ -148,8 +148,7 @@ mod tests {
         let a_edges = graph.edges.get(process_a.get_node_key());
         let edge_to_b = a_edges
             .iter()
-            .map(|e| e.edges.iter())
-            .flatten()
+            .flat_map(|e| e.edges.iter())
             .find(|e| e.to_node_key == process_b.get_node_key());
         let edge_to_b = edge_to_b.expect("missing edge to b");
         assert_eq!(edge_to_b.edge_name, "children");

--- a/src/rust/rust-toolchain.toml
+++ b/src/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.58.1"
+channel = "1.59.0"
 components = ["cargo", "clippy", "rustc", "rustfmt", "rust-src"]


### PR DESCRIPTION
Update Rust to 1.59.0

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖