### PR TITLE
Fix 'make clean-docker-data-volumes'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -586,9 +586,12 @@ clean-docker-images: ## Remove all Grapl images
 
 clean-docker-data-volumes: ## Remove all Grapl labeled volumes
 	# We explicitly don't want to prune the build cache volumes
-	docker volume prune \
-		$(DOCKER_DATA_VOLUME_FILTERS) \
-		--force
+	volumes_to_remove=($$(docker volume ls ${DOCKER_DATA_VOLUME_FILTERS} --quiet))
+	if [ $${#volumes_to_remove[@]} -ne 0 ]; then
+		docker volume rm \
+			"$${volumes_to_remove[@]}" \
+			--force
+	fi
 
 clean-docker-dgraph: ## Remove dgraph images
 	docker images \

--- a/Makefile
+++ b/Makefile
@@ -586,12 +586,8 @@ clean-docker-images: ## Remove all Grapl images
 
 clean-docker-data-volumes: ## Remove all Grapl labeled volumes
 	# We explicitly don't want to prune the build cache volumes
-	volumes_to_remove=($$(docker volume ls ${DOCKER_DATA_VOLUME_FILTERS} --quiet))
-	if [ $${#volumes_to_remove[@]} -ne 0 ]; then
-		docker volume rm \
-			"$${volumes_to_remove[@]}" \
-			--force
-	fi
+	docker volume ls ${DOCKER_DATA_VOLUME_FILTERS} --quiet |
+		xargs --no-run-if-empty docker volume rm --force
 
 clean-docker-dgraph: ## Remove dgraph images
 	docker images \


### PR DESCRIPTION
For some reason, docker volume ls lets you filter by name, but docker volume prune does not.

I'm changing this to a two-step phase:
1. docker volume ls with the folder
2. run the results through docker volume rm

```
docker volume ls --filter name=grapl-data
DRIVER    VOLUME NAME
local     grapl-data-dgraph
local     grapl-e2e_tests_grapl-data-dgraph
local     grapl-integration_tests_grapl-data-dgraph
local     grapl_grapl-data-dgraph

docker volume prune --filter name=grapl-data
WARNING! This will remove all local volumes not used by at least one container.
Are you sure you want to continue? [y/N] y
Error response from daemon: Invalid filter 'name'
```