### PR TITLE
devbox-sync: add a VERBOSE_DEVBOX_SYNC=1 option; add a warning if <5GB remains on devbox

### DIFF
--- a/devbox/devbox-sync.sh
+++ b/devbox/devbox-sync.sh
@@ -12,6 +12,8 @@ readonly SSH_SCRIPT="${THIS_DIR}/ssh.sh"
 readonly VERBOSE_DEVBOX_SYNC="${VERBOSE_DEVBOX_SYNC:-0}"
 
 rsync_progress_args=()
+# These seemingly similar args - --info=progress and --progress2 - 
+# have very different outputs. Notably, --progress outputs each file.
 if [[ ${VERBOSE_DEVBOX_SYNC} -ne 0 ]]; then
     rsync_progress_args+=(--progress --verbose)
 else

--- a/devbox/devbox-sync.sh
+++ b/devbox/devbox-sync.sh
@@ -12,7 +12,7 @@ readonly SSH_SCRIPT="${THIS_DIR}/ssh.sh"
 readonly VERBOSE_DEVBOX_SYNC="${VERBOSE_DEVBOX_SYNC:-0}"
 
 rsync_progress_args=()
-# These seemingly similar args - --info=progress and --progress2 - 
+# These seemingly similar args - --info=progress and --progress2 -
 # have very different outputs. Notably, --progress outputs each file.
 if [[ ${VERBOSE_DEVBOX_SYNC} -ne 0 ]]; then
     rsync_progress_args+=(--progress --verbose)

--- a/devbox/devbox-sync.sh
+++ b/devbox/devbox-sync.sh
@@ -8,9 +8,18 @@ source "${THIS_DIR}/lib.sh"
 # shellcheck disable=SC1090
 source "${GRAPL_DEVBOX_CONFIG}"
 
+readonly VERBOSE_DEVBOX_SYNC="${VERBOSE_DEVBOX_SYNC:-0}"
+
+rsync_progress_args=()
+if [[ ${VERBOSE_DEVBOX_SYNC} -ne 0 ]]; then
+    rsync_progress_args+=(--progress --verbose)
+else
+    rsync_progress_args+=(--info=progress2)
+fi
+
 # the --include stuff was inspired by https://stackoverflow.com/posts/63438492/revisions
 
-if ! rsync --archive --info=progress2 \
+if ! rsync --archive "${rsync_progress_args[@]}" \
     --include='**.gitignore' --exclude='**/.git' --filter=':- .gitignore' --delete-after \
     --rsh "${THIS_DIR}/ssh.sh" \
     "${GRAPL_DEVBOX_LOCAL_GRAPL}/" \

--- a/src/sh/shell_color.sh
+++ b/src/sh/shell_color.sh
@@ -42,3 +42,7 @@ function bright_red() {
 function bright_green() {
     _bold_color "${COLORS[GREEN]}" "${@}"
 }
+
+function bright_yellow() {
+    _bold_color "${COLORS[YELLOW]}" "${@}"
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
none

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
add a VERBOSE_DEVBOX_SYNC=1 option which shows you which files are being synced (and which are being deleted, which is a thing that happens)

add a warning if <5GB remains on devbox

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I bumped the limit to 20GB and got
![Screenshot 2022-05-04 10 56 04 AM](https://user-images.githubusercontent.com/69007229/166709580-45bbb0da-70dc-41c1-be6a-4bdaab599004.png)


<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
