### PR TITLE
Resolve apt failures with a 'cloud-init status --wait', change to server-minimal us-east-2 AMI

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -253,7 +253,3 @@ steps:
       - make dist/firecracker_rootfs.tar.gz
     agents:
       queue: "packer"
-    # This verify step nondeterministically fails. As such, I'm temporarily
-    # allowing it to fail without blocking CI.
-    # https://github.com/grapl-security/issue-tracker/issues/880
-    soft_fail: true

--- a/Makefile
+++ b/Makefile
@@ -644,6 +644,6 @@ dist/firecracker_kernel.tar.gz: firecracker/generate_firecracker_kernel.sh | dis
 FIRECRACKER_ROOTFS_FILES := $(shell find firecracker/packer -type f)
 dist/firecracker_rootfs.tar.gz: $(FIRECRACKER_ROOTFS_FILES) | dist
 	packer init -upgrade firecracker/packer/build-rootfs.pkr.hcl
-	packer build -on-error=ask \
+	packer build \
 	 	-var dist_folder="${GRAPL_ROOT}/dist" \
 		firecracker/packer/build-rootfs.pkr.hcl

--- a/Makefile
+++ b/Makefile
@@ -644,6 +644,6 @@ dist/firecracker_kernel.tar.gz: firecracker/generate_firecracker_kernel.sh | dis
 FIRECRACKER_ROOTFS_FILES := $(shell find firecracker/packer -type f)
 dist/firecracker_rootfs.tar.gz: $(FIRECRACKER_ROOTFS_FILES) | dist
 	packer init -upgrade firecracker/packer/build-rootfs.pkr.hcl
-	packer build \
+	packer build -on-error=ask \
 	 	-var dist_folder="${GRAPL_ROOT}/dist" \
 		firecracker/packer/build-rootfs.pkr.hcl

--- a/firecracker/packer/build-rootfs.pkr.hcl
+++ b/firecracker/packer/build-rootfs.pkr.hcl
@@ -16,20 +16,20 @@ variable "instance_type" {
 variable "region" {
   description = "In which region to build the rootfs. Must match the Base AMI's region."
   type        = string
-  default     = "us-east-2"
+  default     = "us-east-1"
 }
 
 variable "ami_id" {
   description = <<EOF
 Ubuntu AMI ID to build with. Must match var.region. We grab this one with:
 
-AWS_REGION=us-east-2 aws ssm get-parameters --names \ 
+AWS_REGION=us-east-1 aws ssm get-parameters --names \
   /aws/service/canonical/ubuntu/server-minimal/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id \
   | jq .Parameters[0].Value
 }
 EOF
   type        = string
-  default     = "ami-0941c2e6994d23a93"
+  default     = "ami-0623cccc9df636385"
 }
 
 variable "aws_profile" {

--- a/firecracker/packer/build-rootfs.pkr.hcl
+++ b/firecracker/packer/build-rootfs.pkr.hcl
@@ -16,7 +16,20 @@ variable "instance_type" {
 variable "region" {
   description = "In which region to build the rootfs. Must match the Base AMI's region."
   type        = string
-  default     = "us-east-1"
+  default     = "us-east-2"
+}
+
+variable "ami-id" {
+  description = <<EOF
+Ubuntu AMI ID to build with. Must match var.region. We grab this one with:
+
+AWS_REGION=us-east-2 aws ssm get-parameters --names \ 
+  /aws/service/canonical/ubuntu/server-minimal/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id \
+  | jq .Parameters[0].Value
+}
+EOF
+  type        = string
+  default     = "ami-0941c2e6994d23a93"
 }
 
 variable "aws_profile" {
@@ -51,12 +64,10 @@ locals {
 
 data "amazon-ami" "base-ami" {
   filters = {
-    # official amd64 Ubuntu Focal (20.04 LTS) image on us-east-1
-    # per https://cloud-images.ubuntu.com/locator/ec2/
-    image-id = "ami-01896de1f162f0ab7"
+    image-id = var.ami_id
   }
   owners = ["099720109477"] # Canonical / Ubuntu
-  region = "${var.region}"
+  region = var.region
 }
 
 source "amazon-ebs" "grapl-build-rootfs" {
@@ -70,7 +81,7 @@ source "amazon-ebs" "grapl-build-rootfs" {
   ami_description = "Grapl Build Environment for RootFS"
   ami_name        = "grapl-build-rootfs-linux-x86_64"
   instance_type   = "${var.instance_type}"
-  region          = "${var.region}"
+  region          = var.region
   source_ami      = "${data.amazon-ami.base-ami.id}"
   ssh_username    = "ubuntu"
   profile         = "${var.aws_profile}"
@@ -85,6 +96,12 @@ source "amazon-ebs" "grapl-build-rootfs" {
 
 build {
   sources = ["source.amazon-ebs.grapl-build-rootfs"]
+
+  # Prevents non-deterministic apt failures in install_dependencies.sh
+  # https://github.com/grapl-security/issue-tracker/issues/880
+  provisioner "shell" {
+    inline = ["cloud-init status --wait"]
+  }
 
   provisioner "file" {
     direction   = "upload"

--- a/firecracker/packer/build-rootfs.pkr.hcl
+++ b/firecracker/packer/build-rootfs.pkr.hcl
@@ -19,7 +19,7 @@ variable "region" {
   default     = "us-east-2"
 }
 
-variable "ami-id" {
+variable "ami_id" {
   description = <<EOF
 Ubuntu AMI ID to build with. Must match var.region. We grab this one with:
 


### PR DESCRIPTION
### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/880

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
- Resolve the issues in https://github.com/grapl-security/issue-tracker/issues/880 - there were startup commands happening I didn't know about that were conflicting with our `apt` commands.
- Change to server-minimal; results in slightly shorter build time (fewer things occurring at AMI startup)
- Change to us-east-2; the less hardcoded us-east-1 the better
- Document a CLI command to get latest AMI

thanks thomas for pointing out this possibility!

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I'm reasonably convinced this resolves the nondeterminism. I ran it 10x in a row:
```
set -euo pipefail

for i in {1..10}
do
   echo "Attempt ${i}"

   make dist/firecracker_rootfs.tar.gz || \
    (echo "Attempt ${i} failed!" && exit 1)

   rm dist/firecracker_rootfs.tar.gz
done
```

I also tested and saw nondeterministic "sometimes the cloud-init status was already done, sometimes it was still doing things"

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
