### PR TITLE
Set RUST_LOG to WARN for all h2, unset for unused dep serde_xml_rs

### DIFF
--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -212,7 +212,6 @@ def main() -> None:
             "hyper=WARN",
             "rusoto_core=WARN",
             "rustls=WARN",
-            "serde_xml_rs=WARN",
         ]
     )
     py_log_level = "DEBUG"

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -208,7 +208,7 @@ def main() -> None:
     rust_log_levels = ",".join(
         [
             "DEBUG",
-            "h2::codec=WARN",
+            "h2=WARN",
             "hyper=WARN",
             "rusoto_core=WARN",
             "rustls=WARN",


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

Two small edits to the RUST_LOG set in Pulumi:
1. set `WARN` for all `h2`, not just `h2::codec`
2. remove setting for `serde_xml_rs`, it's no longer a depenency.

### How were these changes tested?

CI tests, am testing locally as well atm.
