### PR TITLE
Fix ReadTheDocs builds by using Pants-driven virtualenv instead of a homespun one

### DIFF
--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -6,6 +6,7 @@ THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
 cd "${THIS_DIR}/.."
 # Create a virtualenv from Pants
 ./pants export ::
+# shellcheck disable=SC1090
 source "dist/export/python/virtualenv/$(cat .python-version)/bin/activate"
 
 cd "${THIS_DIR}"

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 set -euo pipefail
-
 THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
-cd "${THIS_DIR}"
 
-python3 -m venv venv
-# shellcheck disable=SC1091
-source venv/bin/activate
+cd "${THIS_DIR}/.."
+# Create a virtualenv from Pants
+./pants export ::
+source "dist/export/python/virtualenv/$(cat .python-version)/bin/activate"
+
+cd "${THIS_DIR}"
 pip install wheel
 pip install -r requirements.txt
 


### PR DESCRIPTION
[wimax](https://app.slack.com/team/U0175EMAA5U)  [11:09 AM](https://grapl-internal.slack.com/archives/C02JCBKS97V/p1653750582427179)
Somewhere along the line, grapl/verify has stopped working for the very-very-legacy Makefile target make build-docs. It doesn't use pants or pyenv or anything, just a python3 -m venv to manage its requirements. This is due to how RtD works, it executes pre-defined commands.
https://docs.readthedocs.io/en/stable/builds.html
https://buildkite.com/grapl/grapl-verify/builds/3627#01810b0d-323a-4b2b-a7f2-dbfc018b73ae