### PR TITLE
Integrate generator-executor into nomad; integrate example-generator into plugin-registry integration tests

### DIFF
--- a/etc/ci_scripts/dump_artifacts/nomad_artifacts.py
+++ b/etc/ci_scripts/dump_artifacts/nomad_artifacts.py
@@ -124,8 +124,10 @@ class NomadTask:
             return None
 
     def get_events(self) -> str:
-        event_list = [event["DisplayMessage"] for event in self.events]
-        return "\n".join(event_list)
+        if self.parent.status not in ["running", "completed"]:
+            event_list = [event["DisplayMessage"] for event in self.events]
+            return "\n".join(event_list)
+        return ""
 
 
 JobToAllocDict = Dict[str, List[NomadAllocation]]

--- a/etc/ci_scripts/dump_artifacts/nomad_artifacts.py
+++ b/etc/ci_scripts/dump_artifacts/nomad_artifacts.py
@@ -124,10 +124,8 @@ class NomadTask:
             return None
 
     def get_events(self) -> str:
-        if self.parent.status not in ["running", "completed"]:
-            event_list = [event["DisplayMessage"] for event in self.events]
-            return "\n".join(event_list)
-        return ""
+        event_list = [event["DisplayMessage"] for event in self.events]
+        return "\n".join(event_list)
 
 
 JobToAllocDict = Dict[str, List[NomadAllocation]]

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -716,9 +716,8 @@ job "grapl-core" {
       }
 
       env {
-        PUBLIC_CERTIFICATE_PEM = ""
-        DNS_RESOLVER_IPS       = var.dns_server
-        DNS_RESOLVER_PORT      = "${NOMAD_PORT_generator-executor-port}"
+        DNS_RESOLVER_IPS  = var.dns_server
+        DNS_RESOLVER_PORT = "${NOMAD_PORT_generator-executor-port}"
         # Upstreams
         PLUGIN_WORK_QUEUE_CLIENT_ADDRESS = "http://${NOMAD_UPSTREAM_ADDR_plugin-work-queue}"
 

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -717,12 +717,13 @@ job "grapl-core" {
 
       env {
         PUBLIC_CERTIFICATE_PEM = ""
-        DNS_RESOLVER_IPS = var.dns_server
-        DNS_RESOLVER_PORT = "${NOMAD_PORT_generator-executor-port}"
+        DNS_RESOLVER_IPS       = var.dns_server
+        DNS_RESOLVER_PORT      = "${NOMAD_PORT_generator-executor-port}"
+        # Upstreams
         PLUGIN_WORK_QUEUE_CLIENT_ADDRESS = "http://${NOMAD_UPSTREAM_ADDR_plugin-work-queue}"
 
-        RUST_LOG                    = var.rust_log
-        RUST_BACKTRACE              = local.rust_backtrace
+        RUST_LOG                        = var.rust_log
+        RUST_BACKTRACE                  = local.rust_backtrace
         OTEL_EXPORTER_JAEGER_AGENT_HOST = local.tracing_jaeger_endpoint_host
         OTEL_EXPORTER_JAEGER_AGENT_PORT = local.tracing_jaeger_endpoint_port
       }
@@ -1427,7 +1428,7 @@ job "grapl-core" {
 
       resources {
         # Probably too much. Let's figure out buffered writes to s3
-        memory = 1024
+        memory = 512
       }
     }
 

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1424,6 +1424,11 @@ job "grapl-core" {
         OTEL_EXPORTER_JAEGER_AGENT_HOST  = local.tracing_jaeger_endpoint_host
         OTEL_EXPORTER_JAEGER_AGENT_PORT  = local.tracing_jaeger_endpoint_port
       }
+
+      resources {
+        # Probably too much. Let's figure out buffered writes to s3
+        memory = 1024
+      }
     }
 
     service {

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -695,6 +695,55 @@ job "grapl-core" {
     }
   }
 
+  #######################################
+  ## Begin actual Grapl core services ##
+  #######################################
+
+  group "generator-executor" {
+    network {
+      mode = "bridge"
+      dns {
+        servers = local.dns_servers
+      }
+      port "generator-executor-port" {}
+    }
+
+    task "generator-executor" {
+      driver = "docker"
+
+      config {
+        image = var.container_images["generator-executor"]
+      }
+
+      env {
+        PUBLIC_CERTIFICATE_PEM = ""
+        DNS_RESOLVER_IPS = "${var.dns_server}" # TODO ????
+        DNS_RESOLVER_PORT = "${NOMAD_PORT_generator-executor-port}"
+
+        RUST_LOG                    = var.rust_log
+        RUST_BACKTRACE              = local.rust_backtrace
+        OTEL_EXPORTER_JAEGER_AGENT_HOST = local.tracing_jaeger_endpoint_host
+        OTEL_EXPORTER_JAEGER_AGENT_PORT = local.tracing_jaeger_endpoint_port
+      }
+    }
+
+    service {
+      name = "generator-executor"
+      connect {
+        sidecar_service {
+          proxy {
+            upstreams {
+              destination_name = "plugin-work-queue"
+              local_bind_port  = 1000
+            }
+            # NOTE: Generator Executor also connects to arbitrary upstreams at
+            # runtime via native Consul Connect in GeneratorClient
+          }
+        }
+      }
+    }
+  }
+
   group "graph-merger" {
     count = var.num_graph_mergers
 

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -717,8 +717,9 @@ job "grapl-core" {
 
       env {
         PUBLIC_CERTIFICATE_PEM = ""
-        DNS_RESOLVER_IPS = "${var.dns_server}" # TODO ????
+        DNS_RESOLVER_IPS = var.dns_server
         DNS_RESOLVER_PORT = "${NOMAD_PORT_generator-executor-port}"
+        PLUGIN_WORK_QUEUE_CLIENT_ADDRESS = "http://${NOMAD_UPSTREAM_ADDR_plugin-work-queue}"
 
         RUST_LOG                    = var.rust_log
         RUST_BACKTRACE              = local.rust_backtrace

--- a/nomad/integration-tests-new.nomad
+++ b/nomad/integration-tests-new.nomad
@@ -51,8 +51,9 @@ variable "integration_tests_kafka_sasl_password" {
   description = "The Confluent Cloud API secret to configure integration test consumers with."
 }
 
-locals {
-  log_level = "DEBUG"
+variable "rust_log" {
+  type        = string
+  description = "Controls the logging behavior of Rust-based services."
 }
 
 job "integration-tests-new" {
@@ -117,10 +118,8 @@ job "integration-tests-new" {
       env {
         AWS_REGION = var.aws_region
 
-        GRAPL_LOG_LEVEL = local.log_level
-
         RUST_BACKTRACE = 1
-        RUST_LOG       = local.log_level
+        RUST_LOG       = var.rust_log
 
         KAFKA_BOOTSTRAP_SERVERS = var.kafka_bootstrap_servers
 
@@ -138,7 +137,7 @@ job "integration-tests-new" {
         # We need a lot of memory because we load the 150MB
         # /test-fixtures/example-generator
         # into memory
-        memory = 1024
+        memory = 512
       }
     }
   }

--- a/nomad/integration-tests-new.nomad
+++ b/nomad/integration-tests-new.nomad
@@ -133,6 +133,13 @@ job "integration-tests-new" {
 
         NOMAD_SERVICE_ADDRESS = "${attr.unique.network.ip-address}:4646"
       }
+
+      resources {
+        # We need a lot of memory because we load the 150MB
+        # /test-fixtures/example-generator
+        # into memory
+        memory = 1024
+      }
     }
   }
 }

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -57,6 +57,7 @@ def _container_images(artifacts: ArtifactGetter) -> Mapping[str, DockerImageId]:
         "analyzer-executor": builder.build_with_tag("analyzer-executor"),
         "dgraph": DockerImageId("dgraph/dgraph:v21.03.1"),
         "engagement-creator": builder.build_with_tag("engagement-creator"),
+        "generator-executor": builder.build_with_tag("generator-executor"),
         "graph-merger": builder.build_with_tag("graph-merger"),
         "graphql-endpoint": builder.build_with_tag("graphql-endpoint"),
         "hax-docker-plugin-runtime": DockerImageId("debian:bullseye-slim"),

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -5,7 +5,7 @@ sys.path.insert(0, "..")
 from typing import List, Mapping, Optional, Set, cast
 
 import pulumi_aws as aws
-from infra import config, dynamodb, emitter
+from infra import config, dynamodb, emitter, log_levels
 from infra.alarms import OpsAlarms
 from infra.api_gateway import ApiGateway
 from infra.artifacts import ArtifactGetter
@@ -217,19 +217,6 @@ def main() -> None:
         ),
     )
 
-    # To learn more about this syntax, see
-    # https://docs.rs/env_logger/0.9.0/env_logger/#enabling-logging
-    rust_log_levels = ",".join(
-        [
-            "DEBUG",
-            "h2=WARN",
-            "hyper=WARN",
-            "rusoto_core=WARN",
-            "rustls=WARN",
-        ]
-    )
-    py_log_level = "DEBUG"
-
     aws_env_vars_for_local = _get_aws_env_vars_for_local()
     pulumi.export("aws-env-vars-for-local", aws_env_vars_for_local)
 
@@ -256,8 +243,8 @@ def main() -> None:
         osquery_generator_queue=osquery_generator_queue.main_queue_url,
         osquery_generator_dead_letter_queue=osquery_generator_queue.dead_letter_queue_url,
         pipeline_ingress_healthcheck_polling_interval_ms=pipeline_ingress_healthcheck_polling_interval_ms,
-        py_log_level=py_log_level,
-        rust_log=rust_log_levels,
+        py_log_level=log_levels.PY_LOG_LEVEL,
+        rust_log=log_levels.RUST_LOG_LEVELS,
         schema_properties_table_name=dynamodb_tables.schema_properties_table.name,
         schema_table_name=dynamodb_tables.schema_table.name,
         session_table_name=dynamodb_tables.dynamic_session_table.name,

--- a/pulumi/infra/log_levels.py
+++ b/pulumi/infra/log_levels.py
@@ -1,0 +1,12 @@
+# To learn more about this syntax, see
+# https://docs.rs/env_logger/0.9.0/env_logger/#enabling-logging
+RUST_LOG_LEVELS = ",".join(
+    [
+        "DEBUG",
+        "h2=WARN",
+        "hyper=WARN",
+        "rusoto_core=WARN",
+        "rustls=WARN",
+    ]
+)
+PY_LOG_LEVEL = "DEBUG"

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -6,7 +6,7 @@ import os
 from typing import Mapping, Optional, cast
 
 import pulumi_aws as aws
-from infra import config
+from infra import config, log_levels
 from infra.artifacts import ArtifactGetter
 from infra.autotag import register_auto_tags
 from infra.docker_images import DockerImageId, DockerImageIdBuilder
@@ -131,6 +131,7 @@ def main() -> None:
         "aws_env_vars_for_local": grapl_stack.aws_env_vars_for_local,
         "aws_region": aws.get_region().name,
         "container_images": _integration_new_container_images(artifacts),
+        "rust_log": log_levels.RUST_LOG_LEVELS,
         "integration_tests_kafka_consumer_group_name": kafka.consumer_group(
             "integration-tests"
         ),

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -842,8 +842,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47582c09be7c8b32c0ab3a6181825ababb713fde6fff20fc573a3870dd45c6a0"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -928,7 +964,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 name = "consul-connect"
 version = "1.0.0"
 dependencies = [
- "structopt",
+ "clap 3.1.17",
  "thiserror",
  "tokio",
  "tracing",
@@ -1016,7 +1052,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "futures",
@@ -1693,11 +1729,11 @@ name = "generator-sdk"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "clap 3.1.17",
  "consul-connect",
  "moka",
  "rust-proto-new",
  "serde",
- "structopt",
  "thiserror",
  "tokio",
  "tracing",
@@ -2994,6 +3030,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+
+[[package]]
 name = "osquery-generator"
 version = "0.1.0"
 dependencies = [
@@ -3216,10 +3258,11 @@ name = "plugin-executor"
 version = "0.0.1"
 dependencies = [
  "async-trait",
+ "clap 3.1.17",
  "generator-sdk",
+ "grapl-config",
  "plugin-work-queue",
  "rust-proto-new",
- "structopt",
  "tokio",
  "tracing",
 ]
@@ -4558,7 +4601,7 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -4714,6 +4757,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -329,6 +329,7 @@ USER nonroot
 FROM scratch AS export-rust-build-artifacts-to-dist
 
 COPY --from=build /outputs/plugin-bootstrap-init /plugin-bootstrap-init/
+COPY --from=build /outputs/example-generator /
 # Just to clarify: we're copying these .service files from the repository,
 # through Docker, and then back out to the dist directory in the repository.
 COPY rust/plugin-bootstrap/grapl-plugin-bootstrap-init.service /plugin-bootstrap-init/

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -272,6 +272,10 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-tests-ap
 # so that it's available to integration test consumers of NomadCli
 COPY --from=build /nomad/nomad /bin
 
+# Grab the example generator so we can deploy it in test_deploy_plugin
+RUN mkdir -p /test-fixtures
+COPY --from=build /outputs/example-generator /test-fixtures
+
 COPY --from=build-test-integration-new /grapl/tests /tests
 
 COPY --chmod=777 <<-"EOF" /run-tests.sh

--- a/src/rust/consul-connect/Cargo.toml
+++ b/src/rust/consul-connect/Cargo.toml
@@ -5,7 +5,11 @@ authors = ["Max Wittek <wimax@graplsecurity.com>"]
 edition = "2021"
 
 [dependencies]
-clap = { version = "3.0", default_features = false, features = ["std", "env", "derive"] }
+clap = { version = "3.0", default_features = false, features = [
+  "std",
+  "env",
+  "derive"
+] }
 thiserror = "1.0.30"
 tokio = { version = "1.17", features = ["full"] }
 tracing = "0.1.29"

--- a/src/rust/consul-connect/Cargo.toml
+++ b/src/rust/consul-connect/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Max Wittek <wimax@graplsecurity.com>"]
 edition = "2021"
 
 [dependencies]
-structopt = { version = "0.3", default-features = false }
+clap = { version = "3.0", default_features = false, features = ["std", "env", "derive"] }
 thiserror = "1.0.30"
 tokio = { version = "1.17", features = ["full"] }
 tracing = "0.1.29"

--- a/src/rust/consul-connect/src/client_dns_config.rs
+++ b/src/rust/consul-connect/src/client_dns_config.rs
@@ -29,23 +29,23 @@ impl<T: FromStr> FromStr for CommaSeparated<T> {
 pub struct ClientDnsConfig {
     /// The port to use for DNS resolutino. Note that even if you have multiple
     /// IP addresses they will all resolve via this port
-    #[clap(env)]
+    #[clap(env, long)]
     pub dns_resolver_port: u16,
 
     /// IP addresses to use when resolving plugins
     /// Should almost always be pointed to Consul
-    #[clap(env)]
+    #[clap(env, long)]
     pub dns_resolver_ips: CommaSeparated<std::net::IpAddr>,
 
     /// The number of entries in the dns cache
-    #[clap(env, default_value = "128")]
+    #[clap(env, long, default_value = "128")]
     pub dns_cache_size: usize,
 
     /// If this is set, any positive responses with a TTL lower than this value
     /// will have a TTL of positive_min_ttl instead.
     /// Unit: Seconds
     /// Default: 1
-    #[clap(env, default_value = "1")]
+    #[clap(env, long, default_value = "1")]
     pub positive_min_ttl: u64,
 }
 

--- a/src/rust/consul-connect/src/client_dns_config.rs
+++ b/src/rust/consul-connect/src/client_dns_config.rs
@@ -1,6 +1,8 @@
-use std::{time::Duration, str::FromStr};
+use std::{
+    str::FromStr,
+    time::Duration,
+};
 
-use structopt::StructOpt;
 use trust_dns_resolver::{
     config::{
         NameServerConfigGroup,
@@ -17,38 +19,34 @@ pub struct CommaSeparated<T: FromStr>(Vec<T>);
 impl<T: FromStr> FromStr for CommaSeparated<T> {
     type Err = <T as FromStr>::Err;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let elements: Result<Vec<_>, _> = s.split(",").map(|s| {
-            T::from_str(s)
-        }).collect();
-        Ok(Self(
-            elements?
-        ))
+        let elements: Result<Vec<_>, _> = s.split(",").map(|s| T::from_str(s)).collect();
+        Ok(Self(elements?))
     }
 }
 
 /// Configuration for the DNS resolver used for plugin service discovery
-#[derive(StructOpt, Debug)]
+#[derive(clap::Parser, Debug)]
 pub struct ClientDnsConfig {
+    /// The port to use for DNS resolutino. Note that even if you have multiple
+    /// IP addresses they will all resolve via this port
+    #[clap(env)]
+    pub dns_resolver_port: u16,
+
+    /// IP addresses to use when resolving plugins
+    /// Should almost always be pointed to Consul
+    #[clap(env)]
+    pub dns_resolver_ips: CommaSeparated<std::net::IpAddr>,
+
     /// The number of entries in the dns cache
-    #[structopt(env, default_value = "128")]
+    #[clap(env, default_value = "128")]
     pub dns_cache_size: usize,
 
     /// If this is set, any positive responses with a TTL lower than this value
     /// will have a TTL of positive_min_ttl instead.
     /// Unit: Seconds
     /// Default: 1
-    #[structopt(env, default_value = "1")]
+    #[clap(env, default_value = "1")]
     pub positive_min_ttl: u64,
-
-    /// The port to use for DNS resolutino. Note that even if you have multiple
-    /// IP addresses they will all resolve via this port
-    #[structopt(env)]
-    pub dns_resolver_port: u16,
-    
-    /// IP addresses to use when resolving plugins
-    /// Should almost always be pointed to Consul
-    #[structopt(env)]
-    pub dns_resolver_ips: CommaSeparated<std::net::IpAddr>,
 }
 
 impl From<ClientDnsConfig> for TokioAsyncResolver {

--- a/src/rust/plugin-executor/Cargo.toml
+++ b/src/rust/plugin-executor/Cargo.toml
@@ -17,7 +17,11 @@ name = "plugin_executor"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 async-trait = "0.1.51"
-clap = { version = "3.0", default_features = false, features = ["std", "env", "derive"] }
+clap = { version = "3.0", default_features = false, features = [
+  "std",
+  "env",
+  "derive"
+] }
 generator-sdk = { path = "../plugin-sdk/generator-sdk", features = ["client"] }
 grapl-config = { path = "../grapl-config" }
 plugin-work-queue = { path = "../plugin-work-queue" }

--- a/src/rust/plugin-executor/Cargo.toml
+++ b/src/rust/plugin-executor/Cargo.toml
@@ -17,10 +17,11 @@ name = "plugin_executor"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 async-trait = "0.1.51"
+clap = { version = "3.0", default_features = false, features = ["std", "env", "derive"] }
 generator-sdk = { path = "../plugin-sdk/generator-sdk", features = ["client"] }
+grapl-config = { path = "../grapl-config" }
 plugin-work-queue = { path = "../plugin-work-queue" }
 rust-proto-new = { path = "../rust-proto-new" }
-structopt = { version = "0.3", default-features = false }
 tokio = { version = "1.17", features = ["macros", "rt", "rt-multi-thread"] }
 tracing = "0.1.29"
 

--- a/src/rust/plugin-registry/src/client.rs
+++ b/src/rust/plugin-registry/src/client.rs
@@ -19,7 +19,10 @@ impl FromEnv<PluginRegistryServiceClient, Box<dyn std::error::Error>>
     async fn from_env() -> Result<PluginRegistryServiceClient, Box<dyn std::error::Error>> {
         let address = std::env::var(ADDRESS_ENV_VAR).expect(ADDRESS_ENV_VAR);
         let endpoint = Endpoint::from_shared(address)?
-            .timeout(Duration::from_secs(5))
+            // Really high timeout due to the potentially-large binary sent
+            // over `create_plugin`.
+            // https://github.com/grapl-security/issue-tracker/issues/937
+            .timeout(Duration::from_secs(20))
             .concurrency_limit(30);
         Self::connect(endpoint).await
     }

--- a/src/rust/plugin-registry/src/db/client.rs
+++ b/src/rust/plugin-registry/src/db/client.rs
@@ -1,5 +1,5 @@
 use grapl_utils::future_ext::GraplFutureExt;
-use rust_proto_new::graplinc::grapl::api::plugin_registry::v1beta1::CreatePluginRequest;
+use rust_proto_new::graplinc::grapl::api::plugin_registry::v1beta1::PluginType;
 
 use super::models::{
     PluginDeploymentRow,
@@ -9,6 +9,12 @@ use super::models::{
 
 pub struct PluginRegistryDbClient {
     pool: sqlx::PgPool,
+}
+
+pub struct DbCreatePluginArgs {
+    pub tenant_id: uuid::Uuid,
+    pub display_name: String,
+    pub plugin_type: PluginType,
 }
 
 impl PluginRegistryDbClient {
@@ -55,11 +61,11 @@ impl PluginRegistryDbClient {
         .await
     }
 
-    #[tracing::instrument(skip(self, request, s3_key), err)]
+    #[tracing::instrument(skip(self, args, s3_key), err)]
     pub async fn create_plugin(
         &self,
         plugin_id: &uuid::Uuid,
-        request: &CreatePluginRequest,
+        args: DbCreatePluginArgs,
         s3_key: &str,
     ) -> Result<(), sqlx::Error> {
         sqlx::query!(
@@ -75,9 +81,9 @@ impl PluginRegistryDbClient {
             ON CONFLICT DO NOTHING;
             ",
             plugin_id,
-            &request.plugin_type.type_name(),
-            &request.display_name,
-            &request.tenant_id,
+            &args.plugin_type.type_name(),
+            &args.display_name,
+            &args.tenant_id,
             s3_key,
         )
         .execute(&self.pool)

--- a/src/rust/plugin-registry/src/error.rs
+++ b/src/rust/plugin-registry/src/error.rs
@@ -2,7 +2,10 @@ use rusoto_s3::{
     GetObjectError,
     PutObjectError,
 };
-use rust_proto_new::SerDeError;
+use rust_proto_new::{
+    protocol::status::Status,
+    SerDeError,
+};
 
 use crate::{
     db::serde::DatabaseSerDeError,
@@ -31,4 +34,36 @@ pub enum PluginRegistryServiceError {
     NomadCliError(#[from] nomad::cli::NomadCliError),
     #[error("NomadJobAllocationError")]
     NomadJobAllocationError,
+    #[error("ArtifactTooLargeError")]
+    ArtifactTooLargeError(String),
+}
+
+impl From<PluginRegistryServiceError> for Status {
+    /**
+     * Convert useful internal errors into tonic::Status that can be
+     * safely sent over the wire. (Don't include any specific IDs etc)
+     */
+    fn from(err: PluginRegistryServiceError) -> Self {
+        type Error = PluginRegistryServiceError;
+        match err {
+            Error::SqlxError(sqlx::Error::Configuration(_)) => {
+                Status::internal("Invalid SQL configuration")
+            }
+            Error::SqlxError(_) => Status::internal("Failed to operate on postgres"),
+            Error::PutObjectError(_) => Status::internal("Failed to put s3 object"),
+            Error::GetObjectError(_) => Status::internal("Failed to get s3 object"),
+            Error::EmptyObject => Status::internal("S3 Object was unexpectedly empty"),
+            Error::IoError(_) => Status::internal("IoError"),
+            Error::SerDeError(_) => Status::invalid_argument("Unable to deserialize message"),
+            Error::DatabaseSerDeError(_) => {
+                Status::invalid_argument("Unable to deserialize message from database")
+            }
+            Error::NomadClientError(_) => Status::internal("Failed RPC with Nomad"),
+            Error::NomadCliError(_) => Status::internal("Failed using Nomad CLI"),
+            Error::NomadJobAllocationError => {
+                Status::internal("Unable to allocate Nomad job - it may be out of resources.")
+            }
+            Error::ArtifactTooLargeError(msg) => Status::invalid_argument(msg),
+        }
+    }
 }

--- a/src/rust/plugin-registry/src/error.rs
+++ b/src/rust/plugin-registry/src/error.rs
@@ -34,8 +34,10 @@ pub enum PluginRegistryServiceError {
     NomadCliError(#[from] nomad::cli::NomadCliError),
     #[error("NomadJobAllocationError")]
     NomadJobAllocationError,
-    #[error("ArtifactTooLargeError")]
+    #[error("ArtifactTooLargeError {0}")]
     ArtifactTooLargeError(String),
+    // TODO: These errs are meant to be human-readable and are not directly
+    // sent over the wire, so add {0}s to them!
 }
 
 impl From<PluginRegistryServiceError> for Status {

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -172,6 +172,7 @@ mod tests {
             plugin_s3_bucket_aws_account_id: Default::default(),
             plugin_s3_bucket_name: Default::default(),
             rootfs_artifact_url: Default::default(),
+            artifact_size_limit_mb: Default::default(),
         }
     }
     /// This is used to keep test coverage on the eventually-desirable-but-

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -8,6 +8,7 @@ use rusoto_s3::{
     GetObjectRequest,
     PutObjectRequest,
     S3Client,
+    StreamingBody,
     S3,
 };
 use rust_proto_new::{
@@ -29,10 +30,7 @@ use rust_proto_new::{
         TearDownPluginRequest,
         TearDownPluginResponse,
     },
-    protocol::{
-        healthcheck::HealthcheckStatus,
-        status::Status,
-    },
+    protocol::healthcheck::HealthcheckStatus,
 };
 use structopt::StructOpt;
 use tokio::{
@@ -43,7 +41,10 @@ use tonic::async_trait;
 
 use crate::{
     db::{
-        client::PluginRegistryDbClient,
+        client::{
+            DbCreatePluginArgs,
+            PluginRegistryDbClient,
+        },
         models::PluginRow,
         serde::try_from,
     },
@@ -55,34 +56,6 @@ use crate::{
     server::deploy_plugin,
 };
 
-impl From<PluginRegistryServiceError> for Status {
-    /**
-     * Convert useful internal errors into tonic::Status that can be
-     * safely sent over the wire. (Don't include any specific IDs etc)
-     */
-    fn from(err: PluginRegistryServiceError) -> Self {
-        type Error = PluginRegistryServiceError;
-        match err {
-            Error::SqlxError(sqlx::Error::Configuration(_)) => {
-                Status::internal("Invalid SQL configuration")
-            }
-            Error::SqlxError(_) => Status::internal("Failed to operate on postgres"),
-            Error::PutObjectError(_) => Status::internal("Failed to put s3 object"),
-            Error::GetObjectError(_) => Status::internal("Failed to get s3 object"),
-            Error::EmptyObject => Status::internal("S3 Object was unexpectedly empty"),
-            Error::IoError(_) => Status::internal("IoError"),
-            Error::SerDeError(_) => Status::invalid_argument("Unable to deserialize message"),
-            Error::DatabaseSerDeError(_) => {
-                Status::invalid_argument("Unable to deserialize message from database")
-            }
-            Error::NomadClientError(_) => Status::internal("Failed RPC with Nomad"),
-            Error::NomadCliError(_) => Status::internal("Failed using Nomad CLI"),
-            Error::NomadJobAllocationError => {
-                Status::internal("Unable to allocate Nomad job - it may be out of resources.")
-            }
-        }
-    }
-}
 #[derive(StructOpt, Debug)]
 pub struct PluginRegistryConfig {
     #[structopt(flatten)]
@@ -121,6 +94,8 @@ pub struct PluginRegistryServiceConfig {
     pub rootfs_artifact_url: String,
     #[structopt(env = "PLUGIN_REGISTRY_HAX_DOCKER_PLUGIN_RUNTIME_IMAGE")]
     pub hax_docker_plugin_runtime_image: String,
+    #[structopt(env = "PLUGIN_REGISTRY_ARTIFACT_SIZE_LIMIT_MB", default_value = "250")]
+    pub artifact_size_limit_mb: usize,
 }
 
 pub struct PluginRegistry {
@@ -129,6 +104,19 @@ pub struct PluginRegistry {
     nomad_cli: NomadCli,
     s3: S3Client,
     config: PluginRegistryServiceConfig,
+}
+
+impl PluginRegistry {
+    fn ensure_artifact_size_limit(&self, bytes: &[u8]) -> Result<(), PluginRegistryServiceError> {
+        let limit_mb = &self.config.artifact_size_limit_mb;
+        if bytes.len() > (limit_mb * 1024 * 1024) {
+            Err(PluginRegistryServiceError::ArtifactTooLargeError(format!(
+                "Artifact exceeds {limit_mb}MB"
+            )))
+        } else {
+            Ok(())
+        }
+    }
 }
 
 #[async_trait]
@@ -140,14 +128,23 @@ impl PluginRegistryApi for PluginRegistry {
         &self,
         request: CreatePluginRequest,
     ) -> Result<CreatePluginResponse, Self::Error> {
-        let plugin_id = generate_plugin_id(&request.tenant_id, request.plugin_artifact.as_slice());
+        let CreatePluginRequest {
+            tenant_id,
+            plugin_artifact, // This could be huge, so don't clone it!
+            display_name,
+            plugin_type,
+        } = request;
 
-        let s3_key = generate_artifact_s3_key(request.plugin_type, &request.tenant_id, &plugin_id);
+        self.ensure_artifact_size_limit(&plugin_artifact)?;
+
+        let plugin_id = generate_plugin_id(&tenant_id, plugin_artifact.as_slice());
+
+        let s3_key = generate_artifact_s3_key(plugin_type, &tenant_id, &plugin_id);
 
         self.s3
             .put_object(PutObjectRequest {
-                content_length: Some(request.plugin_artifact.len() as i64),
-                body: Some(request.plugin_artifact.clone().into()),
+                content_length: Some(plugin_artifact.len() as i64),
+                body: Some(StreamingBody::from(plugin_artifact)),
                 bucket: self.config.plugin_s3_bucket_name.clone(),
                 key: s3_key.clone(),
                 expected_bucket_owner: Some(self.config.plugin_s3_bucket_aws_account_id.clone()),
@@ -156,7 +153,15 @@ impl PluginRegistryApi for PluginRegistry {
             .await?;
 
         self.db_client
-            .create_plugin(&plugin_id, &request, &s3_key)
+            .create_plugin(
+                &plugin_id,
+                DbCreatePluginArgs {
+                    tenant_id,
+                    display_name,
+                    plugin_type,
+                },
+                &s3_key,
+            )
             .await?;
 
         let response = CreatePluginResponse { plugin_id };

--- a/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
@@ -119,6 +119,10 @@ EOF
         PLUGIN_BIN = "/mnt/nomad_task_dir/plugin.bin"
         # Consumed by GeneratorServiceConfig
         PLUGIN_BIND_ADDRESS = "0.0.0.0:${NOMAD_PORT_plugin-grpc-receiver}"
+
+        # Should we make these eventually customizable?
+        RUST_LOG       = "DEBUG"
+        RUST_BACKTRACE = 1
       }
     }
   }

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "new_integration_tests")]
 
+use std::fs;
+
 use grapl_utils::future_ext::GraplFutureExt;
 use plugin_registry::client::FromEnv;
 use rust_proto_new::graplinc::grapl::api::plugin_registry::v1beta1::{
@@ -12,6 +14,13 @@ use rust_proto_new::graplinc::grapl::api::plugin_registry::v1beta1::{
 
 pub const SMALL_TEST_BINARY: &'static [u8] = include_bytes!("./small_test_binary.sh");
 
+pub fn get_example_generator() -> Vec<u8> {
+    // read the whole file
+    let contents = fs::read("/test-fixtures/example-generator")
+        .expect("Something went wrong reading the file");
+    contents
+}
+
 #[test_log::test(tokio::test)]
 async fn test_deploy_plugin() -> Result<(), Box<dyn std::error::Error>> {
     let mut client = PluginRegistryServiceClient::from_env().await?;
@@ -21,7 +30,7 @@ async fn test_deploy_plugin() -> Result<(), Box<dyn std::error::Error>> {
     let create_response = {
         let display_name = uuid::Uuid::new_v4().to_string();
         let request = CreatePluginRequest {
-            plugin_artifact: SMALL_TEST_BINARY.to_vec(),
+            plugin_artifact: get_example_generator(),
             tenant_id: tenant_id.clone(),
             display_name: display_name.clone(),
             plugin_type: PluginType::Generator,

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "new_integration_tests")]
 
-use std::fs;
-
 use grapl_utils::future_ext::GraplFutureExt;
 use plugin_registry::client::FromEnv;
 use rust_proto_new::graplinc::grapl::api::plugin_registry::v1beta1::{
@@ -14,11 +12,8 @@ use rust_proto_new::graplinc::grapl::api::plugin_registry::v1beta1::{
 
 pub const SMALL_TEST_BINARY: &'static [u8] = include_bytes!("./small_test_binary.sh");
 
-pub fn get_example_generator() -> Vec<u8> {
-    // read the whole file
-    let contents = fs::read("/test-fixtures/example-generator")
-        .expect("Something went wrong reading the file");
-    contents
+pub fn get_example_generator() -> Result<Vec<u8>, std::io::Error> {
+    std::fs::read("/test-fixtures/example-generator")
 }
 
 #[test_log::test(tokio::test)]
@@ -30,7 +25,7 @@ async fn test_deploy_plugin() -> Result<(), Box<dyn std::error::Error>> {
     let create_response = {
         let display_name = uuid::Uuid::new_v4().to_string();
         let request = CreatePluginRequest {
-            plugin_artifact: get_example_generator(),
+            plugin_artifact: get_example_generator()?,
             tenant_id: tenant_id.clone(),
             display_name: display_name.clone(),
             plugin_type: PluginType::Generator,

--- a/src/rust/plugin-sdk/generator-sdk/Cargo.toml
+++ b/src/rust/plugin-sdk/generator-sdk/Cargo.toml
@@ -14,7 +14,11 @@ consul-connect = { path = "../../consul-connect" }
 moka = { version = "0.7", features = ["future"] }
 rust-proto-new = { path = "../../rust-proto-new" }
 serde = { version = "1.0.136", features = ["derive"] }
-clap = { version = "3.0", default_features = false, features = ["std", "env", "derive"] }
+clap = { version = "3.0", default_features = false, features = [
+  "std",
+  "env",
+  "derive"
+] }
 thiserror = "1.0.30"
 tokio = { version = "1.17", features = ["full"] }
 tracing = "0.1.29"

--- a/src/rust/plugin-sdk/generator-sdk/Cargo.toml
+++ b/src/rust/plugin-sdk/generator-sdk/Cargo.toml
@@ -14,7 +14,7 @@ consul-connect = { path = "../../consul-connect" }
 moka = { version = "0.7", features = ["future"] }
 rust-proto-new = { path = "../../rust-proto-new" }
 serde = { version = "1.0.136", features = ["derive"] }
-structopt = { version = "0.3", default-features = false }
+clap = { version = "3.0", default_features = false, features = ["std", "env", "derive"] }
 thiserror = "1.0.30"
 tokio = { version = "1.17", features = ["full"] }
 tracing = "0.1.29"

--- a/src/rust/plugin-sdk/generator-sdk/src/client.rs
+++ b/src/rust/plugin-sdk/generator-sdk/src/client.rs
@@ -156,10 +156,7 @@ impl GeneratorClient {
 
         // Sets the CA Certificate against which to verify the server’s TLS certificate.
         let tls_config = if let Some(cert) = &self.certificate {
-            Some(ClientTlsConfig::new(
-                cert.clone(),
-                &resolved_service.domain,
-            ))
+            Some(ClientTlsConfig::new(cert.clone(), &resolved_service.domain))
         } else {
             None
         };

--- a/src/rust/plugin-sdk/generator-sdk/src/client.rs
+++ b/src/rust/plugin-sdk/generator-sdk/src/client.rs
@@ -66,7 +66,7 @@ impl From<ClientConfig> for GeneratorClient {
         let certificate = config
             .client_cert_config
             .public_certificate_pem
-            .and_then(|cert| Some(Certificate::from_pem(&cert.as_bytes().to_vec())));
+            .map(|cert| Certificate::from_pem(&cert.as_bytes().to_vec()));
         let clients = ClientCacheBuilder::from(config.client_cache_config).build();
         Self::new(clients, certificate, resolver)
     }
@@ -155,7 +155,7 @@ impl GeneratorClient {
         let tls_config = self
             .certificate
             .as_ref()
-            .and_then(|cert| Some(ClientTlsConfig::new(cert.clone(), &resolved_service.domain)));
+            .map(|cert| ClientTlsConfig::new(cert.clone(), &resolved_service.domain));
 
         tracing::info!(
             message = "Connecting to plugin",

--- a/src/rust/plugin-sdk/generator-sdk/src/client_config.rs
+++ b/src/rust/plugin-sdk/generator-sdk/src/client_config.rs
@@ -15,8 +15,10 @@ pub struct ClientCacheConfig {
 #[derive(clap::Parser, Debug)]
 pub struct ClientCertConfig {
     // the CA Certificate against which to verify the server’s TLS certificate.
+    // TODO: Temporarily providing the ability to use no certs, until vault is
+    // set up. Eventually remove Option.
     #[clap(env)]
-    pub public_certificate_pem: String,
+    pub public_certificate_pem: Option<String>,
 }
 
 #[derive(clap::Parser, Debug)]

--- a/src/rust/plugin-sdk/generator-sdk/src/client_config.rs
+++ b/src/rust/plugin-sdk/generator-sdk/src/client_config.rs
@@ -18,7 +18,7 @@ pub struct ClientCacheConfig {
 pub struct ClientCertConfig {
     // the CA Certificate against which to verify the server’s TLS certificate.
     #[structopt(env)]
-    pub public_certificate_pem: Vec<u8>,
+    pub public_certificate_pem: String,
 }
 
 #[derive(StructOpt, Debug)]
@@ -26,7 +26,7 @@ pub struct ClientConfig {
     #[structopt(flatten)]
     pub client_cache_config: ClientCacheConfig,
     #[structopt(flatten)]
-    pub client_cert_config: ClientCertConfig,
-    #[structopt(flatten)]
     pub client_dns_config: consul_connect::client_dns_config::ClientDnsConfig,
+    #[structopt(flatten)]
+    pub client_cert_config: ClientCertConfig,
 }

--- a/src/rust/plugin-sdk/generator-sdk/src/client_config.rs
+++ b/src/rust/plugin-sdk/generator-sdk/src/client_config.rs
@@ -1,32 +1,30 @@
-use structopt::StructOpt;
-
 /// Configuration for the cache that holds onto plugin client connections
-#[derive(StructOpt, Debug)]
+#[derive(clap::Parser, Debug)]
 pub struct ClientCacheConfig {
     /// The number of concurrent plugin clients to hold
     /// Defaults to 1000
-    #[structopt(env, default_value = "1000")]
+    #[clap(env, default_value = "1000")]
     pub max_capacity: u64,
     /// Total amount of time a given entry will live in seconds
     /// Default to 2 minutes
-    #[structopt(env, default_value = "120")]
+    #[clap(env, default_value = "120")]
     pub time_to_live: u64,
 }
 
 /// Configuration for the client's TLS certificate
-#[derive(StructOpt, Debug)]
+#[derive(clap::Parser, Debug)]
 pub struct ClientCertConfig {
     // the CA Certificate against which to verify the server’s TLS certificate.
-    #[structopt(env)]
+    #[clap(env)]
     pub public_certificate_pem: String,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(clap::Parser, Debug)]
 pub struct ClientConfig {
-    #[structopt(flatten)]
-    pub client_cache_config: ClientCacheConfig,
-    #[structopt(flatten)]
-    pub client_dns_config: consul_connect::client_dns_config::ClientDnsConfig,
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub client_cert_config: ClientCertConfig,
+    #[clap(flatten)]
+    pub client_dns_config: consul_connect::client_dns_config::ClientDnsConfig,
+    #[clap(flatten)]
+    pub client_cache_config: ClientCacheConfig,
 }

--- a/src/rust/plugin-sdk/generator-sdk/src/client_config.rs
+++ b/src/rust/plugin-sdk/generator-sdk/src/client_config.rs
@@ -3,11 +3,11 @@
 pub struct ClientCacheConfig {
     /// The number of concurrent plugin clients to hold
     /// Defaults to 1000
-    #[clap(env, default_value = "1000")]
+    #[clap(env, long, default_value = "1000")]
     pub max_capacity: u64,
     /// Total amount of time a given entry will live in seconds
     /// Default to 2 minutes
-    #[clap(env, default_value = "120")]
+    #[clap(env, long, default_value = "120")]
     pub time_to_live: u64,
 }
 
@@ -17,7 +17,7 @@ pub struct ClientCertConfig {
     // the CA Certificate against which to verify the server’s TLS certificate.
     // TODO: Temporarily providing the ability to use no certs, until vault is
     // set up. Eventually remove Option.
-    #[clap(env)]
+    #[clap(env, long)]
     pub public_certificate_pem: Option<String>,
 }
 

--- a/src/rust/plugin-sdk/generator-sdk/src/server.rs
+++ b/src/rust/plugin-sdk/generator-sdk/src/server.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use clap::Parser;
 use rust_proto_new::{
     graplinc::grapl::api::plugin_sdk::generators::v1beta1::server::{
         GeneratorApi,
@@ -10,10 +11,9 @@ use rust_proto_new::{
         tls::Identity,
     },
 };
-use structopt::StructOpt;
 use tokio::net::TcpListener;
 
-#[derive(StructOpt, Debug)]
+#[derive(clap::Parser, Debug)]
 pub struct GeneratorServiceConfig {
     #[structopt(env = "PLUGIN_BIND_ADDRESS")]
     pub bind_address: std::net::SocketAddr,
@@ -22,7 +22,7 @@ impl GeneratorServiceConfig {
     /// An alias for Structopt::from_args, so that consumers don't need to
     /// declare a dependency on structopt
     pub fn from_env_vars() -> Self {
-        Self::from_args()
+        Self::parse()
     }
 }
 

--- a/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -37,6 +37,8 @@ impl PluginRegistryServiceClient {
         &mut self,
         request: native::CreatePluginRequest,
     ) -> Result<native::CreatePluginResponse, PluginRegistryServiceClientError> {
+        // Might be nice to add a client-side "business-logic validation" hook
+        // i.e. to error based on .plugin_artifact.len()
         let response = self
             .proto_client
             .create_plugin(proto::CreatePluginRequest::from(request))

--- a/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_registry/v1beta1_server.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_registry/v1beta1_server.rs
@@ -213,7 +213,6 @@ where
                     extensions = ?request.extensions(),
                 )
             })
-            .max_frame_size(4_000_000)
             .add_service(health_service)
             .add_service(PluginRegistryServiceProto::new(GrpcApi::new(
                 self.api_server,

--- a/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_registry/v1beta1_server.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_registry/v1beta1_server.rs
@@ -204,7 +204,16 @@ where
 
         // TODO: add tower tracing, tls_config, concurrency limits
         Ok(Server::builder()
-            .max_frame_size(250_000_000)
+            .trace_fn(|request| {
+                tracing::info_span!(
+                    "Plugin Registry",
+                    headers = ?request.headers(),
+                    method = ?request.method(),
+                    uri = %request.uri(),
+                    extensions = ?request.extensions(),
+                )
+            })
+            .max_frame_size(4_000_000)
             .add_service(health_service)
             .add_service(PluginRegistryServiceProto::new(GrpcApi::new(
                 self.api_server,

--- a/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_registry/v1beta1_server.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_registry/v1beta1_server.rs
@@ -204,6 +204,7 @@ where
 
         // TODO: add tower tracing, tls_config, concurrency limits
         Ok(Server::builder()
+            .max_frame_size(250_000_000)
             .add_service(health_service)
             .add_service(PluginRegistryServiceProto::new(GrpcApi::new(
                 self.api_server,

--- a/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_work_queue/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_work_queue/v1beta1.rs
@@ -252,17 +252,13 @@ impl TryFrom<proto::GetExecuteAnalyzerResponse> for GetExecuteAnalyzerResponse {
     fn try_from(value: proto::GetExecuteAnalyzerResponse) -> Result<Self, Self::Error> {
         let request_id = value.request_id;
         let maybe_job = value.maybe_job.ok_or(Self::Error::MissingField(
-            "GetExecuteAnalyzerResponse.execution_job",
+            "GetExecuteAnalyzerResponse.maybe_job",
         ))?;
         let execution_job: Option<ExecutionJob> = maybe_job.try_into()?;
 
-        let execution_job = execution_job.ok_or(Self::Error::MissingField(
-            "GetExecuteAnalyzerResponse.execution_job",
-        ))?;
-
         Ok(Self {
             request_id,
-            execution_job: Some(execution_job),
+            execution_job: execution_job,
         })
     }
 }
@@ -329,13 +325,9 @@ impl TryFrom<proto::GetExecuteGeneratorResponse> for GetExecuteGeneratorResponse
         ))?;
         let execution_job: Option<ExecutionJob> = maybe_job.try_into()?;
 
-        let execution_job = execution_job.ok_or(Self::Error::MissingField(
-            "proto::GetExecuteGeneratorResponse.execution_job",
-        ))?;
-
         Ok(Self {
             request_id,
-            execution_job: Some(execution_job),
+            execution_job: execution_job,
         })
     }
 }

--- a/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_work_queue/v1beta1.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_work_queue/v1beta1.rs
@@ -258,7 +258,7 @@ impl TryFrom<proto::GetExecuteAnalyzerResponse> for GetExecuteAnalyzerResponse {
 
         Ok(Self {
             request_id,
-            execution_job: execution_job,
+            execution_job,
         })
     }
 }
@@ -327,7 +327,7 @@ impl TryFrom<proto::GetExecuteGeneratorResponse> for GetExecuteGeneratorResponse
 
         Ok(Self {
             request_id,
-            execution_job: execution_job,
+            execution_job,
         })
     }
 }

--- a/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_work_queue/v1beta1_client.rs
+++ b/src/rust/rust-proto-new/src/graplinc/grapl/api/plugin_work_queue/v1beta1_client.rs
@@ -12,7 +12,7 @@ use crate::{
 pub enum PluginWorkQueueServiceClientError {
     #[error("ErrorStatus")]
     ErrorStatus(#[from] tonic::Status),
-    #[error("PluginWorkQueueDeserializationError")]
+    #[error(transparent)]
     PluginRegistryDeserializationError(#[from] SerDeError),
 }
 

--- a/src/rust/rust-proto-new/src/protocol/tls.rs
+++ b/src/rust/rust-proto-new/src/protocol/tls.rs
@@ -23,7 +23,7 @@ pub struct Certificate {
     inner: tonic::transport::Certificate,
 }
 impl Certificate {
-    pub fn from_pem(pem: Vec<u8>) -> Self {
+    pub fn from_pem(pem: &Vec<u8>) -> Self {
         Self {
             inner: tonic::transport::Certificate::from_pem(pem),
         }

--- a/src/rust/rust-proto-new/tests/proto_serde_tests.rs
+++ b/src/rust/rust-proto-new/tests/proto_serde_tests.rs
@@ -384,11 +384,7 @@ mod plugin_work_queue {
         fn test_get_execute_analyzer_responses(
             value in pwq_strats::get_execute_analyzer_responses()
         ) {
-            if let None = value.execution_job {
-                expect_serde_error(value);
-            } else {
-                check_encode_decode_invariant(value)
-            }
+            check_encode_decode_invariant(value)
         }
 
         #[test]
@@ -400,11 +396,7 @@ mod plugin_work_queue {
         fn test_get_execute_generator_responses(
             value in pwq_strats::get_execute_generator_responses()
         ) {
-            if let None = value.execution_job {
-                expect_serde_error(value);
-            } else {
-                check_encode_decode_invariant(value)
-            }
+            check_encode_decode_invariant(value)
         }
 
         #[test]


### PR DESCRIPTION
### Which issue does this PR correspond to?
none

### What changes does this PR make to Grapl? Why?
Unfortunately, this PR is two somewhat-unrelated features:
1. Add generator-executor into Nomad + Pulumi
2. Instead of uploading a small .sh binary during integration tests, upload the real 150MB `example-generator`. 

It's like two trains traveling in opposite directions, but they haven't quite met yet.
The midpoint will be "integration tests [or e2e tests] can kick off a plugin-work-queue request that hits the example-generator".

### How were these changes tested?
We can see the `generator-executor` becomes healthy:
https://grapl-buildkite-artifacts-ecfff1a.s3.amazonaws.com/ef000bc0-54b8-4ea8-b319-0bb169314881/test_artifacts/2022-05-12T01-09-13/grapl-core/generator-executor.stdout.d7d114dc.log

We can see the `plugin-registry` integration test successfully deploys a real binary!!!
https://grapl-buildkite-artifacts-ecfff1a.s3.amazonaws.com/3a967227-5464-4e1e-bf4f-a178d917a9e4/test_artifacts/2022-05-12T01-13-34/namespaces/plugin-6ca5f429-54cb-73eb-2760-1d437a107c54/grapl-plugin/run-plugin.stderr.5d1690fc.log
(It fails because the binary expects SSL certs, but it runs!) 
