### PR TITLE
Update engagement-view Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,17 +30,6 @@ node_modules/
 # corepack installs the node version in .node. Kinda annoying but makes sense since its not yarn-specific
 .node/
 
-# Yarn packages
-src/js/engagement_view/.yarn/install-state.gz
-src/js/engagement_view/.npm/*
-src/js/engagement_view/.yarn/*
-!src/js/engagement_view/.yarn/cache
-!src/js/engagement_view/.yarn/releases
-!src/js/engagement_view/.yarn/plugins
-!src/js/engagement_view/.yarn/sdks
-!src/js/engagement_view/.yarn/versions
-src/js/engagement_view/coverage
-
 # Web UI frontend artifacts
 src/rust/grapl-web-ui/frontend/*
 
@@ -67,18 +56,11 @@ pyrightconfig.json
 # https://www.pantsbuild.org/docs/gitignore
 ########################################################################
 /.pants.d/
-
-# A note: You can't ignore /dist dir and then unignore on a single file.
-# instead you have to ignore /dist/*
-/dist/*
-!/dist/.gitkeep
-
 /.pids
 /.pants.workdir.file_lock*
-/.cache
+
 # See build-support/manage_virtualenv.sh
 /build-support/grapl-venv
-.yarn/
 
 # Generated when profiling rust code
 *.profdata

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ build-e2e-pex-files:
 .PHONY: build-engagement-view
 build-engagement-view: ## Build website assets to include in grapl-web-ui
 	@echo "--- Building the engagement view"
-	$(ENGAGEMENT_VIEW_MAKE) build
+	$(ENGAGEMENT_VIEW_MAKE) build-code
 	cp -r \
 		"${PWD}/src/js/engagement_view/build/." \
 		"${PWD}/src/rust/grapl-web-ui/frontend/"
@@ -271,7 +271,7 @@ test-unit-graphql-endpoint: ## Test Graphql Endpoint
 
 .PHONY: test-unit-engagement-view
 test-unit-engagement-view: ## Test Engagement View
-	$(ENGAGEMENT_VIEW_MAKE) test
+	$(ENGAGEMENT_VIEW_MAKE) run-tests
 
 .PHONY: test-unit-python
 # Long term, it would be nice to organize the tests with Pants

--- a/src/js/engagement_view/.gitignore
+++ b/src/js/engagement_view/.gitignore
@@ -1,14 +1,29 @@
+# For the time being, we'll keep the specific files-to-ignore here in
+# this directory-specific .gitignore file; it makes things a bit
+# easier to reason about.
+
 # As recommended by https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
-.yarn/*
-.npm/*
+.yarn
 !.yarn/patches
-!.yarn/releases
 !.yarn/plugins
+!.yarn/releases
 !.yarn/sdks
 !.yarn/versions
 
-# We use this with Docker volumes for storing build state and cache
-!.yarn/state/.gitignore
+node_modules
 
-/coverage
+coverage/*
 
+# These are empty target files used by our Makefile; see
+# https://www.gnu.org/software/make/manual/html_node/Empty-Targets.html
+# for details.
+build-image
+install-dependencies
+build-code
+
+# While we set $HOME in our build container to our mounted directory,
+# we can generate additional files that should not be committed.
+.bash_history
+.cache/
+.node/
+.npm/

--- a/src/js/engagement_view/.yarn/state/.gitignore
+++ b/src/js/engagement_view/.yarn/state/.gitignore
@@ -1,6 +1,0 @@
-# This exists to keep the existence of the node_modules directory in git.
-# Doing this is useful for preserving file permissions when building with
-# Docker.
-*
-!.gitignore
-

--- a/src/js/engagement_view/Makefile
+++ b/src/js/engagement_view/Makefile
@@ -1,46 +1,117 @@
-#
-# Makefile for building Engagement View
-#
+.DEFAULT_GOAL := build-code
 
-.DEFAULT_GOAL := build
-# Disable implicit rules, not needed for our use case
-.SUFFIXES:
+build_image_tag := grapl-engagement-view-build-env:latest
 
-DOCKER_RUN := docker run \
+# Additional arguments to pass to `docker run` before the image
+# name. This can be modified on a target-by-target basis as needed.
+extra_docker_run_args =
+
+# NOTE: This **must** be `=` and not `:=` because we want to reserve
+# the ability to inject additional Docker arguments on a
+# target-by-target basis
+DOCKER_RUN = docker run \
 		--rm \
-		--user "$(shell id -u):$(shell id -g)" \
-		--workdir /engagement_view \
-		--env HOME=/engagement_view \
-		--mount type=volume,source=grapl-yarn-state-engagement-view,target=/engagement_view/.yarn/state \
-		--mount type=volume,source=grapl-node-modules-engagement-view,target=/engagement_view/node_modules \
-		--mount type=bind,source="$(shell pwd)",target=/engagement_view \
-		grapl/engagement-view-build-env
+		--user="$(shell id --user):$(shell id --group)" \
+		--workdir=/engagement_view \
+		--env=HOME=/engagement_view \
+		--mount=type=bind,source="$(shell pwd)",target=/engagement_view \
+		--mount=type=volume,source=grapl-engagement-view-yarn,target=/engagement_view/.yarn/state \
+		--mount=type=volume,source=grapl-engagement-view-node-modules,target=/engagement_view/node_modules \
+		$(extra_docker_run_args) \
+		-- \
+		$(build_image_tag)
 
-# These are used to declare Makefile dependencies.
-# If an ASSET_DIRS/FILES has changed, rebuild! Otherwise we're likely up to date!
-ASSET_FILTER = -not -path "./node_modules/*" -not -path "./.yarn/*" -not -path "./build/*" -not -path "./build" -not -path "./.npm/*"
-ASSET_DIRS = $(shell find . -type d $(ASSET_FILTER))
-ASSET_FILES = $(shell find . -type f $(ASSET_FILTER))
+# Changes to any of these files will trigger a rebuild of the code
+FILES := $(shell find src -type f) $(shell find public -type f) componentMap/components.txt tsconfig.json
 
-.PHONY: build-env-image
-build-env-image:
+build-image: build-env.Dockerfile
+build-image: ## Build the build image if necessary
 	docker buildx build \
-		--tag grapl/engagement-view-build-env \
-		- < build-env.Dockerfile
+		--file=build-env.Dockerfile \
+		--tag=$(build_image_tag) \
+		.
+	touch $@
 
-# This will run every time, because all PHONYs (e.g. build-env-image) run every time.
-node_modules: build-env-image package.json yarn.lock
+# ----------------------------------------------------------------------
+
+# These directories are the ones we'll back with Docker volumes. They
+# must exist on the workstation already or else they'll end up being
+# created with root ownership, which complicates cleanup. These should
+# be included as order-only prerequisites for any targets that use the
+# $(DOCKER_RUN) macro.
+
+volume_dirs := .yarn/state node_modules
+
+$(volume_dirs):
+	mkdir -p $@
+
+# ----------------------------------------------------------------------
+
+install-dependencies: build-image package.json yarn.lock
+install-dependencies: | $(volume_dirs)
+install-dependencies: ## Install dependencies in the build container if necessary
 	$(DOCKER_RUN) yarn install
+	touch $@
 
-build: node_modules $(ASSET_DIRS) $(ASSET_FILES)
+# Not named `build` because a directory of that name gets generated
+# during the build process
+build-code: install-dependencies $(FILES)
+build-code: ## Build the code if any files have changed
 	$(DOCKER_RUN) yarn build
+	touch $@
 
-.PHONY: test
-test: node_modules
-	$(DOCKER_RUN) yarn test --coverage --watchAll=false --coverageDirectory=/engagement_view/coverage/
+# Note that `run-tests` is a phony target, so it will run each time it
+# is invoked, whether code has changed or not.
+.PHONY: run-tests
+run-tests: build-code
+run-tests: ## Run all unit tests and gather coverage statistics
+	$(DOCKER_RUN) yarn test \
+		--coverage \
+		--watchAll=false \
+		--coverageDirectory=/engagement_view/coverage/
+
+.PHONY: shell
+shell: extra_docker_run_args := --interactive --tty
+shell: build-image
+shell: ## Drop into a shell inside the build container
+	$(DOCKER_RUN) bash
+
+# Clean
+########################################################################
 
 .PHONY: clean
-clean:
-	docker volume rm \
-		grapl-node-modules-engagement-view \
-		grapl-yarn-state-engagement-view
+clean: clean-image
+clean: clean-volumes
+clean: clean-files
+clean: ## Remove all generated state and artifacts
+
+.PHONY: clean-image
+clean-image: ## Remove the build image
+	docker rmi --force "$(build_image_tag)" 2> /dev/null
+	rm -f build-image
+
+.PHONY: clean-volumes
+clean-volumes: ## Remove all Docker volumes
+
+define make-clean-volume-rule
+clean-volumes: clean-volume-$1
+
+.PHONY: clean-volume-$1
+clean-volume-$1: ## Remove the $1 volume
+	docker volume remove --force $1
+	rm -f install-dependencies
+	rm -f build-code
+endef
+volumes = grapl-engagement-view-node-modules grapl-engagement-view-yarn
+$(foreach volume,${volumes},$(eval $(call make-clean-volume-rule,$(volume))))
+
+.PHONY: clean-files
+clean-files: ## Remove all additional generated files and directories
+	rm -f .bash_history
+	rm -Rf build
+	rm -Rf .cache
+	rm -Rf coverage
+	rm -Rf .node
+	rm -Rf node_modules
+	rm -Rf .npm
+	rm -Rf .yarn

--- a/src/js/engagement_view/build-env.Dockerfile
+++ b/src/js/engagement_view/build-env.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-bullseye-slim
+FROM node:16-bullseye
 
 SHELL ["/bin/bash", "-c"]
 
@@ -14,12 +14,21 @@ SHELL ["/bin/bash", "-c"]
 #`typescript@patch:typescript@npm%3A4.6.2#~builtin<compat/typescript>::version=4.6.2&hash=493e53: Cannot apply hunk #11`
 # error is fixed. Apparently corepack applies a strict setting, which yarn set doesn't.
 
-########## Set docker mount points mode ###################
-# Manually create Docker volume mount points so we can set the mode
-# to make them a+w.
 ENV YARN_VERSION 3.1.1
 
 # Don't think this is necessarily an issue for us:
 # hadolint ignore=SC2174
-RUN yarn set version $YARN_VERSION && \
-mkdir --mode=777 --parents /engagement_view/{.yarn/state,node_modules}
+RUN yarn set version ${YARN_VERSION}
+
+########## Set docker mount points mode ###################
+# Manually create Docker volume mount points so we can set the mode
+# to make them a+w.
+RUN mkdir --parents \
+    /engagement_view/.yarn/state \
+    /engagement_view/node_modules \
+    && chmod --recursive 777 \
+    /engagement_view/.yarn/state \
+    /engagement_view/node_modules
+
+VOLUME /engagement_view/.yarn/state
+VOLUME /engagement_view/node_modules


### PR DESCRIPTION
Rather than building the build container image before every operation,
we'll use some empty target files and some finer-grained prerequisites
to better capture the true dependencies.

Of particular note:

- The `ASSET_FILTER`/`ASSET_FILES`/`ASSET_DIRS` macros were too
permissive. Rather than filtering out files we don't care about, now
we just specify the files we _do_ care about in the `FILES` macro.

- More complete cleanup is done in the `clean` target.

- No more `.gitkeep` files to preserve `.yarn/state` and
`node_modules`. The `.gitignore` rules for these files didn't actually
work, and in any event, it's easier to ensure these directories exist
by creating targets for them. This also allows us to easily clean
these directories from the `clean` target.

- A new `shell` target is added to allow you to easily enter the build
container for debugging purposes. This was done by conditionally
adding `--interactive --tty` flags to the `DOCKER_RUN` macro just for
the `shell` target.

- The files to ignore are added to a local `.gitignore` file, rather
than the one from the repository root. I felt it was easier to manage
the empty target files (and other files) closer to the code.

- The base image of our build container is now `node:16-bullseye`
rather than `node:16-bullsye-slim`; the former has `git` installed,
which appears to be needed for building our code.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
