### PR TITLE
start_detach: Capture cases where nomad agent or consul agent fail

### DIFF
--- a/nomad/local/nomad_run_local_infra.sh
+++ b/nomad/local/nomad_run_local_infra.sh
@@ -15,22 +15,6 @@ source "${THIS_DIR}/../lib/nomad_cli_tools.sh"
 
 echo "Deploying Nomad local infrastructure"
 
-# Wait a short period of time before attempting to deploy infrastructure
-(
-    readonly wait_secs=45
-    # shellcheck disable=SC2016
-    timeout --foreground "${wait_secs}" bash -c -- "$(
-        cat << EOF
-            wait_attempt=1
-            while [[ -z \$(nomad node status 2>&1 | grep ready) ]]; do
-                echo "Waiting for nomad-agent [\${wait_attempt}/${wait_secs}]"
-                sleep 1
-                ((wait_attempt=wait_attempt+1))
-            done
-EOF
-    )"
-)
-
 # Do a Validate before a Plan. Helps end-users catch errors.
 nomad job validate "${NOMAD_VARS[@]}" "${LOCAL_INFRA_NOMAD_FILE}"
 

--- a/nomad/local/start_detach.sh
+++ b/nomad/local/start_detach.sh
@@ -78,14 +78,15 @@ start_nomad_detach() {
         # shellcheck disable=SC2016
         timeout --foreground "${wait_secs}" bash -c -- "$(
             cat << EOF
+                # General rule: Variable defined in this EOF? Use \$
                 set -euo pipefail
                 wait_attempt=1
                 while [[ -z \$(nomad node status 2>&1 | grep ready) ]]; do
-                    if ! ps -p "\${nomad_agent_pid}" > /dev/null; then
+                    if ! ps -p "${nomad_agent_pid}" > /dev/null; then
                         echo "Nomad Agent unexpectedly exited?"
                         exit 42
                     fi
-                    if ! ps -p "\${consul_agent_pid}" > /dev/null; then
+                    if ! ps -p "${consul_agent_pid}" > /dev/null; then
                         echo "Consul Agent unexpectedly exited?"
                         exit 42
                     fi

--- a/nomad/local/start_detach.sh
+++ b/nomad/local/start_detach.sh
@@ -64,13 +64,11 @@ start_nomad_detach() {
         -config="${THIS_DIR}/nomad-agent-conf.nomad" \
         -dev-connect > "${NOMAD_LOGS_DEST}" &
     local -r nomad_agent_pid="$!"
-    export nomad_agent_pid
     # The client is set to 0.0.0.0 here so that it can be reached via pulumi in docker.
     consul agent \
         -client 0.0.0.0 -config-file "${THIS_DIR}/consul-agent-conf.hcl" \
         -dev > "${CONSUL_LOGS_DEST}" &
     local -r consul_agent_pid="$!"
-    export consul_agent_pid
 
     # Wait a short period of time before attempting to deploy infrastructure
     (

--- a/nomad/local/start_detach.sh
+++ b/nomad/local/start_detach.sh
@@ -63,10 +63,40 @@ start_nomad_detach() {
     sudo nomad agent \
         -config="${THIS_DIR}/nomad-agent-conf.nomad" \
         -dev-connect > "${NOMAD_LOGS_DEST}" &
+    local -r nomad_agent_pid="$!"
+    export nomad_agent_pid
     # The client is set to 0.0.0.0 here so that it can be reached via pulumi in docker.
     consul agent \
         -client 0.0.0.0 -config-file "${THIS_DIR}/consul-agent-conf.hcl" \
         -dev > "${CONSUL_LOGS_DEST}" &
+    local -r consul_agent_pid="$!"
+    export consul_agent_pid
+
+    # Wait a short period of time before attempting to deploy infrastructure
+    (
+        readonly wait_secs=45
+        # shellcheck disable=SC2016
+        timeout --foreground "${wait_secs}" bash -c -- "$(
+            cat << EOF
+                set -euo pipefail
+                wait_attempt=1
+                while [[ -z \$(nomad node status 2>&1 | grep ready) ]]; do
+                    if ! ps -p "\${nomad_agent_pid}" > /dev/null; then
+                        echo "Nomad Agent unexpectedly exited?"
+                        exit 42
+                    fi
+                    if ! ps -p "\${consul_agent_pid}" > /dev/null; then
+                        echo "Consul Agent unexpectedly exited?"
+                        exit 42
+                    fi
+
+                    echo "Waiting for nomad-agent [\${wait_attempt}/${wait_secs}]"
+                    sleep 1
+                    ((wait_attempt=wait_attempt+1))
+                done
+EOF
+        )"
+    )
 
     "${THIS_DIR}/nomad_run_local_infra.sh"
     echo "Deployment complete"


### PR DESCRIPTION

So I saw the following in one of Thomas's PRs:
https://buildkite.com/grapl/grapl-verify/builds/3365#55569814-1b58-4d26-99f3-05078faf1cb7
```
nomad/local/start_detach.sh
--
  | Starting nomad and consul locally. Logs @ /tmp/nomad-agent.log and /tmp/consul-agent.log.
  | Deploying Nomad local infrastructure
  | ==> Error loading configuration from nomad/local/nomad-agent-conf.nomad: Error loading nomad/local/nomad-agent-conf.nomad: unexpected keys ui
  | Waiting for nomad-agent [1/45]
  | Waiting for nomad-agent [2/45]
  | Waiting for nomad-agent [3/45]
  | Waiting for nomad-agent [4/45]
  | Waiting for nomad-agent [5/45]
```

Now, obviously, we should bail if the nomad pid ever exits, right?

ALSO, I decided the "wait for the nomad agents to be healthy" logic should be in start_detach, not nomad_run_local_infra.sh