### PR TITLE
Proof-of-concept http (not grpc) grapl plugin to experiment with consul proxy stuff

### DIFF
--- a/firecracker/rootfs/scripts/install_dependencies.sh
+++ b/firecracker/rootfs/scripts/install_dependencies.sh
@@ -9,4 +9,4 @@ set -o xtrace
 sudo apt update
 
 sudo apt install --yes --no-install-recommends \
-    debootstrap=1.0.118ubuntu1.6
+    debootstrap

--- a/src/rust/plugin-registry/src/nomad/client.rs
+++ b/src/rust/plugin-registry/src/nomad/client.rs
@@ -54,6 +54,7 @@ impl NomadClient {
     }
 
     /// Create or update a namespace (primary key'd on `name`)
+    #[tracing::instrument(skip(self, new_namespace), err)]
     pub async fn create_update_namespace(
         &self,
         new_namespace: models::Namespace,
@@ -71,6 +72,7 @@ impl NomadClient {
         .map_err(NomadClientError::from)
     }
 
+    #[tracing::instrument(skip(self, job, job_name, namespace), err)]
     pub async fn create_job(
         &self,
         job: &models::Job,
@@ -93,6 +95,7 @@ impl NomadClient {
         .map_err(NomadClientError::from)
     }
 
+    #[tracing::instrument(skip(self, job, job_name, namespace), err)]
     pub async fn plan_job(
         &self,
         job: &models::Job,

--- a/src/rust/plugin-registry/tests/BUILD
+++ b/src/rust/plugin-registry/tests/BUILD
@@ -1,0 +1,1 @@
+shell_sources()

--- a/src/rust/plugin-registry/tests/small_test_binary.sh
+++ b/src/rust/plugin-registry/tests/small_test_binary.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+echo "Hello, I am small_test_binary.sh"
+echo "Starting a simple server on ${BIND_PORT}..."
+apt-get update
+apt-get install --yes python3
+python3 -m http.server "${BIND_PORT}"

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -10,6 +10,8 @@ use rust_proto_new::graplinc::grapl::api::plugin_registry::v1beta1::{
     PluginType,
 };
 
+pub const SMALL_TEST_BINARY: &'static [u8] = include_bytes!("./small_test_binary.sh");
+
 #[test_log::test(tokio::test)]
 async fn test_deploy_plugin() -> Result<(), Box<dyn std::error::Error>> {
     let mut client = PluginRegistryServiceClient::from_env().await?;
@@ -19,7 +21,7 @@ async fn test_deploy_plugin() -> Result<(), Box<dyn std::error::Error>> {
     let create_response = {
         let display_name = uuid::Uuid::new_v4().to_string();
         let request = CreatePluginRequest {
-            plugin_artifact: b"dummy vec for now".to_vec(),
+            plugin_artifact: SMALL_TEST_BINARY.to_vec(),
             tenant_id: tenant_id.clone(),
             display_name: display_name.clone(),
             plugin_type: PluginType::Generator,


### PR DESCRIPTION
`test_deploy_plugin` will now deploy a plugin that just runs `python3 -m http.server`; this will in the _very_ near future be replaced with a grpc server implementing the plugin sdk, but in the meantime, this really helps me validate that the proxy stuff is working correctly.

---

To use it:

# Start environment and deploy plugin
KEEP_TEST_ENV=1 make test-integration-new

# Get a proxy into the plugin service
PLUGIN_SERVICE="plugin-5fe1d97a-3d86-6e04-0193-8b121dba1a26"
consul connect proxy -service respresenting-devbox-1 -upstream ${PLUGIN_SERVICE}:9999

# In another tab, curl against the proxy
```
$ curl http://localhost:9999
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
<title>Directory listing for /</title>
...
```