### PR TITLE
Add 'make restart-web-ui' to make frontend dev loop quicker than full down/up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -506,6 +506,17 @@ stop: ## docker-compose stop - stops (but preserves) the containers
 	@$(WITH_LOCAL_GRAPL_ENV)
 	docker-compose $(EVERY_COMPOSE_FILE) stop
 
+# This is a convenience target for our frontend engineers, to make the dev loop
+# slightly less arduous for grapl-web-ui/engagement-view development.
+# It will *rebuild* the JS/Rust grapl-web-ui dependences, and then 
+# restart a currently-running `make up` web ui allocation, which will then
+# retrieve the latest, newly-rebuilt Docker container.
+.PHONY: restart-web-ui
+restart-web-ui: build-engagement-view  ## Rebuild web-ui image, and restart web-ui task in Nomad
+	$(DOCKER_BUILDX_BAKE_HCL) grapl-web-ui
+	source ./nomad/lib/nomad_cli_tools.sh
+	nomad alloc restart "$$(nomad_get_alloc_id grapl-core web-ui)"
+
 ##@ Venv Management
 ########################################################################
 .PHONY: generate-constraints

--- a/Makefile
+++ b/Makefile
@@ -511,6 +511,8 @@ stop: ## docker-compose stop - stops (but preserves) the containers
 # It will *rebuild* the JS/Rust grapl-web-ui dependences, and then 
 # restart a currently-running `make up` web ui allocation, which will then
 # retrieve the latest, newly-rebuilt Docker container.
+#
+# Will only work as expected as long as tag is "dev".
 .PHONY: restart-web-ui
 restart-web-ui: build-engagement-view  ## Rebuild web-ui image, and restart web-ui task in Nomad
 	$(DOCKER_BUILDX_BAKE_HCL) grapl-web-ui

--- a/nomad/lib/nomad_cli_tools.sh
+++ b/nomad/lib/nomad_cli_tools.sh
@@ -110,6 +110,14 @@ check_for_task_failures_in_job() {
     fi
 }
 
+nomad_get_alloc_id() {
+    # Inspired by
+    # https://github.com/hashicorp/nomad/issues/698#issuecomment-1031683060
+    local -r job_id="${1}"
+    local -r task_id="${2}"
+    nomad job status "${job_id}" | grep "${task_id}" | awk '/run(.*)running/{print $1}'
+}
+
 important_looking_banner() {
     local -r message="${1}"
     echo -e "\n\n--- \e[30;46m${message}\e[m ---\n"

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -12,12 +12,13 @@ SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 #
 # Ignore this lint about deleteing the apt-get lists (we're caching!)
 # hadolint ignore=DL3009,SC1089
-RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-base-apt \
-    apt-get update \
-    && apt-get install --yes --no-install-recommends \
-        curl=7.74.0-1.3+deb11u1 \
-        jq=1.6-2.1 \
-        unzip=6.0-26
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-base-apt <<EOF
+apt-get update
+apt-get install --yes --no-install-recommends \
+    curl=7.74.0-1.3+deb11u1 \
+    jq=1.6-2.1 \
+    unzip=6.0-26
+EOF
 
 # Grab a Nomad binary, which we use in plugin-registry for parsing
 # HCL2-with-variables into JSON.
@@ -26,8 +27,8 @@ RUN <<EOF
 set -euo pipefail
 curl --remote-name --proto '=https' --tlsv1.2 -sSf \
   https://releases.hashicorp.com/nomad/1.2.4/nomad_1.2.4_linux_amd64.zip
-unzip *.zip
-rm *.zip
+unzip ./*.zip
+rm ./*.zip
 EOF
 
 # Install rust toolchain before copying sources to avoid unecessarily

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -12,13 +12,12 @@ SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 #
 # Ignore this lint about deleteing the apt-get lists (we're caching!)
 # hadolint ignore=DL3009,SC1089
-RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-base-apt <<EOF
-apt-get update
-apt-get install --yes --no-install-recommends \
-    curl=7.74.0-1.3+deb11u1 \
-    jq=1.6-2.1 \
-    unzip=6.0-26
-EOF
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-base-apt \
+    apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        curl=7.74.0-1.3+deb11u1 \
+        jq=1.6-2.1 \
+        unzip=6.0-26
 
 # Grab a Nomad binary, which we use in plugin-registry for parsing
 # HCL2-with-variables into JSON.
@@ -27,8 +26,8 @@ RUN <<EOF
 set -euo pipefail
 curl --remote-name --proto '=https' --tlsv1.2 -sSf \
   https://releases.hashicorp.com/nomad/1.2.4/nomad_1.2.4_linux_amd64.zip
-unzip ./*.zip
-rm ./*.zip
+unzip *.zip
+rm *.zip
 EOF
 
 # Install rust toolchain before copying sources to avoid unecessarily


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None. Adhoc request from Andrea.

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Add a utility function that makes it easy to rebuild and redeploy Engagement View changes to a currently running `make up` session.

Time to run with no changes: 7s (mostly existing tech debt in engagement-view Makefile that always reruns a .PHONY)
Time to run with changes: 2m32s, mostly rust compilation
*Over 1 minute of that time-to-run may disappear ASAP*: See [this thread.](https://grapl-internal.slack.com/archives/C02J5JYS92S/p1646876969973139)

For comparison, a full up/down (with no code changes) is 5m5s + 17s

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Make a small UI change to engagement-view
Run `make restart-web-ui`
go to localhost:1234 to see it reflected there.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
