### PR TITLE
Run an initial updateTableStateWithLenses upon loading engagements page instead of waiting 5s

### DIFF
--- a/src/js/engagement_view/src/components/engagementView/sidebar/tables/toggleLensTable.tsx
+++ b/src/js/engagement_view/src/components/engagementView/sidebar/tables/toggleLensTable.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useEffectUponMount } from "lib/custom_react_hooks";
 
 import Button from "@material-ui/core/Button";
 import KeyboardArrowDownOutlinedIcon from "@material-ui/icons/KeyboardArrowDownOutlined";
@@ -48,29 +49,27 @@ export function ToggleLensTable({ setLens }: ToggleLensTableProps) {
         setPageState(0);
     };
 
+    async function updateTableStateWithLenses() {
+        const response = await getLenses(
+            toggleTableState.first,
+            toggleTableState.offset
+        );
+        if (response.lenses && response.lenses !== toggleTableState.lenses) {
+            const lenses = toggleTableState.lenses.concat(response.lenses);
+            setLensRetrievedState(lenses as any);
+            setToggleTableState({
+                ...toggleTableState,
+                offset: toggleTableState.offset + response.lenses.length || 0,
+                lenses,
+            });
+        }
+    }
+    // Do an initial updateTableStateWithLenses just once.
+    useEffectUponMount(updateTableStateWithLenses);
+
+    // Schedule an updateTableStateWithLenses every N seconds
     useEffect(() => {
-        const interval = setInterval(() => {
-            getLenses(toggleTableState.first, toggleTableState.offset).then(
-                (response) => {
-                    if (
-                        response.lenses &&
-                        response.lenses !== toggleTableState.lenses
-                    ) {
-                        const lenses = toggleTableState.lenses.concat(
-                            response.lenses
-                        );
-                        setLensRetrievedState(lenses as any);
-                        setToggleTableState({
-                            ...toggleTableState,
-                            offset:
-                                toggleTableState.offset +
-                                    response.lenses.length || 0,
-                            lenses,
-                        });
-                    }
-                }
-            );
-        }, 5000);
+        const interval = setInterval(updateTableStateWithLenses, 5000);
         return () => clearInterval(interval);
     });
 

--- a/src/js/engagement_view/src/lib/custom_react_hooks.ts
+++ b/src/js/engagement_view/src/lib/custom_react_hooks.ts
@@ -1,0 +1,8 @@
+import React, { useEffect } from "react";
+
+export function useEffectUponMount(fn: () => any) {
+    // a React Hooks equivalent to componentDidMount.
+    // Runs an effect once and only once.
+    // https://medium.com/@felippenardi/how-to-do-componentdidmount-with-react-hooks-553ba39d1571
+    useEffect(fn, []);
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
I was tooling around the new UI and re-encountered a tihng that's bothered me for a while. I finally decided to dive into React and learn how to fix it.

This method can also be applied to src/js/engagement_view/src/components/engagementView/EngagementView.tsx
which currently has a `renderedOnce` check

...but that I'm saving for a different PR.


<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
checked the timings for initial graphql call in F12 chrome tools, way better with this change.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
