### PR TITLE
Update grapl-security/codecov Buildkite Plugin to v0.1.6

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -187,7 +187,7 @@ steps:
               secrets:
                 - grapl/TOOLCHAIN_AUTH_TOKEN
                 - grapl/CODECOV_TOKEN
-          - grapl-security/codecov#v0.1.5
+          - grapl-security/codecov#v0.1.6
 
       - label: ":rust: Unit Tests"
         command:
@@ -197,7 +197,7 @@ steps:
           - grapl-security/vault-env#v0.1.0:
               secrets:
                 - grapl/CODECOV_TOKEN
-          - grapl-security/codecov#v0.1.5
+          - grapl-security/codecov#v0.1.6
         agents:
           queue: "beefy"
 
@@ -210,7 +210,7 @@ steps:
           - grapl-security/vault-env#v0.1.0:
               secrets:
                 - grapl/CODECOV_TOKEN
-          - grapl-security/codecov#v0.1.5
+          - grapl-security/codecov#v0.1.6
 
       - label: ":writing_hand: Test Grapl Template Generator"
         command:


### PR DESCRIPTION
Update grapl-security/codecov Buildkite plugin version to v0.1.6

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖