### PR TITLE
Avoid glob import

### DIFF
--- a/src/rust/grapl-graphql-codegen/src/main.rs
+++ b/src/rust/grapl-graphql-codegen/src/main.rs
@@ -67,7 +67,7 @@ fn read_in_schema(input: &Option<PathBuf>) -> Result<String> {
 fn standin_imports() -> String {
     let mut code = String::new();
     code.push_str("from __future__ import annotations\n");
-    code.push_str("from typing import *\n");
+    code.push_str("from typing import Optional, Any, Set, List, Dict, Tuple\n");
     code.push_str("import grapl_analyzerlib\n");
     code.push_str("import grapl_analyzerlib.node_types\n");
     code.push_str("import grapl_analyzerlib.nodes.entity\n");


### PR DESCRIPTION
### Which issue does this PR correspond to?
None, this is a one line fix.

### What changes does this PR make to Grapl? Why?
Avoids generating a glob import, which is unnecessary. Imports the types it needs explicitly instead.

### How were these changes tested?
I ran flake8 and mypy on the generated code.