### PR TITLE
wire up the new integration test creds

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -162,11 +162,6 @@ variable "pipeline_ingress_healthcheck_polling_interval_ms" {
   description = "The amount of time to wait between each healthcheck execution."
 }
 
-variable "pipeline_ingress_kafka_consumer_group_name" {
-  type        = string
-  description = "The consumer group for pipeline ingress consumers to join."
-}
-
 variable "pipeline_ingress_kafka_sasl_username" {
   type        = string
   description = "The username to authenticate with Confluent Cloud cluster."
@@ -1260,7 +1255,6 @@ job "grapl-core" {
         RUST_LOG                                         = var.rust_log
         PIPELINE_INGRESS_HEALTHCHECK_POLLING_INTERVAL_MS = var.pipeline_ingress_healthcheck_polling_interval_ms
         KAFKA_BOOTSTRAP_SERVERS                          = var.kafka_bootstrap_servers
-        KAFKA_CONSUMER_GROUP_NAME                        = var.pipeline_ingress_kafka_consumer_group_name
         KAFKA_SASL_USERNAME                              = var.pipeline_ingress_kafka_sasl_username
         KAFKA_SASL_PASSWORD                              = var.pipeline_ingress_kafka_sasl_password
 

--- a/nomad/integration-tests-new.nomad
+++ b/nomad/integration-tests-new.nomad
@@ -36,19 +36,19 @@ variable "pipeline_ingress_healthcheck_polling_interval_ms" {
   description = "The amount of time to wait between each healthcheck execution."
 }
 
-variable "pipeline_ingress_kafka_consumer_group_name" {
+variable "integration_tests_kafka_consumer_group_name" {
   type        = string
-  description = "The name of the consumer group the pipeline-ingress consumers will join."
+  description = "The name of the consumer group the integration test consumers will join."
 }
 
-variable "pipeline_ingress_kafka_sasl_username" {
+variable "integration_tests_kafka_sasl_username" {
   type        = string
-  description = "The Confluent Cloud API key to configure pipeline-ingress producers and consumers with."
+  description = "The Confluent Cloud API key to configure integration test consumers with."
 }
 
-variable "pipeline_ingress_kafka_sasl_password" {
+variable "integration_tests_kafka_sasl_password" {
   type        = string
-  description = "The Confluent Cloud API secret to configure pipeline-ingress producers and consumers with."
+  description = "The Confluent Cloud API secret to configure integration test consumers with."
 }
 
 locals {
@@ -118,10 +118,11 @@ job "integration-tests-new" {
 
         KAFKA_BOOTSTRAP_SERVERS = var.kafka_bootstrap_servers
 
-        PIPELINE_INGRESS_CLIENT_ADDRESS                 = "http://${NOMAD_UPSTREAM_ADDR_pipeline_ingress}"
-        PIPELINE_INGRESS_KAFKA_SASL_USERNAME            = var.pipeline_ingress_kafka_sasl_username
-        PIPELINE_INGRESS_KAFKA_SASL_PASSWORD            = var.pipeline_ingress_kafka_sasl_password
-        PIPELINE_INGRESS_TEST_KAFKA_CONSUMER_GROUP_NAME = "pipeline-ingress-test"
+        PIPELINE_INGRESS_CLIENT_ADDRESS = "http://${NOMAD_UPSTREAM_ADDR_pipeline_ingress}"
+
+        INTEGRATION_TESTS_KAFKA_SASL_USERNAME       = var.integration_tests_kafka_sasl_username
+        INTEGRATION_TESTS_KAFKA_SASL_PASSWORD       = var.integration_tests_kafka_sasl_password
+        INTEGRATION_TESTS_KAFKA_CONSUMER_GROUP_NAME = var.integration_tests_kafka_consumer_group_name
 
         NOMAD_SERVICE_ADDRESS = "${attr.unique.network.ip-address}:4646"
       }

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -32,21 +32,6 @@ variable "redis_endpoint" {
   description = "Where can services find Redis?"
 }
 
-variable "kafka_bootstrap_servers" {
-  type        = string
-  description = "The URL(s) (possibly comma-separated) of the Kafka bootstrap servers."
-}
-
-variable "kafka_sasl_username" {
-  type        = string
-  description = "The Confluent Cloud API key to configure producers and consumers with."
-}
-
-variable "kafka_sasl_password" {
-  type        = string
-  description = "The Confluent Cloud API secret to configure producers and consumers with."
-}
-
 variable "schema_properties_table_name" {
   type        = string
   description = "What is the name of the schema properties table?"
@@ -207,13 +192,10 @@ job "integration-tests" {
         GRAPL_LOG_LEVEL = local.log_level
         # This is a hack, because IDK how to share locals across files
         #MG_ALPHAS                   = local.alpha_grpc_connect_str # TODO: Figure out how to do this
-        MG_ALPHAS               = "localhost:9080"
-        RUST_BACKTRACE          = 1
-        RUST_LOG                = local.log_level
-        REDIS_ENDPOINT          = var.redis_endpoint
-        KAFKA_BOOTSTRAP_SERVERS = var.kafka_bootstrap_servers
-        KAFKA_SASL_USERNAME     = var.kafka_sasl_username
-        KAFKA_SASL_PASSWORD     = var.kafka_sasl_password
+        MG_ALPHAS      = "localhost:9080"
+        RUST_BACKTRACE = 1
+        RUST_LOG       = local.log_level
+        REDIS_ENDPOINT = var.redis_endpoint
 
         GRAPL_MODEL_PLUGIN_DEPLOYER_HOST = "0.0.0.0"
         GRAPL_MODEL_PLUGIN_DEPLOYER_PORT = "${NOMAD_UPSTREAM_PORT_model-plugin-deployer}"
@@ -332,10 +314,6 @@ job "integration-tests" {
         MESSAGECACHE_ADDR = "${local.redis_host}"
         MESSAGECACHE_PORT = "${local.redis_port}"
         IS_RETRY          = "False"
-
-        KAFKA_BOOTSTRAP_SERVERS = var.kafka_bootstrap_servers
-        KAFKA_SASL_USERNAME     = var.kafka_sasl_username
-        KAFKA_SASL_PASSWORD     = var.kafka_sasl_password
 
         GRAPL_LOG_LEVEL = local.log_level
         MG_ALPHAS       = "localhost:9080"

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -197,14 +197,6 @@ def main() -> None:
         pipeline_ingress_healthcheck_polling_interval_ms,
     )
 
-    pipeline_ingress_kafka_consumer_group_name = kafka.consumer_group(
-        "pipeline-ingress"
-    )
-    pulumi.export(
-        "pipeline-ingress-kafka-consumer-group-name",
-        pipeline_ingress_kafka_consumer_group_name,
-    )
-
     pulumi.export(
         "integration-tests-kafka-consumer-group-name",
         kafka.consumer_group("integration-tests"),
@@ -275,7 +267,6 @@ def main() -> None:
         osquery_generator_queue=osquery_generator_queue.main_queue_url,
         osquery_generator_dead_letter_queue=osquery_generator_queue.dead_letter_queue_url,
         pipeline_ingress_healthcheck_polling_interval_ms=pipeline_ingress_healthcheck_polling_interval_ms,
-        pipeline_ingress_kafka_consumer_group_name=pipeline_ingress_kafka_consumer_group_name,
         py_log_level=py_log_level,
         rust_log=rust_log_levels,
         schema_properties_table_name=dynamodb_tables.schema_properties_table.name,

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -197,20 +197,6 @@ def main() -> None:
         pipeline_ingress_healthcheck_polling_interval_ms,
     )
 
-    pulumi.export(
-        "integration-tests-kafka-consumer-group-name",
-        kafka.consumer_group("integration-tests"),
-    )
-    integration_tests_kafka_credentials = kafka.service_credentials("integration-tests")
-    pulumi.export(
-        "integration-tests-kafka-sasl-username",
-        integration_tests_kafka_credentials.apply(lambda c: c.api_key),
-    )
-    pulumi.export(
-        "integration-tests-kafka-sasl-password",
-        integration_tests_kafka_credentials.apply(lambda c: c.api_secret),
-    )
-
     plugins_bucket = Bucket("plugins-bucket", sse=True)
     pulumi.export("plugins-bucket", plugins_bucket.bucket)
 
@@ -304,20 +290,6 @@ def main() -> None:
     }
 
     nomad_grapl_core_timeout = "5m"
-
-    pulumi.export("kafka-bootstrap-servers", kafka.bootstrap_servers())
-
-    e2e_kafka_credentials = kafka.service_credentials(service_name="e2e-test-runner")
-
-    pulumi.export(
-        "kafka-e2e-sasl-username", e2e_kafka_credentials.apply(lambda c: c.api_key)
-    )
-    pulumi.export(
-        "kafka-e2e-sasl-password", e2e_kafka_credentials.apply(lambda c: c.api_secret)
-    )
-    pulumi.export(
-        "kafka-e2e-consumer-group-name", kafka.consumer_group("e2e-test-runner")
-    )
 
     pipeline_ingress_kafka_credentials = kafka.service_credentials("pipeline-ingress")
 

--- a/pulumi/infra/kafka.py
+++ b/pulumi/infra/kafka.py
@@ -187,7 +187,7 @@ class Kafka(pulumi.ComponentResource):
 
     def consumer_group(self, service_name: str) -> pulumi.Output[str]:
         if self.confluent_environment is None:
-            return pulumi.Output.from_input("e2e-test-runner")
+            return pulumi.Output.from_input(service_name)
         else:
             return self.confluent_environment.apply(
                 lambda e: _expect(e.services[service_name].consumer_group_name)

--- a/pulumi/infra/kafka.py
+++ b/pulumi/infra/kafka.py
@@ -116,6 +116,7 @@ class Kafka(pulumi.ComponentResource):
         name: str,
         confluent_environment_name: str,
         opts: Optional[pulumi.ResourceOptions] = None,
+        create_local_topics: bool = True,
     ):
         super().__init__("grapl:Kafka", name=name, props=None, opts=opts)
 
@@ -148,15 +149,16 @@ class Kafka(pulumi.ComponentResource):
                 bootstrap_servers=["host.docker.internal:29092"],
                 tls_enabled=False,
             )
-            for topic in topics:
-                KafkaTopic(
-                    f"grapl:kafka:Topic:{topic}",
-                    name=topic,
-                    partitions=1,
-                    replication_factor=1,
-                    config={"compression.type": "zstd"},
-                    opts=pulumi.ResourceOptions(provider=provider),
-                )
+            if create_local_topics:
+                for topic in topics:
+                    KafkaTopic(
+                        f"grapl:kafka:Topic:{topic}",
+                        name=topic,
+                        partitions=1,
+                        replication_factor=1,
+                        config={"compression.type": "zstd"},
+                        opts=pulumi.ResourceOptions(provider=provider),
+                    )
         else:
             confluent_stack_output = StackReference(
                 "grapl/ccloud-bootstrap/ccloud-bootstrap"

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -119,11 +119,11 @@ def main() -> None:
         "aws_env_vars_for_local": grapl_stack.aws_env_vars_for_local,
         "aws_region": aws.get_region().name,
         "container_images": _integration_new_container_images(artifacts),
+        "integration_tests_kafka_consumer_group_name": grapl_stack.integration_tests_kafka_consumer_group_name,
+        "integration_tests_kafka_sasl_username": grapl_stack.integration_tests_kafka_sasl_username,
+        "integration_tests_kafka_sasl_password": grapl_stack.integration_tests_kafka_sasl_password,
         "kafka_bootstrap_servers": grapl_stack.kafka_bootstrap_servers,
         "pipeline_ingress_healthcheck_polling_interval_ms": grapl_stack.pipeline_ingress_healthcheck_polling_interval_ms,
-        "pipeline_ingress_kafka_consumer_group_name": grapl_stack.pipeline_ingress_kafka_consumer_group_name,
-        "pipeline_ingress_kafka_sasl_username": grapl_stack.pipeline_ingress_kafka_sasl_username,
-        "pipeline_ingress_kafka_sasl_password": grapl_stack.pipeline_ingress_kafka_sasl_password,
     }
 
     integration_tests_new = NomadJob(
@@ -220,17 +220,18 @@ class GraplStack:
             "kafka-e2e-consumer-group-name"
         )
 
+        self.integration_tests_kafka_consumer_group_name = require_str(
+            "integration-tests-kafka-consumer-group-name"
+        )
+        self.integration_tests_kafka_sasl_username = require_str(
+            "integration-tests-kafka-sasl-username"
+        )
+        self.integration_tests_kafka_sasl_password = require_str(
+            "integration-tests-kafka-sasl-password"
+        )
+
         self.pipeline_ingress_healthcheck_polling_interval_ms = require_str(
             "pipeline-ingress-healthcheck-polling-interval-ms"
-        )
-        self.pipeline_ingress_kafka_consumer_group_name = require_str(
-            "pipeline-ingress-kafka-consumer-group-name"
-        )
-        self.pipeline_ingress_kafka_sasl_username = require_str(
-            "pipeline-ingress-kafka-sasl-username"
-        )
-        self.pipeline_ingress_kafka_sasl_password = require_str(
-            "pipeline-ingress-kafka-sasl-password"
         )
 
         self.test_user_password_secret_id = require_str("test-user-password-secret-id")

--- a/src/rust/pipeline-ingress/tests/integration_test.rs
+++ b/src/rust/pipeline-ingress/tests/integration_test.rs
@@ -77,12 +77,12 @@ impl AsyncTestContext for PipelineIngressTestContext {
 
         let bootstrap_servers = std::env::var("KAFKA_BOOTSTRAP_SERVERS")
             .expect("missing environment variable KAFKA_BOOTSTRAP_SERVERS");
-        let sasl_username = std::env::var("PIPELINE_INGRESS_KAFKA_SASL_USERNAME")
-            .expect("missing environment variable PIPELINE_INGRESS_KAFKA_SASL_USERNAME");
-        let sasl_password = std::env::var("PIPELINE_INGRESS_KAFKA_SASL_PASSWORD")
-            .expect("missing environment variable PIPELINE_INGRESS_KAFKA_SASL_PASSWORD");
-        let consumer_group_name = std::env::var("PIPELINE_INGRESS_TEST_KAFKA_CONSUMER_GROUP_NAME")
-            .expect("missing environment variable PIPELINE_INGRESS_TEST_KAFKA_CONSUMER_GROUP_NAME");
+        let sasl_username = std::env::var("INTEGRATION_TESTS_KAFKA_SASL_USERNAME")
+            .expect("missing environment variable INTEGRATION_TESTS_KAFKA_SASL_USERNAME");
+        let sasl_password = std::env::var("INTEGRATION_TESTS_KAFKA_SASL_PASSWORD")
+            .expect("missing environment variable INTEGRATION_TESTS_KAFKA_SASL_PASSWORD");
+        let consumer_group_name = std::env::var("INTEGRATION_TESTS_TEST_KAFKA_CONSUMER_GROUP_NAME")
+            .expect("missing environment variable INTEGRATION_TESTS_KAFKA_CONSUMER_GROUP_NAME");
 
         tracing::info!(
             message = "waiting 10s for pipeline-ingress to report healthy",

--- a/src/rust/pipeline-ingress/tests/integration_test.rs
+++ b/src/rust/pipeline-ingress/tests/integration_test.rs
@@ -81,7 +81,7 @@ impl AsyncTestContext for PipelineIngressTestContext {
             .expect("missing environment variable INTEGRATION_TESTS_KAFKA_SASL_USERNAME");
         let sasl_password = std::env::var("INTEGRATION_TESTS_KAFKA_SASL_PASSWORD")
             .expect("missing environment variable INTEGRATION_TESTS_KAFKA_SASL_PASSWORD");
-        let consumer_group_name = std::env::var("INTEGRATION_TESTS_TEST_KAFKA_CONSUMER_GROUP_NAME")
+        let consumer_group_name = std::env::var("INTEGRATION_TESTS_KAFKA_CONSUMER_GROUP_NAME")
             .expect("missing environment variable INTEGRATION_TESTS_KAFKA_CONSUMER_GROUP_NAME");
 
         tracing::info!(


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
 NA
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

This PR updates the infrastructure configurations to account for the changes in https://github.com/grapl-security/confluent-cloud-infrastructure/pull/3.

The upshot of this is now we have Kafka credentials specifically for the integration test consumers, and we use them instead of trying to piggy-back on e.g. the pipeline-ingress credentials.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Automated tests
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
