### PR TITLE
Add a step to `grapl-provision` that will nuke dgraph data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,6 +323,7 @@ test-e2e: ## Build and run e2e tests
 .PHONY: test-with-env
 test-with-env: # (Do not include help text - not to be used directly)
 	stopGrapl() {
+		$(MAKE) dump-artifacts-local
 		# skip if KEEP_TEST_ENV is set
 		if [[ -z "${KEEP_TEST_ENV}" ]]; then
 			@echo "Tearing down test environment"
@@ -331,7 +332,6 @@ test-with-env: # (Do not include help text - not to be used directly)
 		fi
 		# Unset COMPOSE_FILE to help ensure it will be ignored with use of --file
 		unset COMPOSE_FILE
-		$(MAKE) dump-artifacts-local
 		$(MAKE) down
 	}
 	# Ensure we call stop even after test failure, and return exit code from

--- a/nomad/consul-intentions/dgraph-alpha-0-http.json
+++ b/nomad/consul-intentions/dgraph-alpha-0-http.json
@@ -1,0 +1,12 @@
+{
+  "Kind": "service-intentions",
+  "Name": "dgraph-alpha-0-http",
+  "Sources": [
+    {
+      "Name": "provisioner",
+      "Action": "allow",
+      "Precedence": 9,
+      "Type": "consul"
+    }
+  ]
+}

--- a/nomad/e2e-tests.nomad
+++ b/nomad/e2e-tests.nomad
@@ -122,14 +122,18 @@ job "e2e-tests" {
         sidecar_service {
           proxy {
             upstreams {
-              # This is a hack, because IDK how to share locals across files
+              # This non-dynamic upstream is a hack, 
+              # because IDK how to share locals across files
               destination_name = "dgraph-alpha-0-grpc-public"
-              local_bind_port  = 9080
+              # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
+              local_bind_port = 1000
             }
             upstreams {
               destination_name = "web-ui"
-              local_bind_port  = 1234
+              # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
+              local_bind_port = 1001
             }
+
           }
         }
       }
@@ -205,7 +209,7 @@ EOF
         GRAPL_TEST_USER_NAME               = var.test_user_name
         GRAPL_TEST_USER_PASSWORD_SECRET_ID = var.test_user_password_secret_id
 
-        MG_ALPHAS      = "localhost:9080"
+        MG_ALPHAS      = "localhost:${NOMAD_UPSTREAM_PORT_dgraph-alpha-0-grpc-public}"
         RUST_BACKTRACE = 1
         RUST_LOG       = local.log_level
 
@@ -215,5 +219,6 @@ EOF
         KAFKA_CONSUMER_GROUP_NAME = var.kafka_consumer_group_name
       }
     }
+
   }
 }

--- a/nomad/grapl-provision.nomad
+++ b/nomad/grapl-provision.nomad
@@ -90,7 +90,7 @@ job "grapl-provision" {
         image      = var.container_images["provisioner"]
         entrypoint = ["/bin/bash", "-c", "-o", "errexit", "-o", "nounset", "-c"]
         command = trimspace(<<EOF
-if [[ -n "${DGRAPH_DROP_ALL_DATA}" ]]; then
+if [[ "${DGRAPH_DROP_ALL_DATA}" -ne 0 ]]; then
   # Drop all existing data from dgraph
   # from https://discuss.dgraph.io/t/drop-all-data-from-dgraph/5866 
   curl -X POST "${DGRAPH_HTTP_ADDRESS}"/alter -d '{"drop_op": "ALL"}'

--- a/nomad/grapl-provision.nomad
+++ b/nomad/grapl-provision.nomad
@@ -87,7 +87,18 @@ job "grapl-provision" {
       driver = "docker"
 
       config {
-        image = var.container_images["provisioner"]
+        image      = var.container_images["provisioner"]
+        entrypoint = ["/bin/bash", "-c", "-o", "errexit", "-o", "nounset", "-c"]
+        command = trimspace(<<EOF
+if [[ -n "${DGRAPH_DROP_ALL_DATA}" ]]; then
+  # Drop all existing data from dgraph
+  # from https://discuss.dgraph.io/t/drop-all-data-from-dgraph/5866 
+  curl -X POST "${DGRAPH_HTTP_ADDRESS}"/alter -d '{"drop_op": "ALL"}'
+fi
+
+./provisioner.pex
+EOF
+        )
       }
 
       lifecycle {
@@ -106,9 +117,11 @@ job "grapl-provision" {
       env {
         # This is a hack, because IDK how to share locals across files.
         # It's fine if `provision` only hits one alpha.
-        MG_ALPHAS = "localhost:9080"
+        MG_ALPHAS = "localhost:${NOMAD_UPSTREAM_PORT_dgraph-alpha-0-grpc-public}"
 
         AWS_DEFAULT_REGION                 = var.aws_region
+        DGRAPH_DROP_ALL_DATA               = 1
+        DGRAPH_HTTP_ADDRESS                = "${NOMAD_UPSTREAM_ADDR_dgraph-alpha-0-http}"
         GRAPL_SCHEMA_TABLE                 = var.schema_table_name
         GRAPL_SCHEMA_PROPERTIES_TABLE      = var.schema_properties_table_name
         GRAPL_USER_AUTH_TABLE              = var.user_auth_table
@@ -125,9 +138,19 @@ job "grapl-provision" {
         sidecar_service {
           proxy {
             upstreams {
-              # This is a hack, because IDK how to share locals across files
+              # This non-dynamic upstream is a hack, 
+              # because IDK how to share locals across files
               destination_name = "dgraph-alpha-0-grpc-public"
-              local_bind_port  = 9080
+              # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
+              local_bind_port = 1000
+            }
+
+            upstreams {
+              # This non-dynamic upstream is a hack, 
+              # because IDK how to share locals across files
+              destination_name = "dgraph-alpha-0-http"
+              # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
+              local_bind_port = 1001
             }
           }
         }

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -595,9 +595,7 @@ def main() -> None:
         pulumi.export(
             "stateful-resource-urns",
             [
-                # grapl-core contains our dgraph instances
-                nomad_grapl_core.urn,
-                # We need to re-provision after we start a new dgraph
+                # We need to re-provision
                 nomad_grapl_provision.urn,
                 dynamodb_tables.urn,
             ],

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends \
         bash=5.1-2+b3 \
         libstdc++6=10.2.1-6 \
+        curl=7.74.0-1.3+deb11u1 \
     && rm -rf /var/lib/apt/lists/* \
     && adduser \
         --disabled-password \
@@ -33,7 +34,7 @@ CMD ["./engagement-creator.pex"]
 ################################################################################
 FROM grapl-python-base AS provisioner-deploy
 COPY ./dist/provisioner.pex .
-CMD ["./provisioner.pex"]
+CMD [":"]
 
 # e2e tests
 ################################################################################


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/904
Relates to https://github.com/grapl-security/grapl/pull/1615

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Add a step to `grapl-provision` that will RPC to dgraph and tell it to drop all data.
With the addition of persistent volumes, we need to handle this case somehow.

Currently, it will -always- do that, but it's hooked up to an env{} flag for easy orchestration down the line.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I will try to play with these changes on top of the dgraph PR and see how it behaves. 
