### PR TITLE
Add debugging around allocation IDs on run_parameterized_job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -524,7 +524,7 @@ stop: ## docker-compose stop - stops (but preserves) the containers
 restart-web-ui: build-engagement-view  ## Rebuild web-ui image, and restart web-ui task in Nomad
 	$(DOCKER_BUILDX_BAKE_HCL) grapl-web-ui
 	source ./nomad/lib/nomad_cli_tools.sh
-	nomad alloc restart "$$(nomad_get_alloc_id grapl-core web-ui)"
+	nomad alloc restart "$$(nomad_get_alloc_id_for_task grapl-core web-ui)"
 
 ##@ Venv Management
 ########################################################################

--- a/nomad/lib/nomad_cli_tools.sh
+++ b/nomad/lib/nomad_cli_tools.sh
@@ -13,13 +13,17 @@ curl_quiet() {
     fi
 }
 
-nomad_dispatch() {
-    # Grab the new Job ID from the Dispatch command
+nomad_allocations_for_eval() {
+    local -r eval_id="${1}"
+    local -r output="$(curl_quiet --request GET "${NOMAD_ADDRESS}/v1/evaluation/${eval_id}/allocations")"
+    local -r alloc_ids="$(echo "${output}" | jq -r '[ .[].ID ]')"
+    echo "${alloc_ids}"
+}
 
+nomad_dispatch() {
     local -r parameterized_batch_job="${1}"
-    local -r dispatch_output=$(curl_quiet --request POST --data "{}" "${NOMAD_ADDRESS}/v1/job/${parameterized_batch_job}/dispatch")
-    local -r job_id=$(echo "${dispatch_output}" | jq -r ".DispatchedJobID")
-    echo "${job_id}"
+    local -r dispatch_output="$(curl_quiet --request POST --data "{}" "${NOMAD_ADDRESS}/v1/job/${parameterized_batch_job}/dispatch")"
+    echo "${dispatch_output}"
 }
 
 url_to_nomad_job_in_ui() {
@@ -110,7 +114,7 @@ check_for_task_failures_in_job() {
     fi
 }
 
-nomad_get_alloc_id() {
+nomad_get_alloc_id_for_task() {
     # Inspired by
     # https://github.com/hashicorp/nomad/issues/698#issuecomment-1031683060
     local -r job_id="${1}"


### PR DESCRIPTION
We had this happen in slack today, where 1 e2e test resulted in 2 invokes. We have no idea how or why this happened.
Ideally this logging will at least give us some more info

https://buildkite.com/grapl/grapl-testing/builds/261#b4d7cc4d-5536-479b-94d3-6a5c3080209e/157
```
if you look at artifacts on colin's link
there's actually two e2e runs in there
e2e-tests.events.8c9d0e94.log
and
e2e-tests.events.905b3860.log
i have no idea how that's happening
```