### PR TITLE
internal 580 kafka library

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,6 +71,7 @@ BUILD @christophermaier
 /src/rust/grapl-service/ @inickles-grapl
 /src/rust/grapl-utils/ @inickles-grapl
 /src/rust/grapl-web-ui/ @inickles-grapl
+/src/rust/kafka/ @grapl-security/wg-data-infra
 /src/rust/model-plugin-deployer/ @wimax-grapl
 /src/rust/organization-management/ @andrea-grapl
 /src/rust/plugin-bootstrap/ @colin-grapl

--- a/buf.yaml
+++ b/buf.yaml
@@ -7,7 +7,6 @@ lint:
   use:
     - DEFAULT
     - COMMENTS
-    - UNARY_RPC
     - OTHER
   ignore:
     # We have vendored some of the Google protobuf definitions; we

--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -43,7 +43,9 @@ install_build_tooling() {
     tools=(
         apt-utils
         build-essential
+        cmake
         libclang1
+        libsasl2-dev
         lsb-release
         software-properties-common # for `apt-add-repository``
     )

--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -43,7 +43,7 @@ install_build_tooling() {
     tools=(
         apt-utils
         build-essential
-        cmake
+        cmake # necessary for building rust-rdkafka
         libclang1
         lsb-release
         software-properties-common # for `apt-add-repository``

--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -45,7 +45,6 @@ install_build_tooling() {
         build-essential
         cmake
         libclang1
-        libsasl2-dev
         lsb-release
         software-properties-common # for `apt-add-repository``
     )

--- a/src/proto/graplinc/common/v1beta1/types.proto
+++ b/src/proto/graplinc/common/v1beta1/types.proto
@@ -36,7 +36,11 @@ message Duration {
 }
 
 // A specific point in time, expressed as a duration before or since unix epoch
-// (1970-01-01T00:00:00.000000000Z), with (up to) nanosecond subsecond precision.
+// (1970-01-01T00:00:00.000000000Z), with (up to) nanosecond subsecond
+// precision.
+//
+// NOTE: timestamps are assumed to be UTC. Applications are responsible for
+// doing their own timezone conversion if necessary.
 message Timestamp {
   // A Timestamp contains a duration that specifies a particular instant in time
   // either before or since unix epoch.

--- a/src/proto/graplinc/grapl/api/pipeline_ingress/v1beta1/pipeline_ingress.proto
+++ b/src/proto/graplinc/grapl/api/pipeline_ingress/v1beta1/pipeline_ingress.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package graplinc.grapl.api.pipeline_ingress.v1beta1;
+
+import "graplinc/common/v1beta1/types.proto";
+
+// Publish a log event to the Grapl data pipeline
+message PublishRawLogsRequest {
+  // The event source from which this log event originated
+  graplinc.common.v1beta1.Uuid event_source_id = 1;
+
+  // The tenant to which the event source belongs
+  graplinc.common.v1beta1.Uuid tenant_id = 2;
+
+  // The raw log event
+  bytes log_event = 3;
+}
+
+// Response corresponding to a particular PublishRawLogsRequest
+message PublishRawLogsResponse {
+  // The wall clock time at which the event was persisted
+  graplinc.common.v1beta1.Timestamp created_time = 1;
+}
+
+// RPC service to publish raw logs to the Grapl data pipeline
+service PipelineIngressService {
+  // Publish raw logs to the Grapl data pipeline
+  // Returns one PublishRawLogsResponse for each PublishRawLogsRequest, in order
+  rpc PublishRawLogs(stream PublishRawLogsRequest) returns (stream PublishRawLogsResponse);
+}

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2262,6 +2262,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "krb5-src"
+version = "0.3.2+1.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44cd3b7e7735d48bc3793837041294f2eb747bd0f63bbc081e89972abb9e48fb"
+dependencies = [
+ "duct",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3864,6 +3873,7 @@ checksum = "21d3579e03127aee0792cc0e2d739fe05b1652f396ee92127d15b2748be9adf7"
 dependencies = [
  "cc",
  "duct",
+ "krb5-src",
  "libc",
  "pkg-config",
 ]

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.4",
+ "rand 0.8.5",
  "sha-1 0.10.0",
  "smallvec",
 ]
@@ -113,20 +113,20 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e7472ac180abb0a8e592b653744345983a7a14f44691c8394a799d0df4dbbf"
+checksum = "0da34f8e659ea1b077bb4637948b815cd3768ad5a188fdcd74ff4d84240cd824"
 dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
  "futures-core",
  "futures-util",
- "log",
  "mio",
  "num_cpus",
  "socket2 0.4.4",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -298,7 +298,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.5",
  "once_cell",
  "version_check",
 ]
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.53"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arc-swap"
@@ -379,9 +379,9 @@ checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
 name = "argon2"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a21e93ce9e91fcd0e01744e4f205fb9192f82915646a7e880dfef0ab4a38d8"
+checksum = "25df3c03f1040d0069fcd3907e24e36d59f9b6fa07ba49be0eb25a794f036ba7"
 dependencies = [
  "base64ct",
  "blake2",
@@ -444,18 +444,18 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
+checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
 dependencies = [
  "event-listener",
 ]
 
 [[package]]
 name = "async-stream"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -463,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "awc"
@@ -535,7 +535,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.4",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
 ]
@@ -723,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
@@ -803,10 +803,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "color-eyre"
-version = "0.6.0"
+name = "cmake"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6ec7641ff3474b7593009c809db602c414cd97c7d47a78ed004162b74ff96c"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ebf286c900a6d5867aeff75cfee3192857bb7f24b547d4f0df2ed6baa812c90"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -888,7 +897,7 @@ dependencies = [
  "hkdf",
  "hmac 0.12.1",
  "percent-encoding",
- "rand 0.8.4",
+ "rand 0.8.5",
  "sha2 0.10.2",
  "subtle",
  "time 0.3.7",
@@ -897,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -913,9 +922,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
@@ -937,9 +946,9 @@ checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -984,12 +993,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils 0.8.8",
 ]
 
 [[package]]
@@ -999,8 +1008,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.6",
- "crossbeam-utils 0.8.6",
+ "crossbeam-epoch 0.9.8",
+ "crossbeam-utils 0.8.8",
 ]
 
 [[package]]
@@ -1020,12 +1029,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
+ "autocfg",
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils 0.8.8",
  "lazy_static",
  "memoffset 0.6.5",
  "scopeguard",
@@ -1033,12 +1043,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b979d76c9fcb84dffc80a73f7290da0f83e4c95773494674cb44b76d13a7a110"
+checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils 0.8.8",
 ]
 
 [[package]]
@@ -1054,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -1240,7 +1250,7 @@ dependencies = [
  "http",
  "lazy_static",
  "prost 0.9.0",
- "rand 0.8.4",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1281,7 +1291,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer 0.10.0",
+ "block-buffer 0.10.2",
  "crypto-common",
  "subtle",
 ]
@@ -1307,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
@@ -1338,6 +1348,18 @@ name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "duct"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc6a0a59ed0888e0041cf708e66357b7ae1a82f1c67247e1f93b5e0818f7d8d"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
 
 [[package]]
 name = "either"
@@ -1369,11 +1391,11 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
+checksum = "570d109b813e904becc80d8d5da38376818a143348413f7149f1340fe04754d4"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1406,9 +1428,9 @@ checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "eyre"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc225d8f637923fe585089fcf03e705c222131232d2c1fb622e84ecf725d0eb8"
+checksum = "9289ed2c0440a6536e65119725cf91fc2c6b5e513bfd2e36e1134d7cca6ca12f"
 dependencies = [
  "indenter",
  "once_cell",
@@ -1481,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1496,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1506,15 +1528,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1534,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-lite"
@@ -1555,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1577,21 +1599,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1676,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1752,7 +1774,7 @@ dependencies = [
  "log",
  "lru",
  "prost 0.9.0",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rusoto_core",
  "rusoto_credential",
  "rusoto_dynamodb",
@@ -1883,7 +1905,7 @@ dependencies = [
  "futures-util",
  "grapl-config",
  "hmap",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rusoto_core",
  "rusoto_dynamodb",
  "serde",
@@ -1897,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
+checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
 dependencies = [
  "bytes",
  "fnv",
@@ -1946,6 +1968,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -2037,9 +2065,9 @@ checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -2049,9 +2077,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.16"
+version = "0.14.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2062,7 +2090,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "pin-project-lite",
  "socket2 0.4.4",
  "tokio",
@@ -2096,9 +2124,9 @@ checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.20.2",
+ "rustls 0.20.4",
  "tokio",
- "tokio-rustls 0.23.2",
+ "tokio-rustls 0.23.3",
 ]
 
 [[package]]
@@ -2169,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "itertools"
@@ -2222,6 +2250,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kafka"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "futures",
+ "proptest",
+ "rdkafka",
+ "rust-proto-new",
+ "thiserror",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,9 +2275,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libflate"
@@ -2257,6 +2297,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
 dependencies = [
  "rle-decode-fast",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f35facd4a5673cb5a48822be2be1d4236c1c99cb4113cab7061ac720d5bf859"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2303,9 +2355,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
+checksum = "fcb87f3080f6d1d69e8c564c0fcfde1d7aa8cc451ce40cae89479111f03bc0eb"
 dependencies = [
  "hashbrown",
 ]
@@ -2421,9 +2473,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
 dependencies = [
  "mime",
  "unicase",
@@ -2494,35 +2546,27 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00ecaecb5ad0d5f7c8ccd8eef26cb164941ebfa32dba5a5e4395a44dda096cc"
+checksum = "26e1a0803406a47496169480f26cab92e78936c1180ad439ee18d36478c1509c"
 dependencies = [
  "async-io",
  "async-lock",
  "crossbeam-channel",
- "crossbeam-utils 0.8.6",
+ "crossbeam-epoch 0.8.2",
+ "crossbeam-utils 0.8.8",
  "futures-util",
- "moka-cht",
  "num_cpus",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "quanta",
  "scheduled-thread-pool",
  "skeptic",
  "smallvec",
+ "tagptr",
  "thiserror",
+ "triomphe",
  "uuid",
-]
-
-[[package]]
-name = "moka-cht"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829e4b3f52dff046d1824842169dc0a91319f5e923e20a651b4e85697e03feea"
-dependencies = [
- "crossbeam-epoch 0.8.2",
- "num_cpus",
 ]
 
 [[package]]
@@ -2573,13 +2617,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
- "version_check",
 ]
 
 [[package]]
@@ -2595,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
@@ -2632,10 +2675,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.3"
+name = "num_enum"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
 dependencies = [
  "libc",
 ]
@@ -2651,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "oorandom"
@@ -2674,10 +2738,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-sys"
+version = "0.9.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "organization-management"
 version = "0.1.0"
 dependencies = [
- "argon2 0.3.3",
+ "argon2 0.3.4",
  "grapl-config",
  "grapl-utils",
  "prost 0.9.0",
@@ -2693,6 +2770,16 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "os_pipe"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2717,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20448fd678ec04e6ea15bbe0476874af65e98a01515d667aa49f1434dc44ebf4"
+checksum = "5e72e30578e0d0993c8ae20823dd9cff2bc5517d2f586a8aef462a581e8a03eb"
 
 [[package]]
 name = "parking"
@@ -2862,6 +2949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+
+[[package]]
 name = "plotters"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,6 +3079,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+dependencies = [
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3030,7 +3133,7 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "quick-error 2.0.1",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
@@ -3065,7 +3168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.3.3",
  "itertools 0.10.3",
  "log",
  "multimap",
@@ -3083,7 +3186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.3.3",
  "itertools 0.10.3",
  "lazy_static",
  "log",
@@ -3159,7 +3262,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
 dependencies = [
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils 0.8.8",
  "libc",
  "mach",
  "once_cell",
@@ -3189,7 +3292,7 @@ checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger",
  "log",
- "rand 0.8.4",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3205,9 +3308,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
 dependencies = [
  "proc-macro2",
 ]
@@ -3222,19 +3325,18 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_hc",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -3272,7 +3374,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.5",
 ]
 
 [[package]]
@@ -3282,15 +3384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -3304,9 +3397,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "10.2.0"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "929f54e29691d4e6a9cc558479de70db7aa3d98cd6fe7ab86d7507aa2886b9d2"
+checksum = "738bc47119e3eeccc7e94c4a506901aea5e7b4944ecd0829cbebf4af04ceda12"
 dependencies = [
  "bitflags",
 ]
@@ -3331,9 +3424,42 @@ checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils 0.8.8",
  "lazy_static",
  "num_cpus",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de127f294f2dba488ed46760b129d5ecbeabbd337ccbf3739cb29d50db2161c"
+dependencies = [
+ "futures",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.2.0+1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e542c6863b04ce0fa0c5719bc6b7b348cf8dd21af1bb03c9db5f9805b2a6473"
+dependencies = [
+ "cmake",
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "openssl-sys",
+ "pkg-config",
+ "sasl2-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -3360,21 +3486,22 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "7776223e2696f1aa4c6b0170e83212f47296a00424305117d013dfe86fb0fe55"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.5",
  "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -3414,9 +3541,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
+checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
  "base64",
  "bytes",
@@ -3436,19 +3563,19 @@ dependencies = [
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.2",
+ "rustls 0.20.4",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls 0.23.2",
+ "tokio-rustls 0.23.3",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.22.2",
- "winreg 0.7.0",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -3615,7 +3742,7 @@ dependencies = [
  "prost-types 0.9.0",
  "quickcheck",
  "quickcheck_macros",
- "rand 0.8.4",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "thiserror",
@@ -3631,14 +3758,13 @@ name = "rust-proto-new"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "log",
+ "futures",
  "proptest",
  "prost 0.9.0",
  "prost-types 0.9.0",
  "thiserror",
  "tonic",
  "tonic-build 0.6.2",
- "tracing",
  "uuid",
 ]
 
@@ -3672,9 +3798,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.2"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
+checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
 dependencies = [
  "log",
  "ring",
@@ -3696,9 +3822,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
 dependencies = [
  "base64",
 ]
@@ -3728,6 +3854,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sasl2-sys"
+version = "0.1.19+2.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d3579e03127aee0792cc0e2d739fe05b1652f396ee92127d15b2748be9adf7"
+dependencies = [
+ "cc",
+ "duct",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3777,9 +3915,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fed7948b6c68acbb6e20c334f55ad635dc0f75506963de4464289fbd3b051ac"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3790,9 +3928,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57321bf8bc2362081b2599912d2961fe899c0efadf1b4b2f8d48b3e253bb96c"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3800,9 +3938,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 dependencies = [
  "serde",
 ]
@@ -3850,11 +3988,10 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "indexmap",
  "itoa 1.0.1",
  "ryu",
  "serde",
@@ -3945,6 +4082,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6be9f7d5565b1483af3e72975e2dee33879b3b86bd48c0929fccf6585d79e65a"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4026,9 +4173,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692749de69603d81e016212199d73a2e14ee20e2def7d7914919e8db5d4d48b9"
+checksum = "fc15591eb44ffb5816a4a70a7efd5dd87bfd3aa84c4c200401c4396140525826"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -4036,9 +4183,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518be6f6fff5ca76f985d434f9c37f3662af279642acf730388f271dff7b9016"
+checksum = "195183bf6ff8328bb82c0511a83faf60aacf75840103388851db61d7a9854ae3"
 dependencies = [
  "ahash",
  "atoi",
@@ -4048,9 +4195,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "crossbeam-channel",
  "crossbeam-queue",
- "crossbeam-utils 0.8.6",
  "dirs",
  "either",
  "futures-channel",
@@ -4067,9 +4212,9 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "parking_lot 0.11.2",
+ "paste",
  "percent-encoding",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rustls 0.19.1",
  "serde",
  "serde_json",
@@ -4090,13 +4235,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e45140529cf1f90a5e1c2e561500ca345821a1c513652c8f486bbf07407cc8"
+checksum = "eee35713129561f5e55c554bba1c378e2a7e67f81257b7311183de98c50e6f94"
 dependencies = [
  "dotenv",
  "either",
- "heck",
+ "heck 0.3.3",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -4112,9 +4257,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8061cbaa91ee75041514f67a09398c65a64efed72c90151ecd47593bad53da99"
+checksum = "b555e70fbbf84e269ec3858b7a6515bcfe7a166a7cc9c636dd6efd20431678b6"
 dependencies = [
  "once_cell",
  "tokio",
@@ -4150,6 +4295,12 @@ dependencies = [
  "tracing-futures",
  "uuid",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stringprep"
@@ -4190,7 +4341,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -4205,9 +4356,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4261,6 +4412,12 @@ dependencies = [
  "uuid",
  "xmlparser",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"
@@ -4439,11 +4596,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.2"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
+checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
 dependencies = [
- "rustls 0.20.2",
+ "rustls 0.20.4",
  "tokio",
  "webpki 0.22.0",
 ]
@@ -4485,6 +4642,15 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4560,20 +4726,19 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5651b5f6860a99bd1adb59dbfe1db8beb433e73709d9032b413a77e2fb7c066a"
+checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
 dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.4",
+ "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-stream",
- "tokio-util 0.6.9",
+ "tokio-util 0.7.0",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4593,9 +4758,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -4606,9 +4771,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94571df2eae3ed4353815ea5a90974a594a1792d8782ff2cbcc9392d1101f366"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
  "time 0.3.7",
@@ -4617,9 +4782,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4628,11 +4793,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -4668,9 +4834,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
  "serde",
  "tracing-core",
@@ -4678,9 +4844,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
+checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
 dependencies = [
  "ansi_term",
  "lazy_static",
@@ -4698,10 +4864,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.20.3"
+name = "triomphe"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0d7f5db438199a6e2609debe3f69f808d074e0a2888ee0bccb45fe234d03f4"
+checksum = "c45e322b26410d7260e00f64234810c2f17d7ece356182af4df8f7ff07890f09"
+dependencies = [
+ "memoffset 0.6.5",
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca94d4e9feb6a181c690c4040d7a24ef34018d8313ac5044a61d21222ae24e31"
 dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
@@ -4714,7 +4891,7 @@ dependencies = [
  "ipnet",
  "lazy_static",
  "log",
- "rand 0.8.4",
+ "rand 0.8.5",
  "smallvec",
  "thiserror",
  "tinyvec",
@@ -4724,9 +4901,9 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad17b608a64bd0735e67bde16b0636f8aa8591f831a25d18443ed00a699770"
+checksum = "ecae383baad9995efaa34ce8e57d12c3f305e545887472a492b838f4b5cfb77a"
 dependencies = [
  "cfg-if 1.0.0",
  "futures-util",
@@ -4780,9 +4957,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -4845,9 +5022,21 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.5",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -5046,9 +5235,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.4"
+version = "4.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
 dependencies = [
  "either",
  "lazy_static",
@@ -5156,9 +5345,9 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.7.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
@@ -5177,9 +5366,9 @@ checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
 
 [[package]]
 name = "zeroize"
-version = "1.5.2"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c88870063c39ee00ec285a2f8d6a966e5b6fb2becc4e8dac77ed0d370ed6006"
+checksum = "7eb5728b8afd3f280a869ce1d4c554ffaed35f45c231fc41bfbd0381bef50317"
 
 [[package]]
 name = "zstd"

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2747,6 +2747,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.18.0+1.1.1n"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2755,6 +2764,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "./grapl-service",
   "./grapl-web-ui",
   "./grapl-utils",
+  "./kafka",
   "./model-plugin-deployer",
   "./node-identifier",
   "./nomad-client-gen",

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -17,7 +17,13 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-base-apt
     && apt-get install --yes --no-install-recommends \
         curl=7.74.0-1.3+deb11u1 \
         jq=1.6-2.1 \
-        unzip=6.0-26
+        unzip=6.0-26 \
+        cmake=3.18.4-2+deb11u1 \
+        pkg-config=0.29.2-1 \
+        libssl-dev=1.1.1k-1+deb11u2 \
+        tcl=8.6.11+1 \
+        perl=5.32.1-4+deb11u2 \
+        build-essential=12.9
 
 # Grab a Nomad binary, which we use in plugin-registry for parsing
 # HCL2-with-variables into JSON.

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -9,6 +9,8 @@ ARG RUST_BUILD=debug
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 
 # curl, jq, and unzip are used by various commands in this Dockerfile.
+# build-essential, cmake, libssl-dev, perl, pkg-config, and tcl are needed
+# for building rust-rdkafka.
 #
 # Ignore this lint about deleteing the apt-get lists (we're caching!)
 # hadolint ignore=DL3009,SC1089
@@ -18,12 +20,13 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-base-apt
         curl=7.74.0-1.3+deb11u1 \
         jq=1.6-2.1 \
         unzip=6.0-26 \
-        cmake=3.18.4-2+deb11u1 \
-        pkg-config=0.29.2-1 \
-        libssl-dev=1.1.1k-1+deb11u2 \
-        tcl=8.6.11+1 \
-        perl=5.32.1-4+deb11u2 \
-        build-essential=12.9
+    && apt-get install --yes --no-install-recommends \
+         build-essential=12.9 \
+         cmake=3.18.4-2+deb11u1 \
+         libssl-dev=1.1.1k-1+deb11u2 \
+         perl=5.32.1-4+deb11u2 \
+         pkg-config=0.29.2-1 \
+         tcl=8.6.11+1
 
 # Grab a Nomad binary, which we use in plugin-registry for parsing
 # HCL2-with-variables into JSON.

--- a/src/rust/Makefile
+++ b/src/rust/Makefile
@@ -55,11 +55,6 @@ lint-clippy: image
 lint-clippy: ## Run Clippy
 	$(docker_run) bin/lint
 
-.PHONY: cargo-udeps
-cargo-udeps: image
-cargo-udeps: # Run cargo-udeps
-	$(docker_run) bin/udeps
-
 ########################################################################
 
 image: build-env.Dockerfile

--- a/src/rust/Makefile
+++ b/src/rust/Makefile
@@ -55,6 +55,11 @@ lint-clippy: image
 lint-clippy: ## Run Clippy
 	$(docker_run) bin/lint
 
+.PHONY: cargo-udeps
+cargo-udeps: image
+cargo-udeps: # Run cargo-udeps
+	$(docker_run) bin/udeps
+
 ########################################################################
 
 image: build-env.Dockerfile

--- a/src/rust/build-env.Dockerfile
+++ b/src/rust/build-env.Dockerfile
@@ -10,7 +10,11 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-build-en
     # compilation of the `cargo-tarpaulin` tool itself.
     apt-get install --yes --no-install-recommends \
          libssl-dev=1.1.1k-1+deb11u2 \
-         pkg-config=0.29.2-1
+         pkg-config=0.29.2-1 \
+         cmake=3.18.4-2+deb11u1 \
+         tcl=8.6.11+1 \
+         perl=5.32.1-4+deb11u2 \
+         build-essential=12.9
 EOF
 
 # This is where tarpaulin gets installed; using a volume means we get

--- a/src/rust/build-env.Dockerfile
+++ b/src/rust/build-env.Dockerfile
@@ -8,13 +8,15 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-build-en
     apt-get update
     # `libssl-dev` and `pkg-config` are needed for the initial
     # compilation of the `cargo-tarpaulin` tool itself.
+    # build-essential, cmake, libssl-dev, perl, pkg-config, and tcl are needed
+    # for building rust-rdkafka.
     apt-get install --yes --no-install-recommends \
-         libssl-dev=1.1.1k-1+deb11u2 \
-         pkg-config=0.29.2-1 \
+         build-essential=12.9 \
          cmake=3.18.4-2+deb11u1 \
-         tcl=8.6.11+1 \
+         libssl-dev=1.1.1k-1+deb11u2 \
          perl=5.32.1-4+deb11u2 \
-         build-essential=12.9
+         pkg-config=0.29.2-1 \
+         tcl=8.6.11+1
 EOF
 
 # This is where tarpaulin gets installed; using a volume means we get

--- a/src/rust/kafka/Cargo.toml
+++ b/src/rust/kafka/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "kafka"
+version = "0.1.0"
+authors = ["Grapl, Inc. <sales@graplsecurity.com>"]
+edition = "2021"
+description = "Library for Grapl's Kafka services"
+license = "MIT"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bytes = "1.1.0"
+futures = "0.3.0"
+rdkafka = { version = "0.28.0", features = ["cmake-build", "ssl", "sasl", "tokio", "zstd"] }
+rust-proto-new = { path = "../rust-proto-new", version = "*" }
+thiserror = "1.0.30"
+
+[dev-dependencies]
+proptest = "1.0.0"

--- a/src/rust/kafka/Cargo.toml
+++ b/src/rust/kafka/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [dependencies]
 bytes = "1.1.0"
 futures = "0.3.0"
-rdkafka = { version = "0.28.0", features = ["cmake-build", "ssl", "sasl", "tokio", "zstd"] }
+rdkafka = { version = "0.28.0", features = ["cmake-build", "ssl", "gssapi-vendored", "tokio", "zstd"] }
 rust-proto-new = { path = "../rust-proto-new", version = "*" }
 thiserror = "1.0.30"
 

--- a/src/rust/kafka/Cargo.toml
+++ b/src/rust/kafka/Cargo.toml
@@ -7,11 +7,16 @@ description = "Library for Grapl's Kafka services"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 bytes = "1.1.0"
 futures = "0.3.0"
-rdkafka = { version = "0.28.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "tokio", "zstd"] }
+rdkafka = { version = "0.28.0", features = [
+  "cmake-build",
+  "ssl-vendored",
+  "gssapi-vendored",
+  "tokio",
+  "zstd"
+] }
 rust-proto-new = { path = "../rust-proto-new", version = "*" }
 thiserror = "1.0.30"
 

--- a/src/rust/kafka/Cargo.toml
+++ b/src/rust/kafka/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [dependencies]
 bytes = "1.1.0"
 futures = "0.3.0"
-rdkafka = { version = "0.28.0", features = ["cmake-build", "ssl", "gssapi-vendored", "tokio", "zstd"] }
+rdkafka = { version = "0.28.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "tokio", "zstd"] }
 rust-proto-new = { path = "../rust-proto-new", version = "*" }
 thiserror = "1.0.30"
 

--- a/src/rust/kafka/src/lib.rs
+++ b/src/rust/kafka/src/lib.rs
@@ -229,20 +229,20 @@ pub enum StreamProcessorError {
 // A stream processor consumes data from a topic, does things with the data, and
 // produces data to another topic. This stream processor deserializes the data
 // after consuming and serializes data before producing.
-pub struct StreamProcessor<T, U>
+pub struct StreamProcessor<C, P>
 where
-    T: SerDe,
-    U: SerDe,
+    C: SerDe,
+    P: SerDe,
 {
-    consumer: Consumer<T>,
-    producer: Producer<U>,
+    consumer: Consumer<C>,
+    producer: Producer<P>,
 }
 
-impl<T: SerDe, U: SerDe> StreamProcessor<T, U> {
+impl<C: SerDe, P: SerDe> StreamProcessor<C, P> {
     pub fn new(
         consumer_topic: &str,
         producer_topic: &str,
-    ) -> Result<StreamProcessor<T, U>, ConfigurationError> {
+    ) -> Result<StreamProcessor<C, P>, ConfigurationError> {
         Ok(StreamProcessor {
             consumer: Consumer::new(consumer_topic)?,
             producer: Producer::new(producer_topic)?,
@@ -254,7 +254,7 @@ impl<T: SerDe, U: SerDe> StreamProcessor<T, U> {
         event_handler: F,
     ) -> Result<impl Stream<Item = Result<(), StreamProcessorError>> + 'a, ConfigurationError>
     where
-        F: FnMut(Result<T, StreamProcessorError>) -> Result<U, E> + 'a,
+        F: FnMut(Result<C, StreamProcessorError>) -> Result<P, E> + 'a,
         E: Display,
     {
         Ok(self

--- a/src/rust/kafka/src/lib.rs
+++ b/src/rust/kafka/src/lib.rs
@@ -1,0 +1,277 @@
+use std::{
+    fmt::Display,
+    marker::PhantomData,
+};
+
+use futures::{
+    stream::{
+        Stream,
+        StreamExt
+    },
+    FutureExt,
+    TryFutureExt,
+    TryStreamExt
+};
+use rdkafka::{
+    consumer::stream_consumer::StreamConsumer,
+    producer::{
+        FutureProducer,
+        FutureRecord
+    },
+    config::ClientConfig,
+    error::KafkaError,
+    Message,
+    util::Timeout
+};
+use rust_proto_new::{
+    SerDe,
+    SerDeError
+};
+use thiserror::Error;
+
+//
+// Kafka configurations
+//
+
+#[derive(Error, Debug)]
+pub enum ConfigurationError {
+    #[error("failed to retrieve value from environment variable {0}")]
+    EnvironmentError(#[from] std::env::VarError),
+
+    #[error("failed to construct kafka producer {0}")]
+    ProducerCreateFailed(KafkaError),
+
+    #[error("failed to construct kafka consumer {0}")]
+    ConsumerCreateFailed(KafkaError),
+
+    #[error("failed to subscribe kafka consumer {0}")]
+    SubscriptionFailed(KafkaError)
+}
+
+fn configure() -> Result<ClientConfig, std::env::VarError> {
+    let bootstrap_servers = std::env::var("KAFKA_BOOTSTRAP_SERVERS")?;
+    if bootstrap_servers.starts_with("SASL_SSL") { // running in aws w/ ccloud
+        // https://docs.confluent.io/cloud/current/client-apps/config-client.html#librdkafka-based-c-clients
+        Ok(ClientConfig::new()
+           .set("bootstrap.servers", bootstrap_servers)
+           .set("security.protocol", "SASL_SSL")
+           .set("sasl.mechanisms", "PLAIN")
+           .set("sasl.username", std::env::var("KAFKA_SASL_USERNAME")?)
+           .set("sasl.password", std::env::var("KAFKA_SASL_PASSWORD")?)
+           .set("broker.address.ttl", "30000")
+           .set("api.version.request", "true")
+           .set("api.version.fallback.ms", "0")
+           .set("broker.version.fallback", "0.10.0.0")
+           .to_owned())
+    } else { // running locally
+        Ok(ClientConfig::new()
+           .set("bootstrap.servers", bootstrap_servers)
+           .set("security.protocol", "PLAINTEXT")
+           .to_owned())
+    }
+}
+
+//
+// Producer
+//
+
+fn producer() -> Result<FutureProducer, ConfigurationError> {
+    configure()?
+        .set("acks", "all")
+        .create()
+        .map_err(|e| ConfigurationError::ProducerCreateFailed(e))
+}
+
+#[derive(Error, Debug)]
+pub enum ProducerError {
+    #[error("failed to serialize message {0}")]
+    SerializationError(#[from] SerDeError),
+
+    #[error("failed to deliver message to kafka {0}")]
+    KafkaError(#[from] KafkaError)
+}
+
+pub struct Producer<T>
+where
+    T: SerDe
+{
+    producer: FutureProducer,
+    topic: String,
+    _t: PhantomData<T>
+}
+
+impl <T: SerDe> Clone for Producer<T> {
+    fn clone(&self) -> Self {
+        // this should be approximately just as cheap as
+        // FutureProducer::clone(), which is documented to be very inexpensive,
+        // so it's probably good enough?
+        Producer {
+            producer: self.producer.clone(),
+            topic: self.topic.clone(),
+            _t: PhantomData
+        }
+    }
+}
+
+// A producer publishes data to a topic. This producer serializes the data it is
+// given before publishing.
+impl <T: SerDe> Producer<T> {
+    pub fn new(topic: &str) -> Result<Producer<T>, ConfigurationError> {
+        Ok(Producer {
+            producer: producer()?,
+            topic: topic.to_owned(),
+            _t: PhantomData
+        })
+    }
+
+    pub async fn send(&self, msg: T) -> Result<(), ProducerError> {
+        let serialized = msg.serialize()?.to_vec();
+        let record: FutureRecord<Vec<u8>, Vec<u8>> = FutureRecord::to(&self.topic)
+            .payload(&serialized);
+
+        self.producer
+            .send(record, Timeout::Never)
+            .map(|res| -> Result<(), ProducerError> {
+                res
+                    .map_err(|(e, _)| -> ProducerError {
+                        e.into() // TODO: add erroneous message to error
+                    })
+                    .map(|_| ()) // TODO: debug log partition and offset
+            }).await
+    }
+}
+
+//
+// Consumer
+//
+
+fn consumer() -> Result<StreamConsumer, ConfigurationError> {
+    configure()?
+        .set("group.id", std::env::var("KAFKA_CONSUMER_GROUP_NAME")?)
+        .set("enable.auto.commit", "true")
+        .set("auto.offset.reset", "earliest")
+        .set("session.timeout.ms", "45000")
+        .create()
+        .map_err(|e| ConfigurationError::ConsumerCreateFailed(e))
+}
+
+#[derive(Error, Debug)]
+pub enum ConsumerError {
+    #[error("failed to deserialize message {0}")]
+    DeserializationError(#[from] SerDeError),
+
+    #[error("failed to consume message from kafka {0}")]
+    KafkaConsumptionFailed(#[from] KafkaError),
+
+    #[error("message payload absent")]
+    PayloadAbsent
+}
+
+// A consumer consumes data from a topic. This consumer deserializes each
+// message after consuming it, and yields the deserialized message to the
+// caller.
+pub struct Consumer<T>
+where
+    T: SerDe
+{
+    consumer: StreamConsumer,
+    topic: String,
+    _t: PhantomData<T>,
+}
+
+impl <T: SerDe> Consumer<T> {
+    pub fn new(topic: &str) -> Result<Consumer<T>, ConfigurationError> {
+        Ok(Consumer {
+            consumer: consumer()?,
+            topic: topic.to_owned(),
+            _t: PhantomData
+        })
+    }
+
+    pub fn stream(&self) -> Result<impl Stream<Item = Result<T, ConsumerError>> + '_, ConfigurationError> {
+        // the .subscribe(..) call must be fully-qualified here because the
+        // Consumer name is shadowed in this crate
+        match rdkafka::consumer::Consumer::subscribe(&self.consumer, &[&self.topic]) {
+            Ok(()) => {
+                Ok(self.consumer.stream()
+                    .map(|res| -> Result<T, ConsumerError> {
+                        res
+                            .map_err(|e| e.into())
+                            .and_then(
+                                |msg| T::deserialize(
+                                    msg.payload().ok_or(ConsumerError::PayloadAbsent)?
+                                ).map_err(|e| e.into())
+                            )
+                    })
+                )
+            },
+            Err(e) => Err(ConfigurationError::SubscriptionFailed(e))
+        }
+    }
+}
+
+//
+// StreamProcessor
+//
+
+#[derive(Error, Debug)]
+pub enum StreamProcessorError {
+    #[error("encountered consumer error {0}")]
+    ConsumerError(#[from] ConsumerError),
+
+    #[error("encountered producer error {0}")]
+    ProducerError(#[from] ProducerError),
+
+    #[error("encountered event handler error {0}")]
+    EventHandlerError(String)
+}
+
+// A stream processor consumes data from a topic, does things with the data, and
+// produces data to another topic. This stream processor deserializes the data
+// after consuming and serializes data before producing.
+pub struct StreamProcessor<T, U>
+where
+    T: SerDe,
+    U: SerDe,
+{
+    consumer: Consumer<T>,
+    producer: Producer<U>,
+}
+
+impl <T: SerDe, U: SerDe> StreamProcessor<T, U> {
+    pub fn new(consumer_topic: &str, producer_topic: &str)
+           -> Result<StreamProcessor<T, U>, ConfigurationError>
+    {
+        Ok(StreamProcessor {
+            consumer: Consumer::new(consumer_topic)?,
+            producer: Producer::new(producer_topic)?,
+        })
+    }
+
+    pub fn stream<'a, F, E>(
+        &'a self, event_handler: F
+    ) -> Result<impl Stream<Item = Result<(), StreamProcessorError>> + 'a, ConfigurationError>
+    where
+        F: FnMut(Result<T, StreamProcessorError>) -> Result<U, E> + 'a,
+        E: Display,
+    {
+        Ok(self.consumer.stream()?
+           .map_err(|e| -> StreamProcessorError {
+               e.into()
+           })
+           .map(event_handler)
+           .map_err(|e| StreamProcessorError::EventHandlerError(e.to_string()))
+           .and_then(move |msg| async move {
+               // The underlying FutureProducer::clone() call is allegedly
+               // inexpensive. It's documented that "It can be cheaply cloned to
+               // get a reference to the same underlying producer", and the
+               // examples in the rust-rdkafka repo show cloning upon receipt of
+               // every message, so I think it's acceptable here?
+               self.producer.clone()
+                   .send(msg)
+                   .map_err(|e| -> StreamProcessorError {
+                       e.into()
+                   }).await
+           }))
+    }
+}

--- a/src/rust/kafka/src/lib.rs
+++ b/src/rust/kafka/src/lib.rs
@@ -200,9 +200,9 @@ impl<T: SerDe> Consumer<T> {
                 .consumer
                 .stream()
                 .map(|res| -> Result<T, ConsumerError> {
-                    res.map_err(|e| e.into()).and_then(|msg| {
+                    res.map_err(ConsumerError::from).and_then(|msg| {
                         T::deserialize(msg.payload().ok_or(ConsumerError::PayloadAbsent)?)
-                            .map_err(|e| e.into())
+                            .map_err(ConsumerError::from)
                     })
                 })),
             Err(e) => Err(ConfigurationError::SubscriptionFailed(e)),
@@ -260,7 +260,7 @@ impl<T: SerDe, U: SerDe> StreamProcessor<T, U> {
         Ok(self
             .consumer
             .stream()?
-            .map_err(|e| -> StreamProcessorError { e.into() })
+            .map_err(StreamProcessorError::from)
             .map(event_handler)
             .map_err(|e| StreamProcessorError::EventHandlerError(e.to_string()))
             .and_then(move |msg| async move {
@@ -272,7 +272,7 @@ impl<T: SerDe, U: SerDe> StreamProcessor<T, U> {
                 self.producer
                     .clone()
                     .send(msg)
-                    .map_err(|e| -> StreamProcessorError { e.into() })
+                    .map_err(StreamProcessorError::from)
                     .await
             }))
     }

--- a/src/rust/rust-proto-new/Cargo.toml
+++ b/src/rust/rust-proto-new/Cargo.toml
@@ -8,12 +8,10 @@ license = "MIT"
 
 [dependencies]
 bytes = "1.1.0"
-log = "0.4.14"
 prost = "0.9.0"
 prost-types = "0.9.0"
 thiserror = "1.0.30"
 tonic = "0.6.1"
-tracing = "0.1.29"
 uuid = { version = "0.8.2", features = ["v4"] }
 
 [build-dependencies]
@@ -21,7 +19,3 @@ tonic-build = { version = "0.6.0", features = ["prost"] }
 
 [dev-dependencies]
 proptest = "1.0.0"
-
-[features]
-default = []
-extra_assertions = []

--- a/src/rust/rust-proto-new/Cargo.toml
+++ b/src/rust/rust-proto-new/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 
 [dependencies]
 bytes = "1.1.0"
+futures = "0.3.0"
 prost = "0.9.0"
 prost-types = "0.9.0"
 thiserror = "1.0.30"

--- a/src/rust/rust-proto-new/build.rs
+++ b/src/rust/rust-proto-new/build.rs
@@ -13,6 +13,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     get_proto_files("../../proto/graplinc", &mut paths)?;
 
     config
+        .build_client(true)
+        .build_server(true)
         .compile(&paths[..], &["../../proto/".to_string()])
         .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
     Ok(())

--- a/src/rust/rust-proto-new/src/graplinc/common/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/common/v1beta1.rs
@@ -139,7 +139,7 @@ impl TryFrom<TimestampProto> for SystemTime {
                 let duration: Duration = duration_proto.into();
                 Ok(UNIX_EPOCH + duration)
             }
-            None => Err(SerDeError::MissingField("duration".to_string())),
+            None => Err(SerDeError::MissingField("duration")),
         }
     }
 }

--- a/src/rust/rust-proto-new/src/graplinc/common/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/common/v1beta1.rs
@@ -9,7 +9,8 @@ use std::time::{
 
 use bytes::{
     Buf,
-    BufMut,
+    BytesMut,
+    Bytes
 };
 use prost::Message;
 pub use uuid::Uuid;
@@ -57,12 +58,10 @@ impl type_url::TypeUrl for Uuid {
 }
 
 impl SerDe for Uuid {
-    fn serialize<B>(self, buf: &mut B) -> Result<(), SerDeError>
-    where
-        B: BufMut,
-    {
-        UuidProto::from(self).encode(buf)?;
-        Ok(())
+    fn serialize(self) -> Result<Bytes, SerDeError> {
+        let mut buf = BytesMut::new();
+        UuidProto::from(self).encode(&mut buf)?;
+        Ok(buf.freeze())
     }
 
     fn deserialize<B>(buf: B) -> Result<Self, SerDeError>
@@ -99,12 +98,10 @@ impl type_url::TypeUrl for Duration {
 }
 
 impl SerDe for Duration {
-    fn serialize<B>(self, buf: &mut B) -> Result<(), SerDeError>
-    where
-        B: BufMut,
-    {
-        DurationProto::from(self).encode(buf)?;
-        Ok(())
+    fn serialize(self) -> Result<Bytes, SerDeError> {
+        let mut buf = BytesMut::new();
+        DurationProto::from(self).encode(&mut buf)?;
+        Ok(buf.freeze())
     }
 
     fn deserialize<B>(buf: B) -> Result<Self, SerDeError>
@@ -178,12 +175,10 @@ impl type_url::TypeUrl for SystemTime {
 }
 
 impl SerDe for SystemTime {
-    fn serialize<B>(self, buf: &mut B) -> Result<(), SerDeError>
-    where
-        B: BufMut,
-    {
-        TimestampProto::try_from(self)?.encode(buf)?;
-        Ok(())
+    fn serialize(self) -> Result<Bytes, SerDeError> {
+        let mut buf = BytesMut::new();
+        TimestampProto::try_from(self)?.encode(&mut buf)?;
+        Ok(buf.freeze())
     }
 
     fn deserialize<B>(buf: B) -> Result<Self, SerDeError>

--- a/src/rust/rust-proto-new/src/graplinc/common/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/common/v1beta1.rs
@@ -9,8 +9,8 @@ use std::time::{
 
 use bytes::{
     Buf,
+    Bytes,
     BytesMut,
-    Bytes
 };
 use prost::Message;
 pub use uuid::Uuid;

--- a/src/rust/rust-proto-new/src/graplinc/common/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/common/v1beta1.rs
@@ -59,8 +59,9 @@ impl type_url::TypeUrl for Uuid {
 
 impl SerDe for Uuid {
     fn serialize(self) -> Result<Bytes, SerDeError> {
-        let mut buf = BytesMut::new();
-        UuidProto::from(self).encode(&mut buf)?;
+        let uuid_proto = UuidProto::from(self);
+        let mut buf = BytesMut::with_capacity(uuid_proto.encoded_len());
+        uuid_proto.encode(&mut buf)?;
         Ok(buf.freeze())
     }
 
@@ -99,8 +100,9 @@ impl type_url::TypeUrl for Duration {
 
 impl SerDe for Duration {
     fn serialize(self) -> Result<Bytes, SerDeError> {
-        let mut buf = BytesMut::new();
-        DurationProto::from(self).encode(&mut buf)?;
+        let duration_proto = DurationProto::from(self);
+        let mut buf = BytesMut::with_capacity(duration_proto.encoded_len());
+        duration_proto.encode(&mut buf)?;
         Ok(buf.freeze())
     }
 
@@ -176,8 +178,9 @@ impl type_url::TypeUrl for SystemTime {
 
 impl SerDe for SystemTime {
     fn serialize(self) -> Result<Bytes, SerDeError> {
-        let mut buf = BytesMut::new();
-        TimestampProto::try_from(self)?.encode(&mut buf)?;
+        let timestamp_proto = TimestampProto::try_from(self)?;
+        let mut buf = BytesMut::with_capacity(timestamp_proto.encoded_len());
+        timestamp_proto.encode(&mut buf)?;
         Ok(buf.freeze())
     }
 

--- a/src/rust/rust-proto-new/src/graplinc/grapl/api/pipeline_ingress/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/api/pipeline_ingress/v1beta1.rs
@@ -1,4 +1,4 @@
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use prost::Message;
 
 use crate::{
@@ -64,12 +64,10 @@ impl type_url::TypeUrl for PublishRawLogsRequest {
 }
 
 impl SerDe for PublishRawLogsRequest {
-    fn serialize<B>(self, buf: &mut B) -> Result<(), SerDeError>
-    where
-        B: bytes::BufMut,
-    {
-        PublishRawLogsRequestProto::from(self).encode(buf)?;
-        Ok(())
+    fn serialize(self) -> Result<Bytes, SerDeError> {
+        let mut buf = BytesMut::new();
+        PublishRawLogsRequestProto::from(self).encode(&mut buf)?;
+        Ok(buf.freeze())
     }
 
     fn deserialize<B>(buf: B) -> Result<Self, SerDeError>
@@ -123,12 +121,10 @@ impl type_url::TypeUrl for PublishRawLogsResponse {
 }
 
 impl SerDe for PublishRawLogsResponse {
-    fn serialize<B>(self, buf: &mut B) -> Result<(), SerDeError>
-    where
-        B: bytes::BufMut,
-    {
-        PublishRawLogsResponseProto::try_from(self)?.encode(buf)?;
-        Ok(())
+    fn serialize(self) -> Result<Bytes, SerDeError> {
+        let mut buf = BytesMut::new();
+        PublishRawLogsResponseProto::try_from(self)?.encode(&mut buf)?;
+        Ok(buf.freeze())
     }
 
     fn deserialize<B>(buf: B) -> Result<Self, SerDeError>

--- a/src/rust/rust-proto-new/src/graplinc/grapl/api/pipeline_ingress/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/api/pipeline_ingress/v1beta1.rs
@@ -1,0 +1,142 @@
+use bytes::Bytes;
+use prost::Message;
+
+use crate::{
+    graplinc::common::v1beta1::{
+        SystemTime,
+        Uuid,
+    },
+    protobufs::graplinc::grapl::api::pipeline_ingress::v1beta1::{
+        PublishRawLogsRequest as PublishRawLogsRequestProto,
+        PublishRawLogsResponse as PublishRawLogsResponseProto,
+    },
+    type_url,
+    SerDe,
+    SerDeError,
+};
+
+//
+// PublishRawLogsRequest
+//
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PublishRawLogsRequest {
+    pub event_source_id: Uuid,
+    pub tenant_id: Uuid,
+    pub log_event: Bytes,
+}
+
+impl TryFrom<PublishRawLogsRequestProto> for PublishRawLogsRequest {
+    type Error = SerDeError;
+
+    fn try_from(
+        publish_raw_logs_request_proto: PublishRawLogsRequestProto,
+    ) -> Result<Self, Self::Error> {
+        let event_source_id = publish_raw_logs_request_proto
+            .event_source_id
+            .ok_or(SerDeError::MissingField("event_source_id".to_string()));
+
+        let tenant_id = publish_raw_logs_request_proto
+            .tenant_id
+            .ok_or(SerDeError::MissingField("tenant_id".to_string()));
+
+        Ok(PublishRawLogsRequest {
+            event_source_id: event_source_id?.into(),
+            tenant_id: tenant_id?.into(),
+            log_event: Bytes::from(publish_raw_logs_request_proto.log_event),
+        })
+    }
+}
+
+impl From<PublishRawLogsRequest> for PublishRawLogsRequestProto {
+    fn from(publish_raw_logs_request: PublishRawLogsRequest) -> Self {
+        PublishRawLogsRequestProto {
+            event_source_id: Some(publish_raw_logs_request.event_source_id.into()),
+            tenant_id: Some(publish_raw_logs_request.tenant_id.into()),
+            log_event: publish_raw_logs_request.log_event.to_vec(),
+        }
+    }
+}
+
+impl type_url::TypeUrl for PublishRawLogsRequest {
+    const TYPE_URL: &'static str =
+        "graplsecurity.com/graplinc.grapl.api.pipeline_ingress.v1beta1.PublishRawLogsRequest";
+}
+
+impl SerDe for PublishRawLogsRequest {
+    fn serialize<B>(self, buf: &mut B) -> Result<(), SerDeError>
+    where
+        B: bytes::BufMut,
+    {
+        PublishRawLogsRequestProto::from(self).encode(buf)?;
+        Ok(())
+    }
+
+    fn deserialize<B>(buf: B) -> Result<Self, SerDeError>
+    where
+        B: bytes::Buf,
+        Self: Sized,
+    {
+        let publish_raw_logs_request_proto: PublishRawLogsRequestProto = Message::decode(buf)?;
+        publish_raw_logs_request_proto.try_into()
+    }
+}
+
+//
+// PublishRawLogsResponse
+//
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PublishRawLogsResponse {
+    pub created_time: SystemTime,
+}
+
+impl TryFrom<PublishRawLogsResponseProto> for PublishRawLogsResponse {
+    type Error = SerDeError;
+
+    fn try_from(
+        publish_raw_logs_response_proto: PublishRawLogsResponseProto,
+    ) -> Result<Self, Self::Error> {
+        let created_time = publish_raw_logs_response_proto
+            .created_time
+            .ok_or(SerDeError::MissingField("created_time".to_string()));
+
+        Ok(PublishRawLogsResponse {
+            created_time: created_time?.try_into()?,
+        })
+    }
+}
+
+impl TryFrom<PublishRawLogsResponse> for PublishRawLogsResponseProto {
+    type Error = SerDeError;
+
+    fn try_from(publish_raw_logs_response: PublishRawLogsResponse) -> Result<Self, Self::Error> {
+        Ok(PublishRawLogsResponseProto {
+            created_time: Some(publish_raw_logs_response.created_time.try_into()?),
+        })
+    }
+}
+
+impl type_url::TypeUrl for PublishRawLogsResponse {
+    const TYPE_URL: &'static str =
+        "grapsecurity.com/graplinc.grapl.api.pipeline_ingress.v1beta1.PublishRawLogsResponse";
+}
+
+impl SerDe for PublishRawLogsResponse {
+    fn serialize<B>(self, buf: &mut B) -> Result<(), SerDeError>
+    where
+        B: bytes::BufMut,
+    {
+        PublishRawLogsResponseProto::try_from(self)?.encode(buf)?;
+        Ok(())
+    }
+
+    fn deserialize<B>(buf: B) -> Result<Self, SerDeError>
+    where
+        B: bytes::Buf,
+        Self: Sized,
+    {
+        let publish_raw_logs_response_proto: PublishRawLogsResponseProto = Message::decode(buf)?;
+        publish_raw_logs_response_proto.try_into()
+    }
+}

--- a/src/rust/rust-proto-new/src/graplinc/grapl/api/pipeline_ingress/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/api/pipeline_ingress/v1beta1.rs
@@ -1,4 +1,7 @@
-use bytes::{Bytes, BytesMut};
+use bytes::{
+    Bytes,
+    BytesMut,
+};
 use prost::Message;
 
 use crate::{

--- a/src/rust/rust-proto-new/src/graplinc/grapl/api/pipeline_ingress/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/api/pipeline_ingress/v1beta1.rs
@@ -32,31 +32,29 @@ pub struct PublishRawLogsRequest {
 impl TryFrom<PublishRawLogsRequestProto> for PublishRawLogsRequest {
     type Error = SerDeError;
 
-    fn try_from(
-        publish_raw_logs_request_proto: PublishRawLogsRequestProto,
-    ) -> Result<Self, Self::Error> {
-        let event_source_id = publish_raw_logs_request_proto
+    fn try_from(request_proto: PublishRawLogsRequestProto) -> Result<Self, Self::Error> {
+        let event_source_id = request_proto
             .event_source_id
-            .ok_or_else(|| SerDeError::MissingField("event_source_id".to_string()));
+            .ok_or(SerDeError::MissingField("event_source_id"))?;
 
-        let tenant_id = publish_raw_logs_request_proto
+        let tenant_id = request_proto
             .tenant_id
-            .ok_or_else(|| SerDeError::MissingField("tenant_id".to_string()));
+            .ok_or(SerDeError::MissingField("tenant_id"))?;
 
         Ok(PublishRawLogsRequest {
-            event_source_id: event_source_id?.into(),
-            tenant_id: tenant_id?.into(),
-            log_event: Bytes::from(publish_raw_logs_request_proto.log_event),
+            event_source_id: event_source_id.into(),
+            tenant_id: tenant_id.into(),
+            log_event: Bytes::from(request_proto.log_event),
         })
     }
 }
 
 impl From<PublishRawLogsRequest> for PublishRawLogsRequestProto {
-    fn from(publish_raw_logs_request: PublishRawLogsRequest) -> Self {
+    fn from(request: PublishRawLogsRequest) -> Self {
         PublishRawLogsRequestProto {
-            event_source_id: Some(publish_raw_logs_request.event_source_id.into()),
-            tenant_id: Some(publish_raw_logs_request.tenant_id.into()),
-            log_event: publish_raw_logs_request.log_event.to_vec(),
+            event_source_id: Some(request.event_source_id.into()),
+            tenant_id: Some(request.tenant_id.into()),
+            log_event: request.log_event.to_vec(),
         }
     }
 }
@@ -68,9 +66,9 @@ impl type_url::TypeUrl for PublishRawLogsRequest {
 
 impl SerDe for PublishRawLogsRequest {
     fn serialize(self) -> Result<Bytes, SerDeError> {
-        let publish_raw_logs_request_proto = PublishRawLogsRequestProto::from(self);
-        let mut buf = BytesMut::with_capacity(publish_raw_logs_request_proto.encoded_len());
-        publish_raw_logs_request_proto.encode(&mut buf)?;
+        let request_proto = PublishRawLogsRequestProto::from(self);
+        let mut buf = BytesMut::with_capacity(request_proto.encoded_len());
+        request_proto.encode(&mut buf)?;
         Ok(buf.freeze())
     }
 
@@ -79,8 +77,8 @@ impl SerDe for PublishRawLogsRequest {
         B: bytes::Buf,
         Self: Sized,
     {
-        let publish_raw_logs_request_proto: PublishRawLogsRequestProto = Message::decode(buf)?;
-        publish_raw_logs_request_proto.try_into()
+        let request_proto: PublishRawLogsRequestProto = Message::decode(buf)?;
+        request_proto.try_into()
     }
 }
 
@@ -96,15 +94,13 @@ pub struct PublishRawLogsResponse {
 impl TryFrom<PublishRawLogsResponseProto> for PublishRawLogsResponse {
     type Error = SerDeError;
 
-    fn try_from(
-        publish_raw_logs_response_proto: PublishRawLogsResponseProto,
-    ) -> Result<Self, Self::Error> {
-        let created_time = publish_raw_logs_response_proto
+    fn try_from(response_proto: PublishRawLogsResponseProto) -> Result<Self, Self::Error> {
+        let created_time = response_proto
             .created_time
-            .ok_or_else(|| SerDeError::MissingField("created_time".to_string()));
+            .ok_or(SerDeError::MissingField("created_time"))?;
 
         Ok(PublishRawLogsResponse {
-            created_time: created_time?.try_into()?,
+            created_time: created_time.try_into()?,
         })
     }
 }
@@ -112,9 +108,9 @@ impl TryFrom<PublishRawLogsResponseProto> for PublishRawLogsResponse {
 impl TryFrom<PublishRawLogsResponse> for PublishRawLogsResponseProto {
     type Error = SerDeError;
 
-    fn try_from(publish_raw_logs_response: PublishRawLogsResponse) -> Result<Self, Self::Error> {
+    fn try_from(response: PublishRawLogsResponse) -> Result<Self, Self::Error> {
         Ok(PublishRawLogsResponseProto {
-            created_time: Some(publish_raw_logs_response.created_time.try_into()?),
+            created_time: Some(response.created_time.try_into()?),
         })
     }
 }
@@ -126,9 +122,9 @@ impl type_url::TypeUrl for PublishRawLogsResponse {
 
 impl SerDe for PublishRawLogsResponse {
     fn serialize(self) -> Result<Bytes, SerDeError> {
-        let publish_raw_logs_response_proto = PublishRawLogsResponseProto::try_from(self)?;
-        let mut buf = BytesMut::with_capacity(publish_raw_logs_response_proto.encoded_len());
-        publish_raw_logs_response_proto.encode(&mut buf)?;
+        let response_proto = PublishRawLogsResponseProto::try_from(self)?;
+        let mut buf = BytesMut::with_capacity(response_proto.encoded_len());
+        response_proto.encode(&mut buf)?;
         Ok(buf.freeze())
     }
 
@@ -137,7 +133,7 @@ impl SerDe for PublishRawLogsResponse {
         B: bytes::Buf,
         Self: Sized,
     {
-        let publish_raw_logs_response_proto: PublishRawLogsResponseProto = Message::decode(buf)?;
-        publish_raw_logs_response_proto.try_into()
+        let response_proto: PublishRawLogsResponseProto = Message::decode(buf)?;
+        response_proto.try_into()
     }
 }

--- a/src/rust/rust-proto-new/src/graplinc/grapl/api/pipeline_ingress/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/api/pipeline_ingress/v1beta1.rs
@@ -37,11 +37,11 @@ impl TryFrom<PublishRawLogsRequestProto> for PublishRawLogsRequest {
     ) -> Result<Self, Self::Error> {
         let event_source_id = publish_raw_logs_request_proto
             .event_source_id
-            .ok_or(SerDeError::MissingField("event_source_id".to_string()));
+            .ok_or_else(|| SerDeError::MissingField("event_source_id".to_string()));
 
         let tenant_id = publish_raw_logs_request_proto
             .tenant_id
-            .ok_or(SerDeError::MissingField("tenant_id".to_string()));
+            .ok_or_else(|| SerDeError::MissingField("tenant_id".to_string()));
 
         Ok(PublishRawLogsRequest {
             event_source_id: event_source_id?.into(),
@@ -68,8 +68,9 @@ impl type_url::TypeUrl for PublishRawLogsRequest {
 
 impl SerDe for PublishRawLogsRequest {
     fn serialize(self) -> Result<Bytes, SerDeError> {
-        let mut buf = BytesMut::new();
-        PublishRawLogsRequestProto::from(self).encode(&mut buf)?;
+        let publish_raw_logs_request_proto = PublishRawLogsRequestProto::from(self);
+        let mut buf = BytesMut::with_capacity(publish_raw_logs_request_proto.encoded_len());
+        publish_raw_logs_request_proto.encode(&mut buf)?;
         Ok(buf.freeze())
     }
 
@@ -100,7 +101,7 @@ impl TryFrom<PublishRawLogsResponseProto> for PublishRawLogsResponse {
     ) -> Result<Self, Self::Error> {
         let created_time = publish_raw_logs_response_proto
             .created_time
-            .ok_or(SerDeError::MissingField("created_time".to_string()));
+            .ok_or_else(|| SerDeError::MissingField("created_time".to_string()));
 
         Ok(PublishRawLogsResponse {
             created_time: created_time?.try_into()?,
@@ -125,8 +126,9 @@ impl type_url::TypeUrl for PublishRawLogsResponse {
 
 impl SerDe for PublishRawLogsResponse {
     fn serialize(self) -> Result<Bytes, SerDeError> {
-        let mut buf = BytesMut::new();
-        PublishRawLogsResponseProto::try_from(self)?.encode(&mut buf)?;
+        let publish_raw_logs_response_proto = PublishRawLogsResponseProto::try_from(self)?;
+        let mut buf = BytesMut::with_capacity(publish_raw_logs_response_proto.encoded_len());
+        publish_raw_logs_response_proto.encode(&mut buf)?;
         Ok(buf.freeze())
     }
 

--- a/src/rust/rust-proto-new/src/graplinc/grapl/pipeline/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/pipeline/v1beta1.rs
@@ -92,8 +92,9 @@ impl type_url::TypeUrl for Metadata {
 
 impl SerDe for Metadata {
     fn serialize(self) -> Result<Bytes, SerDeError> {
-        let mut buf = BytesMut::new();
-        MetadataProto::try_from(self)?.encode(&mut buf)?;
+        let metadata_proto = MetadataProto::try_from(self)?;
+        let mut buf = BytesMut::with_capacity(metadata_proto.encoded_len());
+        metadata_proto.encode(&mut buf)?;
         Ok(buf.freeze())
     }
 
@@ -152,8 +153,9 @@ impl type_url::TypeUrl for Envelope {
 
 impl SerDe for Envelope {
     fn serialize(self) -> Result<Bytes, SerDeError> {
-        let mut buf = BytesMut::new();
-        EnvelopeProto::try_from(self)?.encode(&mut buf)?;
+        let envelope_proto = EnvelopeProto::try_from(self)?;
+        let mut buf = BytesMut::with_capacity(envelope_proto.encoded_len());
+        envelope_proto.encode(&mut buf)?;
         Ok(buf.freeze())
     }
 
@@ -198,8 +200,9 @@ impl type_url::TypeUrl for RawLog {
 
 impl SerDe for RawLog {
     fn serialize(self) -> Result<Bytes, SerDeError> {
-        let mut buf = BytesMut::new();
-        RawLogProto::from(self).encode(&mut buf)?;
+        let raw_log_proto = RawLogProto::from(self);
+        let mut buf = BytesMut::with_capacity(raw_log_proto.encoded_len());
+        raw_log_proto.encode(&mut buf)?;
         Ok(buf.freeze())
     }
 

--- a/src/rust/rust-proto-new/src/graplinc/grapl/pipeline/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/pipeline/v1beta1.rs
@@ -2,8 +2,8 @@ use std::time::SystemTimeError;
 
 use bytes::{
     Buf,
-    BufMut,
     Bytes,
+    BytesMut,
 };
 use prost::Message;
 
@@ -91,12 +91,10 @@ impl type_url::TypeUrl for Metadata {
 }
 
 impl SerDe for Metadata {
-    fn serialize<B>(self, buf: &mut B) -> Result<(), SerDeError>
-    where
-        B: BufMut,
-    {
-        MetadataProto::try_from(self)?.encode(buf)?;
-        Ok(())
+    fn serialize(self) -> Result<Bytes, SerDeError> {
+        let mut buf = BytesMut::new();
+        MetadataProto::try_from(self)?.encode(&mut buf)?;
+        Ok(buf.freeze())
     }
 
     fn deserialize<B>(buf: B) -> Result<Self, SerDeError>
@@ -153,12 +151,10 @@ impl type_url::TypeUrl for Envelope {
 }
 
 impl SerDe for Envelope {
-    fn serialize<B>(self, buf: &mut B) -> Result<(), SerDeError>
-    where
-        B: BufMut,
-    {
-        EnvelopeProto::try_from(self)?.encode(buf)?;
-        Ok(())
+    fn serialize(self) -> Result<Bytes, SerDeError> {
+        let mut buf = BytesMut::new();
+        EnvelopeProto::try_from(self)?.encode(&mut buf)?;
+        Ok(buf.freeze())
     }
 
     fn deserialize<B>(buf: B) -> Result<Self, SerDeError>
@@ -201,12 +197,10 @@ impl type_url::TypeUrl for RawLog {
 }
 
 impl SerDe for RawLog {
-    fn serialize<B>(self, buf: &mut B) -> Result<(), SerDeError>
-    where
-        B: BufMut,
-    {
-        RawLogProto::from(self).encode(buf)?;
-        Ok(())
+    fn serialize(self) -> Result<Bytes, SerDeError> {
+        let mut buf = BytesMut::new();
+        RawLogProto::from(self).encode(&mut buf)?;
+        Ok(buf.freeze())
     }
 
     fn deserialize<B>(buf: B) -> Result<Self, SerDeError>

--- a/src/rust/rust-proto-new/src/graplinc/grapl/pipeline/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/pipeline/v1beta1.rs
@@ -42,23 +42,23 @@ impl TryFrom<MetadataProto> for Metadata {
     fn try_from(metadata_proto: MetadataProto) -> Result<Self, Self::Error> {
         let tenant_id = metadata_proto
             .tenant_id
-            .ok_or(SerDeError::MissingField("tenant_id".to_string()));
+            .ok_or_else(|| SerDeError::MissingField("tenant_id".to_string()));
 
         let trace_id = metadata_proto
             .trace_id
-            .ok_or(SerDeError::MissingField("trace_id".to_string()));
+            .ok_or_else(|| SerDeError::MissingField("trace_id".to_string()));
 
         let created_time = metadata_proto
             .created_time
-            .ok_or(SerDeError::MissingField("created_time".to_string()));
+            .ok_or_else(|| SerDeError::MissingField("created_time".to_string()));
 
         let last_updated_time = metadata_proto
             .last_updated_time
-            .ok_or(SerDeError::MissingField("last_updated_time".to_string()));
+            .ok_or_else(|| SerDeError::MissingField("last_updated_time".to_string()));
 
         let event_source_id = metadata_proto
             .event_source_id
-            .ok_or(SerDeError::MissingField("event_source_id".to_string()));
+            .ok_or_else(|| SerDeError::MissingField("event_source_id".to_string()));
 
         Ok(Metadata {
             tenant_id: tenant_id?.into(),
@@ -124,7 +124,7 @@ impl TryFrom<EnvelopeProto> for Envelope {
     fn try_from(envelope_proto: EnvelopeProto) -> Result<Self, Self::Error> {
         let metadata = envelope_proto
             .metadata
-            .ok_or(SerDeError::MissingField("metadata".to_string()));
+            .ok_or_else(|| SerDeError::MissingField("metadata".to_string()));
 
         Ok(Envelope {
             metadata: metadata?.try_into()?,

--- a/src/rust/rust-proto-new/src/graplinc/grapl/pipeline/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/pipeline/v1beta1.rs
@@ -42,31 +42,31 @@ impl TryFrom<MetadataProto> for Metadata {
     fn try_from(metadata_proto: MetadataProto) -> Result<Self, Self::Error> {
         let tenant_id = metadata_proto
             .tenant_id
-            .ok_or_else(|| SerDeError::MissingField("tenant_id".to_string()));
+            .ok_or(SerDeError::MissingField("tenant_id"))?;
 
         let trace_id = metadata_proto
             .trace_id
-            .ok_or_else(|| SerDeError::MissingField("trace_id".to_string()));
+            .ok_or(SerDeError::MissingField("trace_id"))?;
 
         let created_time = metadata_proto
             .created_time
-            .ok_or_else(|| SerDeError::MissingField("created_time".to_string()));
+            .ok_or(SerDeError::MissingField("created_time"))?;
 
         let last_updated_time = metadata_proto
             .last_updated_time
-            .ok_or_else(|| SerDeError::MissingField("last_updated_time".to_string()));
+            .ok_or(SerDeError::MissingField("last_updated_time"))?;
 
         let event_source_id = metadata_proto
             .event_source_id
-            .ok_or_else(|| SerDeError::MissingField("event_source_id".to_string()));
+            .ok_or(SerDeError::MissingField("event_source_id"))?;
 
         Ok(Metadata {
-            tenant_id: tenant_id?.into(),
-            trace_id: trace_id?.into(),
+            tenant_id: tenant_id.into(),
+            trace_id: trace_id.into(),
             retry_count: metadata_proto.retry_count,
-            created_time: created_time?.try_into()?,
-            last_updated_time: last_updated_time?.try_into()?,
-            event_source_id: event_source_id?.into(),
+            created_time: created_time.try_into()?,
+            last_updated_time: last_updated_time.try_into()?,
+            event_source_id: event_source_id.into(),
         })
     }
 }
@@ -125,10 +125,10 @@ impl TryFrom<EnvelopeProto> for Envelope {
     fn try_from(envelope_proto: EnvelopeProto) -> Result<Self, Self::Error> {
         let metadata = envelope_proto
             .metadata
-            .ok_or_else(|| SerDeError::MissingField("metadata".to_string()));
+            .ok_or(SerDeError::MissingField("metadata"))?;
 
         Ok(Envelope {
-            metadata: metadata?.try_into()?,
+            metadata: metadata.try_into()?,
             inner_type: envelope_proto.inner_type,
             inner_message: Bytes::from(envelope_proto.inner_message),
         })

--- a/src/rust/rust-proto-new/src/graplinc/grapl/pipeline/v1beta2.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/pipeline/v1beta2.rs
@@ -74,8 +74,9 @@ where
     T: SerDe,
 {
     fn serialize(self) -> Result<Bytes, SerDeError> {
-        let mut buf = BytesMut::new();
-        NewEnvelopeProto::try_from(self)?.encode(&mut buf)?;
+        let envelope_proto = NewEnvelopeProto::try_from(self)?;
+        let mut buf = BytesMut::with_capacity(envelope_proto.encoded_len());
+        envelope_proto.encode(&mut buf)?;
         Ok(buf.freeze())
     }
 

--- a/src/rust/rust-proto-new/src/graplinc/grapl/pipeline/v1beta2.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/pipeline/v1beta2.rs
@@ -32,7 +32,7 @@ where
     fn try_from(envelope_proto: NewEnvelopeProto) -> Result<Self, Self::Error> {
         let metadata = envelope_proto
             .metadata
-            .ok_or(SerDeError::MissingField("metadata".to_string()));
+            .ok_or_else(|| SerDeError::MissingField("metadata".to_string()));
 
         if let Some(any_proto) = envelope_proto.inner_message {
             Ok(Envelope {

--- a/src/rust/rust-proto-new/src/graplinc/grapl/pipeline/v1beta2.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/pipeline/v1beta2.rs
@@ -32,15 +32,15 @@ where
     fn try_from(envelope_proto: NewEnvelopeProto) -> Result<Self, Self::Error> {
         let metadata = envelope_proto
             .metadata
-            .ok_or_else(|| SerDeError::MissingField("metadata".to_string()));
+            .ok_or(SerDeError::MissingField("metadata"))?;
 
         if let Some(any_proto) = envelope_proto.inner_message {
             Ok(Envelope {
-                metadata: metadata?.try_into()?,
+                metadata: metadata.try_into()?,
                 inner_message: SerDe::deserialize(Bytes::from(any_proto.value))?,
             })
         } else {
-            Err(SerDeError::MissingField("inner_message".to_string()))
+            Err(SerDeError::MissingField("inner_message"))
         }
     }
 }

--- a/src/rust/rust-proto-new/src/lib.rs
+++ b/src/rust/rust-proto-new/src/lib.rs
@@ -32,6 +32,15 @@ pub(crate) mod protobufs {
                     }
                 }
 
+                pub(crate) mod pipeline_ingress {
+                    pub(crate) mod v1beta1 {
+                        include!(concat!(
+                            env!("OUT_DIR"),
+                            "/graplinc.grapl.api.pipeline_ingress.v1beta1.rs"
+                        ));
+                    }
+                }
+
                 pub(crate) mod plugin_bootstrap {
                     pub(crate) mod v1beta1 {
                         include!(concat!(
@@ -107,6 +116,10 @@ pub mod graplinc {
 
             pub mod model_plugin_deployer {
                 pub mod v1;
+            }
+
+            pub mod pipeline_ingress {
+                pub mod v1beta1;
             }
 
             pub mod plugin_bootstrap {

--- a/src/rust/rust-proto-new/src/lib.rs
+++ b/src/rust/rust-proto-new/src/lib.rs
@@ -1,8 +1,8 @@
 use std::time::SystemTimeError;
 
 use bytes::{
+    Bytes,
     Buf,
-    BufMut,
 };
 use prost::{
     DecodeError,
@@ -190,9 +190,7 @@ pub enum SerDeError {
 }
 
 pub trait SerDe: type_url::TypeUrl {
-    fn serialize<B>(self, buf: &mut B) -> Result<(), SerDeError>
-    where
-        B: BufMut;
+    fn serialize(self) -> Result<Bytes, SerDeError>;
 
     fn deserialize<B>(buf: B) -> Result<Self, SerDeError>
     where

--- a/src/rust/rust-proto-new/src/lib.rs
+++ b/src/rust/rust-proto-new/src/lib.rs
@@ -174,6 +174,7 @@ pub(crate) mod type_url {
     }
 }
 
+#[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum SerDeError {
     #[error("failed to serialize {0}")]
@@ -186,10 +187,10 @@ pub enum SerDeError {
     BadTimestamp(#[from] SystemTimeError),
 
     #[error("missing message field {0}")]
-    MissingField(String),
+    MissingField(&'static str),
 }
 
-pub trait SerDe: type_url::TypeUrl {
+pub trait SerDe: type_url::TypeUrl + Clone {
     fn serialize(self) -> Result<Bytes, SerDeError>;
 
     fn deserialize<B>(buf: B) -> Result<Self, SerDeError>

--- a/src/rust/rust-proto-new/src/lib.rs
+++ b/src/rust/rust-proto-new/src/lib.rs
@@ -1,8 +1,8 @@
 use std::time::SystemTimeError;
 
 use bytes::{
-    Bytes,
     Buf,
+    Bytes,
 };
 use prost::{
     DecodeError,

--- a/src/rust/rust-proto-new/tests/integration_test.rs
+++ b/src/rust/rust-proto-new/tests/integration_test.rs
@@ -165,11 +165,8 @@ where
     T: SerDe + PartialEq + Clone + Debug,
 {
     let cloned = serializable.clone();
-    let serialized = serializable
-        .serialize()
-        .expect("serialization failed");
-    let deserialized = T::deserialize(serialized)
-        .expect("deserialization failed");
+    let serialized = serializable.serialize().expect("serialization failed");
+    let deserialized = T::deserialize(serialized).expect("deserialization failed");
     assert!(cloned == deserialized);
 }
 

--- a/src/rust/rust-proto-new/tests/integration_test.rs
+++ b/src/rust/rust-proto-new/tests/integration_test.rs
@@ -164,12 +164,12 @@ fn check_encode_decode_invariant<T>(serializable: T)
 where
     T: SerDe + PartialEq + Clone + Debug,
 {
-    let mut buf = BytesMut::new();
     let cloned = serializable.clone();
-    serializable
-        .serialize(&mut buf)
+    let serialized = serializable
+        .serialize()
         .expect("serialization failed");
-    let deserialized = T::deserialize(buf).expect("deserialization failed");
+    let deserialized = T::deserialize(serialized)
+        .expect("deserialization failed");
     assert!(cloned == deserialized);
 }
 

--- a/src/rust/rust-proto-new/tests/integration_test.rs
+++ b/src/rust/rust-proto-new/tests/integration_test.rs
@@ -12,13 +12,19 @@ use rust_proto_new::{
             SystemTime,
             Uuid,
         },
-        grapl::pipeline::{
-            v1beta1::{
-                Envelope as EnvelopeV1,
-                Metadata,
-                RawLog,
+        grapl::{
+            api::pipeline_ingress::v1beta1::{
+                PublishRawLogsRequest,
+                PublishRawLogsResponse,
             },
-            v1beta2::Envelope,
+            pipeline::{
+                v1beta1::{
+                    Envelope as EnvelopeV1,
+                    Metadata,
+                    RawLog,
+                },
+                v1beta2::Envelope,
+            },
         },
     },
     SerDe,
@@ -117,6 +123,38 @@ where
 }
 
 //
+// PublishRawLogsRequest
+//
+
+prop_compose! {
+    fn publish_raw_logs_requests()(
+        event_source_id in uuids(),
+        tenant_id in uuids(),
+        log_event in bytes(256),
+    ) -> PublishRawLogsRequest {
+        PublishRawLogsRequest {
+            event_source_id,
+            tenant_id,
+            log_event
+        }
+    }
+}
+
+//
+// PublishRawLogsResponse
+//
+
+prop_compose! {
+    fn publish_raw_logs_responses()(
+        created_time in any::<SystemTime>(),
+    ) -> PublishRawLogsResponse {
+        PublishRawLogsResponse {
+            created_time,
+        }
+    }
+}
+
+//
 // ---------------- helpers ---------------------------------------------------
 //
 
@@ -140,6 +178,10 @@ where
 //
 
 proptest! {
+    //
+    // common
+    //
+
     #[test]
     fn test_duration_encode_decode(duration in any::<Duration>()) {
         check_encode_decode_invariant(duration)
@@ -154,6 +196,10 @@ proptest! {
     fn test_uuid_encode_decode(uuid in uuids()) {
         check_encode_decode_invariant(uuid)
     }
+
+    //
+    // pipeline
+    //
 
     #[test]
     fn test_metadata_encode_decode(metadata in metadatas()) {
@@ -188,6 +234,24 @@ proptest! {
     #[test]
     fn test_raw_log_envelope_encode_decode(envelope in envelopes(raw_logs())) {
         check_encode_decode_invariant(envelope)
+    }
+
+    //
+    // api.pipeline_ingress
+    //
+
+    #[test]
+    fn test_publish_raw_logs_request_encode_decode(
+        publish_raw_logs_request in publish_raw_logs_requests()
+    ) {
+        check_encode_decode_invariant(publish_raw_logs_request)
+    }
+
+    #[test]
+    fn test_publish_raw_logs_response_encode_decode(
+        publish_raw_logs_response in publish_raw_logs_responses()
+    ) {
+        check_encode_decode_invariant(publish_raw_logs_response)
     }
 
     // TODO: add more here as they're implemented

--- a/src/rust/rust-proto-new/tests/integration_test.rs
+++ b/src/rust/rust-proto-new/tests/integration_test.rs
@@ -1,9 +1,6 @@
 use std::fmt::Debug;
 
-use bytes::{
-    Bytes,
-    BytesMut,
-};
+use bytes::Bytes;
 use proptest::prelude::*;
 use rust_proto_new::{
     graplinc::{


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/580
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

This PR updates some ergonomics in `rust-proto-new`, particularly `SerDe::serialize()` now returns an owned `Bytes` instead of mutating a reference to a buffer.

Additionally, we have added a `kafka` library to encapsulate the `rust-rdkafka` dependency in such a way that the library types `Consumer<T>`, `Producer<T>`, and `StreamProcessor<T, U>` transparently handle serializing and deserializing our `rust-proto-new` types.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

- The `rust-proto-new` changes are well covered by automated tests.
- *TBD:* The `kafka` library will be exercised in integration tests (not written yet). 

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
