### PR TITLE
use the correct key to lookup the consumer group

### DIFF
--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -108,7 +108,7 @@ def main() -> None:
         "kafka_bootstrap_servers": kafka.bootstrap_servers(),
         "kafka_sasl_username": e2e_kafka_credentials.apply(lambda c: c.api_key),
         "kafka_sasl_password": e2e_kafka_credentials.apply(lambda c: c.api_secret),
-        "kafka_consumer_group_name": kafka.consumer_group("e2e-tests"),
+        "kafka_consumer_group_name": kafka.consumer_group("e2e-test-runner"),
         "schema_properties_table_name": grapl_stack.schema_properties_table_name,
         "sysmon_log_bucket": grapl_stack.sysmon_log_bucket,
         "schema_table_name": grapl_stack.schema_table_name,


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
NA
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Previously we were trying to look up the `e2e-test-runner` consumer group with the wrong key. Now we use the right one.
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Automated tests
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
