### PR TITLE
'shuttle-rust-to-dist': a way to pull binary artifacts out of `rust-build` into `dist/`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -659,11 +659,11 @@ dist/firecracker_kernel.tar.gz: firecracker/kernel/build.sh | dist
 # NOTE: While this target is PHONY, it *does* represent a real directory in
 # dist/
 .PHONY: dist/plugin-bootstrap-init
-dist/plugin-bootstrap-init: _shuttle-rust-to-dist  ## Build the Plugin Bootstrap Init (+ associated files) and copy it to dist/
+dist/plugin-bootstrap-init: _export-rust-build-artifacts-to-dist  ## Build the Plugin Bootstrap Init (+ associated files) and copy it to dist/
 
-.PHONY: _shuttle-rust-to-dist
-_shuttle-rust-to-dist: | dist  ## Copy all specified Rust binary artifacts to dist/
-	$(DOCKER_BUILDX_BAKE_HCL) shuttle-rust-to-dist
+.PHONY: _export-rust-build-artifacts-to-dist
+_export-rust-build-artifacts-to-dist: | dist  ## Copy all specified Rust binary artifacts to dist/
+	$(DOCKER_BUILDX_BAKE_HCL) export-rust-build-artifacts-to-dist
 
 # TODO: Would be nice to be able to specify the input file prerequisites of
 # this target, once `dist/plugin-bootstrap-init` is non-PHONY

--- a/Makefile
+++ b/Makefile
@@ -659,8 +659,11 @@ dist/firecracker_kernel.tar.gz: firecracker/kernel/build.sh | dist
 # NOTE: While this target is PHONY, it *does* represent a real directory in
 # dist/
 .PHONY: dist/plugin-bootstrap-init
-dist/plugin-bootstrap-init: | dist  ## Build the Plugin Bootstrap Init (+ associated files) and copy it to dist/
-	$(DOCKER_BUILDX_BAKE_HCL) plugin-bootstrap-init
+dist/plugin-bootstrap-init: _shuttle-rust-to-dist  ## Build the Plugin Bootstrap Init (+ associated files) and copy it to dist/
+
+.PHONY: _shuttle-rust-to-dist
+_shuttle-rust-to-dist: | dist  ## Copy all specified Rust binary artifacts to dist/
+	$(DOCKER_BUILDX_BAKE_HCL) shuttle-rust-to-dist
 
 # TODO: Would be nice to be able to specify the input file prerequisites of
 # this target, once `dist/plugin-bootstrap-init` is non-PHONY

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -248,7 +248,7 @@ group "all" {
     "all-tests",
     "local-only-services",
     "grapl-services",
-    "shuttle-rust-to-dist",
+    "export-rust-build-artifacts-to-dist",
   ]
 }
 
@@ -365,9 +365,9 @@ target "plugin-bootstrap" {
 
 # A somewhat special target among the Rust targets, as it
 # has an `output =` that dumps its contents into `dist/`.
-target "shuttle-rust-to-dist" {
+target "export-rust-build-artifacts-to-dist" {
   inherits = ["_rust-base"]
-  target   = "shuttle-rust-to-dist"
+  target   = "export-rust-build-artifacts-to-dist"
   output = [
     "type=local,dest=${DIST_DIR}"
   ]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -248,7 +248,7 @@ group "all" {
     "all-tests",
     "local-only-services",
     "grapl-services",
-    "plugin-bootstrap-init",
+    "shuttle-rust-to-dist",
   ]
 }
 
@@ -331,7 +331,6 @@ target "node-identifier-retry" {
   ]
 }
 
-
 target "organization-management" {
   inherits = ["_rust-base"]
   target   = "organization-management-deploy"
@@ -364,11 +363,13 @@ target "plugin-bootstrap" {
   ]
 }
 
-target "plugin-bootstrap-init" {
+# A somewhat special target among the Rust targets, as it
+# has an `output =` that dumps its contents into `dist/`.
+target "shuttle-rust-to-dist" {
   inherits = ["_rust-base"]
-  target   = "plugin-bootstrap-init-output"
+  target   = "shuttle-rust-to-dist"
   output = [
-    "type=local,dest=${DIST_DIR}/plugin-bootstrap-init"
+    "type=local,dest=${DIST_DIR}"
   ]
 }
 

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -322,6 +322,18 @@ FROM gcr.io/distroless/cc:debug AS rust-dist
 
 USER nonroot
 
+##### shuttle-rust-to-dist
+# There are a number of artifacts we want to bring back to the host OS.
+# This image will eventually dump its root contents into the host's `dist/`
+# courtesy of its `docker-bake.hcl` specification.
+FROM scratch AS shuttle-rust-to-dist
+
+COPY --from=build /outputs/plugin-bootstrap-init /plugin-bootstrap-init/
+# Just to clarify: we're copying these .service files from the repository,
+# through Docker, and then back out to the dist directory in the repository.
+COPY rust/plugin-bootstrap/grapl-plugin-bootstrap-init.service /plugin-bootstrap-init/
+COPY rust/plugin-bootstrap/grapl-plugin.service /plugin-bootstrap-init/
+
 ##### analyzer-dispatcher
 FROM rust-dist AS analyzer-dispatcher-deploy
 
@@ -359,16 +371,6 @@ FROM rust-dist AS plugin-bootstrap-deploy
 
 COPY --from=build /outputs/plugin-bootstrap /
 ENTRYPOINT ["/plugin-bootstrap"]
-
-##### plugin-bootstrap-init.
-# Not "-deploy" since we copy it to dist/.
-FROM scratch AS plugin-bootstrap-init-output
-
-COPY --from=build /outputs/plugin-bootstrap-init /
-# Just to clarify: we're copying these .service files from the repository,
-# through Docker, and then back out to the dist directory in the repository.
-COPY rust/plugin-bootstrap/grapl-plugin-bootstrap-init.service /
-COPY rust/plugin-bootstrap/grapl-plugin.service /
 
 ##### node-identifier
 FROM rust-dist AS node-identifier-deploy

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -322,11 +322,11 @@ FROM gcr.io/distroless/cc:debug AS rust-dist
 
 USER nonroot
 
-##### shuttle-rust-to-dist
+##### export-rust-build-artifacts-to-dist
 # There are a number of artifacts we want to bring back to the host OS.
 # This image will eventually dump its root contents into the host's `dist/`
 # courtesy of its `docker-bake.hcl` specification.
-FROM scratch AS shuttle-rust-to-dist
+FROM scratch AS export-rust-build-artifacts-to-dist
 
 COPY --from=build /outputs/plugin-bootstrap-init /plugin-bootstrap-init/
 # Just to clarify: we're copying these .service files from the repository,


### PR DESCRIPTION
So, we actually _already had this functionality_ for plugin-bootstrap-init, but I wanted to genericize the approach. 
I realized we'd need this because I'll soon be shuttling a Generator plugin binary out into `dist/`.

There's no real reason to separate this into separate images (i.e. one for the generator binary, one for the plugin-bootstrap-init binary).
- All of the binaries are built together all at once
- Nothing directly consumes the image, it's just an implementation detail of pulling stuff out into dist/
