### PR TITLE
Add a 'serde' feature flag to derive Serialize and Deserialize for

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -4478,6 +4478,7 @@ dependencies = [
  "criterion",
  "derive-into-owned",
  "memchr",
+ "serde",
  "thiserror",
  "uuid",
  "xmlparser",

--- a/src/rust/sysmon-parser/Cargo.toml
+++ b/src/rust/sysmon-parser/Cargo.toml
@@ -10,13 +10,30 @@ edition = "2021"
 [lib]
 bench = false
 
+[features]
+default = ["serde"]
+serde = ["serde_crate", "uuid/serde", "chrono/serde"]
+
 [dependencies]
-chrono = { version = "0.4", features = [] }
+chrono = { version = "0.4", features = ["std"] }
 derive-into-owned = "0.2"
 memchr = "2"
 thiserror = "1.0"
 uuid = "0.8"
 xmlparser = "0.13"
+
+# Because we're enabling feature flags in our dependencies for 'serde' we can't
+# have a feature named 'serde' and depend on it as well. A workaround is to
+# rename the serde crate internally, instead of exposing such naming
+# workarounds to our users. See:
+# https://github.com/rust-lang/api-guidelines/discussions/180
+# https://github.com/serde-rs/serde/issues/1938
+[dependencies.serde_crate]
+package = "serde"
+optional = true
+version = "1.0"
+default-features = false
+features = ["derive"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/rust/sysmon-parser/src/event.rs
+++ b/src/rust/sysmon-parser/src/event.rs
@@ -15,7 +15,13 @@ use crate::{
 /// Windows Event data of parsed Sysmon events.
 ///
 /// `<https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon>`
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_crate::Serialize, serde_crate::Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct SysmonEvent<'a> {
     /// Defines the information that identifies the provider and how it was enabled, the event, the
     /// channel to which the event was written, and system information such as the process and

--- a/src/rust/sysmon-parser/src/event_data.rs
+++ b/src/rust/sysmon-parser/src/event_data.rs
@@ -12,9 +12,14 @@ pub use process_terminated::ProcessTerminatedEventData;
 
 pub const UTC_TIME_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.3f";
 
+/// Event-specific data for the Sysmon event. This inludes the data found in the `<EventData>` element.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
-/// Event-specific data for the Sysmon event. This inludes the data found in the `<EventData>` element.
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_crate::Serialize, serde_crate::Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub enum EventData<'a> {
     /// Event ID 11: FileCreate
     ///

--- a/src/rust/sysmon-parser/src/event_data/file_create.rs
+++ b/src/rust/sysmon-parser/src/event_data/file_create.rs
@@ -28,6 +28,11 @@ use crate::{
 /// <https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-11-filecreate>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_crate::Serialize, serde_crate::Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct FileCreateEventData<'a> {
     /// <data name="RuleName" inType="win:UnicodeString" outType="xs:string" />
     pub rule_name: Option<Cow<'a, str>>,

--- a/src/rust/sysmon-parser/src/event_data/network_connect.rs
+++ b/src/rust/sysmon-parser/src/event_data/network_connect.rs
@@ -32,6 +32,11 @@ use crate::{
 /// <https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-3-network-connection>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_crate::Serialize, serde_crate::Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct NetworkConnectionEventData<'a> {
     /// <data name="RuleName" inType="win:UnicodeString" outType="xs:string" />
     pub rule_name: Option<Cow<'a, str>>,

--- a/src/rust/sysmon-parser/src/event_data/process_creation.rs
+++ b/src/rust/sysmon-parser/src/event_data/process_creation.rs
@@ -29,6 +29,11 @@ use crate::{
 /// <https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-1-process-creation>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_crate::Serialize, serde_crate::Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct ProcessCreateEventData<'a> {
     /// <data name="RuleName" inType="win:UnicodeString" outType="xs:string" />
     pub rule_name: Option<Cow<'a, str>>,

--- a/src/rust/sysmon-parser/src/event_data/process_terminated.rs
+++ b/src/rust/sysmon-parser/src/event_data/process_terminated.rs
@@ -27,6 +27,11 @@ use crate::{
 /// <https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-5-process-terminated>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_crate::Serialize, serde_crate::Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct ProcessTerminatedEventData<'a> {
     /// <data name="RuleName" inType="win:UnicodeString" outType="xs:string" />
     pub rule_name: Option<Cow<'a, str>>,

--- a/src/rust/sysmon-parser/src/system.rs
+++ b/src/rust/sysmon-parser/src/system.rs
@@ -37,7 +37,13 @@ pub use time_created::TimeCreated;
 /// IDs.
 ///
 /// <https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-systempropertiestype-complextype>
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_crate::Serialize, serde_crate::Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct System<'a> {
     /// Identifies the provider that logged the event.
     ///

--- a/src/rust/sysmon-parser/src/system/correlation.rs
+++ b/src/rust/sysmon-parser/src/system/correlation.rs
@@ -3,6 +3,11 @@
 /// <https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-correlation-systempropertiestype-element>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_crate::Serialize, serde_crate::Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct Correlation {
     /// A globally unique identifier that identifies the current activity. The events that are
     /// published with this identifier are part of the same activity.

--- a/src/rust/sysmon-parser/src/system/event_id.rs
+++ b/src/rust/sysmon-parser/src/system/event_id.rs
@@ -3,6 +3,11 @@
 /// <https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#events>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_crate::Serialize, serde_crate::Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub enum EventId {
     ProcessCreation,
     ProcessChangedFileCreationTime,

--- a/src/rust/sysmon-parser/src/system/execution.rs
+++ b/src/rust/sysmon-parser/src/system/execution.rs
@@ -3,6 +3,11 @@
 /// <https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-execution-systempropertiestype-element>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_crate::Serialize, serde_crate::Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct Execution {
     /// Identifies the process that generated the event.
     pub process_id: u32,

--- a/src/rust/sysmon-parser/src/system/provider.rs
+++ b/src/rust/sysmon-parser/src/system/provider.rs
@@ -7,6 +7,11 @@ use derive_into_owned::IntoOwned;
 /// <https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-provider-systempropertiestype-element>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_crate::Serialize, serde_crate::Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct Provider<'a> {
     /// The name of the event provider that logged the event.
     pub name: Option<Cow<'a, str>>,

--- a/src/rust/sysmon-parser/src/system/security.rs
+++ b/src/rust/sysmon-parser/src/system/security.rs
@@ -7,6 +7,11 @@ use derive_into_owned::IntoOwned;
 /// <https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-security-systempropertiestype-element>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_crate::Serialize, serde_crate::Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct Security<'a> {
     /// The security identifier (SID) of the user in string form.
     pub user_id: Option<Cow<'a, str>>,

--- a/src/rust/sysmon-parser/src/system/time_created.rs
+++ b/src/rust/sysmon-parser/src/system/time_created.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde")]
+use chrono::serde::ts_milliseconds;
 use chrono::{
     DateTime,
     Utc,
@@ -8,7 +10,13 @@ use chrono::{
 /// <https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-timecreated-systempropertiestype-element>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_crate::Serialize, serde_crate::Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct TimeCreated {
     /// The system time of when the event was logged.
+    #[cfg_attr(feature = "serde", serde(with = "ts_milliseconds"))]
     pub system_time: DateTime<Utc>,
 }


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This adds a create feature for including serde derive Serialize and Deserialize for the types provided by the sysmon-parser crate. This new feature is included by default.

We aren't making use of these derived methods at the moment in Grapl and there are no immediate plans for that yet, but this library intends to be useful outside of use in Grapl, and effectively (eventually?) replace the public `sysmon` crate that Colin wrote a while ago (that we were previously using): https://crates.io/crates/sysmon. These are generally helpful for public types and I wanted to knock this out now while I was working with it.

The feature flag for this was added because I want it to be generally usable publicly, putting serde behind a flag seems like a decent feature to _optionally_ include, as many crates do, including this crate's dependencies `uuid` and `chrono`.

While debugging the Sysmon generator, which uses this crate, I was thinking it'd be really nice if the tracing formatter (we're using `tracing_subscriber::fmt::format::Json`) could do something like use serde_json's Serialize for printing value, instead of just `std::fmt::Debug`. I thought I should really should have just provided these serde derives in the first place.

It looks like support for what I want from directly from tracing_subscriber is still experimental, though it doesn't use serde: `https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Json.html#valuable-support`. That said, we might be able to leverage something else like tracing-serde for formatting values to JSON in Grapl services. I'm not sure, but that's beyond this PR.

### How were these changes tested?

Just CI tests.
