### PR TITLE
Use system zstd library for compiling zstd crate

### DIFF
--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -44,7 +44,9 @@ install_build_tooling() {
         apt-utils
         build-essential
         libclang1
+        libzstd-dev # for zstd crate builds
         lsb-release
+        pkg-config                 # for zstd crate builds (to find libzstd locally)
         software-properties-common # for `apt-add-repository``
     )
     sudo apt install -y "${tools[@]}"

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -3036,6 +3036,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+
+[[package]]
 name = "plotters"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5499,4 +5505,5 @@ checksum = "2daf2f248d9ea44454bfcb2516534e8b8ad2fc91bf818a1885495fc42bc8ac9f"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -8,7 +8,7 @@ ARG RUST_BUILD=debug
 
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 
-# Necessary for rdkafka; pkg-config & libssl-dev for cargo-tarpaulin build
+# pkg-config & libssl-dev for cargo-tarpaulin build
 #
 # pkg-config and libzstd-dev are required for our zstd crate build (we
 # use a system library to compile against, rather than compiling it in

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -10,6 +10,10 @@ SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 
 # Necessary for rdkafka; pkg-config & libssl-dev for cargo-tarpaulin build
 #
+# pkg-config and libzstd-dev are required for our zstd crate build (we
+# use a system library to compile against, rather than compiling it in
+# the course of our crate builds).
+#
 # Ignore this lint about deleteing the apt-get lists (we're caching!)
 # hadolint ignore=DL3009,SC1089
 RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-base-apt \
@@ -21,7 +25,8 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-base-apt
         pkg-config=0.29.2-1 \
         zlib1g-dev=1:1.2.11.dfsg-2 \
         curl=7.74.0-1.3+deb11u1 \
-        unzip=6.0-26
+        unzip=6.0-26 \
+        libzstd-dev=1.4.8+dfsg-2.1
 
 # Grab a Nomad binary, which we use in plugin-registry for parsing
 # HCL2-with-variables into JSON.

--- a/src/rust/analyzer-dispatcher/Cargo.toml
+++ b/src/rust/analyzer-dispatcher/Cargo.toml
@@ -27,7 +27,7 @@ rusoto_sqs = { version = "0.47.0", default_features = false, features = [
 rusoto_credential = "0.47.0"
 async-trait = "0.1.51"
 zstd = { version = "0.9.0", default_features = false, features = [
-  "pkg-config"
+  "pkg-config", "bindgen"
 ] }
 tokio = { version = "1.14.0", features = [
   "sync",

--- a/src/rust/analyzer-dispatcher/Cargo.toml
+++ b/src/rust/analyzer-dispatcher/Cargo.toml
@@ -26,7 +26,9 @@ rusoto_sqs = { version = "0.47.0", default_features = false, features = [
 ] }
 rusoto_credential = "0.47.0"
 async-trait = "0.1.51"
-zstd = "0.9.0"
+zstd = { version = "0.9.0", default_features = false, features = [
+  "pkg-config"
+] }
 tokio = { version = "1.14.0", features = [
   "sync",
   "rt",

--- a/src/rust/generators/generic-subgraph-generator/Cargo.toml
+++ b/src/rust/generators/generic-subgraph-generator/Cargo.toml
@@ -26,7 +26,9 @@ rusoto_sqs = { version = "0.47.0", default_features = false, features = [
 ] }
 futures = "0.3.18"
 async-trait = "0.1.51"
-zstd = "0.9.0"
+zstd = { version = "0.9.0", default_features = false, features = [
+  "pkg-config"
+] }
 tokio = { version = "1.14.0", features = [
   "sync",
   "rt",

--- a/src/rust/generators/generic-subgraph-generator/Cargo.toml
+++ b/src/rust/generators/generic-subgraph-generator/Cargo.toml
@@ -27,7 +27,7 @@ rusoto_sqs = { version = "0.47.0", default_features = false, features = [
 futures = "0.3.18"
 async-trait = "0.1.51"
 zstd = { version = "0.9.0", default_features = false, features = [
-  "pkg-config"
+  "pkg-config", "bindgen"
 ] }
 tokio = { version = "1.14.0", features = [
   "sync",

--- a/src/rust/generators/graph-generator-lib/Cargo.toml
+++ b/src/rust/generators/graph-generator-lib/Cargo.toml
@@ -30,7 +30,7 @@ serde = "1.0.130"
 serde_json = "1.0.72"
 log = "0.4.14"
 zstd = { version = "0.9.0", default_features = false, features = [
-  "pkg-config"
+  "pkg-config", "bindgen"
 ] }
 chrono = "0.4.19"
 tokio = "1.14.0"

--- a/src/rust/generators/graph-generator-lib/Cargo.toml
+++ b/src/rust/generators/graph-generator-lib/Cargo.toml
@@ -29,6 +29,8 @@ prost = "0.9.0"
 serde = "1.0.130"
 serde_json = "1.0.72"
 log = "0.4.14"
-zstd = "0.9.0"
+zstd = { version = "0.9.0", default_features = false, features = [
+  "pkg-config"
+] }
 chrono = "0.4.19"
 tokio = "1.14.0"

--- a/src/rust/graph-merger/Cargo.toml
+++ b/src/rust/graph-merger/Cargo.toml
@@ -39,7 +39,9 @@ rusoto_dynamodb = { version = "0.47.0", default_features = false, features = [
 ] }
 rusoto_credential = "0.47.0"
 sha2 = "0.9.8"
-zstd = "0.9.0"
+zstd = { version = "0.9.0", default_features = false, features = [
+  "pkg-config"
+] }
 prost = "0.9.0"
 base64 = "0.13.0"
 rand = "0.8.4"

--- a/src/rust/graph-merger/Cargo.toml
+++ b/src/rust/graph-merger/Cargo.toml
@@ -40,7 +40,7 @@ rusoto_dynamodb = { version = "0.47.0", default_features = false, features = [
 rusoto_credential = "0.47.0"
 sha2 = "0.9.8"
 zstd = { version = "0.9.0", default_features = false, features = [
-  "pkg-config"
+  "pkg-config", "bindgen"
 ] }
 prost = "0.9.0"
 base64 = "0.13.0"

--- a/src/rust/grapl-service/Cargo.toml
+++ b/src/rust/grapl-service/Cargo.toml
@@ -10,7 +10,7 @@ sqs-executor = { path = "../sqs-executor" }
 rust-proto = { path = "../rust-proto" }
 grapl-config = { path = "../grapl-config" }
 zstd = { version = "0.9.0", default_features = false, features = [
-  "pkg-config"
+  "pkg-config", "bindgen"
 ] }
 libflate = "1.1.1"
 prost = "0.9.0"

--- a/src/rust/grapl-service/Cargo.toml
+++ b/src/rust/grapl-service/Cargo.toml
@@ -9,7 +9,9 @@ edition = "2021"
 sqs-executor = { path = "../sqs-executor" }
 rust-proto = { path = "../rust-proto" }
 grapl-config = { path = "../grapl-config" }
-zstd = "0.9.0"
+zstd = { version = "0.9.0", default_features = false, features = [
+  "pkg-config"
+] }
 libflate = "1.1.1"
 prost = "0.9.0"
 tracing = "0.1.29"

--- a/src/rust/node-identifier/Cargo.toml
+++ b/src/rust/node-identifier/Cargo.toml
@@ -43,7 +43,9 @@ serde_dynamodb = { version = "0.9.0", default_features = false, features = [
 ] }
 sha2 = "0.9.8"
 sqs-executor = { path = "../sqs-executor/" }
-zstd = "0.9.0"
+zstd = { version = "0.9.0", default_features = false, features = [
+  "pkg-config"
+] }
 futures = "0.3.18"
 serde = "1.0.130"
 serde_json = "1.0.72"

--- a/src/rust/node-identifier/Cargo.toml
+++ b/src/rust/node-identifier/Cargo.toml
@@ -44,7 +44,7 @@ serde_dynamodb = { version = "0.9.0", default_features = false, features = [
 sha2 = "0.9.8"
 sqs-executor = { path = "../sqs-executor/" }
 zstd = { version = "0.9.0", default_features = false, features = [
-  "pkg-config"
+  "pkg-config", "bindgen"
 ] }
 futures = "0.3.18"
 serde = "1.0.130"


### PR DESCRIPTION
Rather than compiling `libzstd` during our `cargo build` process, we
can just link against a system library.

This change appears to shave off ~20 seconds from the overall compile
time, as judged from the output of `cargo +nightly build --timings`.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>