### PR TITLE
Firecracker Rootfs asset: upload to S3, and pipe all the way through to plugin.nomad

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1196,16 +1196,16 @@ job "grapl-core" {
       }
 
       env {
-        AWS_REGION                       = var.aws_region
-        NOMAD_SERVICE_ADDRESS            = "${attr.unique.network.ip-address}:4646"
-        PLUGIN_REGISTRY_BIND_ADDRESS     = "0.0.0.0:${NOMAD_PORT_plugin-registry-port}"
-        PLUGIN_REGISTRY_DB_HOSTNAME      = var.plugin_registry_db_hostname
-        PLUGIN_REGISTRY_DB_PASSWORD      = var.plugin_registry_db_password
-        PLUGIN_REGISTRY_DB_PORT          = var.plugin_registry_db_port
-        PLUGIN_REGISTRY_DB_USERNAME      = var.plugin_registry_db_username
-        PLUGIN_BOOTSTRAP_CONTAINER_IMAGE = var.container_images["plugin-bootstrap"]
-        KERNEL_ARTIFACT_URL              = var.plugin_registry_kernel_artifact_url
-        ROOTFS_ARTIFACT_URL              = var.plugin_registry_rootfs_artifact_url
+        AWS_REGION                          = var.aws_region
+        NOMAD_SERVICE_ADDRESS               = "${attr.unique.network.ip-address}:4646"
+        PLUGIN_REGISTRY_BIND_ADDRESS        = "0.0.0.0:${NOMAD_PORT_plugin-registry-port}"
+        PLUGIN_REGISTRY_DB_HOSTNAME         = var.plugin_registry_db_hostname
+        PLUGIN_REGISTRY_DB_PASSWORD         = var.plugin_registry_db_password
+        PLUGIN_REGISTRY_DB_PORT             = var.plugin_registry_db_port
+        PLUGIN_REGISTRY_DB_USERNAME         = var.plugin_registry_db_username
+        PLUGIN_BOOTSTRAP_CONTAINER_IMAGE    = var.container_images["plugin-bootstrap"]
+        PLUGIN_REGISTRY_KERNEL_ARTIFACT_URL = var.plugin_registry_kernel_artifact_url
+        PLUGIN_REGISTRY_ROOTFS_ARTIFACT_URL = var.plugin_registry_rootfs_artifact_url
         # Plugin Execution code/image doesn't exist yet; change this once it does!
         PLUGIN_EXECUTION_CONTAINER_IMAGE = "grapl/plugin-execution-sidecar-TODO"
         PLUGIN_S3_BUCKET_AWS_ACCOUNT_ID  = var.plugin_s3_bucket_aws_account_id

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1200,6 +1200,7 @@ job "grapl-core" {
         PLUGIN_REGISTRY_DB_USERNAME      = var.plugin_registry_db_username
         PLUGIN_BOOTSTRAP_CONTAINER_IMAGE = var.container_images["plugin-bootstrap"]
         KERNEL_ARTIFACT_URL              = var.plugin_registry_kernel_artifact_url
+        ROOTFS_ARTIFACT_URL              = var.plugin_registry_rootfs_artifact_url
         # Plugin Execution code/image doesn't exist yet; change this once it does!
         PLUGIN_EXECUTION_CONTAINER_IMAGE = "grapl/plugin-execution-sidecar-TODO"
         PLUGIN_S3_BUCKET_AWS_ACCOUNT_ID  = var.plugin_s3_bucket_aws_account_id

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -120,7 +120,12 @@ variable "plugin_registry_db_password" {
 
 variable "plugin_registry_kernel_artifact_url" {
   type        = string
-  description = "S3 URL specifying the kernel for the Firecracker VM"
+  description = "URL specifying the kernel.tar.gz for the Firecracker VM"
+}
+
+variable "plugin_registry_rootfs_artifact_url" {
+  type        = string
+  description = "URL specifying the rootfs.tar.gz for the Firecracker VM"
 }
 
 variable "organization_management_db_hostname" {

--- a/pulumi/grapl/Pulumi.local-grapl.yaml
+++ b/pulumi/grapl/Pulumi.local-grapl.yaml
@@ -29,6 +29,7 @@ config:
   grapl:cloudsmith-repository-name: grapl/testing
   grapl:artifacts:
     "firecracker_kernel.tar.gz": "firecracker-v1.0.0-kernel-4.14.174"
+    "firecracker_rootfs.tar.gz": "20220329205538-5ba93c6"
   kafka:bootstrapServers:
     # If this ever changes - i.e. to localhost - you'll need to change the
     # `host.docker.internal` that occurs in grapl-local-infra.nomad::kafka

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -253,6 +253,7 @@ def main() -> None:
         user_auth_table=dynamodb_tables.user_auth_table.name,
         user_session_table=dynamodb_tables.user_session_table.name,
         plugin_registry_kernel_artifact_url=firecracker_s3objs.kernel_s3obj_url,
+        plugin_registry_rootfs_artifact_url=firecracker_s3objs.rootfs_s3obj_url,
         plugin_s3_bucket_aws_account_id=config.AWS_ACCOUNT_ID,
         plugin_s3_bucket_name=plugins_bucket.bucket,
     )

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -38,24 +38,15 @@ pub async fn deploy_plugin(
     let job_name = "grapl-plugin"; // Matches what's in `plugin.nomad`
     let job = {
         let job_file_hcl = static_files::PLUGIN_JOB;
-        // TODO: Deprecate this in next PR and replace with passed-in env variable
-        // ~ wimax Feb 2022
-        let kernel_artifact_url = format!(
-            "https://{bucket}.s3.amazonaws.com/{key}",
-            bucket = service_config.plugin_s3_bucket_name,
-            key = "kernel/v0.tar.gz",
-        );
-        let rootfs_artifact_url = format!(
-            "https://{bucket}.s3.amazonaws.com/{key}",
-            bucket = service_config.plugin_s3_bucket_name,
-            key = "rootfs/v0.rootfs.tar.gz",
-        );
         let job_file_vars: NomadVars = HashMap::from([
             (
                 "aws_account_id",
-                service_config.plugin_s3_bucket_aws_account_id.to_string(),
+                service_config.plugin_s3_bucket_aws_account_id.to_owned(),
             ),
-            ("kernel_artifact_url", kernel_artifact_url),
+            (
+                "kernel_artifact_url",
+                service_config.kernel_artifact_url.to_owned(),
+            ),
             ("plugin_artifact_url", plugin.artifact_s3_key),
             (
                 "plugin_bootstrap_container_image",
@@ -66,7 +57,10 @@ pub async fn deploy_plugin(
                 service_config.plugin_execution_container_image.to_owned(),
             ),
             ("plugin_id", plugin.plugin_id.to_string()),
-            ("rootfs_artifact_url", rootfs_artifact_url),
+            (
+                "rootfs_artifact_url",
+                service_config.rootfs_artifact_url.to_owned(),
+            ),
             ("tenant_id", plugin.tenant_id.to_string()),
         ]);
         cli.parse_hcl2(job_file_hcl, job_file_vars)?

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -129,9 +129,9 @@ pub struct PluginRegistryServiceConfig {
     pub plugin_bootstrap_container_image: String,
     #[structopt(env)]
     pub plugin_execution_container_image: String,
-    #[structopt(env)]
+    #[structopt(env = "PLUGIN_REGISTRY_KERNEL_ARTIFACT_URL")]
     pub kernel_artifact_url: String,
-    #[structopt(env)]
+    #[structopt(env = "PLUGIN_REGISTRY_ROOTFS_ARTIFACT_URL")]
     pub rootfs_artifact_url: String,
 }
 

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -129,9 +129,10 @@ pub struct PluginRegistryServiceConfig {
     pub plugin_bootstrap_container_image: String,
     #[structopt(env)]
     pub plugin_execution_container_image: String,
-    // TODO in my followup PR ~ wimax Feb 2022
-    // Leaving this as a TODO because it requires a larger refactor
-    // kernel_artifact_url: String,
+    #[structopt(env)]
+    pub kernel_artifact_url: String,
+    #[structopt(env)]
+    pub rootfs_artifact_url: String,
 }
 
 pub struct PluginRegistry {

--- a/src/rust/plugin-registry/src/static_files/plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/plugin.nomad
@@ -141,7 +141,7 @@ job "grapl-plugin" {
 
       artifact {
         source      = var.kernel_artifact_url
-        destination = "local/vmlinux"
+        destination = "local/"
         headers {
           x-amz-expected-bucket-owner = var.aws_account_id
           x-amz-meta-client-id        = "nomad-deployer"
@@ -150,7 +150,7 @@ job "grapl-plugin" {
 
       artifact {
         source      = var.rootfs_artifact_url
-        destination = "local/rootfs.ext4"
+        destination = "local/"
         headers {
           x-amz-expected-bucket-owner = var.aws_account_id
           x-amz-meta-client-id        = "nomad-deployer"


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/742

Relates to https://github.com/grapl-security/issue-tracker/issues/857

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Upload the Firecracker rootfs asset to S3 in both prod and local (this decision can be re-litigated later; see the above 857 issue).
This is the same thing we currently do for the kernel.

~then~ we pipe the s3url all the way from:
Pulumi -> grapl-core.nomad -> plugin-registry -> plugin.nomad

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
make test-integration
the plugin task group still fails because it tries to download the artifact for plugin, but that's something I'll solve in a later PR.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
