### PR TITLE
Ensure Consul agent is up before Nomad starts

### DIFF
--- a/nomad/local/start_detach.sh
+++ b/nomad/local/start_detach.sh
@@ -84,7 +84,7 @@ start_nomad_detach() {
 
     # Ensure Consul agent is up and running
     (
-        readonly wait_secs=45
+        readonly wait_secs=15
         # shellcheck disable=SC2016
         timeout --foreground "${wait_secs}" bash -c -- "$(
             cat << EOF
@@ -114,7 +114,7 @@ EOF
 
     # Ensure Nomad agent is ready
     (
-        readonly wait_secs=45
+        readonly wait_secs=30
         # shellcheck disable=SC2016
         timeout --foreground "${wait_secs}" bash -c -- "$(
             cat << EOF

--- a/nomad/local/start_detach.sh
+++ b/nomad/local/start_detach.sh
@@ -73,12 +73,8 @@ start_nomad_detach() {
     create_dynamic_consul_config
 
     echo "Starting nomad and consul locally. Logs @ ${NOMAD_LOGS_DEST} and ${CONSUL_LOGS_DEST}."
-    # These will run forever until `make stop-nomad-ci` is invoked."
-    # shellcheck disable=SC2024
-    sudo nomad agent \
-        -config="${THIS_DIR}/nomad-agent-conf.nomad" \
-        -dev-connect > "${NOMAD_LOGS_DEST}" &
-    local -r nomad_agent_pid="$!"
+    # Consul/Nomad  will run forever until `make down` is invoked."
+
     # The client is set to 0.0.0.0 here so that it can be reached via pulumi in docker.
     consul agent \
         -client 0.0.0.0 -config-file "${THIS_DIR}/consul-agent-conf.hcl" \
@@ -109,6 +105,12 @@ start_nomad_detach() {
 EOF
         )"
     )
+
+    # shellcheck disable=SC2024
+    sudo nomad agent \
+        -config="${THIS_DIR}/nomad-agent-conf.nomad" \
+        -dev-connect > "${NOMAD_LOGS_DEST}" &
+    local -r nomad_agent_pid="$!"
 
     # Ensure Nomad agent is ready
     (


### PR DESCRIPTION
[wimax](https://app.slack.com/team/U0175EMAA5U)  [2:07 PM](https://grapl-internal.slack.com/archives/C02JCBKS97V/p1653070056555209)

I'm seeing CI having trouble with nomad_local_infrastructure. Not 100% sure why, but I just found the following in the logs:
```
    2022-05-20T15:44:20Z: Task Group "plugin-work-queue-db" (failed to place 1 allocation):
      * Constraint "${attr.consul.version} semver >= 1.7.0": 1 nodes excluded by filter
    2022-05-20T15:44:20Z: Task Group "organization-management-db" (failed to place 1 allocation):
      * Constraint "${attr.consul.version} semver >= 1.7.0": 1 nodes excluded by filter
etc etc
```

[wimax](https://app.slack.com/team/U0175EMAA5U)  [2:45 PM](https://grapl-internal.slack.com/archives/C02JCBKS97V/p1653072305270219)
i can repro locally after updating to nomad 1.3.0
it appears to be nondeterministic
as such, my suspicion is that the nomad agent expects the consul agent to be fully up-and-ready before you deploy anything to it, and we don't have any explicit check for that
[2:45](https://grapl-internal.slack.com/archives/C02JCBKS97V/p1653072346751579)
and this expectation is new as of nomad 1.3 (edited)


Relates to https://github.com/hashicorp/nomad/issues/12958