### PR TITLE
DONTREVIEWYET: Change PluginRegistry::create_plugin to a streaming RPC

### DIFF
--- a/src/proto/graplinc/grapl/api/plugin_registry/v1beta1/plugin_registry.proto
+++ b/src/proto/graplinc/grapl/api/plugin_registry/v1beta1/plugin_registry.proto
@@ -109,7 +109,7 @@ message GetAnalyzersForTenantResponse {
 // A service that manages the state of plugins
 service PluginRegistryService {
   // create a new plugin
-  rpc CreatePlugin(CreatePluginRequest) returns (CreatePluginResponse);
+  rpc CreatePlugin(stream CreatePluginRequest) returns (CreatePluginResponse);
 
   // retrieve the plugin corresponding to the given plugin_id
   rpc GetPlugin(GetPluginRequest) returns (GetPluginResponse);

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -3995,6 +3995,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "futures",
+ "grapl-utils",
  "proptest",
  "prost 0.10.1",
  "prost-types 0.10.1",

--- a/src/rust/rust-proto-new/Cargo.toml
+++ b/src/rust/rust-proto-new/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 [dependencies]
 bytes = "1.1"
 futures = "0.3"
+grapl-utils = { path = "../grapl-utils" }
 prost = "0.10"
 prost-types = "0.10"
 thiserror = "1.0"

--- a/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
@@ -228,7 +228,7 @@ impl CreatePluginRequest {
         // `move` so we can capture base_proto_request
         let chunked_requests = plugin_artifact_byte_chunks.map(move |byte_chunk| {
             let mut chunk_proto_request = base_proto_request.clone();
-            chunk_proto_request.plugin_artifact = byte_chunk.to_owned();
+            chunk_proto_request.plugin_artifact = byte_chunk;
             chunk_proto_request
         });
 

--- a/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -37,10 +37,10 @@ impl PluginRegistryServiceClient {
         &mut self,
         request: native::CreatePluginRequest,
     ) -> Result<native::CreatePluginResponse, PluginRegistryServiceClientError> {
-        let response = self
-            .proto_client
-            .create_plugin(proto::CreatePluginRequest::from(request))
-            .await?;
+        // Special case: this RPC is client-side streaming.
+        let request_stream = request.into_stream(4_000_000);
+
+        let response = self.proto_client.create_plugin(request_stream).await?;
         let response = native::CreatePluginResponse::try_from(response.into_inner())?;
         Ok(response)
     }


### PR DESCRIPTION


### Which issue does this PR correspond to?
none
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

create_plugin needs to be able to transfer up to a 250MB binary as the plugin.
This isn't really well-supported by any of our infrastructure;
- protobuf supports many "small" (in the eye of the beholder) messages on the wire, but doesn't play well with large ones.
- the envoy proxy times out during a single long request

I started toying with this and it turns out Tonic makes this very, very easy.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
CI right here right now

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
