### PR TITLE
Use single tokenizer across all input for Sysmon parser iterator.

### DIFF
--- a/src/rust/sysmon-parser/src/error.rs
+++ b/src/rust/sysmon-parser/src/error.rs
@@ -6,6 +6,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[non_exhaustive]
 #[derive(Error, Debug, PartialEq)]
 pub enum Error {
+    #[error("starting Sysmon event XML element not found")]
+    SysmonEventNotFound,
     #[error("event is not `{0}`")]
     ExpectEventType(&'static str),
     #[error("failed to parse IP address `{value}` at position `{position}` with `{source}`")]

--- a/src/rust/sysmon-parser/src/event.rs
+++ b/src/rust/sysmon-parser/src/event.rs
@@ -81,24 +81,58 @@ impl<'a> SysmonEvent<'a> {
     pub fn from_str(input: &'a str) -> Result<SysmonEvent<'a>> {
         let mut tokenizer = xmlparser::Tokenizer::from(input);
 
-        let system = System::try_from(&mut tokenizer)?;
-
-        let event_data = match system.event_id {
-            EventId::FileCreate => {
-                EventData::FileCreate(event_data::FileCreateEventData::try_from(&mut tokenizer)?)
-            }
-            EventId::NetworkConnection => EventData::NetworkConnect(
-                event_data::NetworkConnectionEventData::try_from(&mut tokenizer)?,
-            ),
-            EventId::ProcessCreation => EventData::ProcessCreate(
-                event_data::ProcessCreateEventData::try_from(&mut tokenizer)?,
-            ),
-            EventId::ProcessTerminated => EventData::ProcessTerminate(
-                event_data::ProcessTerminatedEventData::try_from(&mut tokenizer)?,
-            ),
-            _ => EventData::Unsupported,
-        };
-
-        Ok(SysmonEvent { system, event_data })
+        from_tokenizer(&mut tokenizer)
     }
+}
+
+#[inline]
+fn find_start_element(tokenizer: &mut xmlparser::Tokenizer) -> Result<()> {
+    for token in tokenizer.by_ref() {
+        match token? {
+            xmlparser::Token::ElementStart { local, .. } if local.as_str() == "Event" => {
+                return Ok(());
+            }
+            _ => {}
+        }
+    }
+
+    Err(crate::error::Error::SysmonEventNotFound)
+}
+
+pub(crate) fn from_tokenizer<'a, 'b: 'a>(
+    tokenizer: &mut xmlparser::Tokenizer<'b>,
+) -> Result<SysmonEvent<'a>> {
+    find_start_element(tokenizer)?;
+
+    let system = System::try_from(tokenizer)?;
+
+    let event_data = match system.event_id {
+        EventId::FileCreate => {
+            EventData::FileCreate(event_data::FileCreateEventData::try_from(tokenizer)?)
+        }
+        EventId::NetworkConnection => {
+            EventData::NetworkConnect(event_data::NetworkConnectionEventData::try_from(tokenizer)?)
+        }
+        EventId::ProcessCreation => {
+            EventData::ProcessCreate(event_data::ProcessCreateEventData::try_from(tokenizer)?)
+        }
+        EventId::ProcessTerminated => EventData::ProcessTerminate(
+            event_data::ProcessTerminatedEventData::try_from(tokenizer)?,
+        ),
+        _ => EventData::Unsupported,
+    };
+
+    // Advance tokenizer to end of event
+    for token in tokenizer.by_ref() {
+        match token? {
+            xmlparser::Token::ElementEnd {
+                end: xmlparser::ElementEnd::Close(_, name),
+                ..
+            } if name.as_str() == "Event" => break,
+
+            _ => {}
+        }
+    }
+
+    Ok(SysmonEvent { system, event_data })
 }

--- a/src/rust/sysmon-parser/src/events.rs
+++ b/src/rust/sysmon-parser/src/events.rs
@@ -8,44 +8,51 @@ use crate::error::Result;
 /// This is created by calling [`sysmon_parser::parse_events`]. See its documentation for more
 /// information.
 pub struct SysmonEvents<'a> {
-    input: &'a str,
-    len: usize,
-    cursor: usize,
+    previous_error: bool,
+    tokenizer: xmlparser::Tokenizer<'a>,
 }
 
 impl<'a> SysmonEvents<'a> {
-    pub(super) fn new(input: &'a str) -> Self {
+    pub(super) fn from(input: &'a str) -> Self {
         SysmonEvents {
-            input,
-            len: input.len(),
-            cursor: 0,
+            previous_error: false,
+            tokenizer: xmlparser::Tokenizer::from_fragment(
+                input,
+                std::ops::Range {
+                    start: 0,
+                    end: input.len(),
+                },
+            ),
         }
     }
 }
 
-// This is close to being functionally equivelent to
-// `input.split_inclusive("</Event>").map(SysmonEvent::try_from)` but it handles trailing data,
-// including whitespace in a way that won't result in errors
 impl<'a> Iterator for SysmonEvents<'a> {
     type Item = Result<SysmonEvent<'a>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let haystack = &self.input[self.cursor..self.len];
-        let needle = b"</Event>";
-
-        let element_end_pos = if let Some(pos) = memchr::memmem::find(haystack.as_bytes(), needle) {
-            // add needle length here to have this position cover the end element
-            pos + needle.len()
-        } else {
+        if self.previous_error {
             return None;
-        };
+        }
+        let result_new = super::event::from_tokenizer(&mut self.tokenizer);
 
-        let element_substr = &haystack[0..element_end_pos];
-        let result = SysmonEvent::from_str(element_substr);
+        match result_new {
+            Ok(_) => Some(result_new),
+            Err(crate::error::Error::SysmonEventNotFound) => {
+                // This is expected when there's nothing left to process
 
-        self.cursor += element_end_pos;
+                // This setting is effectively a no-op because we impl FusedIterator
+                // but we'll do it for kicks in case someone removes that.
+                self.previous_error = true;
 
-        Some(result)
+                None
+            }
+            Err(e) => {
+                self.previous_error = true;
+
+                Some(Err(e))
+            }
+        }
     }
 }
 

--- a/src/rust/sysmon-parser/src/lib.rs
+++ b/src/rust/sysmon-parser/src/lib.rs
@@ -125,5 +125,5 @@ pub use crate::system::System;
 ///
 /// ```
 pub fn parse_events(input: &str) -> SysmonEvents<'_> {
-    SysmonEvents::new(input)
+    SysmonEvents::from(input)
 }

--- a/src/rust/sysmon-parser/tests/multi_event_line_comments.rs
+++ b/src/rust/sysmon-parser/tests/multi_event_line_comments.rs
@@ -1,0 +1,103 @@
+#[test]
+fn comments() -> Result<(), Box<dyn std::error::Error>> {
+    // TODO(inickles): use data from the file under 'tests/data' directory after we move this
+    // package to its own repo
+    let xml = r#"
+    <!-- example process creation event -->
+    <!-- <Event><System></System><EventData></EventData></Event> -->
+    <Event>
+        <System>
+            <Provider Name="Linux-Sysmon" Guid="{ff032593-a8d3-4f13-b0d6-01fc615a0f97}"/>
+            <EventID>1</EventID>
+            <Version>5</Version>
+            <Level>4</Level>
+            <Task>1</Task>
+            <Opcode>0</Opcode>
+            <Keywords>0x8000000000000000</Keywords>
+            <TimeCreated SystemTime="2022-01-04T19:54:15.665400000Z"/>
+            <EventRecordID>77</EventRecordID>
+            <Correlation/>
+            <Execution ProcessID="49514" ThreadID="49514"/>
+            <Channel>Linux-Sysmon/Operational</Channel>
+            <Computer>tux</Computer>
+            <Security UserId="0"/>
+        </System>
+        <EventData>
+            <Data Name="RuleName">-</Data>
+            <Data Name="UtcTime">2022-01-04 19:54:15.661</Data>
+            <Data Name="ProcessGuid">{49e2a5f6-a5e7-61d4-119e-dc77a5550000}</Data>
+            <Data Name="ProcessId">49570</Data>
+            <Data Name="Image">/usr/bin/tr</Data>
+            <Data Name="FileVersion">-</Data>
+            <Data Name="Description">-</Data>
+            <Data Name="Product">-</Data>
+            <Data Name="Company">-</Data>
+            <Data Name="OriginalFileName">-</Data>
+            <Data Name="CommandLine">tr [:upper:][:lower:]</Data>
+            <Data Name="CurrentDirectory">/root</Data>
+            <Data Name="User">root</Data>
+            <Data Name="LogonGuid">{49e2a5f6-0000-0000-0000-000000000000}</Data>
+            <Data Name="LogonId">0</Data>
+            <Data Name="TerminalSessionId">3</Data>
+            <Data Name="IntegrityLevel">no level</Data>
+            <Data Name="Hashes">-</Data>
+            <Data Name="ParentProcessGuid">{00000000-0000-0000-0000-000000000000}</Data>
+            <Data Name="ParentProcessId">49568</Data>
+            <Data Name="ParentImage">-</Data>
+            <Data Name="ParentCommandLine">-</Data>
+            <Data Name="ParentUser">-</Data>
+        </EventData>
+    </Event>
+    <!-- example process creation event -->
+    <!-- <Event><System></System><EventData></EventData></Event> -->
+    <Event>
+        <System>
+            <Provider Name="Linux-Sysmon" Guid="{ff032593-a8d3-4f13-b0d6-01fc615a0f97}"/>
+            <EventID>1</EventID>
+            <Version>5</Version>
+            <Level>4</Level>
+            <Task>1</Task>
+            <Opcode>0</Opcode>
+            <Keywords>0x8000000000000000</Keywords>
+            <TimeCreated SystemTime="2022-01-04T19:54:15.665400000Z"/>
+            <EventRecordID>77</EventRecordID>
+            <Correlation/>
+            <Execution ProcessID="49514" ThreadID="49514"/>
+            <Channel>Linux-Sysmon/Operational</Channel>
+            <Computer>tux</Computer>
+            <Security UserId="0"/>
+        </System>
+        <EventData>
+            <Data Name="RuleName">-</Data>
+            <Data Name="UtcTime">2022-01-04 19:54:15.661</Data>
+            <Data Name="ProcessGuid">{49e2a5f6-a5e7-61d4-119e-dc77a5550000}</Data>
+            <Data Name="ProcessId">49570</Data>
+            <Data Name="Image">/usr/bin/tr</Data>
+            <Data Name="FileVersion">-</Data>
+            <Data Name="Description">-</Data>
+            <Data Name="Product">-</Data>
+            <Data Name="Company">-</Data>
+            <Data Name="OriginalFileName">-</Data>
+            <Data Name="CommandLine">tr [:upper:][:lower:]</Data>
+            <Data Name="CurrentDirectory">/root</Data>
+            <Data Name="User">root</Data>
+            <Data Name="LogonGuid">{49e2a5f6-0000-0000-0000-000000000000}</Data>
+            <Data Name="LogonId">0</Data>
+            <Data Name="TerminalSessionId">3</Data>
+            <Data Name="IntegrityLevel">no level</Data>
+            <Data Name="Hashes">-</Data>
+            <Data Name="ParentProcessGuid">{00000000-0000-0000-0000-000000000000}</Data>
+            <Data Name="ParentProcessId">49568</Data>
+            <Data Name="ParentImage">-</Data>
+            <Data Name="ParentCommandLine">-</Data>
+            <Data Name="ParentUser">-</Data>
+        </EventData>
+    </Event>
+    <!-- fin -->"#;
+
+    assert_eq!(sysmon_parser::parse_events(xml).count(), 2);
+
+    assert!(sysmon_parser::parse_events(xml).all(|res| res.is_ok()));
+
+    Ok(())
+}

--- a/src/rust/sysmon-parser/tests/parse_events.rs
+++ b/src/rust/sysmon-parser/tests/parse_events.rs
@@ -10,5 +10,7 @@ fn parse_events_events6() {
 <Event><System><Provider Name="Linux-Sysmon" Guid="{ff032593-a8d3-4f13-b0d6-01fc615a0f97}"/><EventID>5</EventID><Version>3</Version><Level>4</Level><Task>5</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime="2022-01-04T19:52:55.683744000Z"/><EventRecordID>11</EventRecordID><Correlation/><Execution ProcessID="49514" ThreadID="49514"/><Channel>Linux-Sysmon/Operational</Channel><Computer>user-VirtualBox</Computer><Security UserId="0"/></System><EventData><Data Name="RuleName">-</Data><Data Name="UtcTime">2022-01-04 19:52:55.688</Data><Data Name="ProcessGuid">{49e2a5f6-a597-61d4-5d7a-861de5550000}</Data><Data Name="ProcessId">49521</Data><Data Name="Image">/usr/bin/systemctl</Data><Data Name="User">user</Data></EventData></Event>
 "#;
 
+    assert_eq!(sysmon_parser::parse_events(xml).count(), 5);
+
     assert!(sysmon_parser::parse_events(xml).all(|res| res.is_ok()));
 }


### PR DESCRIPTION
### Which issue does this PR correspond to?

The sysmon-parser would incorrectly return an error when parsing multiple events is there was an XML comment that included the ending element tag of an event.

### What changes does this PR make to Grapl? Why?

This uses a single xmlparser::Tokenizer for processing multiple events from a single input. I hadn't previously noticed `xmlparser::Tokenizer::from_fragment` that allows for this.

### How were these changes tested?

I reproduced the issue by first adding new test case to sysmon-parser. I then used that to verify this fix.
