### PR TITLE
Rust integration tests now do not capture stdout even if they pass

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1986,6 +1986,7 @@ name = "grapl-utils"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "clap 3.1.17",
  "rusoto_core",
  "rusoto_dynamodb",
  "tokio",

--- a/src/rust/grapl-utils/Cargo.toml
+++ b/src/rust/grapl-utils/Cargo.toml
@@ -14,3 +14,11 @@ rusoto_core = { version = "0.47.0", default_features = false, features = [
 rusoto_dynamodb = { version = "0.47.0", default_features = false, features = [
   "rustls"
 ] }
+# Only if clap-ext feature is enabled
+clap = { version = "3.0", optional = true, default_features = false, features = [
+  "env",
+  "derive",
+] }
+
+[features]
+clap = ["dep:clap"]

--- a/src/rust/grapl-utils/src/clap_ext.rs
+++ b/src/rust/grapl-utils/src/clap_ext.rs
@@ -1,0 +1,17 @@
+use clap::Parser;
+
+pub trait ParserExt: Parser {
+    /// The default parse() in Clap reads arguments from the CLI.
+    /// This can cause some unexpected interop with Cargo Test --nocapture.
+    /// Since we only use the environment variables, I'm jut short-circuiting
+    /// that behavior.
+    fn parse_from_env() -> Self {
+        // P.S. I've added a request to clap-rs for this to become a fully
+        // supported feature:
+        // https://github.com/clap-rs/clap/issues/3741
+        let iter = std::iter::empty::<&str>();
+        Self::parse_from(iter)
+    }
+}
+
+impl<T> ParserExt for T where T: Parser {}

--- a/src/rust/grapl-utils/src/lib.rs
+++ b/src/rust/grapl-utils/src/lib.rs
@@ -1,3 +1,6 @@
 pub mod future_ext;
 pub mod iter_ext;
 pub mod rusoto_ext;
+
+#[cfg(feature = "clap")]
+pub mod clap_ext;

--- a/src/rust/plugin-registry/Cargo.toml
+++ b/src/rust/plugin-registry/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "3.0", default_features = false, features = [
   "derive"
 ] }
 grapl-config = { path = "../grapl-config" }
-grapl-utils = { path = "../grapl-utils" }
+grapl-utils = { path = "../grapl-utils", features = ["clap"] }
 rust-proto-new = { path = "../rust-proto-new" }
 nomad-client-gen = { path = "../nomad-client-gen" }
 serde_json = "1.0.72"

--- a/src/rust/plugin-registry/src/nomad/client.rs
+++ b/src/rust/plugin-registry/src/nomad/client.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use clap::Parser;
+use grapl_utils::clap_ext::ParserExt;
 use nomad_client_gen::{
     apis::{
         configuration::Configuration as InternalConfig,
@@ -41,7 +41,7 @@ pub enum NomadClientError {
 impl NomadClient {
     /// Create a client from environment
     pub fn from_env() -> Self {
-        Self::from_client_config(NomadClientConfig::parse())
+        Self::from_client_config(NomadClientConfig::parse_from_env())
     }
 
     pub fn from_client_config(nomad_client_config: NomadClientConfig) -> Self {

--- a/test/run/rust-integration-tests.sh
+++ b/test/run/rust-integration-tests.sh
@@ -13,7 +13,7 @@ declare -a FAILING_TESTS=()
 for test in $(find /tests -type f -executable -exec readlink -f {} \;); do
     echo "--- Executing ${test}"
     # Redirect stderr so it's inline with stdout
-    "${test}"
+    "${test}" --nocapture 2>&1
     exit_code=$?
     if [[ ${exit_code} -ne 0 ]]; then
         FAILING_TESTS+=("${test}")


### PR DESCRIPTION
Currently, integration tests will just swallow all their output if they succeed.

This verbosity can help with debugging.

Relates to https://github.com/clap-rs/clap/issues/3741