### PR TITLE
Stop uploading Firecracker assets in Pulumi, because it seems to slow down localstack/pulumi a lot?

### DIFF
--- a/pulumi/infra/firecracker_assets.py
+++ b/pulumi/infra/firecracker_assets.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Protocol
 
 import pulumi_aws as aws
 from infra import config
@@ -47,7 +47,20 @@ class FirecrackerAssets(pulumi.ComponentResource):
         )
 
 
-class FirecrackerS3BucketObjects(pulumi.ComponentResource):
+class FirecrackerS3BucketObjectsProtocol(Protocol):
+    kernel_s3obj_url: pulumi.Output[str]
+    rootfs_s3obj_url: pulumi.Output[str]
+
+
+class MockFirecrackerS3BucketObjects(FirecrackerS3BucketObjectsProtocol):
+    def __init__(self) -> None:
+        self.kernel_s3obj_url = pulumi.Output.from_input("mock kernel s3obj url")
+        self.rootfs_s3obj_url = pulumi.Output.from_input("mock rootfs s3obj url")
+
+
+class FirecrackerS3BucketObjects(
+    pulumi.ComponentResource, FirecrackerS3BucketObjectsProtocol
+):
     def __init__(
         self,
         name: str,

--- a/pulumi/infra/firecracker_assets.py
+++ b/pulumi/infra/firecracker_assets.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from typing import Optional
-from typing_extensions import Protocol
 
 import pulumi_aws as aws
 from infra import config
@@ -8,6 +7,7 @@ from infra.artifacts import ArtifactGetter
 from infra.bucket import Bucket
 from infra.path import path_from_root
 from infra.s3_url import get_s3_url
+from typing_extensions import Protocol
 
 import pulumi
 

--- a/pulumi/infra/firecracker_assets.py
+++ b/pulumi/infra/firecracker_assets.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import Optional
+from typing_extensions import Protocol
 
 import pulumi_aws as aws
 from infra import config


### PR DESCRIPTION
Per Jesse:
> [can confirm commenting out all that firecracker_assets stuff speeds up the build considerably
](https://grapl-internal.slack.com/archives/C02JCBKS97V/p1653083673716289
)

Since Firecracker is currently on the backburner, let's temporarily feature gate this stuff away.

### Which issue does this PR correspond to?
Relates to https://github.com/grapl-security/issue-tracker/issues/908
Once we switch back to Firecracker we need to remove this feature gate.


<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Hide a big S3 upload behind an `if false` basically

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
CI

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
