### PR TITLE
Improvements around "waiting for nomad agent..."

### DIFF
--- a/nomad/local/nomad_run_local_infra.sh
+++ b/nomad/local/nomad_run_local_infra.sh
@@ -16,8 +16,20 @@ source "${THIS_DIR}/../lib/nomad_cli_tools.sh"
 echo "Deploying Nomad local infrastructure"
 
 # Wait a short period of time before attempting to deploy infrastructure
-# shellcheck disable=SC2016
-timeout --foreground 60 bash -c -- 'while [[ -z $(nomad node status 2>&1 | grep ready) ]]; do printf "Waiting for nomad-agent\n";sleep 1;done'
+(
+    readonly wait_secs=45
+    # shellcheck disable=SC2016
+    timeout --foreground "${wait_secs}" bash -c -- "$(
+        cat << EOF
+            wait_attempt=1
+            while [[ -z \$(nomad node status 2>&1 | grep ready) ]]; do
+                echo "Waiting for nomad-agent [\${wait_attempt}/${wait_secs}]"
+                sleep 1
+                ((wait_attempt=wait_attempt+1))
+            done
+EOF
+    )"
+)
 
 # Do a Validate before a Plan. Helps end-users catch errors.
 nomad job validate "${NOMAD_VARS[@]}" "${LOCAL_INFRA_NOMAD_FILE}"

--- a/nomad/local/nomad_run_local_infra.sh
+++ b/nomad/local/nomad_run_local_infra.sh
@@ -17,7 +17,7 @@ echo "Deploying Nomad local infrastructure"
 
 # Wait a short period of time before attempting to deploy infrastructure
 # shellcheck disable=SC2016
-timeout 60 bash -c -- 'while [[ -z $(nomad node status 2>&1 | grep ready) ]]; do printf "Waiting for nomad-agent\n";sleep 1;done'
+timeout --foreground 60 bash -c -- 'while [[ -z $(nomad node status 2>&1 | grep ready) ]]; do printf "Waiting for nomad-agent\n";sleep 1;done'
 
 # Do a Validate before a Plan. Helps end-users catch errors.
 nomad job validate "${NOMAD_VARS[@]}" "${LOCAL_INFRA_NOMAD_FILE}"


### PR DESCRIPTION
1. add ctrl-c support with --foreground
2. make it multiline now that i understand how cat eof fully works
3. add a [1/45] attempt counter