### PR TITLE
Bump container image upload sleep from 30 to 60 seconds

### DIFF
--- a/.buildkite/scripts/build_and_upload_images.sh
+++ b/.buildkite/scripts/build_and_upload_images.sh
@@ -38,7 +38,7 @@ echo "--- Building all ${IMAGE_TAG} images"
 make build-image-prerequisites
 docker buildx bake --file="${BUILDX_BAKE_FILE}" --push "${BUILDX_TARGET}"
 
-readonly sleep_seconds=30
+readonly sleep_seconds=60
 echo "--- :sleeping::sob: Sleeping for ${sleep_seconds} seconds to give CDNs time to update"
 # Lately, we've seen failures where images aren't showing up when we
 # run `docker manifest inspect` (see below), but rerunning the job


### PR DESCRIPTION
We're still occasionally seeing failures to pull manifests after a
container image upload to Cloudsmith. We'll try sleeping a bit longer
:(

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
