### PR TITLE
Update .dockerignore to match all sub-directories under src/rust named 'target'

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,9 @@
 .pids
 .yarn
 build-support/grapl-venv
-src/rust/target/**
+
+# match any directory named 'target', which can result from building creates
+# individually as one might do during local development.
+src/rust/**/target/**
+
 test_artifacts/**


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This updates the top-level .dockerignore file to match not just `src/rust/target`, but all directories named `target` under `src/rust`, which can happen when building one of the crates individually.

### How were these changes tested?

I realized I had large (hundreds of MB) context transfers for Rust Dockerfile stages, which didn't seem right. Turns out this was due to a directory `src/rust/generators/sysmon-generator/target` I had from working with that crate directly.

With this change I noticed these context transfer sizes were much closer to the size of the sources under proto and rust.