### PR TITLE
Refactor PluginRegistry configs. Split them up and pass them around

### DIFF
--- a/src/rust/plugin-registry/src/main.rs
+++ b/src/rust/plugin-registry/src/main.rs
@@ -1,13 +1,13 @@
 use plugin_registry::server::service::{
     exec_service,
-    PluginRegistryServiceConfig,
+    PluginRegistryConfig,
 };
 use structopt::StructOpt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (_env, _guard) = grapl_config::init_grapl_env!();
-    let config = PluginRegistryServiceConfig::from_args();
+    let config = PluginRegistryConfig::from_args();
     tracing::info!(message="Starting Plugin Registry Service", config=?config);
 
     exec_service(config).await?;


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
This is the eventual implementation of a discussion we had about configs here:
https://grapl-internal.slack.com/archives/C017H7ST8HJ/p1645043686554179

Basically, I was sick of constantly having to pipe an environment variable through like 3 places to eventually gain access to it.

Passing around the bare config struct itself is far nicer.

Also, I split the config in two, following a similar pattern in plugin-sdk/generator-sdk/src/lib.rs 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
ci
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
