### PR TITLE
Test out new `grapl-rc` plugin

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -97,7 +97,7 @@ steps:
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - PULUMI_ACCESS_TOKEN
-      - grapl-security/grapl-rc#v0.1.6:
+      - grapl-security/grapl-rc#94da28ac09ec580e8bc698f9bb928ca4e45ed22c:
           artifact_file: all_artifacts.json
           stacks:
             - grapl/grapl/testing


### PR DESCRIPTION
This uses the commit of the merged
https://github.com/grapl-security/grapl-rc-buildkite-plugin/pull/27
PR.

Provided this behaves as we expect (i.e., removes all the files on the
`rc` branch that we've deleted from the `main` branch), we'll cut a
formal release of that plugin and use _that_, rather than a raw commit
SHA.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>