### PR TITLE
Conditionally remove workaround for Cloudsmith promotion bug

### DIFF
--- a/.buildkite/scripts/build_and_upload_images.sh
+++ b/.buildkite/scripts/build_and_upload_images.sh
@@ -66,89 +66,104 @@ else
     done
 fi
 
-readonly sleep_seconds=60
-echo "--- :sleeping::sob: Sleeping for ${sleep_seconds} seconds to give CDNs time to update"
-# Lately, we've seen failures where images aren't showing up when we
-# run `docker manifest inspect` (see below), but rerunning the job
-# succeeds. For the time being, we'll add a sleep to account for that.
+# https://github.com/grapl-security/issue-tracker/issues/932
 #
-# Yes, I hate it, too.
-sleep "${sleep_seconds}"
-
-########################################################################
-# Determine whether or not this image is "new"
+# There's not really a good way to check to see whether this will work
+# or not, since the promotion doesn't take place here. For now, we'll
+# just remove our workaround the first time we run this job; if it
+# needs to be re-run, we'll use our old logic.
 #
-# Cloudsmith apparently has a bug that affects promotions when an
-# artifact already exists in the destination repository. It seems to
-# detect that the artifact is present and doesn't overwrite it, but it
-# also doesn't carry tags / labels over. Thus, when we have services
-# that don't change, we end up losing them in Cloudsmith.
-#
-# Until we can inspect the source of our Rust services to determine if
-# they need a new image, we will build the images, but then query the
-# upstream registry to see if that content exists there already or
-# not.
-#
-# This does require us to build the images first (which wastes a bit
-# of time). It also requires us to push the images to our `raw`
-# repository first in order to obtain the image's sha256 checksum
-# (there doesn't appear to be a way to do this purely locally,
-# amazingly enough!). It also requires this script to be aware that
-# we'll ultimately be promoting to our `testing` repository. These are
-# all unfortunate, but it does allow us to sidestep this Cloudsmith
-# bug. More importantly, it should make deployments quicker and more
-# responsive, since services should churn less (they'll only restart
-# when a new image is available, rather than for every single
-# deployment). As such, we should keep this general logic even after
-# the Cloudsmith bug is fixed.
+# When we can show that the workaround isn't needed, we can remove it.
+if [[ "${BUILDKITE_RETRY_COUNT}" -eq 0 ]]; then
+    mapfile -t services < <(docker buildx bake --file="docker-bake.hcl" cloudsmith-images --print | jq --raw-output '.target | to_entries[] | .key')
+    artifact_json "${IMAGE_TAG}" "${services[@]}" > "$(artifacts_file_for containers)"
+else
+    echo "--- :bangbang: Using workaround for Cloudsmith Promotion bug"
 
-# This is the list of services that actually have different images.
-new_services=()
+    readonly sleep_seconds=60
+    echo "--- :sleeping::sob: Sleeping for ${sleep_seconds} seconds to give CDNs time to update"
+    # Lately, we've seen failures where images aren't showing up when we
+    # run `docker manifest inspect` (see below), but rerunning the job
+    # succeeds. For the time being, we'll add a sleep to account for that.
+    #
+    # Yes, I hate it, too.
+    sleep "${sleep_seconds}"
 
-# This is where our images will ultimately be promoted to. It is the
-# registry we'll need to query to see if an image with the same
-# content already exists.
-readonly UPSTREAM_REGISTRY="docker.cloudsmith.io/grapl/testing"
+    ########################################################################
+    # Determine whether or not this image is "new"
+    #
+    # Cloudsmith apparently has a bug that affects promotions when an
+    # artifact already exists in the destination repository. It seems to
+    # detect that the artifact is present and doesn't overwrite it, but it
+    # also doesn't carry tags / labels over. Thus, when we have services
+    # that don't change, we end up losing them in Cloudsmith.
+    #
+    # Until we can inspect the source of our Rust services to determine if
+    # they need a new image, we will build the images, but then query the
+    # upstream registry to see if that content exists there already or
+    # not.
+    #
+    # This does require us to build the images first (which wastes a bit
+    # of time). It also requires us to push the images to our `raw`
+    # repository first in order to obtain the image's sha256 checksum
+    # (there doesn't appear to be a way to do this purely locally,
+    # amazingly enough!). It also requires this script to be aware that
+    # we'll ultimately be promoting to our `testing` repository. These are
+    # all unfortunate, but it does allow us to sidestep this Cloudsmith
+    # bug. More importantly, it should make deployments quicker and more
+    # responsive, since services should churn less (they'll only restart
+    # when a new image is available, rather than for every single
+    # deployment). As such, we should keep this general logic even after
+    # the Cloudsmith bug is fixed.
 
-# It seems you can only get the sha256 sum of an image after pushing
-# it to a registry. Fun.
-#
-# Returns a string like `sha256:deadbeef....`
-sha256_of_image() {
-    docker manifest inspect --verbose "${1}" | jq --raw-output '.Descriptor.digest'
-}
+    # This is the list of services that actually have different images.
+    new_services=()
 
-# Returns 0 if it is present; 1 if not.
-#
-# We'll go ahead and allow the output to go to our logs; that will
-# help debugging.
-image_present_upstream() {
-    docker manifest inspect "${1}"
-}
+    # This is where our images will ultimately be promoted to. It is the
+    # registry we'll need to query to see if an image with the same
+    # content already exists.
+    readonly UPSTREAM_REGISTRY="docker.cloudsmith.io/grapl/testing"
 
-echo "--- :cloudsmith::sleuth_or_spy: Checking upstream repository to determine what to promote"
-# Generate a TSV of "${SERVICE}\t${TAG}" for each image we're
-# pushing to Cloudsmith
-#
-# NOTE: This assumes that we have at least one tag for each image
-# (which should be true!) and that this tag is for our Cloudsmith
-# "raw" repository (which should also be true!)
-while IFS=$'\t' read -r service tag; do
-    echo "--- :cloudsmith: Checking '${service}:${IMAGE_TAG}' in 'grapl/testing'"
-    sha256="$(sha256_of_image "${tag}")"
-    echo "${tag} has identifier '${sha256}'"
-    upstream_sha256_identifier="${UPSTREAM_REGISTRY}/${service}@${sha256}"
+    # It seems you can only get the sha256 sum of an image after pushing
+    # it to a registry. Fun.
+    #
+    # Returns a string like `sha256:deadbeef....`
+    function sha256_of_image() {
+        docker manifest inspect --verbose "${1}" | jq --raw-output '.Descriptor.digest'
+    }
 
-    echo "Checking the existence of '${upstream_sha256_identifier}'"
-    if ! image_present_upstream "${upstream_sha256_identifier}"; then
-        echo "Image not present upstream; adding '${service}' to the list of images to promote"
-        new_services+=("${service}")
-    else
-        echo "Image already found upstream; nothing else to be done"
-    fi
-done < <(docker buildx bake --file="${BUILDX_BAKE_FILE}" "${BUILDX_TARGET}" --print |
-    jq --raw-output '.target | to_entries[] | [.key, .value.tags[0]] | @tsv')
+    # Returns 0 if it is present; 1 if not.
+    #
+    # We'll go ahead and allow the output to go to our logs; that will
+    # help debugging.
+    function image_present_upstream() {
+        docker manifest inspect "${1}"
+    }
 
-# Now that we've filtered out things that already exist upstream, we
-# only need to care about the new stuff.
-artifact_json "${IMAGE_TAG}" "${new_services[@]}" > "$(artifacts_file_for containers)"
+    echo "--- :cloudsmith::sleuth_or_spy: Checking upstream repository to determine what to promote"
+    # Generate a TSV of "${SERVICE}\t${TAG}" for each image we're
+    # pushing to Cloudsmith
+    #
+    # NOTE: This assumes that we have at least one tag for each image
+    # (which should be true!) and that this tag is for our Cloudsmith
+    # "raw" repository (which should also be true!)
+    while IFS=$'\t' read -r service tag; do
+        echo "--- :cloudsmith: Checking '${service}:${IMAGE_TAG}' in 'grapl/testing'"
+        sha256="$(sha256_of_image "${tag}")"
+        echo "${tag} has identifier '${sha256}'"
+        upstream_sha256_identifier="${UPSTREAM_REGISTRY}/${service}@${sha256}"
+
+        echo "Checking the existence of '${upstream_sha256_identifier}'"
+        if ! image_present_upstream "${upstream_sha256_identifier}"; then
+            echo "Image not present upstream; adding '${service}' to the list of images to promote"
+            new_services+=("${service}")
+        else
+            echo "Image already found upstream; nothing else to be done"
+        fi
+    done < <(docker buildx bake --file="${BUILDX_BAKE_FILE}" "${BUILDX_TARGET}" --print |
+        jq --raw-output '.target | to_entries[] | [.key, .value.tags[0]] | @tsv')
+
+    # Now that we've filtered out things that already exist upstream, we
+    # only need to care about the new stuff.
+    artifact_json "${IMAGE_TAG}" "${new_services[@]}" > "$(artifacts_file_for containers)"
+fi


### PR DESCRIPTION
To determine if Cloudsmith has addressed the underlying promotion bug,
we'll remove our workaround from the first time we run this "build and
upload images" job. This is not perfect, as we can't really know
whether the fix works from within this job, but it preserves the
workaround logic for now.

Tip for reviewers: view this PR with whitespace changes suppressed.

Fixes https://github.com/grapl-security/issue-tracker/issues/932