### PR TITLE
Update SerDeError to include two new variants

### DIFF
--- a/src/rust/rust-proto-new/src/lib.rs
+++ b/src/rust/rust-proto-new/src/lib.rs
@@ -193,7 +193,7 @@ pub enum SerDeError {
     InvalidField {
         field_name: &'static str,
         assertion: String,
-    }
+    },
 
     #[error("Unknown enum variant")]
     UnknownVariant(&'static str),

--- a/src/rust/rust-proto-new/src/lib.rs
+++ b/src/rust/rust-proto-new/src/lib.rs
@@ -188,6 +188,15 @@ pub enum SerDeError {
 
     #[error("missing message field {0}")]
     MissingField(&'static str),
+
+    #[error("field {field_name} failed assertion {assertion}")]
+    InvalidField {
+        field_name: &'static str,
+        assertion: String,
+    }
+
+    #[error("Unknown enum variant")]
+    UnknownVariant(&'static str),
 }
 
 pub trait SerDe: type_url::TypeUrl + Clone + std::fmt::Debug {


### PR DESCRIPTION
### Which issue does this PR correspond to?
None, it's a small change that will play a role in future PRs.

### What changes does this PR make to Grapl? Why?
Add two new enum variants.

One is for unknown protobuf enum variants. The other is for arbitrary assertions.

The assertion error is for cases where we want to ensure that certain cases are upheld. As an example, it may not be valid for an integer to be 0, or beyond a specific range, etc.

### How were these changes tested?
No additional testing.