### PR TITLE
Add gRPC health checks to a few of our services.

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1375,6 +1375,13 @@ job "grapl-core" {
         sidecar_service {
         }
       }
+
+      check {
+        type     = "grpc"
+        port     = "pipeline-ingress-port"
+        interval = "10s"
+        timeout  = "3s"
+      }
     }
   }
 
@@ -1438,6 +1445,13 @@ job "grapl-core" {
         sidecar_service {
         }
       }
+
+      check {
+        type     = "grpc"
+        port     = "plugin-registry-port"
+        interval = "10s"
+        timeout  = "3s"
+      }
     }
   }
 
@@ -1489,6 +1503,13 @@ job "grapl-core" {
       connect {
         sidecar_service {
         }
+      }
+
+      check {
+        type     = "grpc"
+        port     = "plugin-work-queue-port"
+        interval = "10s"
+        timeout  = "3s"
       }
     }
   }

--- a/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
@@ -76,6 +76,13 @@ job "grapl-plugin" {
           }
         }
       }
+
+      check {
+        type         = "grpc"
+        port         = "pipeline-ingress-port"
+        interval     = "10s"
+        timeout      = "3s"
+      }
     }
 
     # a Docker task holding:

--- a/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
@@ -78,10 +78,10 @@ job "grapl-plugin" {
       }
 
       check {
-        type         = "grpc"
-        port         = "pipeline-ingress-port"
-        interval     = "10s"
-        timeout      = "3s"
+        type     = "grpc"
+        port     = "pipeline-ingress-port"
+        interval = "10s"
+        timeout  = "3s"
       }
     }
 


### PR DESCRIPTION
Namely, the services that we've ported to the repeatable pattern established in rust-proto-new.  