### PR TITLE
Improve logging in Sysmon generator

### DIFF
--- a/src/rust/generators/sysmon-generator/src/generator.rs
+++ b/src/rust/generators/sysmon-generator/src/generator.rs
@@ -75,8 +75,6 @@ where
                     Err(error) => {
                         completed.add_identity(event, EventStatus::Failure);
 
-                        tracing::error!(message = "graph generation error", %error);
-
                         if first_error.is_none() {
                             first_error = Some(error);
                         }

--- a/src/rust/generators/sysmon-generator/src/models.rs
+++ b/src/rust/generators/sysmon-generator/src/models.rs
@@ -17,6 +17,7 @@ mod file;
 mod network;
 mod process;
 
+#[tracing::instrument(err, skip(sysmon_event))]
 pub(crate) fn generate_graph_from_event(
     sysmon_event: &SysmonEvent,
 ) -> Result<Option<GraphDescription>> {
@@ -42,7 +43,7 @@ pub(crate) fn generate_graph_from_event(
                 Some(graph)
             } else {
                 // TODO(inickles): fix graph model for networking and support this
-                tracing::warn!("found inbound connection, which is not currenlty supported.");
+                tracing::warn!("found inbound connection, which is not currenlty supported");
 
                 None
             }
@@ -50,6 +51,12 @@ pub(crate) fn generate_graph_from_event(
         // We do not expect to handle all Sysmon event types
         _ => None,
     };
+
+    tracing::debug!(
+        message = "completed graph generation",
+        node_count = graph.as_ref().map(|graph| graph.nodes.len()),
+        edge_count = graph.as_ref().map(|graph| graph.edges.len()),
+    );
 
     Ok(graph)
 }

--- a/src/rust/generators/sysmon-generator/src/models/file/create.rs
+++ b/src/rust/generators/sysmon-generator/src/models/file/create.rs
@@ -26,10 +26,13 @@ use crate::{
 /// The subgraph generation for a `FileCreateEvent` includes the following:
 /// * A creator `Process` node - denotes the process that created the file
 /// * A subject `File` node - the file that is created as part of this event
+#[tracing::instrument]
 pub fn generate_file_create_subgraph(
     system: &System,
     event_data: &FileCreateEventData<'_>,
 ) -> Result<GraphDescription, SysmonGeneratorError> {
+    tracing::trace!("generating graph from event");
+
     let timestamp = utc_to_epoch(&event_data.creation_utc_time)?;
     let mut graph = GraphDescription::new();
 

--- a/src/rust/generators/sysmon-generator/src/models/network/inbound.rs
+++ b/src/rust/generators/sysmon-generator/src/models/network/inbound.rs
@@ -16,10 +16,13 @@ use crate::models::utc_to_epoch;
 // https://github.com/grapl-security/grapl/commit/e5e2c50d2ccb99b08e1d0c520f4f7a00cfc9e9a6,
 // pending further refactoring. It's not yet really "dead code", but it
 // currently technically is.
+#[tracing::instrument]
 #[allow(dead_code)]
 pub fn generate_inbound_connection_subgraph(
     conn_log: &NetworkEvent,
 ) -> Result<GraphDescription,failure::Error> {
+    tracing::trace!("generating graph from event");
+
     let timestamp = utc_to_epoch(&conn_log.event_data.utc_time)?;
 
     let mut graph = GraphDescription::new();

--- a/src/rust/generators/sysmon-generator/src/models/network/outbound.rs
+++ b/src/rust/generators/sysmon-generator/src/models/network/outbound.rs
@@ -33,10 +33,13 @@ use crate::{
 /// * A subject `OutboundConnection` node - indicating the network connection triggered by the process
 /// * Source and Destination IP Address and Port nodes
 /// * IP connection and Network connection nodes
+#[tracing::instrument]
 pub fn generate_outbound_connection_subgraph(
     system: &System,
     event_data: &NetworkConnectionEventData<'_>,
 ) -> Result<GraphDescription, SysmonGeneratorError> {
+    tracing::trace!("generating graph from event");
+
     let timestamp = utc_to_epoch(&event_data.utc_time)?;
 
     let mut graph = GraphDescription::new();

--- a/src/rust/generators/sysmon-generator/src/models/process/create.rs
+++ b/src/rust/generators/sysmon-generator/src/models/process/create.rs
@@ -28,10 +28,13 @@ use crate::{
 /// * A parent `Process` node - indicating the process that created the subject process
 /// * A subject `Process` node - indicating the process created per the `ProcessCreateEvent`
 /// * A process `File` node - indicating the file executed in creating the new process
+#[tracing::instrument]
 pub fn generate_process_create_subgraph(
     system: &System,
     event_data: &ProcessCreateEventData<'_>,
 ) -> Result<GraphDescription, SysmonGeneratorError> {
+    tracing::trace!("generating graph from event");
+
     let timestamp = utc_to_epoch(&event_data.utc_time)?;
     let mut graph = GraphDescription::new();
 

--- a/src/rust/generators/sysmon-generator/src/serialization.rs
+++ b/src/rust/generators/sysmon-generator/src/serialization.rs
@@ -1,9 +1,6 @@
 use grapl_service::decoder::decompress::PayloadDecompressionError;
 use sqs_executor::event_decoder::PayloadDecoder;
-use sysmon_parser::{
-    system::EventId,
-    SysmonEvent,
-};
+use sysmon_parser::SysmonEvent;
 
 #[derive(Debug, Clone, Default)]
 pub struct SysmonDecoder;
@@ -11,7 +8,7 @@ pub struct SysmonDecoder;
 impl<'a> PayloadDecoder<Vec<SysmonEvent<'static>>> for SysmonDecoder {
     type DecoderError = PayloadDecompressionError;
 
-    #[tracing::instrument(skip(self), err)]
+    #[tracing::instrument(skip(self, body), err)]
     fn decode(&mut self, body: Vec<u8>) -> Result<Vec<SysmonEvent<'static>>, Self::DecoderError> {
         let decompressed = grapl_service::decoder::decompress::maybe_decompress(body.as_slice())?;
 
@@ -19,29 +16,19 @@ impl<'a> PayloadDecoder<Vec<SysmonEvent<'static>>> for SysmonDecoder {
         let sysmon_events: Vec<_> = sysmon_parser::parse_events(xml.as_ref())
             .filter_map(|result| {
                 match &result {
-                    Ok(_) => {
-                        tracing::trace!(message = "Deserialized sysmon event");
+                    Ok(sysmon_event) => {
+                        tracing::trace!(message = "deserialized Sysmon event", event_type =? sysmon_event.system.event_id);
                     }
                     Err(error) => {
                         tracing::error!(
-                            message = "Unable to deserialize Sysmon event",
+                            message = "unable to deserialize Sysmon event",
                             %error,
                         );
                     }
                 }
 
-                result.ok()
+                result.ok().map(SysmonEvent::into_owned)
             })
-            .filter(|event| {
-                matches!(
-                    event.system.event_id,
-                    EventId::ProcessCreation
-                        | EventId::ProcessTerminated
-                        | EventId::FileCreate
-                        | EventId::NetworkConnection
-                )
-            })
-            .map(|event| event.into_owned())
             .collect();
 
         Ok(sysmon_events)


### PR DESCRIPTION

### What changes does this PR make to Grapl? Why?

This improves logging in the Sysmon generator in a number of small ways:
- add new tracing instrumentation.
- provide additional logging.
- skip instrumenting `body` param for impl for PayloadDecoder. that was blowing up logs and wasn't helpful.
- remove redundant event filtering.

### How were these changes tested?

Inspecting logs from the Sysmon generator before and after these changes while debugging the generator.