### PR TITLE
Add correct perms to plugin_registry bucket; clean up naming around it in Pulumi, Nomad, rust

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -192,12 +192,12 @@ variable "plugin_work_queue_db_password" {
   description = "What is the password for the plugin work queue table?"
 }
 
-variable "plugin_s3_bucket_aws_account_id" {
+variable "plugin_registry_bucket_aws_account_id" {
   type        = string
   description = "The account id that owns the bucket where plugins are stored"
 }
 
-variable "plugin_s3_bucket_name" {
+variable "plugin_registry_bucket_name" {
   type        = string
   description = "The name of the bucket where plugins are stored"
 }
@@ -1423,13 +1423,15 @@ job "grapl-core" {
         PLUGIN_REGISTRY_ROOTFS_ARTIFACT_URL             = var.plugin_registry_rootfs_artifact_url
         PLUGIN_REGISTRY_HAX_DOCKER_PLUGIN_RUNTIME_IMAGE = var.container_images["hax-docker-plugin-runtime"]
         # Plugin Execution code/image doesn't exist yet; change this once it does!
-        PLUGIN_EXECUTION_CONTAINER_IMAGE = "grapl/plugin-execution-sidecar-TODO"
-        PLUGIN_S3_BUCKET_AWS_ACCOUNT_ID  = var.plugin_s3_bucket_aws_account_id
-        PLUGIN_S3_BUCKET_NAME            = var.plugin_s3_bucket_name
-        RUST_BACKTRACE                   = local.rust_backtrace
-        RUST_LOG                         = var.rust_log
-        OTEL_EXPORTER_JAEGER_AGENT_HOST  = local.tracing_jaeger_endpoint_host
-        OTEL_EXPORTER_JAEGER_AGENT_PORT  = local.tracing_jaeger_endpoint_port
+        PLUGIN_EXECUTION_CONTAINER_IMAGE      = "grapl/plugin-execution-sidecar-TODO"
+        PLUGIN_REGISTRY_BUCKET_AWS_ACCOUNT_ID = var.plugin_registry_bucket_aws_account_id
+        PLUGIN_REGISTRY_BUCKET_NAME           = var.plugin_registry_bucket_name
+
+        # common Rust env vars
+        RUST_BACKTRACE                  = local.rust_backtrace
+        RUST_LOG                        = var.rust_log
+        OTEL_EXPORTER_JAEGER_AGENT_HOST = local.tracing_jaeger_endpoint_host
+        OTEL_EXPORTER_JAEGER_AGENT_PORT = local.tracing_jaeger_endpoint_port
       }
 
       resources {
@@ -1488,12 +1490,12 @@ job "grapl-core" {
         PLUGIN_WORK_QUEUE_DB_USERNAME  = var.plugin_work_queue_db_username
         # Hardcoded, but makes little sense to pipe up through Pulumi
         PLUGIN_WORK_QUEUE_HEALTHCHECK_POLLING_INTERVAL_MS = 5000
-        PLUGIN_S3_BUCKET_AWS_ACCOUNT_ID                   = var.plugin_s3_bucket_aws_account_id
-        PLUGIN_S3_BUCKET_NAME                             = var.plugin_s3_bucket_name
-        RUST_BACKTRACE                                    = local.rust_backtrace
-        RUST_LOG                                          = var.rust_log
-        OTEL_EXPORTER_JAEGER_AGENT_HOST                   = local.tracing_jaeger_endpoint_host
-        OTEL_EXPORTER_JAEGER_AGENT_PORT                   = local.tracing_jaeger_endpoint_port
+
+        # common Rust env vars
+        RUST_BACKTRACE                  = local.rust_backtrace
+        RUST_LOG                        = var.rust_log
+        OTEL_EXPORTER_JAEGER_AGENT_HOST = local.tracing_jaeger_endpoint_host
+        OTEL_EXPORTER_JAEGER_AGENT_PORT = local.tracing_jaeger_endpoint_port
       }
     }
 

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -189,9 +189,9 @@ def main() -> None:
     engagement_creator_queue.subscribe_to_emitter(analyzer_matched_emitter)
 
     analyzers_bucket = Bucket("analyzers-bucket", sse=True)
+    pulumi.export("analyzers-bucket", analyzers_bucket.bucket)
     model_plugins_bucket = Bucket("model-plugins-bucket", sse=False)
     plugin_registry_bucket = Bucket("plugin-registry-bucket", sse=True)
-    pulumi.export("analyzers-bucket", analyzers_bucket.bucket)
 
     all_plugin_buckets = [
         analyzers_bucket,

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -189,9 +189,15 @@ def main() -> None:
     engagement_creator_queue.subscribe_to_emitter(analyzer_matched_emitter)
 
     analyzers_bucket = Bucket("analyzers-bucket", sse=True)
-    pulumi.export("analyzers-bucket", analyzers_bucket.bucket)
     model_plugins_bucket = Bucket("model-plugins-bucket", sse=False)
-    pulumi.export("model-plugins-bucket", model_plugins_bucket.bucket)
+    plugin_registry_bucket = Bucket("plugin-registry-bucket", sse=True)
+    pulumi.export("analyzers-bucket", analyzers_bucket.bucket)
+
+    all_plugin_buckets = [
+        analyzers_bucket,
+        model_plugins_bucket,
+        plugin_registry_bucket,
+    ]
 
     pipeline_ingress_healthcheck_polling_interval_ms = "5000"
     pulumi.export(
@@ -199,17 +205,9 @@ def main() -> None:
         pipeline_ingress_healthcheck_polling_interval_ms,
     )
 
-    plugins_bucket = Bucket("plugins-bucket", sse=True)
-    pulumi.export("plugins-bucket", plugins_bucket.bucket)
-
-    plugin_buckets = [
-        analyzers_bucket,
-        model_plugins_bucket,
-    ]
-
     firecracker_s3objs = FirecrackerS3BucketObjects(
         "firecracker-s3-bucket-objects",
-        plugins_bucket=plugins_bucket,
+        plugins_bucket=plugin_registry_bucket,
         firecracker_assets=FirecrackerAssets(
             "firecracker-assets",
             repository_name=config.cloudsmith_repository_name(),
@@ -258,8 +256,8 @@ def main() -> None:
         user_session_table=dynamodb_tables.user_session_table.name,
         plugin_registry_kernel_artifact_url=firecracker_s3objs.kernel_s3obj_url,
         plugin_registry_rootfs_artifact_url=firecracker_s3objs.rootfs_s3obj_url,
-        plugin_s3_bucket_aws_account_id=config.AWS_ACCOUNT_ID,
-        plugin_s3_bucket_name=plugins_bucket.bucket,
+        plugin_registry_bucket_aws_account_id=config.AWS_ACCOUNT_ID,
+        plugin_registry_bucket_name=plugin_registry_bucket.bucket,
     )
 
     provision_vars: Final[NomadVars] = {
@@ -459,11 +457,11 @@ def main() -> None:
             subnet_ids
         ).apply(subnets_to_single_az)
 
-        for _bucket in plugin_buckets:
-            _bucket.grant_put_permission_to(nomad_agent_role)
+        for bucket in all_plugin_buckets:
+            bucket.grant_put_permission_to(nomad_agent_role)
             # Analyzer Dispatcher needs to be able to ListObjects on Analyzers
             # Analyzer Executor needs to be able to ListObjects on Model Plugins
-            _bucket.grant_get_and_list_to(nomad_agent_role)
+            bucket.grant_get_and_list_to(nomad_agent_role)
         for _emitter in all_emitters:
             _emitter.grant_write_to(nomad_agent_role)
             _emitter.grant_read_to(nomad_agent_role)

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -51,7 +51,7 @@ pub fn get_job(
 ) -> Result<models::Job, NomadCliError> {
     let plugin_artifact_url = {
         let key = &plugin.artifact_s3_key;
-        let bucket = &service_config.plugin_s3_bucket_name;
+        let bucket = &service_config.bucket_name;
         get_s3_url(bucket, key)
     };
     match plugin_runtime {
@@ -60,7 +60,7 @@ pub fn get_job(
             let job_file_vars: NomadVars = HashMap::from([
                 (
                     "aws_account_id",
-                    service_config.plugin_s3_bucket_aws_account_id.to_owned(),
+                    service_config.bucket_aws_account_id.to_owned(),
                 ),
                 ("plugin_artifact_url", plugin_artifact_url),
                 (
@@ -79,7 +79,7 @@ pub fn get_job(
             let job_file_vars: NomadVars = HashMap::from([
                 (
                     "aws_account_id",
-                    service_config.plugin_s3_bucket_aws_account_id.to_owned(),
+                    service_config.bucket_aws_account_id.to_owned(),
                 ),
                 (
                     "kernel_artifact_url",
@@ -169,8 +169,8 @@ mod tests {
             kernel_artifact_url: Default::default(),
             plugin_bootstrap_container_image: Default::default(),
             plugin_execution_container_image: Default::default(),
-            plugin_s3_bucket_aws_account_id: Default::default(),
-            plugin_s3_bucket_name: Default::default(),
+            bucket_aws_account_id: Default::default(),
+            bucket_name: Default::default(),
             rootfs_artifact_url: Default::default(),
             artifact_size_limit_mb: Default::default(),
         }

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -79,7 +79,7 @@ pub struct PluginRegistryDbConfig {
 pub struct PluginRegistryServiceConfig {
     #[clap(long, env = "PLUGIN_REGISTRY_BUCKET_AWS_ACCOUNT_ID")]
     pub bucket_aws_account_id: String,
-    #[clap(long, env = "PLUGIN_REGISTRY_BUCKET_AWS_ACCOUNT_NAME")]
+    #[clap(long, env = "PLUGIN_REGISTRY_BUCKET_NAME")]
     pub bucket_name: String,
     #[clap(long, env)]
     pub plugin_registry_bind_address: SocketAddr,

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -77,10 +77,10 @@ pub struct PluginRegistryDbConfig {
 
 #[derive(clap::Parser, Debug)]
 pub struct PluginRegistryServiceConfig {
-    #[clap(long, env)]
-    pub plugin_s3_bucket_aws_account_id: String,
-    #[clap(long, env)]
-    pub plugin_s3_bucket_name: String,
+    #[clap(long, env = "PLUGIN_REGISTRY_BUCKET_AWS_ACCOUNT_ID")]
+    pub bucket_aws_account_id: String,
+    #[clap(long, env = "PLUGIN_REGISTRY_BUCKET_AWS_ACCOUNT_NAME")]
+    pub bucket_name: String,
     #[clap(long, env)]
     pub plugin_registry_bind_address: SocketAddr,
     #[clap(long, env)]
@@ -148,9 +148,9 @@ impl PluginRegistryApi for PluginRegistry {
             .put_object(PutObjectRequest {
                 content_length: Some(plugin_artifact.len() as i64),
                 body: Some(StreamingBody::from(plugin_artifact)),
-                bucket: self.config.plugin_s3_bucket_name.clone(),
+                bucket: self.config.bucket_name.clone(),
                 key: s3_key.clone(),
-                expected_bucket_owner: Some(self.config.plugin_s3_bucket_aws_account_id.clone()),
+                expected_bucket_owner: Some(self.config.bucket_aws_account_id.clone()),
                 ..Default::default()
             })
             .await?;
@@ -190,9 +190,9 @@ impl PluginRegistryApi for PluginRegistry {
         let get_object_output = self
             .s3
             .get_object(GetObjectRequest {
-                bucket: self.config.plugin_s3_bucket_name.clone(),
+                bucket: self.config.bucket_name.clone(),
                 key: s3_key.clone(),
-                expected_bucket_owner: Some(self.config.plugin_s3_bucket_aws_account_id.clone()),
+                expected_bucket_owner: Some(self.config.bucket_aws_account_id.clone()),
                 ..Default::default()
             })
             .await?;


### PR DESCRIPTION
> [4:06](https://grapl-internal.slack.com/archives/C017F10727P/p1652904407194439)
```
    plugins_bucket = Bucket("plugins-bucket", sse=True)
    pulumi.export("plugins-bucket", plugins_bucket.bucket)

    plugin_buckets = [
        analyzers_bucket,
        model_plugins_bucket,
    ]
the variable plugins_bucket is not in plugin_buckets
```
> [cm] [4:07 PM](https://grapl-internal.slack.com/archives/C017F10727P/p1652904470386639)
> That's a thorny bit of code from a naming perspective... plugins_bucket, model_plugins_bucket, plugin_buckets