### PR TITLE
Upgrade libssl in some dockerfiles to 1.1.1k-1+deb11u2

### DIFF
--- a/firecracker/packer/scripts/install_dependencies.sh
+++ b/firecracker/packer/scripts/install_dependencies.sh
@@ -6,11 +6,12 @@ set -o xtrace
 ########################################
 # Install dependencies (currently, just debootstrap)
 ########################################
-sudo apt update
+readonly APT_GET_WITH_LOCK=(apt-get -o dpkg::lock::timeout=10)
+sudo "${APT_GET_WITH_LOCK[@]}" update
 
 # Print available versions for debugging purposes.
 # (You might say, "madison? what's madison?" Just a badly named apt command.)
 sudo apt-cache madison debootstrap
 
-sudo apt install --yes --no-install-recommends \
+sudo "${APT_GET_WITH_LOCK[@]}" install --yes --no-install-recommends \
     debootstrap=1.0.118ubuntu1.6

--- a/firecracker/packer/scripts/install_dependencies.sh
+++ b/firecracker/packer/scripts/install_dependencies.sh
@@ -8,9 +8,5 @@ set -o xtrace
 ########################################
 sudo apt update
 
-# Print available versions for debugging purposes.
-# (You might say, "madison? what's madison?" Just a badly named apt command.)
-sudo apt-cache madison debootstrap
-
 sudo apt install --yes --no-install-recommends \
     debootstrap=1.0.118ubuntu1.6

--- a/firecracker/packer/scripts/install_dependencies.sh
+++ b/firecracker/packer/scripts/install_dependencies.sh
@@ -6,12 +6,11 @@ set -o xtrace
 ########################################
 # Install dependencies (currently, just debootstrap)
 ########################################
-readonly APT_GET_WITH_LOCK=(apt-get -o dpkg::lock::timeout=10)
-sudo "${APT_GET_WITH_LOCK[@]}" update
+sudo apt update
 
 # Print available versions for debugging purposes.
 # (You might say, "madison? what's madison?" Just a badly named apt command.)
 sudo apt-cache madison debootstrap
 
-sudo "${APT_GET_WITH_LOCK[@]}" install --yes --no-install-recommends \
+sudo apt install --yes --no-install-recommends \
     debootstrap=1.0.118ubuntu1.6

--- a/firecracker/packer/scripts/install_dependencies.sh
+++ b/firecracker/packer/scripts/install_dependencies.sh
@@ -6,5 +6,11 @@ set -o xtrace
 ########################################
 # Install dependencies (currently, just debootstrap)
 ########################################
-sudo apt-get update
-sudo apt-get install debootstrap=1.0.118ubuntu1
+sudo apt update
+
+# Print available versions for debugging purposes.
+# (You might say, "madison? what's madison?" Just a badly named apt command.)
+sudo apt-cache madison debootstrap
+
+sudo apt install --yes --no-install-recommends \
+    debootstrap=1.0.118ubuntu1.6

--- a/src/js/graphql_endpoint/Dockerfile
+++ b/src/js/graphql_endpoint/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && apt-get --yes install --no-install-recommends \
         build-essential=12.9 \
         libffi-dev=3.3-6 \
-        libssl-dev=1.1.1k-1+deb11u1 \
+        libssl-dev=1.1.1k-1+deb11u2 \
         python3=3.9.2-3 \
         zip=3.0-12 \
     && rm -rf /var/lib/apt/lists/* \

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -95,7 +95,7 @@ FROM base AS tarpaulin
 RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-tarpaulin-apt \
     apt-get update \
     && apt-get install --yes --no-install-recommends \
-        libssl-dev=1.1.1k-1+deb11u1 \
+        libssl-dev=1.1.1k-1+deb11u2 \
         pkg-config=0.29.2-1
 
 # For test coverage reports

--- a/src/rust/build-env.Dockerfile
+++ b/src/rust/build-env.Dockerfile
@@ -9,7 +9,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-build-en
     # `libssl-dev` and `pkg-config` are needed for the initial
     # compilation of the `cargo-tarpaulin` tool itself.
     apt-get install --yes --no-install-recommends \
-         libssl-dev=1.1.1k-1+deb11u1 \
+         libssl-dev=1.1.1k-1+deb11u2 \
          pkg-config=0.29.2-1
 EOF
 


### PR DESCRIPTION
Resolves the following Slack post I made:
```
Potential deps issue:
src/rust/Dockerfile specifies libssl-dev
        libssl-dev=1.1.1k-1+deb11u1 \
i got this error in ci:
#9 2.635 Some packages could not be installed. This may mean that you have
#9 2.635 requested an impossible situation or if you are using the unstable
#9 2.635 distribution that some required packages have not yet been created
#9 2.635 or been moved out of Incoming.
#9 2.635 The following information may help to resolve the situation:
#9 2.635
#9 2.635 The following packages have unmet dependencies:
#9 2.682  libssl-dev : Depends: libssl1.1 (= 1.1.1k-1+deb11u1) but 1.1.1k-1+deb11u2 is to be installed
https://buildkite.com/grapl/grapl-verify/builds/2889#06ee30e2-1d1f-4257-97fd-01003e75164f
```

our theory is deb11u1 was yanked