### PR TITLE
Revert "Run an initial updateTableStateWithLenses upon loading engagements page instead of waiting 5s (#1621)"

### DIFF
--- a/src/js/engagement_view/src/components/engagementView/sidebar/tables/toggleLensTable.tsx
+++ b/src/js/engagement_view/src/components/engagementView/sidebar/tables/toggleLensTable.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { useEffectUponMount } from "lib/custom_react_hooks";
 
 import Button from "@material-ui/core/Button";
 import KeyboardArrowDownOutlinedIcon from "@material-ui/icons/KeyboardArrowDownOutlined";
@@ -49,27 +48,29 @@ export function ToggleLensTable({ setLens }: ToggleLensTableProps) {
         setPageState(0);
     };
 
-    async function updateTableStateWithLenses() {
-        const response = await getLenses(
-            toggleTableState.first,
-            toggleTableState.offset
-        );
-        if (response.lenses && response.lenses !== toggleTableState.lenses) {
-            const lenses = toggleTableState.lenses.concat(response.lenses);
-            setLensRetrievedState(lenses as any);
-            setToggleTableState({
-                ...toggleTableState,
-                offset: toggleTableState.offset + response.lenses.length || 0,
-                lenses,
-            });
-        }
-    }
-    // Do an initial updateTableStateWithLenses just once.
-    useEffectUponMount(updateTableStateWithLenses);
-
-    // Schedule an updateTableStateWithLenses every N seconds
     useEffect(() => {
-        const interval = setInterval(updateTableStateWithLenses, 5000);
+        const interval = setInterval(() => {
+            getLenses(toggleTableState.first, toggleTableState.offset).then(
+                (response) => {
+                    if (
+                        response.lenses &&
+                        response.lenses !== toggleTableState.lenses
+                    ) {
+                        const lenses = toggleTableState.lenses.concat(
+                            response.lenses
+                        );
+                        setLensRetrievedState(lenses as any);
+                        setToggleTableState({
+                            ...toggleTableState,
+                            offset:
+                                toggleTableState.offset +
+                                    response.lenses.length || 0,
+                            lenses,
+                        });
+                    }
+                }
+            );
+        }, 5000);
         return () => clearInterval(interval);
     });
 

--- a/src/js/engagement_view/src/lib/custom_react_hooks.ts
+++ b/src/js/engagement_view/src/lib/custom_react_hooks.ts
@@ -1,8 +1,0 @@
-import React, { useEffect } from "react";
-
-export function useEffectUponMount(fn: () => any) {
-    // a React Hooks equivalent to componentDidMount.
-    // Runs an effect once and only once.
-    // https://medium.com/@felippenardi/how-to-do-componentdidmount-with-react-hooks-553ba39d1571
-    useEffect(fn, []);
-}


### PR DESCRIPTION

This reverts commit fd9f0c9191ab7ad2c0cf160c5770bd1b9726a47c.

---
Behavior was poorly tested, so, reverting for now.

Engagement view if you click nothing and wait ~15 seconds: very few RPCs
![Screenshot 2022-04-13 5 56 03 PM](https://user-images.githubusercontent.com/69007229/163277076-ed329bf4-1758-4d12-8f00-b292272b139e.png)

Engagement view if you click a lens and wait another 10 seconds: rapid fire, getting ever worse
![Screenshot 2022-04-13 5 56 14 PM](https://user-images.githubusercontent.com/69007229/163277121-f2f03366-bf90-4c5c-ac06-950f68fb5c25.png)

