### PR TITLE
`@christophermaier` owns Makefiles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,6 @@ BUILD @christophermaier
 /LICENSE @christophermaier
 /local-grapl.env @christophermaier
 /LOCAL_UI_WORKFLOW.md @christophermaier
-/Makefile @christophermaier
 /nomad @twunderlich-grapl
 /pants @christophermaier
 /pants.ci.toml @christophermaier
@@ -84,6 +83,8 @@ BUILD @christophermaier
 /src/rust/sysmon-parser/ @inickles-grapl
 /test/docker-compose* @inickles-grapl @christophermaier
 /test/run @wimax-grapl
+
+**/Makefile @christophermaier
 
 # This needs to be kept at the end??
 .gitkeep @christophermaier


### PR DESCRIPTION
Slight rearrangement of the CODEOWNERS file so that I get tagged for
any `Makefile` updates.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>