### PR TITLE
Add a pipeline_message_flow analysis to dump_artifacts, to easily figure out "why are my e2e tests failing?"

### DIFF
--- a/etc/ci_scripts/dump_artifacts/analysis/BUILD
+++ b/etc/ci_scripts/dump_artifacts/analysis/BUILD
@@ -1,0 +1,3 @@
+python_tests(name="tests")
+
+python_sources()

--- a/etc/ci_scripts/dump_artifacts/analysis/pipeline_message_flow.py
+++ b/etc/ci_scripts/dump_artifacts/analysis/pipeline_message_flow.py
@@ -1,0 +1,103 @@
+import json
+import re
+from pathlib import Path
+from typing import List, Optional
+
+# Declares the order in which to print diagnoses out.
+# Models the order of messages flowing through the pipeline.
+PRIORITIZATION = [
+    "sysmon-generator.stdout",
+    "osquery-generator.stdout",
+    "node-identifier.stdout",
+    "node-identifier-retry.stdout",
+    "graph-merger.stdout",
+    "analyzer-dispatcher.stdout",
+    "analyzer-executor.stdout",
+    "engagement-creator.stdout",
+]
+
+
+def analyze_grapl_core(artifacts_dir: Path, analysis_dir: Path) -> None:
+    logs_in_grapl_core = list((artifacts_dir / "grapl-core").iterdir())
+    # Find any logs that match the patterns listed in PRIORITIZATION,
+    # in that order.
+    maybe_paths = [
+        next((l for l in logs_in_grapl_core if l.name.startswith(pattern)), None)
+        for pattern in PRIORITIZATION
+    ]
+    paths = [p for p in maybe_paths if p]
+    output = analyze_paths(paths)
+    with open(analysis_dir / "pipeline_message_flow.txt", "w") as f:
+        f.write(output)
+
+
+def analyze_paths(paths: List[Path]) -> str:
+    output = []
+    for path in paths:
+        with open(path, "r") as file:
+            lines = file.readlines()
+            num_received_messages = get_num_received_messages(lines)
+            output.append(f"File {path.name}: received {num_received_messages}")
+    return "\n".join(output)
+
+
+########################################
+# Helpers
+########################################
+
+
+def get_num_received_messages(lines: List[str]) -> int:
+    """
+    Given a split-lines input, count up all receives.
+    """
+    total_receives = 0
+    for line in lines:
+        total_receives += get_receive_count_for_line(line) or 0
+    return total_receives
+
+
+def get_receive_count_for_line(line: str) -> Optional[int]:
+    """
+    Given a single line, parse for receive-count data.
+    """
+    # Try different heuristics for the same line depending on which log format
+    res = get_receive_count_for_rust_sqs_executor_line(line)
+    if res is None:
+        res = get_receive_count_for_py_sqs_timeout_manager(line)
+    return res
+
+
+def get_receive_count_for_rust_sqs_executor_line(line: str) -> Optional[int]:
+    """
+    Corresponds to logs output from
+    info!(message_batch_len = message_batch_len, "Received messages");
+    in sqs-executor/lib.rs
+    """
+    try:
+        json_line = json.loads(line)
+    except json.decoder.JSONDecodeError:
+        # Definitely not handlable by the rust sqs_executor parser
+        return None
+    try:
+        message = json_line["fields"]["message"]
+        if not message == "Received messages":
+            return None
+        received_batch_len: int = json_line["fields"]["message_batch_len"]
+        return received_batch_len
+    except KeyError:
+        return None
+
+
+PY_SQS_TIMEOUT_MANAGER_PATTERN = re.compile(r"SQS MessageID [0-9a-f\-]+\: Loop 1 .*")
+
+
+def get_receive_count_for_py_sqs_timeout_manager(line: str) -> Optional[int]:
+    """
+    Corresponds to logs output from
+    sqs_timeout_manager.py
+    """
+    # Not necessarily the best signal, but since SQS is being deprecated soon
+    # due to kafka, it's fine for now
+    if re.match(PY_SQS_TIMEOUT_MANAGER_PATTERN, line):
+        return 1
+    return None

--- a/etc/ci_scripts/dump_artifacts/analysis/pipeline_message_flow_test.py
+++ b/etc/ci_scripts/dump_artifacts/analysis/pipeline_message_flow_test.py
@@ -1,0 +1,38 @@
+from ci_scripts.dump_artifacts.analysis.pipeline_message_flow import (
+    get_num_received_messages,
+)
+
+TEST_INPUT_FROM_SYSMON_GENERATOR = """
+{"timestamp":"2022-04-21T15:04:51.531623Z","level":"DEBUG","fields":{"message":"overriding region_name: \"us-east-1\""},"target":"grapl_config::env_helpers"}
+{"timestamp":"2022-04-21T15:04:51.533053Z","level":"INFO","fields":{"message":"Starting process_loop"},"target":"graph_generator_lib"}
+MONITORING|sysmon_generator|2022-04-21T15:05:11.560Z|sqs_executor.receive_message:20026|h|#success:true,empty_receive:true
+{"timestamp":"2022-04-21T15:05:52.109084Z","level":"INFO","fields":{"message":"Received messages","message_batch_len":0},"target":"sqs_executor","span":{},"spans":[]}
+MONITORING|sysmon_generator|2022-04-21T15:06:12.389Z|sqs_executor.receive_message:20028|h|#success:true,empty_receive:true
+{"timestamp":"2022-04-21T15:06:12.389242Z","level":"INFO","fields":{"message":"Received messages","message_batch_len":3},"target":"sqs_executor","span":{},"spans":[]}
+MONITORING|sysmon_generator|2022-04-21T15:06:13.155Z|sqs_executor.receive_message:515|h|#success:true,empty_receive:false
+{"timestamp":"2022-04-21T15:06:13.155841Z","level":"INFO","fields":{"message":"Received messages","message_batch_len":1},"target":"sqs_executor","span":{},"spans":[]}
+MONITORING|sysmon_generator|2022-04-21T15:06:13.156Z|redis_cache.all_exist.ms:0|h|#success:true
+""".splitlines()
+
+
+def test_receive_count_sysmon_generator() -> None:
+    input = TEST_INPUT_FROM_SYSMON_GENERATOR
+    receive_count = get_num_received_messages(input)
+    assert receive_count == 4
+
+
+TEST_INPUT_FROM_ANALYZER_EXECUTOR = """
+SQS MessageID 0fa16960-befd-42c1-ae2c-f5be7aca89f8: Loop 1 - waiting 20s for task
+Writing out plugins to: /tmp/model_plugins
+Executing Analyzer: analyzers/suspicious_svchost/main.py
+MONITORING|analyzer-executor|2022-04-21T18:03:14.184+00:00|analyzer-executor.download_s3_file:17|h
+SQS MessageID 0fa16960-befd-42c1-ae2c-f5be7aca89f8: Loop 2 - waiting 20s for task
+SQS MessageID 0fa16960-befd-42c1-ae2c-f5be7aca89f8: Task completed
+SQS MessageID 1c4534e0-202b-413d-bb07-f1fc12a3ae50: Loop 1 - waiting 20s for task
+""".splitlines()
+
+
+def test_receive_count_analyzer_executor() -> None:
+    input = TEST_INPUT_FROM_ANALYZER_EXECUTOR
+    receive_count = get_num_received_messages(input)
+    assert receive_count == 2

--- a/etc/ci_scripts/dump_artifacts/cli.py
+++ b/etc/ci_scripts/dump_artifacts/cli.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 # Odd path is due to the `/etc` root pattern in pants.toml, fyi
 from ci_scripts.dump_artifacts import docker_artifacts, nomad_artifacts
+from ci_scripts.dump_artifacts.analysis import pipeline_message_flow
 
 # need minimum 3.7 for capture_output=True
 assert sys.version_info >= (
@@ -75,6 +76,12 @@ def main() -> None:
     )
 
     nomad_artifacts.dump_all(artifacts_dir, dump_agent_logs=args.dump_agent_logs)
+
+    # Run meta-analyses on the Nomad logs
+    analysis_dir = artifacts_dir / "analysis"
+    os.makedirs(analysis_dir, exist_ok=False)
+    pipeline_message_flow.analyze_grapl_core(artifacts_dir, analysis_dir)
+
     LOGGER.info(f"--- Artifacts dumped to {artifacts_dir}")
 
 

--- a/etc/ci_scripts/dump_artifacts/docker_artifacts.py
+++ b/etc/ci_scripts/dump_artifacts/docker_artifacts.py
@@ -93,10 +93,12 @@ def dump_volume(
 
     # Copy contents of /mounted_volume into artifacts_dir
     subprocess.run(
-        f"docker cp {container_id}:/{volume_name} {artifacts_dir}", shell=True
+        f"docker cp {container_id}:/{volume_name} {artifacts_dir}",
+        shell=True,
+        capture_output=True,
     )
 
-    subprocess.run(f"docker rm {container_id}", shell=True)
+    subprocess.run(f"docker rm {container_id}", shell=True, capture_output=True)
 
 
 def dump_all_docker_logs(compose_project: str, artifacts_dir: Path) -> None:


### PR DESCRIPTION
Long story short, all dumps to `test_artifacts/{timestamp}` will now contain a 

`analysis/pipeline_message_flow.txt`
```
File sysmon-generator.stdout.dcf2ec63.log: received 2
File osquery-generator.stdout.ad035f8d.log: received 0
File node-identifier.stdout.df01981c.log: received 2
File node-identifier-retry.stdout.01528ef9.log: received 2
File graph-merger.stdout.326e6168.log: received 4
File analyzer-dispatcher.stdout.afb9a66b.log: received 4
File analyzer-executor.stdout.3852f406.log: received 8
File engagement-creator.stdout.5ecec833.log: received 12
```

The idea here is that it'd be bone simple to zero-in on "oh, why does graph-merger receive 0? something must have screwed up at node-identifier-retry" without having to peruse through every service's logs