### PR TITLE
Soft-fail rootfs builds in CI until we figure out what's going on

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -253,3 +253,7 @@ steps:
       - make dist/firecracker_rootfs.tar.gz
     agents:
       queue: "packer"
+    # This verify step failures nondeterministically. As such, I'm temporarily
+    # allowing it to fail without blocking CI.
+    # https://github.com/grapl-security/issue-tracker/issues/880
+    soft_fail: true

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -253,7 +253,7 @@ steps:
       - make dist/firecracker_rootfs.tar.gz
     agents:
       queue: "packer"
-    # This verify step failures nondeterministically. As such, I'm temporarily
+    # This verify step nondeterministically fails. As such, I'm temporarily
     # allowing it to fail without blocking CI.
     # https://github.com/grapl-security/issue-tracker/issues/880
     soft_fail: true


### PR DESCRIPTION
This is a temporary stopgap measure for https://github.com/grapl-security/issue-tracker/issues/880 that allows other devs to continue to run grapl CI without blocking them. 

I opted for `soft_fail` instead of straight-up removal so I could continue to collect different failure modes; I was kind of shocked when it failed once-after-another in 2 different ways.