### PR TITLE
An assortment of small fixes around Devbox and chromeos/setup.sh

### DIFF
--- a/devbox/provision/deprovision.sh
+++ b/devbox/provision/deprovision.sh
@@ -9,4 +9,6 @@ source "${THIS_DIR}/../lib.sh"
 
 pulumi destroy --yes --cwd="${GRAPL_ROOT}/devbox/provision"
 
+pulumi config rm "devbox:public-key" --cwd="${GRAPL_ROOT}/devbox/provision"
+
 rm -rf "${GRAPL_DEVBOX_DIR}"

--- a/devbox/provision/provision.sh
+++ b/devbox/provision/provision.sh
@@ -158,5 +158,9 @@ EOF
     )"
     # There's a minor race condition here, where Pulumi starts the box but it's
     # not ready to take SSH-over-SSM commands quite yet.
+    "${THIS_DIR}/../ssh.sh" -- "echo 'ensuring devbox reachable'" || (
+        echo "Wait 5m for the box to come up and rerun to complete provisioning"
+        exit 1
+    )
     "${THIS_DIR}/../ssh.sh" -- "${CMD}"
 )

--- a/etc/chromeos/lib/installs.sh
+++ b/etc/chromeos/lib/installs.sh
@@ -273,7 +273,7 @@ install_hashicorp_tools() {
     PACKER_VERSION="1.8.0"
     VAULT_VERSION="1.10.2-1"
 
-    sudo apt-get install --yes \
+    sudo apt-get install --yes --allow-downgrades \
         consul="${CONSUL_VERSION}" \
         nomad="${NOMAD_VERSION}" \
         packer="${PACKER_VERSION}" \


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
none
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
1. Provisioning, then deprovisioning, then provisioning would fail because we'd preserve the previous SSH key. That's fixed.
2. We had a "downgrade" in our Vault versions (by adding a x.y.z-hyphenated version) to some of our Hashicorp products. Updated the script to allow for this edge case with an --allow-downgrades.
3. Harden the provisioning step where there's an SSH invoke afterwards

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
