### PR TITLE
Refactor frontend artifacts so they're dumped to dist/ not src/rust/grapl-web-ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,6 @@ node_modules/
 # corepack installs the node version in .node. Kinda annoying but makes sense since its not yarn-specific
 .node/
 
-# Web UI frontend artifacts
-src/rust/grapl-web-ui/frontend/*
-
 # Nomad artifacts
 # This is a generated config file for local grapl
 nomad/local/mount-grapl-root-as-volume.nomad

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ build-e2e-pex-files:
 build-engagement-view: ## Build website assets to include in grapl-web-ui
 	@echo "--- Building the engagement view"
 	$(ENGAGEMENT_VIEW_MAKE) build-code
-	TARGET_FRONTEND_DIR="src/rust/grapl-web-ui/frontend"
+	TARGET_FRONTEND_DIR="dist/frontend"
 	rm -rf "$${TARGET_FRONTEND_DIR}/*"  # Clear out old artifacts
 	cp -r \
 		"src/js/engagement_view/build/." \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -412,7 +412,7 @@ target "sysmon-generator" {
 target "_python-base" {
   contexts = {
     dist-ctx = "dist"
-    etc-ctx = "etc"
+    etc-ctx  = "etc"
   }
   dockerfile = "src/python/Dockerfile"
   labels     = oci_labels

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -410,7 +410,10 @@ target "sysmon-generator" {
 # All Python services defined in src/python/Dockerfile should inherit
 # from this target.
 target "_python-base" {
-  context    = "."
+  contexts = {
+    dist-ctx = "dist"
+    etc-ctx = "etc"
+  }
   dockerfile = "src/python/Dockerfile"
   labels     = oci_labels
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -269,7 +269,13 @@ group "all" {
 # All Rust services defined in src/rust/Dockerfile should inherit from
 # this target.
 target "_rust-base" {
-  context    = "src"
+  context = "src"
+
+  # Additional named contexts: 
+  # https://www.docker.com/blog/dockerfiles-now-support-multiple-build-contexts/
+  contexts = {
+    dist-ctx = "dist"
+  }
   dockerfile = "rust/Dockerfile"
   args = {
     RUST_BUILD = "${RUST_BUILD}"

--- a/localstack/Dockerfile
+++ b/localstack/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3-labs
+# syntax=docker/dockerfile:1.4
 
 # Every time we bring up Localstack, it goes and downloads Elasticmq.
 # This "fork" just preloads the JAR in the right spot.

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 # grapl-python-base
 ################################################################################
 FROM python:3.7-slim-bullseye AS grapl-python-base
@@ -21,19 +23,25 @@ ENTRYPOINT ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
 # analyzer-executor
 ################################################################################
 FROM grapl-python-base AS analyzer-executor-deploy
-COPY ./dist/analyzer-executor.pex .
+# Named context support https://github.com/hadolint/hadolint/issues/830
+# hadolint ignore=DL3022
+COPY --from=dist-ctx analyzer-executor.pex .
 CMD ["./analyzer-executor.pex"]
 
 # engagement-creator
 ################################################################################
 FROM grapl-python-base AS engagement-creator-deploy
-COPY ./dist/engagement-creator.pex .
+# Named context support https://github.com/hadolint/hadolint/issues/830
+# hadolint ignore=DL3022
+COPY --from=dist-ctx engagement-creator.pex .
 CMD ["./engagement-creator.pex"]
 
 # Provisioner
 ################################################################################
 FROM grapl-python-base AS provisioner-deploy
-COPY ./dist/provisioner.pex .
+# Named context support https://github.com/hadolint/hadolint/issues/830
+# hadolint ignore=DL3022
+COPY --from=dist-ctx provisioner.pex .
 CMD [":"]
 
 # e2e tests
@@ -42,14 +50,18 @@ FROM grapl-python-base AS e2e-tests
 
 # Copy in the contents of `etc` in order to upload them during e2e tests
 RUN mkdir -p /home/grapl/etc
-COPY --chown=grapl ./etc/local_grapl etc/local_grapl
-COPY --chown=grapl ./etc/sample_data/ etc/sample_data
+COPY --chown=grapl --from=etc-ctx local_grapl etc/local_grapl
+COPY --chown=grapl --from=etc-ctx sample_data/ etc/sample_data
 
 # Copy in `graplctl`, which does the actual uploading during e2e
 RUN mkdir -p /home/grapl/bin
-COPY --chown=grapl dist/src.python.graplctl.graplctl/graplctl.pex /home/grapl/bin/graplctl
+# Named context support https://github.com/hadolint/hadolint/issues/830
+# hadolint ignore=DL3022
+COPY --chown=grapl --from=dist-ctx src.python.graplctl.graplctl/graplctl.pex /home/grapl/bin/graplctl
 
-COPY --chown=grapl ./dist/e2e-tests.pex .
+# Named context support https://github.com/hadolint/hadolint/issues/830
+# hadolint ignore=DL3022
+COPY --chown=grapl --from=dist-ctx e2e-tests.pex .
 CMD ["./e2e-tests.pex"]
 
 ENV PATH=/home/grapl/bin:$PATH

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -50,7 +50,11 @@ FROM grapl-python-base AS e2e-tests
 
 # Copy in the contents of `etc` in order to upload them during e2e tests
 RUN mkdir -p /home/grapl/etc
+# Named context support https://github.com/hadolint/hadolint/issues/830
+# hadolint ignore=DL3022
 COPY --chown=grapl --from=etc-ctx local_grapl etc/local_grapl
+# Named context support https://github.com/hadolint/hadolint/issues/830
+# hadolint ignore=DL3022
 COPY --chown=grapl --from=etc-ctx sample_data/ etc/sample_data
 
 # Copy in `graplctl`, which does the actual uploading during e2e

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -397,9 +397,6 @@ ENTRYPOINT ["/osquery-generator"]
 ##### generator-executor
 FROM rust-dist AS generator-executor-deploy
 
-# Hadolint v2.8.0 appears to be mistaken, this is a false positive
-# https://github.com/hadolint/hadolint/wiki/DL3022
-# hadolint ignore=DL3022
 COPY --from=build /outputs/generator-executor /
 ENTRYPOINT ["/generator-executor"]
 
@@ -407,6 +404,8 @@ ENTRYPOINT ["/generator-executor"]
 FROM rust-dist AS grapl-web-ui-deploy
 
 COPY --from=build /outputs/grapl-web-ui /
+# Named context support https://github.com/hadolint/hadolint/issues/830
+# hadolint ignore=DL3022
 COPY --from=dist-ctx frontend /frontend
 ENTRYPOINT ["/grapl-web-ui"]
 

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3-labs
+# syntax=docker/dockerfile:1.4
 # We use the above syntax for here documents:
 # https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#user-content-here-documents
 
@@ -407,7 +407,7 @@ ENTRYPOINT ["/generator-executor"]
 FROM rust-dist AS grapl-web-ui-deploy
 
 COPY --from=build /outputs/grapl-web-ui /
-COPY rust/grapl-web-ui/frontend /frontend
+COPY --from=dist-ctx frontend /frontend
 ENTRYPOINT ["/grapl-web-ui"]
 
 ##### model plugin deployer

--- a/src/rust/build-env.Dockerfile
+++ b/src/rust/build-env.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3-labs
+# syntax=docker/dockerfile:1.4
 
 ARG RUST_VERSION
 


### PR DESCRIPTION
Currently we are shoving `engagement-view` artifacts in `src/rust` when we don't really need to.

Right now we have the following:
```.PHONY: build-engagement-view
build-engagement-view: ## Build website assets to include in grapl-web-ui
	[...] 
	# copy the built engagement view artifacts to src/rust/grapl-web-ui/frontend```

This cache-busts the Rust build `FROM rust:1-slim-bullseye AS base` because of
`COPY rust rust`

That `frontend/` artifact is not _actually_ used in `rust-base` build at all; it's only used in
```##### web-ui
FROM rust-dist AS grapl-web-ui-deploy

COPY --from=build /outputs/grapl-web-ui /
COPY rust/grapl-web-ui/frontend /frontend
ENTRYPOINT ["/grapl-web-ui"]```

*SOLUTION*
We shove `/frontend` into `dist/` 
We use `dist/` as a named secondary context