### PR TITLE
Slim down our Structopt crate usage

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -816,13 +816,9 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim 0.8.0",
  "textwrap",
  "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -1191,7 +1187,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote 1.0.15",
- "strsim 0.9.3",
+ "strsim",
  "syn 1.0.86",
 ]
 
@@ -4247,12 +4243,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
@@ -5091,12 +5081,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "v_escape",
 ]
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/src/rust/grapl-graphql-codegen/Cargo.toml
+++ b/src/rust/grapl-graphql-codegen/Cargo.toml
@@ -15,7 +15,7 @@ name = "grapl-graphql-codegen"
 graphql-parser = "0.4.0"
 serde_json = "1.0.72"
 thiserror = "1.0.30"
-structopt = "0.3.25"
+structopt = { version = "0.3.26", default-features = false }
 color-eyre = "0.6.0"
 tracing = "0.1.29"
 tracing-subscriber = "0.3.2"

--- a/src/rust/plugin-bootstrap/Cargo.toml
+++ b/src/rust/plugin-bootstrap/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1.14.0", features = ["full"] }
 tonic = "0.6.1"
 tonic-health = "0.5.0"
 tracing = "0.1.29"
-structopt = "0.3"
+structopt = { version = "0.3.26", default-features = false }
 uuid = { version = "0.8.2", features = ["v4"] }
 futures = "0.3.17"
 

--- a/src/rust/plugin-registry/Cargo.toml
+++ b/src/rust/plugin-registry/Cargo.toml
@@ -38,7 +38,7 @@ rusoto_s3 = { version = "0.47.0", default_features = false, features = [
   "rustls"
 ] }
 blake3 = "1.2.0"
-structopt = "0.3"
+structopt = { version = "0.3.26", default-features = false }
 uuid = { version = "0.8.2", features = ["v4"] }
 futures = "0.3.17"
 

--- a/src/rust/plugin-sdk/generator-sdk/Cargo.toml
+++ b/src/rust/plugin-sdk/generator-sdk/Cargo.toml
@@ -15,7 +15,7 @@ uuid = { version = "0.8.2", features = ["v4"] }
 serde = { version = "1.0.136", features = ["derive"] }
 trust-dns-resolver = "0.20.3"
 moka = { version = "0.7", features = ["future"] }
-structopt = "0.3.26"
+structopt = { version = "0.3.26", default-features = false }
 
 [features]
 internal = ["client"]

--- a/src/rust/plugin-work-queue/Cargo.toml
+++ b/src/rust/plugin-work-queue/Cargo.toml
@@ -15,7 +15,7 @@ name = "plugin_work_queue"
 grapl-config = { path = "../grapl-config" }
 grapl-utils = { path = "../grapl-utils" }
 rust-proto = { path = "../rust-proto" }
-structopt = "0.3.25"
+structopt = { version = "0.3.26", default-features = false }
 thiserror = "1.0.30"
 tokio = { version = "1.14.0", features = ["full"] }
 tonic = "0.6.1"


### PR DESCRIPTION
Since our usage of Structopt is limited to servers, which won't be
invoked by humans, we don't actually need several crates that Clap
uses under the hood for nice UX, such as ANSI color codes and
suggestions for mistyped commands. By disabling Structopt's default
features, we can eliminate these crates, shaving a bit off our compile
times (it won't be a ton, but every little bit helps).

(See https://docs.rs/structopt/latest/structopt/#features for
details.)

Signed-off-by: Christopher Maier <chris@graplsecurity.com>