### PR TITLE
[GraphQL->Python codegen] Add node schema method to Node Viewable.

### DIFF
--- a/src/rust/grapl-graphql-codegen/src/node_type.rs
+++ b/src/rust/grapl-graphql-codegen/src/node_type.rs
@@ -248,6 +248,9 @@ impl NodeType {
         viewable.push('\n');
         viewable += &self.generate_viewable_get_methods();
 
+        viewable.push('\n');
+        viewable += &self.generate_queryable_node_schema_method();
+
         viewable
     }
 


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This fixes an issue we found in the GraphQL schema -> Python codegen: a Node's Viewable was missing the `node_schema` override.

### How were these changes tested?

1. I first made the desired change in my generated Python, and verified it resolved the issue I had. I then,
2. Verified this diff produced code similar to that change I'd tested previously.
