### PR TITLE
Fix build_and_upload_images which had a leftover 'push'

### DIFF
--- a/.buildkite/scripts/build_and_upload_images.sh
+++ b/.buildkite/scripts/build_and_upload_images.sh
@@ -66,8 +66,6 @@ else
     done
 fi
 
-push
-
 readonly sleep_seconds=60
 echo "--- :sleeping::sob: Sleeping for ${sleep_seconds} seconds to give CDNs time to update"
 # Lately, we've seen failures where images aren't showing up when we


### PR DESCRIPTION
https://github.com/grapl-security/grapl/pull/1697 was incorrect; the block where I push was previously a function called `push()`; i removed that but didn't remove the callsite.

See https://buildkite.com/grapl/grapl-merge/builds/682#0d731798-8d4d-422d-b95f-55a2c34d91c1 for example failure.

