### PR TITLE
Make 'make test-with-env' not print out a bunch of useless commands; make 'dump_artifacts' fail gracefully

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ test-e2e: ## Build and run e2e tests
 # Think of it as a Context Manager that:
 # - Before test-time, brings up a `make up`
 # - After test-time, tears it all down and dumps artifacts.
-.SILENT:
+.SILENT: test-with-env
 .PHONY: test-with-env
 test-with-env: # (Do not include help text - not to be used directly)
 	stopGrapl() {
@@ -465,7 +465,7 @@ up: build-local-infrastructure _up
 
 # NOTE: Internal target to decouple the building of images from the
 # running of them. Do not invoke this directly.
-.SILENT:
+.SILENT: _up
 .PHONY: _up
 _up:
 	# Primarily used for bringing up an environment for integration testing.

--- a/Makefile
+++ b/Makefile
@@ -331,6 +331,7 @@ test-e2e: ## Build and run e2e tests
 # Think of it as a Context Manager that:
 # - Before test-time, brings up a `make up`
 # - After test-time, tears it all down and dumps artifacts.
+.SILENT:
 .PHONY: test-with-env
 test-with-env: # (Do not include help text - not to be used directly)
 	stopGrapl() {
@@ -464,6 +465,7 @@ up: build-local-infrastructure _up
 
 # NOTE: Internal target to decouple the building of images from the
 # running of them. Do not invoke this directly.
+.SILENT:
 .PHONY: _up
 _up:
 	# Primarily used for bringing up an environment for integration testing.

--- a/etc/ci_scripts/dump_artifacts/analysis/pipeline_message_flow.py
+++ b/etc/ci_scripts/dump_artifacts/analysis/pipeline_message_flow.py
@@ -1,5 +1,7 @@
 import json
+import logging
 import re
+import sys
 from pathlib import Path
 from typing import List, Optional
 
@@ -16,9 +18,17 @@ PRIORITIZATION = [
     "engagement-creator.stdout",
 ]
 
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+LOGGER.addHandler(logging.StreamHandler(stream=sys.stdout))
+
 
 def analyze_grapl_core(artifacts_dir: Path, analysis_dir: Path) -> None:
-    logs_in_grapl_core = list((artifacts_dir / "grapl-core").iterdir())
+    grapl_core_dir = (artifacts_dir / "grapl-core").resolve()
+    if not grapl_core_dir.exists():
+        LOGGER.debug(f"grapl-core didn't come up, cannto analyze")
+        return
+    logs_in_grapl_core = list(grapl_core_dir.iterdir())
     # Find any logs that match the patterns listed in PRIORITIZATION,
     # in that order.
     maybe_paths = [

--- a/etc/ci_scripts/dump_artifacts/analysis/pipeline_message_flow.py
+++ b/etc/ci_scripts/dump_artifacts/analysis/pipeline_message_flow.py
@@ -26,7 +26,7 @@ LOGGER.addHandler(logging.StreamHandler(stream=sys.stdout))
 def analyze_grapl_core(artifacts_dir: Path, analysis_dir: Path) -> None:
     grapl_core_dir = (artifacts_dir / "grapl-core").resolve()
     if not grapl_core_dir.exists():
-        LOGGER.debug(f"grapl-core didn't come up, cannto analyze")
+        LOGGER.debug(f"grapl-core didn't come up, can't analyze")
         return
     logs_in_grapl_core = list(grapl_core_dir.iterdir())
     # Find any logs that match the patterns listed in PRIORITIZATION,


### PR DESCRIPTION
1. test-with-env printed out a bunch of useless commands; `.SILENT` quiets them.

2. `dump_artifacts` would print out a stack trace when grapl-core/ didn't exist for analysis, gross!