### PR TITLE
etc/chromeos/lib/installs.sh - stop reinstalling existing stuff unless FORCE_REINSTALL=1 

### DIFF
--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -27,7 +27,7 @@ should_force_reinstall() {
     fi
 }
 
-_cargo_install() { 
+_cargo_install() {
     declare -a cargo_install_flags=()
     if should_force_reinstall; then
         cargo_install_flags+=("--force")
@@ -35,7 +35,7 @@ _cargo_install() {
 
     echo "Cargo Install:" "${@}"
     echo "(Set FORCE_REINSTALL=1 to force install)"
-    cargo install "${@}" 
+    cargo install "${@}"
 }
 
 get_latest_release() {

--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -105,7 +105,7 @@ install_docker() {
 }
 
 install_rust_and_utilities() {
-    if [[ ! -f "${HOME}/.cargo/env" ]] || should_force_reinstall; then
+    if (! command -v rustu) || should_force_reinstall; then
         echo_banner "Installing rust toolchain"
         curl --proto "=https" \
             --tlsv1.2 \
@@ -205,7 +205,7 @@ install_nvm() {
 }
 
 install_awsv2() {
-    if ! command -v aws || should_force_reinstall; then
+    if (! command -v aws) || should_force_reinstall; then
         echo_banner "Installing awscliv2"
         (
             cd /tmp

--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -83,21 +83,35 @@ install_docker() {
 }
 
 install_rust_and_utilities() {
-    echo_banner "Installing rust toolchain"
-    curl --proto "=https" \
-        --tlsv1.2 \
-        --silent \
-        --show-error \
-        --fail https://sh.rustup.rs | sh
+    if [[ ! -f "${HOME}/.cargo/env" ]]; then
+        echo_banner "Installing rust toolchain"
+        curl --proto "=https" \
+            --tlsv1.2 \
+            --silent \
+            --show-error \
+            --fail https://sh.rustup.rs | sh
+    else
+        echo_banner "Rust toolchain already installed"
+    fi
     # Shellcheck can't follow $HOME or other vars like $USER so we disable the check here
     # shellcheck disable=SC1091
     source "$HOME/.cargo/env"
 
-    echo_banner "Installing rust utilities (ripgrep, fd-find, dua and bat)"
-    cargo install -f ripgrep
-    cargo install -f fd-find
-    cargo install -f dua
-    cargo install -f bat
+    rust_utilities=(
+        ripgrep
+        fd-find
+        dua
+        bat
+    )
+
+    echo_banner "Installing rust utilities (set FORCE_INSTALL_CARGO_UTILITIES=1 to force)"
+
+    declare -a cargo_install_flags=()
+    if [[ -n "${FORCE_INSTALL_CARGO_UTILITIES:-}" ]]; then
+        cargo_install_flags+=("--force")
+    fi
+
+    cargo install "${cargo_install_flags[@]}" "${rust_utilities[@]}"
 }
 
 install_pyenv() {

--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -29,7 +29,7 @@ get_latest_release() {
 
 update_linux() {
     sudo apt update
-    sudo apt upgrade
+    sudo apt upgrade --yes
 }
 
 fix_shell_completion() {
@@ -48,7 +48,7 @@ install_build_tooling() {
         lsb-release
         software-properties-common # for `apt-add-repository``
     )
-    sudo apt install -y "${tools[@]}"
+    sudo apt install --yes "${tools[@]}"
 }
 
 # potentially replace with podman in the future?
@@ -116,7 +116,7 @@ install_rust_and_utilities() {
 
 install_pyenv() {
     echo_banner "Install pyenv and set python version to ${PYENV_PYTHON_VERSION}"
-    sudo apt-get install -y make libssl-dev zlib1g-dev libbz2-dev \
+    sudo apt-get install --yes make libssl-dev zlib1g-dev libbz2-dev \
         libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
         xz-utils tk-dev libffi-dev liblzma-dev
 
@@ -222,7 +222,7 @@ install_pulumi() {
 
 install_utilities() {
     echo_banner "Install useful utilities"
-    sudo apt-get install -y jq dnsutils tree
+    sudo apt-get install --yes jq dnsutils tree
 }
 
 install_hashicorp_tools() {
@@ -237,7 +237,7 @@ install_hashicorp_tools() {
         sudo chmod 644 /etc/apt/trusted.gpg.d/hashicorp-apt.gpg
     sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
     sudo apt-get update
-    sudo apt-get install -y consul nomad packer vault
+    sudo apt-get install --yes consul nomad packer vault
 }
 
 # Download and install a tarball.

--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -35,7 +35,7 @@ _cargo_install() {
 
     echo "Cargo Install:" "${@}"
     echo "(Set FORCE_REINSTALL=1 to force install)"
-    cargo install "${@}"
+    cargo install "${cargo_install_flags[@]}" "${@}"
 }
 
 get_latest_release() {
@@ -105,15 +105,13 @@ install_docker() {
 }
 
 install_rust_and_utilities() {
-    if [[ ! -f "${HOME}/.cargo/env" ]]; then
+    if [[ ! -f "${HOME}/.cargo/env" ]] || should_force_reinstall; then
         echo_banner "Installing rust toolchain"
         curl --proto "=https" \
             --tlsv1.2 \
             --silent \
             --show-error \
             --fail https://sh.rustup.rs | sh
-    else
-        echo_banner "Rust toolchain already installed"
     fi
     # Shellcheck can't follow $HOME or other vars like $USER so we disable the check here
     # shellcheck disable=SC1091

--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -74,13 +74,15 @@ install_build_tooling() {
 # potentially replace with podman in the future?
 install_docker() {
     echo_banner "Install docker"
-    curl --proto "=https" \
-        --tlsv1.2 \
-        --silent \
-        --show-error \
-        --location \
-        https://get.docker.com/ | sh
-    sudo usermod -a -G docker "$USER"
+    if (! command -v docker) || should_force_reinstall; then
+        curl --proto "=https" \
+            --tlsv1.2 \
+            --silent \
+            --show-error \
+            --location \
+            https://get.docker.com/ | sh
+        sudo usermod -a -G docker "$USER"
+    fi
 
     echo_banner "Install docker-compose (v1, old, Python)"
     sudo curl --proto "=https" \
@@ -205,7 +207,7 @@ install_nvm() {
 }
 
 install_awsv2() {
-    if should_force_reinstall || ! aws --version; then
+    if ! command -v aws || should_force_reinstall; then
         echo_banner "Installing awscliv2"
         (
             cd /tmp

--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -105,7 +105,7 @@ install_docker() {
 }
 
 install_rust_and_utilities() {
-    if (! command -v rustu) || should_force_reinstall; then
+    if (! command -v rustup) || should_force_reinstall; then
         echo_banner "Installing rust toolchain"
         curl --proto "=https" \
             --tlsv1.2 \

--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -168,7 +168,7 @@ install_nvm() {
     echo_banner "Installing nvm"
     curl --proto "=https" \
         --tlsv1.2 \
-        https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+        https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
     source_profile
 
     # Make nvm usable ASAP


### PR DESCRIPTION
On origin/main, when this script had previously been already run, it took 8m36s *and* some confirmation prompts (for the timing I did it *as soon* as the prompt showed up on screen) to rerun

Now, when there's a previous run, it takes 35s and is zero touch.

I did not hit _every_ dependency, just the ones that take long (especially the cargo install compilations)