### PR TITLE
Lint BUILD files

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -35,6 +35,10 @@ steps:
     # enforcement, typechecking, etc.
     key: lints
     steps:
+      - label: ":jeans: BUILD Linting"
+        command:
+          - make lint-build
+
       - label: ":nomad: HCL Linting"
         command:
           - make lint-hcl

--- a/Makefile
+++ b/Makefile
@@ -365,6 +365,7 @@ test-with-env: # (Do not include help text - not to be used directly)
 ##@ Lint 🧹
 
 .PHONY: lint
+lint: lint-build
 lint: lint-docker
 lint: lint-hcl
 lint: lint-prettier
@@ -374,6 +375,10 @@ lint: lint-python
 lint: lint-rust
 lint: lint-shell
 lint: ## Run all lint checks
+
+.PHONY: lint-build
+lint-build: ## Lint Pants BUILD files
+	./pants update-build-files --check
 
 .PHONY: lint-docker
 lint-docker: ## Lint Dockerfiles with Hadolint

--- a/src/rust/BUILD
+++ b/src/rust/BUILD
@@ -2,7 +2,4 @@ docker_image(
     name="docker",
 )
 
-docker_image(
-    name="build-environment",
-    source="build-env.Dockerfile"
-)
+docker_image(name="build-environment", source="build-env.Dockerfile")


### PR DESCRIPTION
We now lint our Pants BUILD files in Buildkite.

Because this was missing, we had a single BUILD file that wasn't
properly formatted.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
