### PR TITLE
Add a Dockerized way to build a rootfs. Currently, the rootfs just contains a dummy file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -507,3 +507,7 @@ generate-sqlx-data:  # Regenerate sqlx-data.json based on queries made in Rust c
 # Intentionally not phony, as this generates a real file
 dist/firecracker_kernel.tar.gz: firecracker/generate_firecracker_kernel.sh
 	./firecracker/generate_firecracker_kernel.sh
+
+FIRECRACKER_ROOTFS_DEPENDENCIES = $(shell find firecracker/rootfs)
+dist/firecracker_rootfs.tar.gz: $(FIRECRACKER_ROOTFS_DEPENDENCIES)
+	./firecracker/rootfs/generate_firecracker_rootfs.sh

--- a/firecracker/rootfs/Dockerfile.rootfs
+++ b/firecracker/rootfs/Dockerfile.rootfs
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1.3-labs
+
+FROM debian:bullseye-slim AS rootfs-build
+
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rootfs-apt <<EOF
+    apt update
+    apt install --yes \
+        fuse\
+        fuseext2
+EOF
+
+COPY docker_runtime docker_runtime
+
+ENTRYPOINT [ "./docker_runtime/create_rootfs_image.sh" ]

--- a/firecracker/rootfs/bake.hcl
+++ b/firecracker/rootfs/bake.hcl
@@ -1,0 +1,7 @@
+target "rootfs-build" {
+  context    = "."
+  dockerfile = "Dockerfile.rootfs"
+  tags = [
+    "rootfs-build:dev"
+  ]
+}

--- a/firecracker/rootfs/docker_runtime/create_rootfs_image.sh
+++ b/firecracker/rootfs/docker_runtime/create_rootfs_image.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -o xtrace
+
+readonly IMAGE="/tmp/rootfs.ext4"
+readonly MOUNT_POINT="/tmp/rootfs-mount"
+readonly DIST_FILE="/dist/firecracker_rootfs.tar.gz"
+
+########################################
+# Create image and mount it.
+########################################
+# make a 50mb empty file
+dd if=/dev/zero of="${IMAGE}" bs=1M count=50
+
+# format that filesystem
+/sbin/mkfs.ext4 "${IMAGE}"
+
+# make a mount-point
+mkdir "${MOUNT_POINT}"
+
+# Mount
+mount -t fuse-ext2 -o rw+ "${IMAGE}" "${MOUNT_POINT}"
+
+########################################
+# Mutate image
+########################################
+(
+    cd "${MOUNT_POINT}"
+    echo "hello :)" > hello.txt
+)
+
+########################################
+# Copy rootfs into dist.
+########################################
+# -u is unmount; there is no -- version
+fusermount -u "${MOUNT_POINT}"
+tar --create --gzip --file="${DIST_FILE}" "${IMAGE}"

--- a/firecracker/rootfs/generate_firecracker_rootfs.sh
+++ b/firecracker/rootfs/generate_firecracker_rootfs.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
+readonly THIS_DIR
+
+REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
+readonly REPOSITORY_ROOT
+
+(
+    cd "${THIS_DIR}"
+    docker buildx bake -f bake.hcl rootfs-build
+)
+
+########################################
+# Generate the rootfs.
+# We use Fuse to mount inside Docker.
+########################################
+docker run \
+    --rm \
+    --device /dev/fuse \
+    --cap-add SYS_ADMIN \
+    --volume "${REPOSITORY_ROOT}/dist:/dist" \
+    rootfs-build:dev


### PR DESCRIPTION

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/742

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Provide a mechanism to generate a `dist/firecracker_rootfs.tar.gz`

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Ran `make dist/firecracker_rootfs.tar.gz` in a few different scenarios (files changed, or dist file removed).

I've mounted the resulting file (ungzipped) and it contains the hello.txt as expected. 

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
