### PR TITLE
Assorted Makefile cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ build-e2e-pex-files:
 # Any PEX tagged with `e2e-test-pex` is required for our image. This
 # seems like the most straightforward way of capturing these
 # dependencies at the moment.
-	@echo "--- Building e2e pex files"
+	@echo "--- Building e2e PEX files"
 	./pants --tag="e2e-test-pex" package ::
 
 .PHONY: build-engagement-view

--- a/Makefile
+++ b/Makefile
@@ -405,32 +405,41 @@ lint-shell: ## Run Shell lint checks
 
 ##@ Formatting 💅
 
+.PHONY: format
+format: format-build
+format: format-hcl
+format: format-prettier
+format: format-python
+format: format-rust
+format: format-shell
+format: ## Reformat all code
+
+.PHONY: format-build
+format-build: ## Reformat all Pants BUILD files
+	./pants update-build-files --no-update-build-files-fix-safe-deprecations
+
+.PHONY: format-hcl
+format-hcl: ## Reformat all HCL files
+	${NONROOT_DOCKER_COMPOSE_CHECK} hcl-format
+
+.PHONY: format-prettier
+format-prettier: build-prettier-image
+format-prettier: ## Reformat js/ts/yaml
+	${NONROOT_DOCKER_COMPOSE_CHECK} prettier-format
+
+.PHONY: format-python
+format-python: ## Reformat all Python code
+	./pants filter --target-type=python_sources,python_tests :: \
+		| xargs ./pants fmt
+
 .PHONY: format-rust
 format-rust: ## Reformat all Rust code
 	cd src/rust; bin/format --update
 
-.PHONY: format-python
-format-python: ## Reformat all Python code
-	./pants filter --target-type=python_sources,python_tests :: | xargs ./pants fmt
-
 .PHONY: format-shell
 format-shell: ## Reformat all shell code
-	./pants filter --target-type=shell_sources,shunit2_tests :: | xargs ./pants fmt
-
-.PHONY: format-prettier
-format-prettier: build-prettier-image ## Reformat js/ts/yaml
-	${NONROOT_DOCKER_COMPOSE_CHECK} prettier-format
-
-.PHONY: format-hcl
-format-hcl: ## Reformat all HCLs
-	${NONROOT_DOCKER_COMPOSE_CHECK} hcl-format
-
-.PHONY: format-build
-format-build: ## Reformat BUILD files
-	./pants update-build-files --no-update-build-files-fix-safe-deprecations
-
-.PHONY: format ## Reformat all code
-format: format-python format-shell format-prettier format-rust format-hcl format-build
+	./pants filter --target-type=shell_sources,shunit2_tests :: \
+		| xargs ./pants fmt
 
 ##@ Local Grapl 💻
 

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@
 
 .DEFAULT_GOAL := help
 
--include .env
-
 # This variable is used in a few places, most notably
 # docker-bake.hcl. You can read more about it there, but the TL;DR is
 # that you'll need to set this to a proper version (not "", "latest",
@@ -21,10 +19,6 @@ GID = $(shell id --group)
 PWD = $(shell pwd)
 GRAPL_ROOT = ${PWD}
 COMPOSE_USER=${UID}:${GID}
-DOCKER_BUILDX_BAKE_OPTS ?=
-ifneq ($(GRAPL_RUST_ENV_FILE),)
-DOCKER_BUILDX_BAKE_OPTS += --set *.secrets=id=rust_env,src="$(GRAPL_RUST_ENV_FILE)"
-endif
 COMPOSE_IGNORE_ORPHANS=1
 COMPOSE_PROJECT_NAME ?= grapl
 export
@@ -33,7 +27,7 @@ export EVERY_COMPOSE_FILE=--file docker-compose.yml \
 	--file ./test/docker-compose.unit-tests-rust.yml \
 	--file ./test/docker-compose.unit-tests-js.yml \
 
-DOCKER_BUILDX_BAKE := docker buildx bake $(DOCKER_BUILDX_BAKE_OPTS)
+DOCKER_BUILDX_BAKE := docker buildx bake
 
 # Helper macro to make using the HCL file for builds less
 # verbose. Once we get rid of docker-compose.yml, we can just use

--- a/Makefile
+++ b/Makefile
@@ -386,8 +386,17 @@ lint-python: ## Run Python lint checks
 		| xargs ./pants lint
 
 .PHONY: lint-rust
+lint-rust: lint-rust-clippy
+lint-rust: lint-rust-rustfmt
 lint-rust: ## Run Rust lint checks
-	cd src/rust; bin/format --check; bin/lint
+
+.PHONY: lint-rust-clippy
+lint-rust-clippy: ## Run Clippy on Rust code
+	cd src/rust; bin/lint
+
+.PHONY: lint-rust-rustfmt
+lint-rust-rustfmt: ## Check to see if Rust code is properly formatted
+	cd src/rust; bin/format --check
 
 .PHONY: lint-shell
 lint-shell: ## Run Shell lint checks

--- a/Makefile
+++ b/Makefile
@@ -147,15 +147,15 @@ help: ## Print this help
 build-test-unit: build-test-unit-js
 build-test-unit: build-test-unit-rust
 
-.PHONY: build-test-unit-rust
-build-test-unit-rust:
-	$(DOCKER_BUILDX_BAKE) \
-		--file ./test/docker-compose.unit-tests-rust.yml
-
 .PHONY: build-test-unit-js
 build-test-unit-js:
 	$(DOCKER_BUILDX_BAKE) \
 		--file ./test/docker-compose.unit-tests-js.yml
+
+.PHONY: build-test-unit-rust
+build-test-unit-rust:
+	$(DOCKER_BUILDX_BAKE) \
+		--file ./test/docker-compose.unit-tests-rust.yml
 
 # Build Service Images and their Prerequisites
 ########################################################################

--- a/Makefile
+++ b/Makefile
@@ -150,10 +150,6 @@ help: ## Print this help
 
 ##@ Build 🔨
 
-.PHONY: build-test-unit
-build-test-unit: build-test-unit-js
-build-test-unit: build-test-unit-rust
-
 .PHONY: build-test-unit-js
 build-test-unit-js:
 	$(DOCKER_BUILDX_BAKE) \

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,11 @@ export EVERY_COMPOSE_FILE=--file docker-compose.yml \
 	--file ./test/docker-compose.unit-tests-rust.yml \
 	--file ./test/docker-compose.unit-tests-js.yml \
 
-DOCKER_BUILDX_BAKE := docker buildx bake
-
 # Helper macro to make using the HCL file for builds less
 # verbose. Once we get rid of docker-compose.yml, we can just use
-# ${DOCKER_BUILDX_BAKE}, since it will pick up the HCL file
+# `docker buildx bake`, since it will pick up the HCL file
 # automatically.
-DOCKER_BUILDX_BAKE_HCL := ${DOCKER_BUILDX_BAKE} --file=docker-bake.hcl
+DOCKER_BUILDX_BAKE_HCL := docker buildx bake --file=docker-bake.hcl
 
 COMPOSE_PROJECT_INTEGRATION_TESTS := grapl-integration_tests
 COMPOSE_PROJECT_E2E_TESTS := grapl-e2e_tests
@@ -150,12 +148,12 @@ help: ## Print this help
 
 .PHONY: build-test-unit-js
 build-test-unit-js:
-	$(DOCKER_BUILDX_BAKE) \
+	docker buildx bake \
 		--file ./test/docker-compose.unit-tests-js.yml
 
 .PHONY: build-test-unit-rust
 build-test-unit-rust:
-	$(DOCKER_BUILDX_BAKE) \
+	docker buildx bake \
 		--file ./test/docker-compose.unit-tests-rust.yml
 
 # Build Service Images and their Prerequisites
@@ -220,13 +218,13 @@ build-test-e2e: build-e2e-pex-files
 .PHONY: build-test-integration
 build-test-integration:
 	@echo "--- Building integration test images"
-	$(DOCKER_BUILDX_BAKE) integration-tests
+	docker buildx bake integration-tests
 
 ########################################################################
 
 .PHONY: build-prettier-image
 build-prettier-image:
-	$(DOCKER_BUILDX_BAKE) --file ./docker-compose.check.yml prettier
+	docker buildx bake --file ./docker-compose.check.yml prettier
 
 .PHONY: graplctl
 graplctl: ## Build graplctl and install it to ./bin

--- a/Makefile
+++ b/Makefile
@@ -144,10 +144,8 @@ help: ## Print this help
 ##@ Build 🔨
 
 .PHONY: build-test-unit
-build-test-unit:
-	$(DOCKER_BUILDX_BAKE) \
-		--file ./test/docker-compose.unit-tests-rust.yml \
-		--file ./test/docker-compose.unit-tests-js.yml
+build-test-unit: build-test-unit-js
+build-test-unit: build-test-unit-rust
 
 .PHONY: build-test-unit-rust
 build-test-unit-rust:

--- a/Makefile
+++ b/Makefile
@@ -347,29 +347,30 @@ test-with-env: # (Do not include help text - not to be used directly)
 
 ##@ Lint 🧹
 
+.PHONY: lint
+lint: lint-docker
+lint: lint-hcl
+lint: lint-prettier
+lint: lint-proto
+lint: lint-proto-breaking
+lint: lint-python
+lint: lint-rust
+lint: lint-shell
+lint: ## Run all lint checks
+
 .PHONY: lint-docker
 lint-docker: ## Lint Dockerfiles with Hadolint
-	./pants filter --target-type=docker_image :: | xargs ./pants lint
-
-.PHONY: lint-rust
-lint-rust: ## Run Rust lint checks
-	cd src/rust; bin/format --check; bin/lint
-
-.PHONY: lint-python
-lint-python: ## Run Python lint checks
-	./pants filter --target-type=python_sources,python_tests :: | xargs ./pants lint
-
-.PHONY: lint-shell
-lint-shell: ## Run Shell lint checks
-	./pants filter --target-type=shell_sources,shunit2_tests :: | xargs ./pants lint
-
-.PHONY: lint-prettier
-lint-prettier: build-prettier-image ## Run ts/js/yaml lint checks
-	${NONROOT_DOCKER_COMPOSE_CHECK} prettier-lint
+	./pants filter --target-type=docker_image :: \
+		| xargs ./pants lint
 
 .PHONY: lint-hcl
 lint-hcl: ## Check to see if HCL files are formatted properly
 	${NONROOT_DOCKER_COMPOSE_CHECK} hcl-lint
+
+.PHONY: lint-prettier
+lint-prettier: build-prettier-image
+lint-prettier: ## Run ts/js/yaml lint checks
+	${NONROOT_DOCKER_COMPOSE_CHECK} prettier-lint
 
 .PHONY: lint-proto
 lint-proto: ## Lint all protobuf definitions
@@ -379,8 +380,19 @@ lint-proto: ## Lint all protobuf definitions
 lint-proto-breaking: ## Check protobuf definitions for breaking changes
 	${DOCKER_COMPOSE_CHECK} buf-breaking-change
 
-.PHONY: lint
-lint: lint-docker lint-python lint-prettier lint-rust lint-shell lint-hcl lint-proto lint-proto-breaking ## Run all lint checks
+.PHONY: lint-python
+lint-python: ## Run Python lint checks
+	./pants filter --target-type=python_sources,python_tests :: \
+		| xargs ./pants lint
+
+.PHONY: lint-rust
+lint-rust: ## Run Rust lint checks
+	cd src/rust; bin/format --check; bin/lint
+
+.PHONY: lint-shell
+lint-shell: ## Run Shell lint checks
+	./pants filter --target-type=shell_sources,shunit2_tests :: \
+		| xargs ./pants lint
 
 ##@ Formatting 💅
 

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@
 # `latest` tag from the host machine.)
 IMAGE_TAG ?= dev
 RUST_BUILD ?= debug
-UID = $(shell id -u)
-GID = $(shell id -g)
+UID = $(shell id --user)
+GID = $(shell id --group)
 PWD = $(shell pwd)
 GRAPL_ROOT = ${PWD}
 COMPOSE_USER=${UID}:${GID}

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ build-test-unit-rust:
 
 .PHONY: build-service-pex-files
 build-service-pex-files: ## Build all PEX files needed by Grapl SaaS services
+	@echo "--- Building Grapl service PEX files"
 	./pants --tag="service-pex" package ::
 
 .PHONY: build-e2e-pex-files

--- a/Makefile
+++ b/Makefile
@@ -297,9 +297,10 @@ typecheck: ## Typecheck Python Code
 	./pants check ::
 
 .PHONY: test-integration
-test-integration: ## Build and run integration tests
+test-integration: build-local-infrastructure
+test-integration: build-test-integration
 test-integration: export COMPOSE_PROJECT_NAME := $(COMPOSE_PROJECT_INTEGRATION_TESTS)
-test-integration: build-local-infrastructure build-test-integration
+test-integration: ## Build and run integration tests
 	@$(WITH_LOCAL_GRAPL_ENV)
 	$(MAKE) test-with-env EXEC_TEST_COMMAND="nomad/bin/run_parameterized_job.sh integration-tests 9"
 
@@ -308,9 +309,10 @@ test-grapl-template-generator:  # Test that the Grapl Template Generator spits o
 	./src/python/grapl-template-generator/grapl_template_generator_tests/integration_test.sh
 
 .PHONY: test-e2e
-test-e2e: ## Build and run e2e tests
+test-e2e: build-local-infrastructure
+test-e2e: build-test-e2e
 test-e2e: export COMPOSE_PROJECT_NAME := $(COMPOSE_PROJECT_E2E_TESTS)
-test-e2e: build-local-infrastructure build-test-e2e
+test-e2e: ## Build and run e2e tests
 	@$(WITH_LOCAL_GRAPL_ENV)
 	$(MAKE) test-with-env EXEC_TEST_COMMAND="nomad/bin/run_parameterized_job.sh e2e-tests 6"
 

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ PANTS_PYTHON_FILTER := ./pants filter --target-type=python_sources,python_tests 
 # Run a Pants goal across all shell files
 PANTS_SHELL_FILTER := ./pants filter --target-type=shell_sources,shunit2_tests :: | xargs ./pants
 
+# Helper macro for invoking a target from src/js/engagement_view/Makefile
+ENGAGEMENT_VIEW_MAKE = $(MAKE) --directory=src/js/engagement_view
+
 # Use a single shell for each of our targets, which allows us to use the 'trap'
 # built-in in our targets. We set the 'errexit' shell option to preserve
 # execution behavior, where failure from one line in a target will result in
@@ -189,7 +192,7 @@ build-e2e-pex-files:
 .PHONY: build-engagement-view
 build-engagement-view: ## Build website assets to include in grapl-web-ui
 	@echo "--- Building the engagement view"
-	$(MAKE) -C src/js/engagement_view build
+	$(ENGAGEMENT_VIEW_MAKE) build
 	cp -r \
 		"${PWD}/src/js/engagement_view/build/." \
 		"${PWD}/src/rust/grapl-web-ui/frontend/"
@@ -275,7 +278,7 @@ test-unit-js: ## Build and run unit tests - JavaScript only
 
 .PHONY: test-unit-engagement-view
 test-unit-engagement-view: ## Test Engagement View
-	$(MAKE) -C src/js/engagement_view test
+	$(ENGAGEMENT_VIEW_MAKE) test
 
 .PHONY: test-unit-python
 # Long term, it would be nice to organize the tests with Pants
@@ -508,7 +511,7 @@ clean: ## Prune all docker build cache and remove Grapl containers and images
 	# Remove all Grapl images = continue on error (no images found)
 	docker rmi --force $$(docker images --filter reference="grapl/*" --quiet) 2>/dev/null || true
 	# Clean Engagement View
-	$(MAKE) -C src/js/engagement_view clean
+	$(ENGAGEMENT_VIEW_MAKE) clean
 
 .PHONY: clean-mount-cache
 clean-mount-cache: ## Prune all docker mount cache (used by sccache)

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,11 @@ COMPOSE_PROJECT_E2E_TESTS := grapl-e2e_tests
 DOCKER_COMPOSE_CHECK := docker-compose --file=docker-compose.check.yml run --rm
 NONROOT_DOCKER_COMPOSE_CHECK := ${DOCKER_COMPOSE_CHECK} --user=${COMPOSE_USER}
 
+# Run a Pants goal across all Python files
+PANTS_PYTHON_FILTER := ./pants filter --target-type=python_sources,python_tests :: | xargs ./pants
+# Run a Pants goal across all shell files
+PANTS_SHELL_FILTER := ./pants filter --target-type=shell_sources,shunit2_tests :: | xargs ./pants
+
 # Use a single shell for each of our targets, which allows us to use the 'trap'
 # built-in in our targets. We set the 'errexit' shell option to preserve
 # execution behavior, where failure from one line in a target will result in
@@ -139,7 +144,6 @@ help: ## Print this help
 		 /^##@/ { printf "\n${FMT_BOLD}%s${FMT_END}\n", substr($$0, 5) } ' \
 		 $(MAKEFILE_LIST)
 	@printf '\n'
-
 
 ##@ Build 🔨
 
@@ -382,8 +386,7 @@ lint-proto-breaking: ## Check protobuf definitions for breaking changes
 
 .PHONY: lint-python
 lint-python: ## Run Python lint checks
-	./pants filter --target-type=python_sources,python_tests :: \
-		| xargs ./pants lint
+	$(PANTS_PYTHON_FILTER) lint
 
 .PHONY: lint-rust
 lint-rust: lint-rust-clippy
@@ -400,8 +403,7 @@ lint-rust-rustfmt: ## Check to see if Rust code is properly formatted
 
 .PHONY: lint-shell
 lint-shell: ## Run Shell lint checks
-	./pants filter --target-type=shell_sources,shunit2_tests :: \
-		| xargs ./pants lint
+	$(PANTS_SHELL_FILTER) lint
 
 ##@ Formatting 💅
 
@@ -429,8 +431,7 @@ format-prettier: ## Reformat js/ts/yaml
 
 .PHONY: format-python
 format-python: ## Reformat all Python code
-	./pants filter --target-type=python_sources,python_tests :: \
-		| xargs ./pants fmt
+	$(PANTS_PYTHON_FILTER) fmt
 
 .PHONY: format-rust
 format-rust: ## Reformat all Rust code
@@ -438,8 +439,7 @@ format-rust: ## Reformat all Rust code
 
 .PHONY: format-shell
 format-shell: ## Reformat all shell code
-	./pants filter --target-type=shell_sources,shunit2_tests :: \
-		| xargs ./pants fmt
+	$(PANTS_SHELL_FILTER) fmt
 
 ##@ Local Grapl 💻
 

--- a/Makefile
+++ b/Makefile
@@ -260,10 +260,14 @@ test-unit: ## Build and run all unit tests
 
 .PHONY: test-unit-js
 test-unit-js: test-unit-engagement-view
-test-unit-js: build-test-unit-js
-test-unit-js: export COMPOSE_PROJECT_NAME := grapl-test-unit-js
-test-unit-js: export COMPOSE_FILE := ./test/docker-compose.unit-tests-js.yml
+test-unit-js: test-unit-graphql-endpoint
 test-unit-js: ## Build and run unit tests - JavaScript only
+
+.PHONY: test-unit-graphql-endpoint
+test-unit-graphql-endpoint: build-test-unit-js
+test-unit-graphql-endpoint: export COMPOSE_PROJECT_NAME := grapl-test-unit-js
+test-unit-graphql-endpoint: export COMPOSE_FILE := ./test/docker-compose.unit-tests-js.yml
+test-unit-graphql-endpoint: ## Test Graphql Endpoint
 	test/docker-compose-with-error.sh
 
 .PHONY: test-unit-engagement-view

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,8 @@ build-engagement-view: ## Build website assets to include in grapl-web-ui
 		"${PWD}/src/rust/grapl-web-ui/frontend/"
 
 .PHONY: build-grapl-service-prerequisites
+
+build-grapl-service-prerequisites: ## Build all assets needed for the creation of Grapl SaaS service container images
 # The Python services need the PEX files
 build-grapl-service-prerequisites: build-service-pex-files
 # The grapl-web-ui service needs website assets

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -76,6 +76,29 @@ variable "CONTAINER_REGISTRY" {
   default = "docker.cloudsmith.io/grapl/raw"
 }
 
+# Define a set of standard OCI labels to attach to all images.
+#
+# See https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
+#
+# TODO: Ideally, I would like to define a `_grapl_base` target, set the
+# labels there, and then have all our other "base" targets inherit
+# from that. Unfortunately, there is a bug^[1] where multiple layers
+# of inheritance are not properly resolved. Fortunately, this will be fixed
+# when buildx v0.8.0 is released.
+#
+# [1]: https://github.com/docker/buildx/issues/912
+
+variable "oci_labels" {
+  default = {
+    "org.opencontainers.image.authors" = "https://graplsecurity.com"
+    "org.opencontainers.image.source"  = "https://github.com/grapl-security/grapl",
+    # In particular, this `vendor` label is used by various filters in
+    # our top-level Makefile; if you change this, make sure to update
+    # things over there, too.
+    "org.opencontainers.image.vendor" = "Grapl, Inc."
+  }
+}
+
 # Functions
 ########################################################################
 
@@ -240,6 +263,7 @@ target "_rust-base" {
   args = {
     RUST_BUILD = "${RUST_BUILD}"
   }
+  labels = oci_labels
 }
 
 target "analyzer-dispatcher" {
@@ -338,6 +362,7 @@ target "sysmon-generator" {
 target "_python-base" {
   context    = "."
   dockerfile = "src/python/Dockerfile"
+  labels     = oci_labels
 }
 
 target "analyzer-executor" {
@@ -374,6 +399,7 @@ target "graphql-endpoint" {
   tags = [
     upstream_aware_tag("graphql-endpoint")
   ]
+  labels = oci_labels
 }
 
 # Testing Images
@@ -415,6 +441,7 @@ target "pulumi" {
   tags = [
     local_only_tag("local-pulumi")
   ]
+  labels = oci_labels
 }
 
 target "localstack" {
@@ -423,6 +450,7 @@ target "localstack" {
   tags = [
     local_only_tag("localstack-grapl-fork")
   ]
+  labels = oci_labels
 }
 
 target "postgres" {
@@ -431,4 +459,5 @@ target "postgres" {
   tags = [
     local_only_tag("postgres-ext")
   ]
+  labels = oci_labels
 }

--- a/src/js/engagement_view/Makefile
+++ b/src/js/engagement_view/Makefile
@@ -8,8 +8,6 @@
 
 DOCKER_RUN := docker run \
 		--rm \
-		--interactive \
-		--tty \
 		--user "$(shell id -u):$(shell id -g)" \
 		--workdir /engagement_view \
 		--env HOME=/engagement_view \


### PR DESCRIPTION
This is a bit of a grab-bag of tweaks to our Makefile. In general, I've tried to split things into targets as atomically as possible, in order to more clearly reveal the dependencies between them (as well as make it possible to run particular tasks by themselves, which in some cases was not possible until now). I've also tried to format things consistently to make the file easier to read and navigate.

Probably the most interesting thing is the addition of standard labels to all our images, which we can use to make the various Docker-related `clean-*` targets function properly again.

It's best to review this PR commit-by-commit.