### PR TITLE
Store DGraph data in Docker volumes, instead of leaving in container fs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ NONROOT_DOCKER_COMPOSE_CHECK := ${DOCKER_COMPOSE_CHECK} --user=${COMPOSE_USER}
 DOCKER_FILTER_LABEL := org.opencontainers.image.vendor="Grapl, Inc."
 # We pull some vendor containers directly
 DOCKER_DGRAPH_FILTER_LABEL := maintainer="Dgraph Labs <contact@dgraph.io>"
-# Currently we don't label volumes explicitly. The only labeled volume is the dgraph_export which is labeled
-# automatically by docker-compose
+# Currently we don't label volumes explicitly. The only labeled volume is the
+# grapl-dgraph-data which is labeled automatically by docker-compose
 # TODO label volumes explicitly and then update this filter
 DOCKER_VOLUME_FILTER_LABEL := com.docker.compose.project="grapl"
 
@@ -576,7 +576,7 @@ clean-docker-images: ## Remove all Grapl images
 	| xargs --no-run-if-empty docker rmi --force
 
 clean-docker-volumes: ## Remove all Grapl labeled volumes
-	# Currently only the dgraph_export volume is labeled so that's the only one affected.
+	# Currently only the grapl-dgraph-data volume is labeled so that's the only one affected.
 	# We explicitly don't want to prune the build cache volumes
 	docker volume prune \
 		--filter=label=$(DOCKER_VOLUME_FILTER_LABEL) \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@
 # 84xx - debugger ports (see vsc_debugger.py)
 
 version: "3.8"
-volumes:
-  dgraph_export:
 
 services:
   pulumi:

--- a/docs/development/integration_tests.rst
+++ b/docs/development/integration_tests.rst
@@ -13,7 +13,7 @@ the database from your Github test run!
 
 - Then, go to ``$GRAPLROOT`` and ``docker-compose up``.
 
-- Unzip the artifacts and navigate to the folder that looks something like ``dgraph_export/dgraph.r4730.u1103.0108``
+- Unzip the artifacts and navigate to the folder that looks something like ``grapl-dgraph-data/dgraph.r4730.u1103.0108``
 
 - Run ``dgraph live --files g01.rdf.gz`` - this uploads the database state to your local dgraph instance.
 

--- a/docs/development/integration_tests.rst
+++ b/docs/development/integration_tests.rst
@@ -13,7 +13,7 @@ the database from your Github test run!
 
 - Then, go to ``$GRAPLROOT`` and ``docker-compose up``.
 
-- Unzip the artifacts and navigate to the folder that looks something like ``grapl-dgraph-data/dgraph.r4730.u1103.0108``
+- Unzip the artifacts and navigate to the folder that looks something like ``grapl-data-dgraph/dgraph.r4730.u1103.0108``
 
 - Run ``dgraph live --files g01.rdf.gz`` - this uploads the database state to your local dgraph instance.
 

--- a/etc/ci_scripts/dump_artifacts/cli.py
+++ b/etc/ci_scripts/dump_artifacts/cli.py
@@ -65,7 +65,7 @@ def main() -> None:
         )
         docker_artifacts.dump_volume(
             compose_project=compose_project,
-            volume_name="grapl-dgraph-data",
+            volume_name="grapl-data-dgraph",
             artifacts_dir=artifacts_dir,
         )
 

--- a/etc/ci_scripts/dump_artifacts/cli.py
+++ b/etc/ci_scripts/dump_artifacts/cli.py
@@ -65,7 +65,7 @@ def main() -> None:
         )
         docker_artifacts.dump_volume(
             compose_project=compose_project,
-            volume_name="dgraph_export",
+            volume_name="grapl-dgraph-data",
             artifacts_dir=artifacts_dir,
         )
 

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -308,7 +308,7 @@ locals {
 
   dgraph_volume_args = {
     target = "/dgraph"
-    source = "grapl-dgraph-data"
+    source = "grapl-data-dgraph"
   }
 
   _redis_trimmed = trimprefix(var.redis_endpoint, "redis://")
@@ -374,14 +374,6 @@ job "grapl-core" {
           target   = "${local.dgraph_volume_args.target}"
           source   = "${local.dgraph_volume_args.source}"
           readonly = false
-          volume_options {
-            labels {
-              # This label is used by our root-level Makefile, DOCKER_VOLUME_FILTER_LABEL
-              # TODO(inickles): Give proper label key and update Makefile comment
-              # TODO(inickles): Unfortunately, we're unable to use dots in volume keys here. Decide on a better name then and reconcile with Makefile.
-              owner = "grapl"
-            }
-          }
         }
       }
     }
@@ -455,14 +447,6 @@ job "grapl-core" {
             target   = "${local.dgraph_volume_args.target}"
             source   = "${local.dgraph_volume_args.source}"
             readonly = false
-            volume_options {
-              labels {
-                # This label is used by our root-level Makefile, DOCKER_VOLUME_FILTER_LABEL
-                # TODO(inickles): Give proper label key and update Makefile comment
-                # TODO(inickles): Unfortunately, we're unable to use dots in volume keys here. Decide on a better name then and reconcile with Makefile.
-                owner = "grapl"
-              }
-            }
           }
         }
       }
@@ -572,14 +556,6 @@ job "grapl-core" {
             target   = "${local.dgraph_volume_args.target}"
             source   = "${local.dgraph_volume_args.source}"
             readonly = false
-            volume_options {
-              labels {
-                # This label is used by our root-level Makefile, DOCKER_VOLUME_FILTER_LABEL
-                # TODO(inickles): Give proper label key and update Makefile comment
-                # TODO(inickles): Unfortunately, we're unable to use dots in volume keys here. Decide on a better name then and reconcile with Makefile.
-                owner = "grapl"
-              }
-            }
           }
 
           ports = ["dgraph-alpha-port"]

--- a/src/python/grapl-tests-common/grapl_tests_common/setup_tests.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/setup_tests.py
@@ -22,7 +22,7 @@ def _after_tests() -> None:
     Add any "after tests are executed, but before docker-compose down" stuff here.
     """
     # Issue a command to dgraph to export the whole database.
-    # This is then stored on a volume, `grapl-dgraph-data`.
+    # This is then stored on a volume, `grapl-data-dgraph`.
     # The contents of the volume are made available to Buildkite via `make dump-artifacts`
     if DUMP_ARTIFACTS:
         dgraph_host = environ["DGRAPH_HOST"]

--- a/src/python/grapl-tests-common/grapl_tests_common/setup_tests.py
+++ b/src/python/grapl-tests-common/grapl_tests_common/setup_tests.py
@@ -22,7 +22,7 @@ def _after_tests() -> None:
     Add any "after tests are executed, but before docker-compose down" stuff here.
     """
     # Issue a command to dgraph to export the whole database.
-    # This is then stored on a volume, `dgraph_export` (defined in docker-compose.yml)
+    # This is then stored on a volume, `grapl-dgraph-data`.
     # The contents of the volume are made available to Buildkite via `make dump-artifacts`
     if DUMP_ARTIFACTS:
         dgraph_host = environ["DGRAPH_HOST"]


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/900

### What changes does this PR make to Grapl? Why?

This has Nomad use a Docker volume for storing Dgraph data, allowing it to persist across container resets, which can happen from time to time. This prevents data loss observed during local grapl development. By decoupling Dgraph storage from the execution, I no longer notice when Nomad jobs reset.

Note to reviewers: I'm looking for input on two things:
1. Is there a better way to define these volumes mounts once and refer to them in each task stanza?
2. I'm just piggy-backing off of the auto-label used by the Makefile, which should probably be given a better name (key) and the comments should be updated.

### How were these changes tested?

I tested similar changes in my `inickles/dropper` branch.
