### PR TITLE
Remove a leftover 'lint-proto-format' dependency; that rule was removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,6 @@ lint: lint-hcl
 lint: lint-prettier
 lint: lint-proto
 lint: lint-proto-breaking
-lint: lint-proto-format
 lint: lint-python
 lint: lint-rust
 lint: lint-shell

--- a/Makefile
+++ b/Makefile
@@ -388,7 +388,7 @@ lint-prettier: ## Run ts/js/yaml lint checks
 
 .PHONY: lint-proto
 lint-proto: ## Lint all protobuf definitions
-		$(PANTS_PROTO_FILTER) lint
+	$(PANTS_PROTO_FILTER) lint
 
 .PHONY: lint-proto-breaking
 lint-proto-breaking: ## Check protobuf definitions for breaking changes


### PR DESCRIPTION
Found the commit where the rule was removed by doing
```
git log -c -S'lint-proto-format:' Makefile
```

result: b5194b479b2ef4dc785393df27b538709817b193
https://github.com/grapl-security/grapl/pull/1682