### PR TITLE
Use CAP_NET_BIND_SERVICE for dnsmasq container instead of CAP_NET_ADMIN.

### DIFF
--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -452,7 +452,7 @@ job "grapl-local-infra" {
           "--log-facility=-",
         ]
         cap_add = [
-          "NET_ADMIN",
+          "NET_BIND_SERVICE",
         ]
         logging {
           type = "journald"


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

The dnsmasq container used for routing DNS to Consul is using CAP_NET_ADMIN to bind of port 53, which grants more permissions than necessary. This swaps that for CAP_NET_BIND_SERVICE.

### How were these changes tested?

CI.