### PR TITLE
Update which prebuilt rootfs/kernel we use for local-grapl

### DIFF
--- a/pulumi/grapl/Pulumi.local-grapl.yaml
+++ b/pulumi/grapl/Pulumi.local-grapl.yaml
@@ -28,8 +28,8 @@ config:
   grapl:REDIS_ENDPOINT: redis://host.docker.internal:6379
   grapl:cloudsmith-repository-name: grapl/testing
   grapl:artifacts:
-    "firecracker_kernel.tar.gz": "firecracker-v1.0.0-kernel-4.14.174"
-    "firecracker_rootfs.tar.gz": "20220329205538-5ba93c6"
+    firecracker_kernel.tar.gz: firecracker-v1.0.0-kernel-4.14.174-c595a79
+    firecracker_rootfs.tar.gz: 20220405165304-c595a79
   kafka:bootstrapServers:
     # If this ever changes - i.e. to localhost - you'll need to change the
     # `host.docker.internal` that occurs in grapl-local-infra.nomad::kafka


### PR DESCRIPTION
These have the newly renamed artifacts in them.