### PR TITLE
Ignore `dist` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ nomad/local/mount-grapl-root-as-volume.nomad
 # Distribution / packaging
 build/
 *.zip
+/dist/
 
 # IDE files
 *.code-workspace


### PR DESCRIPTION
Generated artifacts and coverage reports get dumped into this
directory and should not be committed.

(I'm fairly certain I forgot to add this change during my recent
change to how we manage the `dist` directory in our Makefile; mea
culpa.)

Signed-off-by: Christopher Maier <chris@graplsecurity.com>