### PR TITLE
Revert "Update .dockerignore to match all sub-directories under src/rust named"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,9 +7,5 @@
 .pids
 .yarn
 build-support/grapl-venv
-
-# match any directory named 'target', which can result from building creates
-# individually as one might do during local development.
-src/rust/**/target/**
-
+src/rust/target/**
 test_artifacts/**


### PR DESCRIPTION
This reverts commit 20cb57b2d2811db77f8a6caf88b2320f37be2077.

### What changes does this PR make to Grapl? Why?

These sub `target` directories I had were a result only of having used the VS Code Rust extension with the RLS engine. I had recently switched to using this setting because the rust-analyzer VS Code extension was having issues. I've since switched away from Rust extension + RLS again and so this is not something I should personally encounter again.

It's probably unlikely others would encounter this as well, but even if they do, the impact is less significant than someone naming a Rust module `target`, which would cause the build to break with the original commit. The odds of that are probably also low, but that's whatever.

Thanks @christophermaier for your input. 👍 

### How were these changes tested?

CI
