### PR TITLE
Update libssl-dev to 1.1.1n-0+deb11u1

### DIFF
--- a/src/js/graphql_endpoint/Dockerfile
+++ b/src/js/graphql_endpoint/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && apt-get --yes install --no-install-recommends \
         build-essential=12.9 \
         libffi-dev=3.3-6 \
-        libssl-dev=1.1.1k-1+deb11u2 \
+        libssl-dev=1.1.1n-0+deb11u1 \
         python3=3.9.2-3 \
         zip=3.0-12 \
     && rm -rf /var/lib/apt/lists/* \

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -21,12 +21,12 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-base-apt
         jq=1.6-2.1 \
         unzip=6.0-26 \
     && apt-get install --yes --no-install-recommends \
-         build-essential=12.9 \
-         cmake=3.18.4-2+deb11u1 \
-         libssl-dev=1.1.1k-1+deb11u2 \
-         perl=5.32.1-4+deb11u2 \
-         pkg-config=0.29.2-1 \
-         tcl=8.6.11+1
+        build-essential=12.9 \
+        cmake=3.18.4-2+deb11u1 \
+        libssl-dev=1.1.1n-0+deb11u1 \
+        perl=5.32.1-4+deb11u2 \
+        pkg-config=0.29.2-1 \
+        tcl=8.6.11+1
 
 # Grab a Nomad binary, which we use in plugin-registry for parsing
 # HCL2-with-variables into JSON.
@@ -104,7 +104,7 @@ FROM base AS tarpaulin
 RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-tarpaulin-apt \
     apt-get update \
     && apt-get install --yes --no-install-recommends \
-        libssl-dev=1.1.1k-1+deb11u2 \
+        libssl-dev=1.1.1n-0+deb11u1 \
         pkg-config=0.29.2-1
 
 # For test coverage reports

--- a/src/rust/build-env.Dockerfile
+++ b/src/rust/build-env.Dockerfile
@@ -11,12 +11,12 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-build-en
     # build-essential, cmake, libssl-dev, perl, pkg-config, and tcl are needed
     # for building rust-rdkafka.
     apt-get install --yes --no-install-recommends \
-         build-essential=12.9 \
-         cmake=3.18.4-2+deb11u1 \
-         libssl-dev=1.1.1k-1+deb11u2 \
-         perl=5.32.1-4+deb11u2 \
-         pkg-config=0.29.2-1 \
-         tcl=8.6.11+1
+        build-essential=12.9 \
+        cmake=3.18.4-2+deb11u1 \
+        libssl-dev=1.1.1n-0+deb11u1 \
+        perl=5.32.1-4+deb11u2 \
+        pkg-config=0.29.2-1 \
+        tcl=8.6.11+1
 EOF
 
 # This is where tarpaulin gets installed; using a volume means we get


### PR DESCRIPTION
Noticed the following in our weekly maintenance build:
```

#7 3.729 The following packages have unmet dependencies:
#7 3.840  libssl-dev : Depends: libssl1.1 (= 1.1.1k-1+deb11u2) but 1.1.1n-0+deb11u1 is to be installed
#7 3.861 E: Unable to correct problems, you have held broken packages.
```
~ https://buildkite.com/grapl/grapl-verify/builds/3061