### PR TITLE
Split up 'build_and_upload_firecracker_packages' into two build steps and one upload step

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -25,26 +25,52 @@ steps:
     artifact_paths:
       - "*.grapl-artifacts.json"
 
+  # Artifacts consumed by "Upload Firecracker Packages"
+  - label: ":firecracker: Build Kernel"
+    key: "build_firecracker_kernel"
+    command:
+      - "make dist/firecracker_kernel.tar.gz"
+    artifact_paths: &build_firecracker_kernel_artifacts
+      - "dist/firecracker_kernel.tar.gz"
+      - "dist/firecracker_kernel.tar.gz.artifact-metadata.json"
+    agents:
+      queue: "beefy" # TODO: or "docker"?
+
+  # Artifacts consumed by "Upload Firecracker Packages"
+  - label: ":firecracker: Build RootFS"
+    key: "build_firecracker_rootfs"
+    command:
+      - "make dist/firecracker_rootfs.tar.gz"
+    artifact_paths: &build_firecracker_rootfs_artifacts
+      - "dist/firecracker_rootfs.tar.gz"
+      - "dist/firecracker_rootfs.tar.gz.artifact-metadata.json"
+    agents:
+      queue: "packer"
+
   - label: ":firecracker: Upload Firecracker packages"
+    depends_on:
+      - build_firecracker_kernel
+      - build_firecracker_rootfs
     command:
       # Note: these packages are uploaded to the `raw`
       # repository. If they all get built successfully, then we'll
       # promote them as a group later.
       - ".buildkite/scripts/upload_firecracker_packages.sh"
     plugins:
+      - artifacts#v1.4.0:
+          download:
+            <<: *build_firecracker_kernel_artifacts
+            <<: *build_firecracker_rootfs_artifacts
       - grapl-security/vault-login#v0.1.2
       - grapl-security/vault-env#v0.1.0:
           secrets:
             # We need access to the CLOUDSMITH_API_KEY so we can upload
             # to Cloudsmith.
             - CLOUDSMITH_API_KEY
-            - grapl/TOOLCHAIN_AUTH_TOKEN
+            - grapl/TOOLCHAIN_AUTH_TOKEN # TODO: Is this needed? I don't think so
     agents:
-      # This builds both the kernel (in docker) and the rootfs (in packer).
-      # Of those two possible queues to use, 'packer' is the winner; the
-      # 'docker' queue is only important for 'docker login', which we aren't
-      # using.
-      queue: "packer"
+      # the "docker" queue has access to the CLOUDSMITH_API_KEY
+      queue: "docker"
     artifact_paths:
       - "*.grapl-artifacts.json"
 

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -34,7 +34,7 @@ steps:
         artifact_paths:
           - "dist/*"
         agents:
-          queue: "beefy" # TODO: or "docker"? nothing else uses beefy in merge
+          queue: "beefy"
 
       # Artifacts consumed by "Upload Firecracker Packages"
       - label: ":firecracker: Build RootFS"

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -31,9 +31,8 @@ steps:
       - label: ":firecracker: Build Kernel"
         command:
           - "make dist/firecracker_kernel.tar.gz"
-        artifact_paths: &build_firecracker_kernel_artifacts
-          - "dist/firecracker_kernel.tar.gz"
-          - "dist/firecracker_kernel.tar.gz.artifact-metadata.json"
+        artifact_paths:
+          - "dist/*"
         agents:
           queue: "beefy" # TODO: or "docker"? nothing else uses beefy in merge
 
@@ -41,9 +40,8 @@ steps:
       - label: ":firecracker: Build RootFS"
         command:
           - "make dist/firecracker_rootfs.tar.gz"
-        artifact_paths: &build_firecracker_rootfs_artifacts
-          - "dist/firecracker_rootfs.tar.gz"
-          - "dist/firecracker_rootfs.tar.gz.artifact-metadata.json"
+        artifact_paths:
+          - "dist/*"
         agents:
           queue: "packer"
 
@@ -58,8 +56,7 @@ steps:
         plugins:
           - artifacts#v1.4.0:
               download:
-                <<: *build_firecracker_kernel_artifacts
-                <<: *build_firecracker_rootfs_artifacts
+                - "dist/*"
           - grapl-security/vault-login#v0.1.2
           - grapl-security/vault-env#v0.1.0:
               secrets:

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -25,54 +25,53 @@ steps:
     artifact_paths:
       - "*.grapl-artifacts.json"
 
-  # Artifacts consumed by "Upload Firecracker Packages"
-  - label: ":firecracker: Build Kernel"
-    key: "build_firecracker_kernel"
-    command:
-      - "make dist/firecracker_kernel.tar.gz"
-    artifact_paths: &build_firecracker_kernel_artifacts
-      - "dist/firecracker_kernel.tar.gz"
-      - "dist/firecracker_kernel.tar.gz.artifact-metadata.json"
-    agents:
-      queue: "beefy" # TODO: or "docker"?
+  - group: ":firecracker: Build and upload Firecracker packages"
+    steps:
+      # Artifacts consumed by "Upload Firecracker Packages"
+      - label: ":firecracker: Build Kernel"
+        command:
+          - "make dist/firecracker_kernel.tar.gz"
+        artifact_paths: &build_firecracker_kernel_artifacts
+          - "dist/firecracker_kernel.tar.gz"
+          - "dist/firecracker_kernel.tar.gz.artifact-metadata.json"
+        agents:
+          queue: "beefy" # TODO: or "docker"? nothing else uses beefy in merge
 
-  # Artifacts consumed by "Upload Firecracker Packages"
-  - label: ":firecracker: Build RootFS"
-    key: "build_firecracker_rootfs"
-    command:
-      - "make dist/firecracker_rootfs.tar.gz"
-    artifact_paths: &build_firecracker_rootfs_artifacts
-      - "dist/firecracker_rootfs.tar.gz"
-      - "dist/firecracker_rootfs.tar.gz.artifact-metadata.json"
-    agents:
-      queue: "packer"
+      # Artifacts consumed by "Upload Firecracker Packages"
+      - label: ":firecracker: Build RootFS"
+        command:
+          - "make dist/firecracker_rootfs.tar.gz"
+        artifact_paths: &build_firecracker_rootfs_artifacts
+          - "dist/firecracker_rootfs.tar.gz"
+          - "dist/firecracker_rootfs.tar.gz.artifact-metadata.json"
+        agents:
+          queue: "packer"
 
-  - label: ":firecracker: Upload Firecracker packages"
-    depends_on:
-      - build_firecracker_kernel
-      - build_firecracker_rootfs
-    command:
-      # Note: these packages are uploaded to the `raw`
-      # repository. If they all get built successfully, then we'll
-      # promote them as a group later.
-      - ".buildkite/scripts/upload_firecracker_packages.sh"
-    plugins:
-      - artifacts#v1.4.0:
-          download:
-            <<: *build_firecracker_kernel_artifacts
-            <<: *build_firecracker_rootfs_artifacts
-      - grapl-security/vault-login#v0.1.2
-      - grapl-security/vault-env#v0.1.0:
-          secrets:
-            # We need access to the CLOUDSMITH_API_KEY so we can upload
-            # to Cloudsmith.
-            - CLOUDSMITH_API_KEY
-            - grapl/TOOLCHAIN_AUTH_TOKEN # TODO: Is this needed? I don't think so
-    agents:
-      # the "docker" queue has access to the CLOUDSMITH_API_KEY
-      queue: "docker"
-    artifact_paths:
-      - "*.grapl-artifacts.json"
+      - wait
+
+      - label: ":firecracker: Upload Firecracker packages"
+        command:
+          # Note: these packages are uploaded to the `raw`
+          # repository. If they all get built successfully, then we'll
+          # promote them as a group later.
+          - ".buildkite/scripts/upload_firecracker_packages.sh"
+        plugins:
+          - artifacts#v1.4.0:
+              download:
+                <<: *build_firecracker_kernel_artifacts
+                <<: *build_firecracker_rootfs_artifacts
+          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-env#v0.1.0:
+              secrets:
+                # We need access to the CLOUDSMITH_API_KEY so we can upload
+                # to Cloudsmith.
+                - CLOUDSMITH_API_KEY
+                - grapl/TOOLCHAIN_AUTH_TOKEN # TODO: Is this needed? I don't think so
+        agents:
+          # the "docker" queue has access to the CLOUDSMITH_API_KEY
+          queue: "docker"
+        artifact_paths:
+          - "*.grapl-artifacts.json"
 
   - wait
 

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -25,12 +25,12 @@ steps:
     artifact_paths:
       - "*.grapl-artifacts.json"
 
-  - label: ":firecracker: Build Firecracker packages"
+  - label: ":firecracker: Upload Firecracker packages"
     command:
       # Note: these packages are uploaded to the `raw`
       # repository. If they all get built successfully, then we'll
       # promote them as a group later.
-      - ".buildkite/scripts/build_and_upload_firecracker_packages.sh"
+      - ".buildkite/scripts/upload_firecracker_packages.sh"
     plugins:
       - grapl-security/vault-login#v0.1.2
       - grapl-security/vault-env#v0.1.0:

--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -63,7 +63,6 @@ steps:
                 # We need access to the CLOUDSMITH_API_KEY so we can upload
                 # to Cloudsmith.
                 - CLOUDSMITH_API_KEY
-                - grapl/TOOLCHAIN_AUTH_TOKEN # TODO: Is this needed? I don't think so
         agents:
           # the "docker" queue has access to the CLOUDSMITH_API_KEY
           queue: "docker"

--- a/.buildkite/scripts/lib/artifact_metadata.sh
+++ b/.buildkite/scripts/lib/artifact_metadata.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ################################################################################
 # A Manifest represents metadata about a single, built artifact.
-# It is consumed by `build_and_upload_firecracker_packages.sh` to inform
+# It is consumed by `upload_firecracker_packages.sh` to inform
 # Cloudsmith of:
 # * the artifact's version
 # * the SHA256sum of all files used to generate the artifact
@@ -19,8 +19,8 @@ set -euo pipefail
 #
 # $ find . -type f | sort | xargs sha256sum
 # 123veryLongSha  ./BUILD
-# 456veryLongSha  ./build_and_upload_firecracker_packages.sh
-# 789veryLongSha  ./build_and_upload_images.sh
+# 456veryLongSha  ./upload_firecracker_packages.sh
+# 789veryLongSha  ./upload_images.sh
 # veryLongSha012  ./ensure_regenerated_constraints.sh
 # veryLongSha345  ./extract_artifacts.sh
 #

--- a/.buildkite/scripts/lib/artifact_metadata.sh
+++ b/.buildkite/scripts/lib/artifact_metadata.sh
@@ -18,11 +18,11 @@ set -euo pipefail
 # checksums of all the files in this directory (recursively).
 #
 # $ find . -type f | sort | xargs sha256sum
-# 123veryLongSha  ./BUILD
-# 456veryLongSha  ./upload_firecracker_packages.sh
-# 789veryLongSha  ./upload_images.sh
-# veryLongSha012  ./ensure_regenerated_constraints.sh
-# veryLongSha345  ./extract_artifacts.sh
+# 123veryLongSha  ./some_file
+# 456veryLongSha  ./coolfile.sh
+# 789veryLongSha  ./coolfile2.sh
+# veryLongSha012  ./coolfile3.sh
+# veryLongSha345  ./coolfile4.py
 #
 #
 # Taking the SHA256 checksum of this output yields the final

--- a/.buildkite/scripts/upload_firecracker_packages.sh
+++ b/.buildkite/scripts/upload_firecracker_packages.sh
@@ -61,9 +61,6 @@ readonly PACKAGES=(
 # This is the list of packages that actually have different shas
 new_packages=()
 
-echo "--- Building packages"
-make "${PACKAGES[@]}"
-
 echo "--- :cloudsmith::sleuth_or_spy: Checking upstream repository to determine what to promote"
 
 for artifact_path in "${PACKAGES[@]}"; do


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/grapl/pull/1578 didn't work, so this is a more robust solution.

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

- Previously we were building and uploading our FIrecracker packages all in one Buildkite step.
- Turns out, that's really finicky, since our different agents have different keys granted to them.
- So now we split up the building and the uploading into different steps.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
hah, good joke

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
