### PR TITLE
Fix 866 - Firecracker kernel .tar.gz was super nested

### DIFF
--- a/firecracker/generate_firecracker_kernel.sh
+++ b/firecracker/generate_firecracker_kernel.sh
@@ -35,7 +35,6 @@ cd firecracker
 readonly KERNEL_BIN_DIR="${BUILD_DIR}/firecracker//build/kernel/linux-${KERNEL_VERSION}/"
 readonly KERNEL_BIN_FILE="vmlinux-${KERNEL_VERSION}-x86_64.bin"
 readonly DISTRIBUTION="${REPOSITORY_ROOT}/dist/firecracker_kernel.tar.gz"
-tar --create --gzip --file="${DISTRIBUTION}" "${KERNEL_BIN_FILE}"
 
 # NOTE about tar: If you specify the full path of the thing-to-be-tar'd,
 #   the tar will contain that full nested path of directories.

--- a/firecracker/generate_firecracker_kernel.sh
+++ b/firecracker/generate_firecracker_kernel.sh
@@ -32,6 +32,17 @@ cd firecracker
 ########################################
 # Copy kernel into dist.
 ########################################
-readonly KERNEL_BIN_FILE="build/kernel/linux-${KERNEL_VERSION}/vmlinux-${KERNEL_VERSION}-x86_64.bin"
+readonly KERNEL_BIN_DIR="${BUILD_DIR}/firecracker//build/kernel/linux-${KERNEL_VERSION}/"
+readonly KERNEL_BIN_FILE="vmlinux-${KERNEL_VERSION}-x86_64.bin"
 readonly DISTRIBUTION="${REPOSITORY_ROOT}/dist/firecracker_kernel.tar.gz"
 tar --create --gzip --file="${DISTRIBUTION}" "${KERNEL_BIN_FILE}"
+
+# NOTE about tar: If you specify the full path of the thing-to-be-tar'd,
+#   the tar will contain that full nested path of directories.
+#   Hence the --directory, and basename for KERNEL_BIN_FILE
+tar \
+    --directory "${KERNEL_BIN_DIR}" \
+    --file="${DISTRIBUTION}" \
+    --create \
+    --gzip \
+    "${KERNEL_BIN_FILE}"

--- a/firecracker/generate_firecracker_kernel.sh
+++ b/firecracker/generate_firecracker_kernel.sh
@@ -32,7 +32,7 @@ cd firecracker
 ########################################
 # Copy kernel into dist.
 ########################################
-readonly KERNEL_BIN_DIR="${BUILD_DIR}/firecracker//build/kernel/linux-${KERNEL_VERSION}/"
+readonly KERNEL_BIN_DIR="${BUILD_DIR}/firecracker/build/kernel/linux-${KERNEL_VERSION}/"
 readonly KERNEL_BIN_FILE="vmlinux-${KERNEL_VERSION}-x86_64.bin"
 readonly DISTRIBUTION="${REPOSITORY_ROOT}/dist/firecracker_kernel.tar.gz"
 

--- a/firecracker/packer/scripts/create_rootfs_image.sh
+++ b/firecracker/packer/scripts/create_rootfs_image.sh
@@ -67,8 +67,8 @@ sudo debootstrap --include apt,nano "${DEBIAN_VERSION}" \
 sudo umount "${MOUNT_POINT}"
 
 # NOTE about tar: If you specify the full path of the image,
-# the tar will contain that full nested path of directories.
-# Hence the basename.
+#   the tar will contain that full nested path of directories.
+#   Hence the basename.
 tar \
     --directory "${BUILD_DIR}" \
     --file="${OUTPUT_DIR}/${IMAGE_ARCHIVE_NAME}" \


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/866

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Previously if you untar'd the archive it'd be super duper nested in like 5 folders; this fixes it.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Ran the make for the kernel
ran tar -xvf
it extracted the kernel right into the directory :+1:

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
