### PR TITLE
Make etc/chromeos nvm install work in gitpod

### DIFF
--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -185,13 +185,15 @@ install_pipx() {
 
 install_nvm() {
     echo_banner "Installing nvm"
+    # This exported variable is actually used by the NVM install script
+    export NVM_DIR="${HOME}/.config/nvm"
+    mkdir --parents "${NVM_DIR}"
+
     curl --proto "=https" \
         --tlsv1.2 \
         https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
     source_profile
 
-    # Make nvm usable ASAP
-    export NVM_DIR="${HOME}/.config/nvm"
     # shellcheck disable=SC1091
     [ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh" # This loads nvm
     # shellcheck disable=SC1091


### PR DESCRIPTION
slash, any other distro that doesn't have XDG_CONFIG_HOME set up. The existing code assumes the NVM dir will be ~/.config/nvm; we now *declare* that to be so.

Compare with https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh