### PR TITLE
Revert "Merge pull request #1588 from grapl-security/use_gz"

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -30,7 +30,7 @@ steps:
       # Artifacts consumed by "Upload Firecracker Packages"
       - label: ":firecracker: Build Kernel"
         command:
-          - "make dist/firecracker_kernel.gz"
+          - "make dist/firecracker_kernel.tar.gz"
         artifact_paths:
           - "dist/*"
         agents:
@@ -39,7 +39,7 @@ steps:
       # Artifacts consumed by "Upload Firecracker Packages"
       - label: ":firecracker: Build RootFS"
         command:
-          - "make dist/firecracker_rootfs.gz"
+          - "make dist/firecracker_rootfs.tar.gz"
         artifact_paths:
           - "dist/*"
         agents:

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -255,6 +255,6 @@ steps:
 
   - label: ":firecracker: Firecracker RootFS"
     command:
-      - make dist/firecracker_rootfs.gz
+      - make dist/firecracker_rootfs.tar.gz
     agents:
       queue: "packer"

--- a/.buildkite/scripts/upload_firecracker_packages.sh
+++ b/.buildkite/scripts/upload_firecracker_packages.sh
@@ -26,7 +26,7 @@ readonly UPLOAD_TO_REGISTRY="${UPLOAD_TO_REGISTRY:-grapl/raw}"
 
 # Get the json query result of a named package.
 # Usage:
-#  query_package --query="name:^cool_package.tar.gz$""
+#  query_package --query="name:^firecracker_kernel.tar.gz$""
 cloudsmith_query_package() {
     local -r queries="${1}"
     cloudsmith ls packages \
@@ -54,8 +54,8 @@ input_sha_as_tag() {
 ########################################
 # These will be uploaded to Cloudsmith with just their basename.
 readonly PACKAGES=(
-    dist/firecracker_kernel.gz
-    dist/firecracker_rootfs.gz
+    dist/firecracker_kernel.tar.gz
+    dist/firecracker_rootfs.tar.gz
 )
 
 # This is the list of packages that actually have different shas

--- a/Makefile
+++ b/Makefile
@@ -622,7 +622,7 @@ buildx-tracing: ## This is a one-time setup for enabling docker buildx traces
 generate-sqlx-data:  # Regenerate sqlx-data.json based on queries made in Rust code
 	./src/rust/bin/generate_sqlx_data.sh
 
-dist/firecracker_kernel.gz: firecracker/kernel/build.sh | dist
+dist/firecracker_kernel.tar.gz: firecracker/kernel/build.sh | dist
 	./firecracker/kernel/build.sh
 
 # TODO: Would be nice to be able to specify the input file prerequisites of
@@ -636,5 +636,5 @@ dist/plugin-bootstrap-init: | dist  ## Build the Plugin Bootstrap Init (+ associ
 
 # TODO: Would be nice to be able to specify the input file prerequisites of
 # this target, once `dist/plugin-bootstrap-init` is non-PHONY
-dist/firecracker_rootfs.gz: dist/plugin-bootstrap-init | dist
+dist/firecracker_rootfs.tar.gz: dist/plugin-bootstrap-init | dist
 	./firecracker/rootfs/build.sh

--- a/firecracker/kernel/build.sh
+++ b/firecracker/kernel/build.sh
@@ -32,15 +32,21 @@ readonly BUILD_DIR
 )
 
 ########################################
-# Compress kernel and copy it into dist
+# Copy kernel into dist.
 ########################################
 readonly KERNEL_BIN_DIR="${BUILD_DIR}/firecracker/build/kernel/linux-${KERNEL_VERSION}/"
 readonly KERNEL_BIN_FILE="vmlinux-${KERNEL_VERSION}-x86_64.bin"
-readonly ARTIFACT_PATH="${REPOSITORY_ROOT}/dist/firecracker_kernel.gz"
+readonly ARTIFACT_PATH="${REPOSITORY_ROOT}/dist/firecracker_kernel.tar.gz"
 
-gzip --no-name --stdout \
-    "${KERNEL_BIN_DIR}/${KERNEL_BIN_FILE}" \
-    > "${ARTIFACT_PATH}"
+# NOTE about tar: If you specify the full path of the thing-to-be-tar'd,
+#   the tar will contain that full nested path of directories.
+#   Hence the --directory, and basename for KERNEL_BIN_FILE
+tar \
+    --directory "${KERNEL_BIN_DIR}" \
+    --file="${ARTIFACT_PATH}" \
+    --create \
+    --gzip \
+    "${KERNEL_BIN_FILE}"
 
 ########################################
 # Write a .artifact-metadata.json file

--- a/firecracker/rootfs/README.md
+++ b/firecracker/rootfs/README.md
@@ -9,7 +9,7 @@ follows:
 - [NOT DONE YET] Copy the Grapl Plugin Bootstrap Client into the image and hook
   it up to systemd.
 - The final `provisioner "file"` stanza of build-rootfs.pkr.hcl will download
-  that .gz from the EC2 instance and dump it in `${GRAPL_ROOT}/dist/`.
+  that .tar.gz from the EC2 instance and dump it in `${GRAPL_ROOT}/dist/`.
 
 Notably, while we use the amazon-ebs builder, we don't actually create an AMI
 and we certainly don't _consume_ an AMI. Instead we simply use Packer as a handy

--- a/firecracker/rootfs/build-rootfs.pkr.hcl
+++ b/firecracker/rootfs/build-rootfs.pkr.hcl
@@ -53,7 +53,7 @@ EOF
 }
 
 variable "image_name" {
-  description = "The name of the artifact that will end up in var.dist_dir, excluding .gz"
+  description = "The name of the artifact that will end up in var.dist_dir, excluding .tar.gz"
   type        = string
 }
 
@@ -66,7 +66,7 @@ variable "debian_version" {
 ########################################################################
 
 locals {
-  image_archive_filename    = "${var.image_name}.gz"
+  image_archive_filename    = "${var.image_name}.tar.gz"
   destination_in_dist       = "${var.dist_dir}/${local.image_archive_filename}"
   init_artifacts_dir_remote = "/home/ubuntu/${basename(var.plugin_bootstrap_init_artifacts_dir)}"
 

--- a/firecracker/rootfs/build.sh
+++ b/firecracker/rootfs/build.sh
@@ -17,7 +17,7 @@ packer build \
 # Write a .artifact-metadata.json file
 ########################################
 source .buildkite/scripts/lib/artifact_metadata.sh
-readonly ARTIFACT_PATH="${DIST_DIR}/${IMAGE_NAME}.gz"
+readonly ARTIFACT_PATH="${DIST_DIR}/${IMAGE_NAME}.tar.gz"
 ARTIFACT_METADATA_PATH="$(artifact_metadata_path "${ARTIFACT_PATH}")"
 readonly ARTIFACT_METADATA_PATH
 

--- a/firecracker/rootfs/scripts/create_rootfs_image.sh
+++ b/firecracker/rootfs/scripts/create_rootfs_image.sh
@@ -81,6 +81,12 @@ sudo debootstrap --include apt,nano "${DEBIAN_VERSION}" \
 ########################################
 sudo umount "${MOUNT_POINT}"
 
-gzip --no-name --stdout \
-    "${IMAGE}" \
-    > "${OUTPUT_DIR}/${IMAGE_ARCHIVE_NAME}"
+# NOTE about tar: If you specify the full path of the image,
+#   the tar will contain that full nested path of directories.
+#   Hence the basename.
+tar \
+    --directory "${BUILD_DIR}" \
+    --file="${OUTPUT_DIR}/${IMAGE_ARCHIVE_NAME}" \
+    --create \
+    --gzip \
+    "$(basename "${IMAGE}")"

--- a/pulumi/grapl/Pulumi.local-grapl.yaml
+++ b/pulumi/grapl/Pulumi.local-grapl.yaml
@@ -28,11 +28,8 @@ config:
   grapl:REDIS_ENDPOINT: redis://host.docker.internal:6379
   grapl:cloudsmith-repository-name: grapl/testing
   grapl:artifacts:
-    # TODO wimax Mar 30 2022: Fix up these entries once gz artifacts have
-    # been merged. Since we don't test the success of the deployed plugin,
-    # we can get away with this for now.
-    "firecracker_kernel.gz": "fake-stand-in-value"
-    "firecracker_rootfs.gz": "fake-stand-in-value"
+    "firecracker_kernel.tar.gz": "firecracker-v1.0.0-kernel-4.14.174"
+    "firecracker_rootfs.tar.gz": "20220329205538-5ba93c6"
   kafka:bootstrapServers:
     # If this ever changes - i.e. to localhost - you'll need to change the
     # `host.docker.internal` that occurs in grapl-local-infra.nomad::kafka

--- a/pulumi/infra/firecracker_assets.py
+++ b/pulumi/infra/firecracker_assets.py
@@ -9,8 +9,8 @@ from infra.path import path_from_root
 
 import pulumi
 
-FIRECRACKER_KERNEL_FILENAME = "firecracker_kernel.gz"
-FIRECRACKER_ROOTFS_FILENAME = "firecracker_rootfs.gz"
+FIRECRACKER_KERNEL_FILENAME = "firecracker_kernel.tar.gz"
+FIRECRACKER_ROOTFS_FILENAME = "firecracker_rootfs.tar.gz"
 
 
 class FirecrackerAssets(pulumi.ComponentResource):
@@ -32,14 +32,14 @@ class FirecrackerAssets(pulumi.ComponentResource):
         super().__init__("grapl:FirecrackerAssets", name, None, opts)
 
         self.kernel_asset = local_or_remote_asset(
-            local_path=path_from_root(f"dist/{FIRECRACKER_KERNEL_FILENAME}"),
+            local_path=path_from_root("dist/firecracker_kernel.tar.gz"),
             artifacts=artifacts,
             artifact_key=FIRECRACKER_KERNEL_FILENAME,
             repository_name=repository_name,
         )
 
         self.rootfs_asset = local_or_remote_asset(
-            local_path=path_from_root(f"dist/{FIRECRACKER_ROOTFS_FILENAME}"),
+            local_path=path_from_root("dist/firecracker_rootfs.tar.gz"),
             artifacts=artifacts,
             artifact_key=FIRECRACKER_ROOTFS_FILENAME,
             repository_name=repository_name,


### PR DESCRIPTION
This reverts commit eb117d6f08a06699090cec2abf492c4fe08a6d17, reversing
changes made to ca40cfe03acab6a71e0a4c2c23da26d2c07d0e57.

<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
#1588

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
.gz nomad artifacts are poorly documented and causing me trouble:
[“gzip: invalid header”](https://discuss.hashicorp.com/t/gzip-invalid-header-with-a-gz-artifact/37843)

see the above hashicorp discussion. I haven't gotten any traction on that discussion yet, but I want to unblock myself.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
