### PR TITLE
Refactor a rudimentary library for shell colors out of rust/run_in_container.sh into its own library + use it in devbox

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,6 +53,8 @@ BUILD @christophermaier
 /src/python/mypy.ini @christophermaier @wimax-grapl
 /src/python/provisioner/ @jgrillo-grapl
 /src/python/python-proto/ @grapl-security/wg-data-infra
+/src/sh/BUILD @wimax-grapl
+/src/sh/shell_colors.sh @wimax-grapl
 /src/rust/analyzer-dispatcher/ @grapl-security/wg-data-infra
 /src/rust/bin/ @christophermaier
 /src/rust/.cargo @christophermaier

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,7 +54,7 @@ BUILD @christophermaier
 /src/python/provisioner/ @jgrillo-grapl
 /src/python/python-proto/ @grapl-security/wg-data-infra
 /src/sh/BUILD @wimax-grapl
-/src/sh/shell_colors.sh @wimax-grapl
+/src/sh/shell_color.sh @wimax-grapl
 /src/rust/analyzer-dispatcher/ @grapl-security/wg-data-infra
 /src/rust/bin/ @christophermaier
 /src/rust/.cargo @christophermaier

--- a/devbox/devbox-do.sh
+++ b/devbox/devbox-do.sh
@@ -21,7 +21,6 @@ source "${GRAPL_DEVBOX_CONFIG}"
 # Step 1: Sync local files to remote
 ####################
 "${THIS_DIR}/devbox-sync.sh"
-echo "Devbox sync complete"
 
 ####################
 # Step 2

--- a/devbox/devbox-sync.sh
+++ b/devbox/devbox-sync.sh
@@ -15,3 +15,5 @@ rsync --archive --info=progress2 \
     --rsh "${THIS_DIR}/ssh.sh" \
     "${GRAPL_DEVBOX_LOCAL_GRAPL}/" \
     ":${GRAPL_DEVBOX_REMOTE_GRAPL}"
+
+echo_h1 "$(bright_green "Devbox-sync complete")"

--- a/devbox/lib.sh
+++ b/devbox/lib.sh
@@ -3,3 +3,17 @@ set -euo pipefail
 
 export GRAPL_DEVBOX_DIR="${HOME}/.grapl_devbox"
 export GRAPL_DEVBOX_CONFIG="${GRAPL_DEVBOX_DIR}/config"
+
+########################################
+# Print helpers
+########################################
+# Re-export the color functions from shell_color
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")"/../src/sh/shell_color.sh
+
+# I'm using HTML <h1>, <h2> terminology for "just how big is this?"
+echo_h1() {
+    echo -e "\n========================================"
+    echo -e "==> ${@}"
+    echo -e "========================================"
+}

--- a/devbox/lib.sh
+++ b/devbox/lib.sh
@@ -14,6 +14,6 @@ source "$(dirname "${BASH_SOURCE[0]}")"/../src/sh/shell_color.sh
 # I'm using HTML <h1>, <h2> terminology for "just how big is this?"
 echo_h1() {
     echo -e "\n========================================"
-    echo -e "==> ${@}"
+    echo -e "==>" "${@}"
     echo -e "========================================"
 }

--- a/src/rust/bin/run_in_container.sh
+++ b/src/rust/bin/run_in_container.sh
@@ -8,35 +8,8 @@
 
 set -euo pipefail
 
-# ANSI Formatting Codes
-########################################################################
-# Because who wants to remember all those fiddly details?
-
-# CSI = "Control Sequence Introducer"
-CSI="\e["
-END=m
-
-NORMAL=0
-BOLD=1
-
-RED=31
-WHITE=37
-
-RESET="${CSI}${NORMAL}${END}"
-
-function _bold_color() {
-    color="${1}"
-    shift
-    echo "${CSI}${BOLD};${color}${END}${*}${RESET}"
-}
-
-function bright_white() {
-    _bold_color "${WHITE}" "${@}"
-}
-
-function bright_red() {
-    _bold_color "${RED}" "${@}"
-}
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")"/../../sh/shell_color.sh
 
 # Logging
 ########################################################################

--- a/src/sh/BUILD
+++ b/src/sh/BUILD
@@ -1,0 +1,1 @@
+shell_sources()

--- a/src/sh/shell_color.sh
+++ b/src/sh/shell_color.sh
@@ -13,8 +13,15 @@ END=m
 NORMAL=0
 BOLD=1
 
-RED=31
-WHITE=37
+declare -A COLORS=(
+    [RED]=31
+    [GREEN]=32
+    [YELLOW]=33
+    [BLUE]=34
+    [MAGENTA]=35
+    [CYAN]=36
+    [WHITE]=37
+)
 
 RESET="${CSI}${NORMAL}${END}"
 
@@ -25,9 +32,13 @@ function _bold_color() {
 }
 
 function bright_white() {
-    _bold_color "${WHITE}" "${@}"
+    _bold_color "${COLORS[WHITE]}" "${@}"
 }
 
 function bright_red() {
-    _bold_color "${RED}" "${@}"
+    _bold_color "${COLORS[RED]}" "${@}"
+}
+
+function bright_green() {
+    _bold_color "${COLORS[GREEN]}" "${@}"
 }

--- a/src/sh/shell_color.sh
+++ b/src/sh/shell_color.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# ANSI Formatting Codes
+########################################################################
+# Because who wants to remember all those fiddly details?
+
+# CSI = "Control Sequence Introducer"
+CSI="\e["
+END=m
+
+NORMAL=0
+BOLD=1
+
+RED=31
+WHITE=37
+
+RESET="${CSI}${NORMAL}${END}"
+
+function _bold_color() {
+    color="${1}"
+    shift
+    echo "${CSI}${BOLD};${color}${END}${*}${RESET}"
+}
+
+function bright_white() {
+    _bold_color "${WHITE}" "${@}"
+}
+
+function bright_red() {
+    _bold_color "${RED}" "${@}"
+}


### PR DESCRIPTION
This is strictly a readability thing. 

![image](https://user-images.githubusercontent.com/69007229/163429940-1931ea1f-f877-4449-933f-e0c655a9492f.png)
