### PR TITLE
Strip debuginfo in default local-grapl rust builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # required for our local usage of Nomad, because Nomad won't resolve a
 # `latest` tag from the host machine.)
 IMAGE_TAG ?= dev
-RUST_BUILD ?= debug
+RUST_BUILD ?= dev-local-grapl
 UID = $(shell id --user)
 GID = $(shell id --group)
 PWD = $(shell pwd)

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -64,7 +64,7 @@ variable "RELEASE_BUILD" {
 # our Rust projects. Otherwise, we'll stick with the standard debug
 # profile.
 variable "RUST_BUILD" {
-  default = RELEASE_BUILD ? "release" : "debug"
+  default = RELEASE_BUILD ? "release" : "dev-local-grapl"
 }
 
 # This is the directory that certain artifacts will be deposited into

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -35,3 +35,7 @@ members = [
 
 [profile.dev]
 opt-level = 1
+# Remove this if you're trying to debug with gdb.
+# Results in a roughly 20x binary size reduction, for example
+# sysmon-generator: 279M -> 16M
+strip = "debuginfo"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -35,7 +35,10 @@ members = [
 
 [profile.dev]
 opt-level = 1
+
+[profile.dev-local-grapl]
+inherits = "dev"
 # Remove this if you're trying to debug with gdb.
-# Results in a roughly 20x binary size reduction, for example
+# Results in a ~20x binary size reduction, for example
 # sysmon-generator: 279M -> 16M
 strip = "debuginfo"

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM rust:1-slim-bullseye AS base
 
-ARG RUST_BUILD=debug
+ARG RUST_BUILD=dev-local-grapl
 
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 
@@ -76,7 +76,9 @@ RUN --mount=type=cache,target="${CARGO_TARGET_DIR}",sharing=locked \
     --mount=type=cache,target="${RUSTUP_CACHE_TARGET}",sharing=locked <<EOF
     case "${RUST_BUILD}" in
       debug)
-        cargo build ;;
+        cargo build;;
+      dev-local-grapl)
+        cargo build --profile dev-local-grapl;;
       release)
         cargo build --release ;;
       test)


### PR DESCRIPTION
Introduced a new Cargo build profile, `dev-local-grapl`, that's basically the same as debug but without debuginfo.
- Symbols are still there.
- But you basically can't use `gdb` on it.
You can get debuginfo back by running with RUST_BUILD=debug.