### PR TITLE
Run cargo-udeps in our build container

### DIFF
--- a/.buildkite/pipeline.cargo-udeps.sh
+++ b/.buildkite/pipeline.cargo-udeps.sh
@@ -16,43 +16,18 @@
 
 set -euo pipefail
 
-# Hacky way to extract a value from a TOML file T_T
-#
-# This at least automatically keeps things in sync with with our Rust
-# toolchain.
-rust_version="$(grep channel src/rust/rust-toolchain.toml | sed -E 's/channel = "(.*)"/\1/g')"
-readonly rust_version
-
 if [ "${BUILDKITE_PIPELINE_NAME}" == "grapl/cargo-udeps" ]; then
     soft_fail="false"
 else
     soft_fail="true"
 fi
 
-# `cargo-udeps` must run under the nightly toolchain. We must take
-# care to install the nightly toolchain with the default profile to
-# ensure that we also download the `rustfmt` component for nightly as
-# well.
-#
-# We do this because `tonic_build` is currently compiled using the
-# `rustfmt` feature (enabled by default), which formats the generated
-# code and makes for better error messages.
-#
-# See
-# https://docs.rs/tonic-build/latest/tonic_build/index.html#features
-# for details.
 cat << EOF
 ---
 steps:
   - label: ":rust: cargo udeps"
     command:
-      - cd src/rust
-      - cargo install cargo-udeps --locked
-      - rustup toolchain install nightly --profile=default
-      - cargo +nightly udeps --all-features --all-targets
-    plugins:
-      - docker#v3.8.0:
-          image: "rust:${rust_version}"
+      - make -C src/rust cargo-udeps
     soft_fail: ${soft_fail}
     agents:
       queue: beefy

--- a/src/rust/Makefile
+++ b/src/rust/Makefile
@@ -90,3 +90,8 @@ coverage: ## Run `cargo tarpaulin` to generate test coverage statistics.
 	$(docker_run) cargo tarpaulin \
 		--out=Xml \
 		--output-dir=/dist/coverage
+
+.PHONY: shell
+shell: image
+shell: ## Enter a shell in our build container to aid in debugging
+	$(docker_run) bash

--- a/src/rust/Makefile
+++ b/src/rust/Makefile
@@ -53,6 +53,11 @@ lint-rustfmt: ## Check formatting
 lint-clippy: ## Run Clippy
 	bin/lint
 
+.PHONY: cargo-udeps
+cargo-udeps: image
+cargo-udeps: # Run cargo-udeps
+	$(docker_run) bin/udeps
+
 ########################################################################
 
 image: build-env.Dockerfile

--- a/src/rust/bin/udeps
+++ b/src/rust/bin/udeps
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Run `cargo udeps` on our Rust source code. Intended to run within
+# our build container, but can also be run directly on a workstation,
+# if you so choose.
+#
+# `cargo-udeps` must run under the nightly toolchain. We must take
+# care to install the nightly toolchain with the default profile to
+# ensure that we also download the `rustfmt` component for nightly as
+# well.
+#
+# We do this because `tonic_build` is currently compiled using the
+# `rustfmt` feature (enabled by default), which formats the generated
+# code and makes for better error messages.
+#
+# See
+# https://docs.rs/tonic-build/latest/tonic_build/index.html#features
+# for details.
+
+set -euo pipefail
+
+cargo install cargo-udeps --locked
+# --no-self-update is added here for the benefit of running in our
+# build container; rustup likes to update itself by default, but this
+# causes problems when we don't have it installed in CARGO_HOME, as is
+# the case in the container.
+rustup toolchain install nightly --profile=default --no-self-update
+cargo +nightly udeps --all-features --all-targets


### PR DESCRIPTION
The main logic is extracted into a script and then run in our build
container via a make target.

I didn't bother plumbing this through to the top-level Makefile since
it's not generally something that needs to be run by developers on a
regular basis (they _can_, of course, but it's really more of a CI
thing).

This is to make things more robust as we add new system dependencies
that are necessary for compiling our Rust code.

(A bonus `shell` target was added for debugging, as well.)