### PR TITLE
Use Cloudsmith Apt repo proxy to install workstation tooling

### DIFF
--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -11,10 +11,8 @@ PYENV_PYTHON_VERSION="3.7.10"
 # As such this section sets up some architecture variables..
 ARCH=$(arch)
 if [ "${ARCH}" == "x86_64" ]; then
-    hashicorp_arch_alias="amd64"
     ssm_arch_alias="64bit"
 else
-    hashicorp_arch_alias="arm64"
     ssm_arch_alias="arm64"
 fi
 
@@ -59,6 +57,17 @@ get_latest_release() {
         jq --raw-output '.tag_name'
 }
 ## end helper functions
+
+configure_grapl_repository() {
+    echo_banner "Setting up Grapl Repository"
+    curl --proto "=https" \
+        --tlsv1.2 \
+        --location \
+        --fail \
+        --silent \
+        "https://dl.cloudsmith.io/public/grapl/deb/setup.deb.sh" |
+        sudo -E bash
+}
 
 update_linux() {
     sudo apt update
@@ -274,19 +283,11 @@ install_hashicorp_tools() {
     PACKER_VERSION="1.8.0"
     VAULT_VERSION="1.10.2-1"
 
-    curl --proto '=https' \
-        --tlsv1.2 \
-        --silent \
-        --show-error \
-        --fail \
-        https://apt.releases.hashicorp.com/gpg |
-        sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/hashicorp-apt.gpg --import &&
-        sudo chmod 644 /etc/apt/trusted.gpg.d/hashicorp-apt.gpg
-    sudo apt-add-repository "deb [arch=${hashicorp_arch_alias}] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-    # allow installing pre-release versions
-    sudo apt-add-repository "deb [arch=${hashicorp_arch_alias}] https://apt.releases.hashicorp.com $(lsb_release -cs) test"
-    sudo apt-get update
-    sudo apt-get install --yes consul="${CONSUL_VERSION}" nomad="${NOMAD_VERSION}" packer="${PACKER_VERSION}" vault="${VAULT_VERSION}"
+    sudo apt-get install --yes \
+        consul="${CONSUL_VERSION}" \
+        nomad="${NOMAD_VERSION}" \
+        packer="${PACKER_VERSION}" \
+        vault="${VAULT_VERSION}"
 }
 
 # Download and install a tarball.

--- a/etc/chromeos/setup_chromeos.sh
+++ b/etc/chromeos/setup_chromeos.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 source etc/chromeos/lib/installs.sh
 
 echo "Starting ChromeOS automated setup"
+
+configure_grapl_repository
+
 update_linux
 fix_shell_completion
 install_build_tooling


### PR DESCRIPTION
This simplifies our setup script by offloading the upstream repository
configuration to our proxy.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>