### PR TITLE
Add `dist` as an order-only prerequisite for Firecracker kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -623,5 +623,5 @@ generate-sqlx-data:  # Regenerate sqlx-data.json based on queries made in Rust c
 	./src/rust/bin/generate_sqlx_data.sh
 
 # Intentionally not phony, as this generates a real file
-dist/firecracker_kernel.tar.gz: firecracker/generate_firecracker_kernel.sh
+dist/firecracker_kernel.tar.gz: firecracker/generate_firecracker_kernel.sh | dist
 	./firecracker/generate_firecracker_kernel.sh


### PR DESCRIPTION
I previously missed this hidden dependency in a recent Makefile
refactoring. Now, we'll always ensure the directory is present before
trying to build a kernel.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>