### PR TITLE
Change all usage of structopt to clapv3

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1941,10 +1941,10 @@ dependencies = [
 name = "grapl-graphql-codegen"
 version = "0.1.0"
 dependencies = [
+ "clap 3.1.17",
  "color-eyre",
  "graphql-parser",
  "serde_json",
- "structopt",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -3002,12 +3002,12 @@ name = "organization-management"
 version = "0.1.0"
 dependencies = [
  "argon2",
+ "clap 3.1.17",
  "grapl-config",
  "grapl-utils",
  "prost 0.9.0",
  "rust-proto",
  "sqlx",
- "structopt",
  "test-log",
  "thiserror",
  "tokio",
@@ -3240,11 +3240,11 @@ name = "plugin-bootstrap"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "clap 3.1.17",
  "futures",
  "grapl-config",
  "grapl-utils",
  "rust-proto",
- "structopt",
  "thiserror",
  "tokio",
  "tonic 0.6.2",
@@ -3273,6 +3273,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "blake3",
+ "clap 3.1.17",
  "futures",
  "grapl-config",
  "grapl-utils",
@@ -3282,7 +3283,6 @@ dependencies = [
  "rust-proto-new",
  "serde_json",
  "sqlx",
- "structopt",
  "tempfile",
  "test-log",
  "thiserror",
@@ -3299,12 +3299,12 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "clap 3.1.17",
  "futures",
  "grapl-config",
  "grapl-utils",
  "rust-proto-new",
  "sqlx",
- "structopt",
  "thiserror",
  "tokio",
  "tonic-health 0.5.0",
@@ -4594,30 +4594,6 @@ name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "subtle"

--- a/src/rust/grapl-graphql-codegen/Cargo.toml
+++ b/src/rust/grapl-graphql-codegen/Cargo.toml
@@ -15,7 +15,11 @@ name = "grapl-graphql-codegen"
 graphql-parser = "0.4.0"
 serde_json = "1.0.72"
 thiserror = "1.0.30"
-structopt = { version = "0.3", default-features = false }
+clap = { version = "3.0", default_features = false, features = [
+  "std",
+  "env",
+  "derive"
+] }
 color-eyre = "0.6.0"
 tracing = "0.1.29"
 tracing-subscriber = "0.3.2"

--- a/src/rust/grapl-graphql-codegen/src/main.rs
+++ b/src/rust/grapl-graphql-codegen/src/main.rs
@@ -3,12 +3,12 @@ use std::{
     path::PathBuf,
 };
 
+use clap::Parser;
 use color_eyre::eyre::{
     Result,
     WrapErr,
 };
 use graphql_parser::schema::parse_schema;
-use structopt::StructOpt;
 
 pub mod as_static_python;
 pub mod conflict_resolution;
@@ -24,28 +24,28 @@ pub mod node_predicate;
 pub mod node_type;
 pub mod predicate_type;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "grapl-graphql-codegen", about = "Codegen for Grapl plugins")]
+#[derive(clap::Parser, Debug)]
+#[clap(name = "grapl-graphql-codegen", about = "Codegen for Grapl plugins")]
 struct Opt {
     /// Input file, stdin if not present
-    #[structopt(short = "i", long = "input", parse(from_os_str), env)]
+    #[clap(short = 'i', long = "input", parse(from_os_str), env)]
     input: Option<PathBuf>,
 
     /// Output file, stdout if not present
-    #[structopt(short = "o", long = "output", parse(from_os_str), env)]
+    #[clap(short = 'o', long = "output", parse(from_os_str), env)]
     output: Option<PathBuf>,
 
     /// Do not emit any generated code - useful with 'validate'
-    #[structopt(long = "no-emit", parse(from_flag))]
+    #[clap(long = "no-emit", parse(from_flag))]
     no_emit: bool,
 
     /// Build the code with line numbers
-    #[structopt(long = "line-num", parse(from_flag))]
+    #[clap(long = "line-num", parse(from_flag))]
     line_num: bool,
 
     /// Generated code will be passed to the system Python interpreter, and mypy will be executed
     /// against the code as well
-    #[structopt(long = "validate", parse(from_flag))]
+    #[clap(long = "validate", parse(from_flag))]
     validate: bool,
 }
 
@@ -80,7 +80,7 @@ fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
     color_eyre::install()?;
 
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     tracing::debug!(message="Executing grapl-graphql-codegen", options=?opt);
     let raw_schema = read_in_schema(&opt.input)?;

--- a/src/rust/organization-management/Cargo.toml
+++ b/src/rust/organization-management/Cargo.toml
@@ -30,7 +30,11 @@ tracing-subscriber = "0.3"
 rust-proto = { path = "../rust-proto", version = "*" }
 thiserror = "1.0.26"
 argon2 = { version = "0.4", features = ["std"] }
-structopt = { version = "0.3", default-features = false }
+clap = { version = "3.0", default_features = false, features = [
+  "std",
+  "env",
+  "derive"
+] }
 
 [build-dependencies]
 tonic-build = { version = "0.6.0", features = ["prost"] }

--- a/src/rust/organization-management/src/lib.rs
+++ b/src/rust/organization-management/src/lib.rs
@@ -1,20 +1,18 @@
 use std::net::SocketAddr;
 
-use structopt::StructOpt;
-
 pub mod client;
 pub mod server;
 
-#[derive(StructOpt, Debug)]
+#[derive(clap::Parser, Debug)]
 pub struct OrganizationManagementServiceConfig {
-    #[structopt(env)]
+    #[clap(long, env)]
     pub organization_management_bind_address: SocketAddr,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub organization_management_db_hostname: String,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub organization_management_db_port: u16,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub organization_management_db_username: String,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub organization_management_db_password: String,
 }

--- a/src/rust/organization-management/src/main.rs
+++ b/src/rust/organization-management/src/main.rs
@@ -1,13 +1,13 @@
+use clap::Parser;
 use organization_management::{
     server::exec_service,
     OrganizationManagementServiceConfig,
 };
-use structopt::StructOpt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (_env, _guard) = grapl_config::init_grapl_env!();
-    let config = OrganizationManagementServiceConfig::from_args();
+    let config = OrganizationManagementServiceConfig::parse();
     tracing::info!(message="Started organization-manager", config=?config);
 
     exec_service(config).await?;

--- a/src/rust/organization-management/tests/test_create_organization.rs
+++ b/src/rust/organization-management/tests/test_create_organization.rs
@@ -1,12 +1,12 @@
 #![cfg(feature = "integration")]
 
+use clap::Parser;
 use grapl_utils::future_ext::GraplFutureExt;
 use organization_management::{
     client::OrganizationManagementServiceClient,
     OrganizationManagementServiceConfig,
 };
 use rust_proto::organization_management::CreateOrganizationRequest;
-use structopt::StructOpt;
 
 #[test_log::test(tokio::test)]
 async fn test_create_organization() -> Result<(), Box<dyn std::error::Error>> {
@@ -14,7 +14,7 @@ async fn test_create_organization() -> Result<(), Box<dyn std::error::Error>> {
         env=?std::env::args(),
     );
 
-    let service_config = OrganizationManagementServiceConfig::from_args();
+    let service_config = OrganizationManagementServiceConfig::parse();
 
     let postgres_address = format!(
         "postgresql://{}:{}@{}:{}",

--- a/src/rust/organization-management/tests/test_create_user.rs
+++ b/src/rust/organization-management/tests/test_create_user.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "integration")]
 
+use clap::Parser;
 use grapl_utils::future_ext::GraplFutureExt;
 use organization_management::{
     client::OrganizationManagementServiceClient,
@@ -9,7 +10,6 @@ use rust_proto::organization_management::{
     CreateOrganizationRequest,
     CreateUserRequest,
 };
-use structopt::StructOpt;
 
 #[test_log::test(tokio::test)]
 async fn test_create_user() -> Result<(), Box<dyn std::error::Error>> {
@@ -17,7 +17,7 @@ async fn test_create_user() -> Result<(), Box<dyn std::error::Error>> {
         env=?std::env::args(),
     );
 
-    let service_config = OrganizationManagementServiceConfig::from_args();
+    let service_config = OrganizationManagementServiceConfig::parse();
 
     let postgres_address = format!(
         "postgresql://{}:{}@{}:{}",

--- a/src/rust/plugin-bootstrap/Cargo.toml
+++ b/src/rust/plugin-bootstrap/Cargo.toml
@@ -16,6 +16,11 @@ name = "plugin_bootstrap"
 
 [dependencies]
 async-trait = "0.1.51"
+clap = { version = "3.0", default_features = false, features = [
+  "std",
+  "env",
+  "derive"
+] }
 grapl-config = { path = "../grapl-config" }
 grapl-utils = { path = "../grapl-utils" }
 rust-proto = { path = "../rust-proto" }
@@ -24,7 +29,6 @@ tokio = { version = "1.14.0", features = ["full"] }
 tonic = "0.6"
 tonic-health = "0.5.0"
 tracing = "0.1.29"
-structopt = { version = "0.3", default-features = false }
 uuid = { version = "0.8", features = ["v4"] }
 futures = "0.3"
 

--- a/src/rust/plugin-bootstrap/src/lib.rs
+++ b/src/rust/plugin-bootstrap/src/lib.rs
@@ -1,16 +1,14 @@
 use std::net::SocketAddr;
 
-use structopt::StructOpt;
-
 pub mod client;
 pub mod server;
 
-#[derive(StructOpt, Debug)]
+#[derive(clap::Parser, Debug)]
 pub struct PluginBootstrapServiceConfig {
-    #[structopt(env)]
+    #[clap(long, env)]
     pub plugin_registry_bind_address: SocketAddr,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub plugin_binary_path: std::path::PathBuf,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub plugin_certificate_path: std::path::PathBuf,
 }

--- a/src/rust/plugin-bootstrap/src/plugin_bootstrap_service.rs
+++ b/src/rust/plugin-bootstrap/src/plugin_bootstrap_service.rs
@@ -1,13 +1,13 @@
+use clap::Parser;
 use plugin_bootstrap::{
     server::PluginBootstrapper,
     PluginBootstrapServiceConfig,
 };
-use structopt::StructOpt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (_env, _guard) = grapl_config::init_grapl_env!();
-    let config = PluginBootstrapServiceConfig::from_args();
+    let config = PluginBootstrapServiceConfig::parse();
     tracing::info!(message="Starting Plugin Bootstrap Service", config=?config);
 
     let plugin_bootstrapper =

--- a/src/rust/plugin-registry/Cargo.toml
+++ b/src/rust/plugin-registry/Cargo.toml
@@ -12,6 +12,11 @@ name = "plugin_registry"
 
 [dependencies]
 async-trait = "0.1.51"
+clap = { version = "3.0", default_features = false, features = [
+  "std",
+  "env",
+  "derive"
+] }
 grapl-config = { path = "../grapl-config" }
 grapl-utils = { path = "../grapl-utils" }
 rust-proto-new = { path = "../rust-proto-new" }
@@ -38,7 +43,6 @@ rusoto_s3 = { version = "0.47.0", default_features = false, features = [
   "rustls"
 ] }
 blake3 = "1.2.0"
-structopt = { version = "0.3", default-features = false }
 uuid = { version = "0.8", features = ["v4"] }
 futures = "0.3"
 

--- a/src/rust/plugin-registry/src/main.rs
+++ b/src/rust/plugin-registry/src/main.rs
@@ -1,13 +1,13 @@
+use clap::Parser;
 use plugin_registry::server::service::{
     exec_service,
     PluginRegistryConfig,
 };
-use structopt::StructOpt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (_env, _guard) = grapl_config::init_grapl_env!();
-    let config = PluginRegistryConfig::from_args();
+    let config = PluginRegistryConfig::parse();
     tracing::info!(message="Starting Plugin Registry Service", config=?config);
 
     exec_service(config).await?;

--- a/src/rust/plugin-registry/src/nomad/client.rs
+++ b/src/rust/plugin-registry/src/nomad/client.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 
+use clap::Parser;
 use nomad_client_gen::{
     apis::{
         configuration::Configuration as InternalConfig,
@@ -9,12 +10,11 @@ use nomad_client_gen::{
     },
     models,
 };
-use structopt::StructOpt;
 
 /// Represents the environment variables needed to construct a NomadClient
-#[derive(StructOpt, Debug)]
+#[derive(clap::Parser, Debug)]
 pub struct NomadClientConfig {
-    #[structopt(env)]
+    #[clap(long, env)]
     /// "${attr.unique.network.ip-address}:4646
     nomad_service_address: SocketAddr,
 }
@@ -41,7 +41,7 @@ pub enum NomadClientError {
 impl NomadClient {
     /// Create a client from environment
     pub fn from_env() -> Self {
-        Self::from_client_config(NomadClientConfig::from_args())
+        Self::from_client_config(NomadClientConfig::parse())
     }
 
     pub fn from_client_config(nomad_client_config: NomadClientConfig) -> Self {

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -32,7 +32,6 @@ use rust_proto_new::{
     },
     protocol::healthcheck::HealthcheckStatus,
 };
-use structopt::StructOpt;
 use tokio::{
     io::AsyncReadExt,
     net::TcpListener,
@@ -56,7 +55,7 @@ use crate::{
     server::deploy_plugin,
 };
 
-#[derive(StructOpt, Debug)]
+#[derive(clap::Parser, Debug)]
 pub struct PluginRegistryConfig {
     #[structopt(flatten)]
     db_config: PluginRegistryDbConfig,
@@ -64,37 +63,41 @@ pub struct PluginRegistryConfig {
     service_config: PluginRegistryServiceConfig,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(clap::Parser, Debug)]
 pub struct PluginRegistryDbConfig {
-    #[structopt(env)]
+    #[clap(long, env)]
     plugin_registry_db_hostname: String,
-    #[structopt(env)]
+    #[clap(long, env)]
     plugin_registry_db_port: u16,
-    #[structopt(env)]
+    #[clap(long, env)]
     plugin_registry_db_username: String,
-    #[structopt(env)]
+    #[clap(long, env)]
     plugin_registry_db_password: String,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(clap::Parser, Debug)]
 pub struct PluginRegistryServiceConfig {
-    #[structopt(env)]
+    #[clap(long, env)]
     pub plugin_s3_bucket_aws_account_id: String,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub plugin_s3_bucket_name: String,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub plugin_registry_bind_address: SocketAddr,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub plugin_bootstrap_container_image: String,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub plugin_execution_container_image: String,
-    #[structopt(env = "PLUGIN_REGISTRY_KERNEL_ARTIFACT_URL")]
+    #[clap(long, env = "PLUGIN_REGISTRY_KERNEL_ARTIFACT_URL")]
     pub kernel_artifact_url: String,
-    #[structopt(env = "PLUGIN_REGISTRY_ROOTFS_ARTIFACT_URL")]
+    #[clap(long, env = "PLUGIN_REGISTRY_ROOTFS_ARTIFACT_URL")]
     pub rootfs_artifact_url: String,
-    #[structopt(env = "PLUGIN_REGISTRY_HAX_DOCKER_PLUGIN_RUNTIME_IMAGE")]
+    #[clap(long, env = "PLUGIN_REGISTRY_HAX_DOCKER_PLUGIN_RUNTIME_IMAGE")]
     pub hax_docker_plugin_runtime_image: String,
-    #[structopt(env = "PLUGIN_REGISTRY_ARTIFACT_SIZE_LIMIT_MB", default_value = "250")]
+    #[clap(
+        long,
+        env = "PLUGIN_REGISTRY_ARTIFACT_SIZE_LIMIT_MB",
+        default_value = "250"
+    )]
     pub artifact_size_limit_mb: usize,
 }
 

--- a/src/rust/plugin-sdk/generator-sdk/src/server.rs
+++ b/src/rust/plugin-sdk/generator-sdk/src/server.rs
@@ -15,12 +15,12 @@ use tokio::net::TcpListener;
 
 #[derive(clap::Parser, Debug)]
 pub struct GeneratorServiceConfig {
-    #[structopt(env = "PLUGIN_BIND_ADDRESS")]
+    #[clap(long, env = "PLUGIN_BIND_ADDRESS")]
     pub bind_address: std::net::SocketAddr,
 }
 impl GeneratorServiceConfig {
-    /// An alias for Structopt::from_args, so that consumers don't need to
-    /// declare a dependency on structopt
+    /// An alias for clap::parse, so that consumers don't need to
+    /// declare a dependency on clap
     pub fn from_env_vars() -> Self {
         Self::parse()
     }

--- a/src/rust/plugin-work-queue/Cargo.toml
+++ b/src/rust/plugin-work-queue/Cargo.toml
@@ -13,10 +13,14 @@ name = "plugin_work_queue"
 
 [dependencies]
 async-trait = "0.1"
+clap = { version = "3.0", default_features = false, features = [
+  "std",
+  "env",
+  "derive"
+] }
 grapl-config = { path = "../grapl-config" }
 grapl-utils = { path = "../grapl-utils" }
 rust-proto-new = { path = "../rust-proto-new" }
-structopt = { version = "0.3", default-features = false }
 thiserror = "1.0.30"
 tokio = { version = "1.17", features = ["full"] }
 tonic-health = "0.5.0"

--- a/src/rust/plugin-work-queue/src/lib.rs
+++ b/src/rust/plugin-work-queue/src/lib.rs
@@ -1,23 +1,21 @@
 use std::net::SocketAddr;
 
-use structopt::StructOpt;
-
 pub mod client;
 pub mod psql_queue;
 pub mod server;
 
-#[derive(StructOpt, Debug)]
+#[derive(clap::Parser, Debug)]
 pub struct PluginWorkQueueServiceConfig {
-    #[structopt(env)]
+    #[clap(long, env)]
     pub plugin_work_queue_bind_address: SocketAddr,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub plugin_work_queue_healthcheck_polling_interval_ms: u64,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub plugin_work_queue_db_hostname: String,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub plugin_work_queue_db_port: u16,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub plugin_work_queue_db_username: String,
-    #[structopt(env)]
+    #[clap(long, env)]
     pub plugin_work_queue_db_password: String,
 }

--- a/src/rust/plugin-work-queue/src/main.rs
+++ b/src/rust/plugin-work-queue/src/main.rs
@@ -1,13 +1,13 @@
+use clap::Parser;
 use plugin_work_queue::{
     server::exec_service,
     PluginWorkQueueServiceConfig,
 };
-use structopt::StructOpt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (_env, _guard) = grapl_config::init_grapl_env!();
-    let config = PluginWorkQueueServiceConfig::from_args();
+    let config = PluginWorkQueueServiceConfig::parse();
     exec_service(config).await?;
     Ok(())
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/868

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Change from structopt to clapv3. Structopt is in maintenance mode and suggests people use this instead.

One major note: adding `long` along with `env` tells clap to stop doing some unnecessary-for-us command line specific validation, which we just don't care about. 
Including `long` is not necessary in much of our code, _but_ is a pattern I want to cargo-cult to future consumers (think of it as a good habit).

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
CI
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
