### PR TITLE
Revert MANIFEST_UNKNOWN workaround

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -22,6 +22,10 @@ steps:
           server: docker.cloudsmith.io
     agents:
       queue: "docker"
+    retry:
+      automatic:
+        - exit_status: 42 # Special status for "buildx --push failed"
+          limit: 2
     artifact_paths:
       - "*.grapl-artifacts.json"
 

--- a/.buildkite/scripts/build_and_upload_images.sh
+++ b/.buildkite/scripts/build_and_upload_images.sh
@@ -41,21 +41,10 @@ make build-image-prerequisites
 # Build targets
 docker buildx bake --file="${BUILDX_BAKE_FILE}" --progress "plain" "${BUILDX_TARGET}"
 
-# Cloudsmith may be having trouble with `buildx --push`, so, experimenting with
-# uploading each one individually.
-{
-    mapfile -t fully_qualified_images < <(
-        docker buildx bake \
-            --file="${BUILDX_BAKE_FILE}" \
-            --print "${BUILDX_TARGET}" |
-            jq --raw-output '.target | to_entries | .[] | .value.tags[0]'
-    )
-    for fq_image in "${fully_qualified_images[@]}"; do
-        echo "--- Pushing ${fq_image}"
-        retry 3 \
-            docker push "${fq_image}"
-    done
-}
+# If you see MANIFEST_UNKNOWN on this, see 
+# https://github.com/grapl-security/issue-tracker/issues/931
+retry 2 \
+    docker buildx bake --file="${BUILDX_BAKE_FILE}" --progress "plain" --push "${BUILDX_TARGET}"
 
 readonly sleep_seconds=60
 echo "--- :sleeping::sob: Sleeping for ${sleep_seconds} seconds to give CDNs time to update"

--- a/.buildkite/scripts/build_and_upload_images.sh
+++ b/.buildkite/scripts/build_and_upload_images.sh
@@ -42,6 +42,7 @@ make build-image-prerequisites
 docker buildx bake --file="${BUILDX_BAKE_FILE}" --progress "plain" "${BUILDX_TARGET}"
 
 push() {
+    echo "--- Pushing all ${IMAGE_TAG} images"
     # https://github.com/grapl-security/issue-tracker/issues/931
     # Try the `buildx --push` first; if retried on Buildkite, do the slower
     # manual approach.

--- a/.buildkite/scripts/build_and_upload_images.sh
+++ b/.buildkite/scripts/build_and_upload_images.sh
@@ -10,7 +10,6 @@ set -euo pipefail
 
 source .buildkite/scripts/lib/artifacts.sh
 source .buildkite/scripts/lib/version.sh
-source .buildkite/scripts/lib/retry.sh
 
 # While we have Docker Compose files present, we have to explicitly
 # declare we're using an HCL file (compose YAML files are used
@@ -63,8 +62,7 @@ else
     )
     for fq_image in "${fully_qualified_images[@]}"; do
         echo "--- Pushing ${fq_image}"
-        retry 3 \
-            docker push "${fq_image}"
+        docker push "${fq_image}"
     done
 fi
 

--- a/.buildkite/scripts/build_and_upload_images.sh
+++ b/.buildkite/scripts/build_and_upload_images.sh
@@ -42,10 +42,12 @@ make build-image-prerequisites
 
 if [[ "${BUILDKITE_RETRY_COUNT}" -eq 0 ]]; then
     echo "--- Build & Pushing all ${IMAGE_TAG} images"
-    docker buildx bake --file="${BUILDX_BAKE_FILE}" \
-        --progress "plain" \
-        --push \
-        "${BUILDX_TARGET}"
+    if ! docker buildx bake --file="${BUILDX_BAKE_FILE}" \
+        --progress "plain" --push "${BUILDX_TARGET}"; then
+        echo "buildx bake --push failed; Buildkite should auto-retry"
+        # Special status for "buildx --push failed"
+        exit 42
+    fi
 else
     echo "--- Building all ${IMAGE_TAG} images"
     # Build targets


### PR DESCRIPTION
### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/931
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Previously: Buildx --push
Then, a [workaround](https://github.com/grapl-security/grapl/pull/1681): manually push each image
Now: Upon first attempt, do PReviously behavior; on Buildkite retries, do workaround behavior

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
i'm testing on my devbox as we speak
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
