### PR TITLE
Try switching the "build firecracker packages" to packer queue

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -40,10 +40,11 @@ steps:
             - CLOUDSMITH_API_KEY
             - grapl/TOOLCHAIN_AUTH_TOKEN
     agents:
-      # We're building the Firecracker VM image, which uses docker, and we'd
-      # like to take advantage of the docker queue's local cache whenever
-      # possible.
-      queue: "docker"
+      # This builds both the kernel (in docker) and the rootfs (in packer).
+      # Of those two possible queues to use, 'packer' is the winner; the
+      # 'docker' queue is only important for 'docker login', which we aren't
+      # using.
+      queue: "packer"
     artifact_paths:
       - "*.grapl-artifacts.json"
 


### PR DESCRIPTION
https://buildkite.com/grapl/grapl-merge/builds/573#a57b6130-9723-42ce-be57-a4cb8eb97432 failed due to
```
0.4s
--
  | ./firecracker/rootfs/build.sh
  | Installed plugin github.com/hashicorp/amazon v1.0.8 in "/var/lib/buildkite-agent/.config/packer/plugins/github.com/hashicorp/amazon/packer-plugin-amazon_v1.0.8_x5.0_linux_amd64"
  | Error: Datasource.Execute failed: Error querying AMI: UnauthorizedOperation: You are not authorized to perform this operation.
  | status code: 403, request id: f0695d2a-643f-4eba-9977-318074592a73
  |  
  | on firecracker/rootfs/build-rootfs.pkr.hcl line 80:
  | (source code not available)
```

Makes sense, the "docker" queue wasn't the right tool for this ("packer" has more AWS perms). 
I'm reasonably sure we do not need the "docker" queue for building the rootfs-inside-docker.