### PR TITLE
Set 'default-features = false' for chrono imports

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "time 0.3.9",
+ "time",
 ]
 
 [[package]]
@@ -221,7 +221,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2 0.4.4",
- "time 0.3.9",
+ "time",
  "url",
 ]
 
@@ -822,7 +822,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
  "winapi",
 ]
 
@@ -944,7 +943,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.2",
  "subtle",
- "time 0.3.9",
+ "time",
  "version_check",
 ]
 
@@ -4743,17 +4742,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
@@ -5097,7 +5085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.9",
+ "time",
  "tracing-subscriber",
 ]
 

--- a/src/rust/analyzer-dispatcher/Cargo.toml
+++ b/src/rust/analyzer-dispatcher/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { version = "1.17", features = [
   "sync",
   "time",
 ] }
-chrono = "0.4.19"
+chrono = { version = "0.4", default-features = false }
 sqs-executor = { path = "../sqs-executor/" }
 thiserror = "1.0.30"
 serde = { version = "1.0.130", features = ["derive"] }

--- a/src/rust/generators/graph-generator-lib/Cargo.toml
+++ b/src/rust/generators/graph-generator-lib/Cargo.toml
@@ -30,5 +30,5 @@ serde = "1.0.130"
 serde_json = "1.0.72"
 log = "0.4.14"
 zstd = "0.10.0"
-chrono = "0.4.19"
+chrono = { version = "0.4", default-features = false }
 tokio = "1.17"

--- a/src/rust/graph-merger/Cargo.toml
+++ b/src/rust/graph-merger/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1.17", features = [
   "sync",
   "time",
 ] }
-chrono = "0.4.19"
+chrono = { version = "0.4", default-features = false }
 tracing = "0.1.29"
 thiserror = "1.0.30"
 tracing-futures = "0.2.5"

--- a/src/rust/grapl-observe/Cargo.toml
+++ b/src/rust/grapl-observe/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 pin-project = "1.0.8"
-chrono = "0.4.19"
+chrono = { version = "0.4", default-features = false }
 lazy_static = "1.4.0"
 log = "0.4.14"
 regex = "1.5.5"

--- a/src/rust/node-identifier/Cargo.toml
+++ b/src/rust/node-identifier/Cargo.toml
@@ -58,7 +58,7 @@ tokio = { version = "1.17", features = [
   "time",
 ] }
 hmap = "0.1.0"
-chrono = "0.4.19"
+chrono = { version = "0.4", default-features = false }
 uuid = { version = "0.8", features = ["v4"] }
 tap = "1.0.1"
 tracing = "0.1.29"

--- a/src/rust/plugin-work-queue/Cargo.toml
+++ b/src/rust/plugin-work-queue/Cargo.toml
@@ -30,7 +30,7 @@ sqlx = { version = "0.5", features = [
   "uuid",
   "offline",
 ] }
-chrono = "0.4.19"
+chrono = { version = "0.4", default-features = false }
 futures = "0.3"
 
 [dev-dependencies]

--- a/src/rust/sqs-executor/Cargo.toml
+++ b/src/rust/sqs-executor/Cargo.toml
@@ -43,6 +43,6 @@ lazy_static = "1.4.0"
 futures = "0.3"
 num_cpus = "1.13.0"
 hex = "0.4.3"
-chrono = "0.4.19"
+chrono = { version = "0.4", default-features = false }
 lru = "0.7.0"
 itertools = "0.10.1"

--- a/src/rust/sysmon-parser/Cargo.toml
+++ b/src/rust/sysmon-parser/Cargo.toml
@@ -15,7 +15,7 @@ default = ["serde"]
 serde = ["dep:serde", "uuid/serde", "chrono/serde"]
 
 [dependencies]
-chrono = { version = "0.4", features = ["std"] }
+chrono = { version = "0.4", default-features = false }
 derive-into-owned = "0.2"
 memchr = "2"
 thiserror = "1.0"


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

I noticed the chrono import for sysmon-parser isn't what I remembered it being. The default features for chrono include `oldtime`, which adds the `time` crate, which is unused (and is indeed old).

I figured I'd apply this to other projects importing chrono as well.

This removes an unused dependency from sysmon-parser (which we may release independently) and the larger grapl workspace.

### How were these changes tested?

CI.
