### PR TITLE
[sysmon-parser] Undo opt dep + crate name hack now that Rust 1.60 has better support

### DIFF
--- a/src/rust/sysmon-parser/Cargo.toml
+++ b/src/rust/sysmon-parser/Cargo.toml
@@ -12,7 +12,7 @@ bench = false
 
 [features]
 default = ["serde"]
-serde = ["serde_crate", "uuid/serde", "chrono/serde"]
+serde = ["dep:serde", "uuid/serde", "chrono/serde"]
 
 [dependencies]
 chrono = { version = "0.4", features = ["std"] }
@@ -21,19 +21,9 @@ memchr = "2"
 thiserror = "1.0"
 uuid = "0.8"
 xmlparser = "0.13"
-
-# Because we're enabling feature flags in our dependencies for 'serde' we can't
-# have a feature named 'serde' and depend on it as well. A workaround is to
-# rename the serde crate internally, instead of exposing such naming
-# workarounds to our users. See:
-# https://github.com/rust-lang/api-guidelines/discussions/180
-# https://github.com/serde-rs/serde/issues/1938
-[dependencies.serde_crate]
-package = "serde"
-optional = true
-version = "1.0"
-default-features = false
-features = ["derive"]
+serde = { version = "1.0", default-features = false, features = [
+  "derive"
+], optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/rust/sysmon-parser/src/event.rs
+++ b/src/rust/sysmon-parser/src/event.rs
@@ -17,11 +17,7 @@ use crate::{
 /// `<https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon>`
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SysmonEvent<'a> {
     /// Defines the information that identifies the provider and how it was enabled, the event, the
     /// channel to which the event was written, and system information such as the process and

--- a/src/rust/sysmon-parser/src/event_data.rs
+++ b/src/rust/sysmon-parser/src/event_data.rs
@@ -15,11 +15,7 @@ pub const UTC_TIME_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.3f";
 /// Event-specific data for the Sysmon event. This inludes the data found in the `<EventData>` element.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum EventData<'a> {
     /// Event ID 11: FileCreate
     ///

--- a/src/rust/sysmon-parser/src/event_data/file_create.rs
+++ b/src/rust/sysmon-parser/src/event_data/file_create.rs
@@ -28,11 +28,7 @@ use crate::{
 /// <https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-11-filecreate>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FileCreateEventData<'a> {
     /// <data name="RuleName" inType="win:UnicodeString" outType="xs:string" />
     pub rule_name: Option<Cow<'a, str>>,

--- a/src/rust/sysmon-parser/src/event_data/network_connect.rs
+++ b/src/rust/sysmon-parser/src/event_data/network_connect.rs
@@ -32,11 +32,7 @@ use crate::{
 /// <https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-3-network-connection>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NetworkConnectionEventData<'a> {
     /// <data name="RuleName" inType="win:UnicodeString" outType="xs:string" />
     pub rule_name: Option<Cow<'a, str>>,

--- a/src/rust/sysmon-parser/src/event_data/process_creation.rs
+++ b/src/rust/sysmon-parser/src/event_data/process_creation.rs
@@ -29,11 +29,7 @@ use crate::{
 /// <https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-1-process-creation>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ProcessCreateEventData<'a> {
     /// <data name="RuleName" inType="win:UnicodeString" outType="xs:string" />
     pub rule_name: Option<Cow<'a, str>>,

--- a/src/rust/sysmon-parser/src/event_data/process_terminated.rs
+++ b/src/rust/sysmon-parser/src/event_data/process_terminated.rs
@@ -27,11 +27,7 @@ use crate::{
 /// <https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-5-process-terminated>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ProcessTerminatedEventData<'a> {
     /// <data name="RuleName" inType="win:UnicodeString" outType="xs:string" />
     pub rule_name: Option<Cow<'a, str>>,

--- a/src/rust/sysmon-parser/src/system.rs
+++ b/src/rust/sysmon-parser/src/system.rs
@@ -39,11 +39,7 @@ pub use time_created::TimeCreated;
 /// <https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-systempropertiestype-complextype>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct System<'a> {
     /// Identifies the provider that logged the event.
     ///

--- a/src/rust/sysmon-parser/src/system/correlation.rs
+++ b/src/rust/sysmon-parser/src/system/correlation.rs
@@ -3,11 +3,7 @@
 /// <https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-correlation-systempropertiestype-element>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Correlation {
     /// A globally unique identifier that identifies the current activity. The events that are
     /// published with this identifier are part of the same activity.

--- a/src/rust/sysmon-parser/src/system/event_id.rs
+++ b/src/rust/sysmon-parser/src/system/event_id.rs
@@ -3,11 +3,7 @@
 /// <https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#events>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum EventId {
     ProcessCreation,
     ProcessChangedFileCreationTime,

--- a/src/rust/sysmon-parser/src/system/execution.rs
+++ b/src/rust/sysmon-parser/src/system/execution.rs
@@ -3,11 +3,7 @@
 /// <https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-execution-systempropertiestype-element>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Execution {
     /// Identifies the process that generated the event.
     pub process_id: u32,

--- a/src/rust/sysmon-parser/src/system/provider.rs
+++ b/src/rust/sysmon-parser/src/system/provider.rs
@@ -7,11 +7,7 @@ use derive_into_owned::IntoOwned;
 /// <https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-provider-systempropertiestype-element>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Provider<'a> {
     /// The name of the event provider that logged the event.
     pub name: Option<Cow<'a, str>>,

--- a/src/rust/sysmon-parser/src/system/security.rs
+++ b/src/rust/sysmon-parser/src/system/security.rs
@@ -7,11 +7,7 @@ use derive_into_owned::IntoOwned;
 /// <https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-security-systempropertiestype-element>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash, IntoOwned)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Security<'a> {
     /// The security identifier (SID) of the user in string form.
     pub user_id: Option<Cow<'a, str>>,

--- a/src/rust/sysmon-parser/src/system/time_created.rs
+++ b/src/rust/sysmon-parser/src/system/time_created.rs
@@ -10,11 +10,7 @@ use chrono::{
 /// <https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-timecreated-systempropertiestype-element>
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TimeCreated {
     /// The system time of when the event was logged.
     #[cfg_attr(feature = "serde", serde(with = "ts_milliseconds"))]


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

The sysmon-parser was using a crate renaming hack to work around shortcomings of Cargo features and interactions with optional dependencies. That has been resolved with Rust 1.60 and means we can ditch that hack.

https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html#new-syntax-for-cargo-features

More details are available in the comment that is now removed with this PR:

```
# Because we're enabling feature flags in our dependencies for 'serde' we can't
# have a feature named 'serde' and depend on it as well. A workaround is to
# rename the serde crate internally, instead of exposing such naming
# workarounds to our users. See:
# https://github.com/rust-lang/api-guidelines/discussions/180
# https://github.com/serde-rs/serde/issues/1938
```

### How were these changes tested?

CI tests.
