### PR TITLE
Update `grapl-rc` plugin to `v0.1.7`

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -97,7 +97,7 @@ steps:
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - PULUMI_ACCESS_TOKEN
-      - grapl-security/grapl-rc#94da28ac09ec580e8bc698f9bb928ca4e45ed22c:
+      - grapl-security/grapl-rc#v0.1.7:
           artifact_file: all_artifacts.json
           stacks:
             - grapl/grapl/testing


### PR DESCRIPTION
This is the same as we were using previously, but pinned to a tag
rather than a raw commit SHA.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>