### PR TITLE
Update Nomad to 1.3.1 to address a CVE

### DIFF
--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -278,7 +278,7 @@ install_hashicorp_tools() {
 
     # Set specific versions since we're enabling the hashicorp test repo
     CONSUL_VERSION="1.12.0-1"
-    NOMAD_VERSION="1.3.0-1"
+    NOMAD_VERSION="1.3.1-1"
     # packer doesn't have the -1s at the end for some reason
     PACKER_VERSION="1.8.0"
     VAULT_VERSION="1.10.2-1"


### PR DESCRIPTION
See https://github.com/hashicorp/nomad/releases/tag/v1.3.1

Signed-off-by: Christopher Maier <chris@graplsecurity.com>

