### PR TITLE
Un-parallelize our docker push to Cloudsmith, and add some retries

### DIFF
--- a/.buildkite/scripts/build_and_upload_images.sh
+++ b/.buildkite/scripts/build_and_upload_images.sh
@@ -49,6 +49,7 @@ docker buildx bake --file="${BUILDX_BAKE_FILE}" --progress "plain" "${BUILDX_TAR
         docker buildx bake --file="${BUILDX_BAKE_FILE}" --print "${BUILDX_TARGET}" |
             jq --raw-output '.target | keys | .[]'
     )
+    # Ideally we wouldn't duplicate this from the docker-bake.hcl.
     readonly container_repository="${CONTAINER_REPOSITORY:-docker.cloudsmith.io/grapl/raw}"
     for image_name in "${image_names[@]}"; do
         image_with_tag="${image_name}:${IMAGE_TAG}"

--- a/.buildkite/scripts/lib/retry.sh
+++ b/.buildkite/scripts/lib/retry.sh
@@ -30,7 +30,7 @@ function _retry() {
 
 # Usage:
 #   retry 3 echo "hello"
-function retry() {
+function retry_no_cooldown() {
     local -r retries="${1}"
     shift
 
@@ -39,7 +39,7 @@ function retry() {
 
 # Usage:
 #   retry_with_exponential_cooldown 3 echo "hello"
-function retry_with_exponential_cooldown() {
+function retry() {
     local -r retries="${1}"
     shift
 

--- a/.buildkite/scripts/lib/retry.sh
+++ b/.buildkite/scripts/lib/retry.sh
@@ -29,7 +29,7 @@ function _retry() {
 }
 
 # Usage:
-#   retry 3 echo "hello"
+#   retry_no_cooldown 3 echo "hello"
 function retry_no_cooldown() {
     local -r retries="${1}"
     shift
@@ -37,8 +37,9 @@ function retry_no_cooldown() {
     _retry "${retries}" 0 "${@}"
 }
 
+# Retries with an exponential-of-2 cooldown.
 # Usage:
-#   retry_with_exponential_cooldown 3 echo "hello"
+#   retry 3 echo "hello"
 function retry() {
     local -r retries="${1}"
     shift

--- a/.buildkite/scripts/lib/retry.sh
+++ b/.buildkite/scripts/lib/retry.sh
@@ -31,11 +31,11 @@ function _retry() {
 # Usage:
 #   retry 3 echo "hello"
 function retry() {
-    _retry "${@}" 0
+    _retry 0 "${@}"
 }
 
 # Usage:
 #   retry_with_exponential_cooldown 3 echo "hello"
 function retry_with_exponential_cooldown() {
-    _retry "${@}" 2
+    _retry 2 "${@}"
 }

--- a/.buildkite/scripts/lib/retry.sh
+++ b/.buildkite/scripts/lib/retry.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Usage:
+#   retry 3 echo "hello"
+function retry() {
+    local -r retries="${1}"
+    shift
+
+    count=0
+    until "$@"; do
+        exit=$?
+        count=$((count + 1))
+        if [ "${count}" -lt "${retries}" ]; then
+            echo "Retry ${count}/${retries} exited ${exit}, retrying."
+        else
+            echo "Retry ${count}/${retries} exited ${exit}, no more retries left."
+            exit "${exit}"
+        fi
+    done
+}

--- a/.buildkite/scripts/lib/retry.sh
+++ b/.buildkite/scripts/lib/retry.sh
@@ -17,7 +17,7 @@ function _retry() {
         if [ "${count}" -lt "${retries}" ]; then
             echo "Retry ${count}/${retries} exited ${exit}, retrying."
             if [[ ${exponential_backoff} -ne 0 ]]; then
-                sleep_time=$(($exponential_backoff ** count))
+                sleep_time=$((exponential_backoff ** count))
                 echo " >> Sleeping ${sleep_time}"
                 sleep "${sleep_time}"
             fi

--- a/.buildkite/scripts/lib/retry.sh
+++ b/.buildkite/scripts/lib/retry.sh
@@ -17,7 +17,7 @@ function _retry() {
         if [ "${count}" -lt "${retries}" ]; then
             echo "Retry ${count}/${retries} exited ${exit}, retrying."
             if [[ ${exponential_backoff} -ne 0 ]]; then
-                sleep_time=$((${exponential_backoff} ** count))
+                sleep_time=$(($exponential_backoff ** count))
                 echo " >> Sleeping ${sleep_time}"
                 sleep "${sleep_time}"
             fi
@@ -31,11 +31,17 @@ function _retry() {
 # Usage:
 #   retry 3 echo "hello"
 function retry() {
-    _retry 0 "${@}"
+    local -r retries="${1}"
+    shift
+
+    _retry "${retries}" 0 "${@}"
 }
 
 # Usage:
 #   retry_with_exponential_cooldown 3 echo "hello"
 function retry_with_exponential_cooldown() {
-    _retry 2 "${@}"
+    local -r retries="${1}"
+    shift
+
+    _retry "${retries}" 2 "${@}"
 }


### PR DESCRIPTION
Further digging into the issue originally raised in https://github.com/grapl-security/grapl/pull/1679

we are experimenting with retries and de-parallelizing our docker uploads to cloudsmith