### PR TITLE
Update grapl-security/grapl-release Buildkite Plugin to v0.1.2

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -118,4 +118,4 @@ steps:
     command:
       - record_successful_pipeline_run.sh
     plugins:
-      - grapl-security/grapl-release#v0.1.1
+      - grapl-security/grapl-release#v0.1.2

--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -141,4 +141,4 @@ steps:
     command:
       - record_successful_pipeline_run.sh
     plugins:
-      - grapl-security/grapl-release#v0.1.1
+      - grapl-security/grapl-release#v0.1.2

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -117,7 +117,7 @@ steps:
     steps:
       - label: ":thinking_face::rust: Cargo Audit?"
         plugins:
-          - grapl-security/grapl-release#v0.1.1
+          - grapl-security/grapl-release#v0.1.2
           - chronotc/monorepo-diff#v2.2.0:
               diff: grapl_diff.sh
               log_level: "debug"
@@ -132,7 +132,7 @@ steps:
 
       - label: ":thinking_face::nodejs: NPM Audit?"
         plugins:
-          - grapl-security/grapl-release#v0.1.1
+          - grapl-security/grapl-release#v0.1.2
           - chronotc/monorepo-diff#v2.2.0:
               diff: grapl_diff.sh
               log_level: "debug"
@@ -147,7 +147,7 @@ steps:
 
       - label: ":thinking_face::nodejs: Yarn Audit?"
         plugins:
-          - grapl-security/grapl-release#v0.1.1
+          - grapl-security/grapl-release#v0.1.2
           - chronotc/monorepo-diff#v2.2.0:
               diff: grapl_diff.sh
               log_level: "debug"
@@ -162,7 +162,7 @@ steps:
 
       - label: ":thinking_face::rust: Cargo Udeps?"
         plugins:
-          - grapl-security/grapl-release#v0.1.1
+          - grapl-security/grapl-release#v0.1.2
           - chronotc/monorepo-diff#v2.2.0:
               diff: grapl_diff.sh
               log_level: "debug"


### PR DESCRIPTION
Update grapl-security/grapl-release Buildkite plugin version to v0.1.2

This is to pick up better logging functionality.

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖