### PR TITLE
Simplify postgres database stuff by passing it around Pulumi/Nomad as a structured Object

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -114,7 +114,7 @@ variable "plugin_registry_db" {
     username = string
     password = string
   })
-  description = "Vars for the Plugin Registry database"
+  description = "Vars for plugin-registry database"
 }
 
 variable "plugin_registry_kernel_artifact_url" {
@@ -134,7 +134,7 @@ variable "organization_management_db" {
     username = string
     password = string
   })
-  description = "Vars for the Organization Management database"
+  description = "Vars for organization-management database"
 }
 
 variable "pipeline_ingress_healthcheck_polling_interval_ms" {
@@ -159,7 +159,7 @@ variable "plugin_work_queue_db" {
     username = string
     password = string
   })
-  description = "Vars for the plugin-work-queue database"
+  description = "Vars for plugin-work-queue database"
 }
 
 variable "uid_allocator_db" {
@@ -169,7 +169,7 @@ variable "uid_allocator_db" {
     username = string
     password = string
   })
-  description = "Vars for the uid-allocator database"
+  description = "Vars for uid-allocator database"
 }
 
 variable "plugin_registry_bucket_aws_account_id" {

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -107,24 +107,14 @@ variable "session_table_name" {
   description = "What is the name of the session table?"
 }
 
-variable "plugin_registry_db_hostname" {
-  type        = string
-  description = "What is the host for the plugin registry table?"
-}
-
-variable "plugin_registry_db_port" {
-  type        = string
-  description = "What is the port for the plugin registry table?"
-}
-
-variable "plugin_registry_db_username" {
-  type        = string
-  description = "What is the username for the plugin registry table?"
-}
-
-variable "plugin_registry_db_password" {
-  type        = string
-  description = "What is the password for the plugin registry table?"
+variable "plugin_registry_db" {
+  type = object({
+    hostname = string
+    port     = number
+    username = string
+    password = string
+  })
+  description = "Vars for the Plugin Registry database"
 }
 
 variable "plugin_registry_kernel_artifact_url" {
@@ -137,24 +127,14 @@ variable "plugin_registry_rootfs_artifact_url" {
   description = "URL specifying the rootfs.tar.gz for the Firecracker VM"
 }
 
-variable "organization_management_db_hostname" {
-  type        = string
-  description = "What is the host for the organization management database?"
-}
-
-variable "organization_management_db_port" {
-  type        = string
-  description = "What is the port for the organization management database?"
-}
-
-variable "organization_management_db_username" {
-  type        = string
-  description = "What is the username for the organization management database?"
-}
-
-variable "organization_management_db_password" {
-  type        = string
-  description = "What is the password for the organization management database?"
+variable "organization_management_db" {
+  type = object({
+    hostname = string
+    port     = number
+    username = string
+    password = string
+  })
+  description = "Vars for the Organization Management database"
 }
 
 variable "pipeline_ingress_healthcheck_polling_interval_ms" {
@@ -1329,10 +1309,10 @@ job "grapl-core" {
         ORGANIZATION_MANAGEMENT_BIND_ADDRESS = "0.0.0.0:${NOMAD_PORT_organization-management-port}"
         RUST_BACKTRACE                       = local.rust_backtrace
         RUST_LOG                             = var.rust_log
-        ORGANIZATION_MANAGEMENT_DB_HOSTNAME  = var.organization_management_db_hostname
-        ORGANIZATION_MANAGEMENT_DB_PASSWORD  = var.organization_management_db_password
-        ORGANIZATION_MANAGEMENT_DB_PORT      = var.organization_management_db_port
-        ORGANIZATION_MANAGEMENT_DB_USERNAME  = var.organization_management_db_username
+        ORGANIZATION_MANAGEMENT_DB_HOSTNAME  = var.organization_management_db.hostname
+        ORGANIZATION_MANAGEMENT_DB_PASSWORD  = var.organization_management_db.password
+        ORGANIZATION_MANAGEMENT_DB_PORT      = var.organization_management_db.port
+        ORGANIZATION_MANAGEMENT_DB_USERNAME  = var.organization_management_db.username
         OTEL_EXPORTER_JAEGER_AGENT_HOST      = local.tracing_jaeger_endpoint_host
         OTEL_EXPORTER_JAEGER_AGENT_PORT      = local.tracing_jaeger_endpoint_port
       }
@@ -1434,10 +1414,10 @@ job "grapl-core" {
         AWS_REGION                                      = var.aws_region
         NOMAD_SERVICE_ADDRESS                           = "${attr.unique.network.ip-address}:4646"
         PLUGIN_REGISTRY_BIND_ADDRESS                    = "0.0.0.0:${NOMAD_PORT_plugin-registry-port}"
-        PLUGIN_REGISTRY_DB_HOSTNAME                     = var.plugin_registry_db_hostname
-        PLUGIN_REGISTRY_DB_PASSWORD                     = var.plugin_registry_db_password
-        PLUGIN_REGISTRY_DB_PORT                         = var.plugin_registry_db_port
-        PLUGIN_REGISTRY_DB_USERNAME                     = var.plugin_registry_db_username
+        PLUGIN_REGISTRY_DB_HOSTNAME                     = var.plugin_registry_db.hostname
+        PLUGIN_REGISTRY_DB_PASSWORD                     = var.plugin_registry_db.password
+        PLUGIN_REGISTRY_DB_PORT                         = var.plugin_registry_db.port
+        PLUGIN_REGISTRY_DB_USERNAME                     = var.plugin_registry_db.username
         PLUGIN_BOOTSTRAP_CONTAINER_IMAGE                = var.container_images["plugin-bootstrap"]
         PLUGIN_REGISTRY_KERNEL_ARTIFACT_URL             = var.plugin_registry_kernel_artifact_url
         PLUGIN_REGISTRY_ROOTFS_ARTIFACT_URL             = var.plugin_registry_rootfs_artifact_url

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -152,44 +152,24 @@ variable "pipeline_ingress_kafka_sasl_password" {
   description = "The password to authenticate with Confluent Cloud cluster."
 }
 
-variable "plugin_work_queue_db_hostname" {
-  type        = string
-  description = "What is the host for the plugin work queue table?"
+variable "plugin_work_queue_db" {
+  type = object({
+    hostname = string
+    port     = number
+    username = string
+    password = string
+  })
+  description = "Vars for the plugin-work-queue database"
 }
 
-variable "plugin_work_queue_db_port" {
-  type        = string
-  description = "What is the port for the plugin work queue table?"
-}
-
-variable "plugin_work_queue_db_username" {
-  type        = string
-  description = "What is the username for the plugin work queue table?"
-}
-
-variable "plugin_work_queue_db_password" {
-  type        = string
-  description = "What is the password for the plugin work queue table?"
-}
-
-variable "uid_allocator_db_hostname" {
-  type        = string
-  description = "What is the host for the uid-allocator table?"
-}
-
-variable "uid_allocator_db_port" {
-  type        = string
-  description = "What is the port for the uid-allocator table?"
-}
-
-variable "uid_allocator_db_username" {
-  type        = string
-  description = "What is the username for the uid-allocator table?"
-}
-
-variable "uid_allocator_db_password" {
-  type        = string
-  description = "What is the password for the uid-allocator table?"
+variable "uid_allocator_db" {
+  type = object({
+    hostname = string
+    port     = number
+    username = string
+    password = string
+  })
+  description = "Vars for the uid-allocator database"
 }
 
 variable "plugin_registry_bucket_aws_account_id" {
@@ -1484,10 +1464,10 @@ job "grapl-core" {
 
       env {
         PLUGIN_WORK_QUEUE_BIND_ADDRESS = "0.0.0.0:${NOMAD_PORT_plugin-work-queue-port}"
-        PLUGIN_WORK_QUEUE_DB_HOSTNAME  = var.plugin_work_queue_db_hostname
-        PLUGIN_WORK_QUEUE_DB_PASSWORD  = var.plugin_work_queue_db_password
-        PLUGIN_WORK_QUEUE_DB_PORT      = var.plugin_work_queue_db_port
-        PLUGIN_WORK_QUEUE_DB_USERNAME  = var.plugin_work_queue_db_username
+        PLUGIN_WORK_QUEUE_DB_HOSTNAME  = var.plugin_work_queue_db.hostname
+        PLUGIN_WORK_QUEUE_DB_PASSWORD  = var.plugin_work_queue_db.password
+        PLUGIN_WORK_QUEUE_DB_PORT      = var.plugin_work_queue_db.port
+        PLUGIN_WORK_QUEUE_DB_USERNAME  = var.plugin_work_queue_db.username
         # Hardcoded, but makes little sense to pipe up through Pulumi
         PLUGIN_WORK_QUEUE_HEALTHCHECK_POLLING_INTERVAL_MS = 5000
 
@@ -1537,10 +1517,10 @@ job "grapl-core" {
 
       env {
         UID_ALLOCATOR_BIND_ADDRESS      = "0.0.0.0:${NOMAD_PORT_uid-allocator-port}"
-        UID_ALLOCATOR_DB_HOSTNAME       = var.uid_allocator_db_hostname
-        UID_ALLOCATOR_DB_PASSWORD       = var.uid_allocator_db_password
-        UID_ALLOCATOR_DB_PORT           = var.uid_allocator_db_port
-        UID_ALLOCATOR_DB_USERNAME       = var.uid_allocator_db_username
+        UID_ALLOCATOR_DB_HOSTNAME       = var.uid_allocator_db.hostname
+        UID_ALLOCATOR_DB_PASSWORD       = var.uid_allocator_db.password
+        UID_ALLOCATOR_DB_PORT           = var.uid_allocator_db.port
+        UID_ALLOCATOR_DB_USERNAME       = var.uid_allocator_db.username
         RUST_BACKTRACE                  = local.rust_backtrace
         RUST_LOG                        = var.rust_log
         OTEL_EXPORTER_JAEGER_AGENT_HOST = local.tracing_jaeger_endpoint_host

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -35,8 +35,8 @@ variable "zookeeper_port" {
 
 # These Postgres connection data must match what's in
 # `pulumi/grapl/__main__.py`; sorry for the duplication :(
-variable plugin_registry_db {
-  description = "Connection configuration for the Plugin Registry database"
+variable postgres {
+  description = "Connection configuration for every Postgres database"
   type = object({
     username = string
     password = string
@@ -46,48 +46,6 @@ variable plugin_registry_db {
     username = "postgres"
     password = "postgres"
     port     = 5432
-  }
-}
-
-variable plugin_work_queue_db {
-  description = "Connection configuration for the Plugin Work Queue database"
-  type = object({
-    username = string
-    password = string
-    port     = number
-  })
-  default = {
-    username = "postgres"
-    password = "postgres"
-    port     = 5532
-  }
-}
-
-variable organization_management_db {
-  description = "Connection configuration for the Organization Management database"
-  type = object({
-    username = string
-    password = string
-    port     = number
-  })
-  default = {
-    username = "postgres"
-    password = "postgres"
-    port     = 5632
-  }
-}
-
-variable uid_allocator_db {
-  description = "Connection configuration for the Uid Allocator database"
-  type = object({
-    username = string
-    password = string
-    port     = number
-  })
-  default = {
-    username = "postgres"
-    password = "postgres"
-    port     = 5732
   }
 }
 
@@ -306,7 +264,6 @@ job "grapl-local-infra" {
           }
         }
       }
-
     }
   }
 
@@ -358,16 +315,16 @@ job "grapl-local-infra" {
     }
   }
 
-  group "plugin-registry-db" {
+  group "postgres" {
     network {
       mode = "bridge"
       port "postgres" {
-        static = var.plugin_registry_db.port
+        static = var.postgres.port
         to     = 5432 # postgres default
       }
     }
 
-    task "plugin-registry-db" {
+    task "postgres" {
       driver = "docker"
 
       config {
@@ -376,61 +333,18 @@ job "grapl-local-infra" {
       }
 
       env {
-        POSTGRES_USER     = var.plugin_registry_db.username
-        POSTGRES_PASSWORD = var.plugin_registry_db.password
+        POSTGRES_USER     = var.postgres.username
+        POSTGRES_PASSWORD = var.postgres.password
       }
 
       service {
-        name = "plugin-registry-db"
+        name = "postgres"
 
         check {
           type     = "script"
           name     = "check_postgres"
           command  = "pg_isready"
-          args     = ["--username", "${var.plugin_registry_db.username}"]
-          interval = "20s"
-          timeout  = "10s"
-
-          check_restart {
-            limit           = 2
-            grace           = "30s"
-            ignore_warnings = false
-          }
-        }
-      }
-    }
-  }
-
-  group "plugin-work-queue-db" {
-    network {
-      mode = "bridge"
-      port "postgres" {
-        static = var.plugin_work_queue_db.port
-        to     = 5432
-      }
-    }
-
-    task "plugin-work-queue-db" {
-      driver = "docker"
-
-      config {
-        image = "postgres-ext:${var.image_tag}"
-        ports = ["postgres"]
-      }
-
-      env {
-        POSTGRES_USER     = var.plugin_work_queue_db.username
-        POSTGRES_PASSWORD = var.plugin_work_queue_db.password
-      }
-
-      service {
-        name = "plugin-work-queue-db"
-
-        check {
-          type     = "script"
-          name     = "check_postgres"
-          command  = "pg_isready"
-          args     = ["--username", "${var.plugin_work_queue_db.username}"]
+          args     = ["--username", "${var.postgres.username}"]
           interval = "20s"
           timeout  = "10s"
 
@@ -498,94 +412,6 @@ job "grapl-local-infra" {
       }
     }
   }
-
-
-  group "organization-management-db" {
-    network {
-      mode = "bridge"
-      port "postgres" {
-        static = var.organization_management_db.port
-        to     = 5432
-      }
-    }
-
-    task "organization-management-db" {
-      driver = "docker"
-
-      config {
-        image = "postgres-ext:${var.image_tag}"
-        ports = ["postgres"]
-      }
-
-      env {
-        POSTGRES_USER     = var.organization_management_db.username
-        POSTGRES_PASSWORD = var.organization_management_db.password
-      }
-
-      service {
-        name = "organization-management-db"
-
-        check {
-          type     = "script"
-          name     = "check_postgres"
-          command  = "pg_isready"
-          args     = ["--username", "${var.organization_management_db.username}"]
-          interval = "20s"
-          timeout  = "10s"
-
-          check_restart {
-            limit           = 2
-            grace           = "30s"
-            ignore_warnings = false
-          }
-        }
-      }
-    }
-  }
-
-  group "uid-allocator-db" {
-    network {
-      mode = "bridge"
-      port "postgres" {
-        static = var.uid_allocator_db.port
-        to     = 5432
-      }
-    }
-
-    task "uid-allocator-db" {
-      driver = "docker"
-
-      config {
-        image = "postgres-ext:${var.image_tag}"
-        ports = ["postgres"]
-      }
-
-      env {
-        POSTGRES_USER     = var.uid_allocator_db.username
-        POSTGRES_PASSWORD = var.uid_allocator_db.password
-      }
-
-      service {
-        name = "uid-allocator-db"
-
-        check {
-          type     = "script"
-          name     = "check_postgres"
-          command  = "pg_isready"
-          args     = ["--username", "${var.uid_allocator_db.username}"]
-          interval = "20s"
-          timeout  = "10s"
-
-          check_restart {
-            limit           = 2
-            grace           = "30s"
-            ignore_warnings = false
-          }
-        }
-      }
-    }
-  }
-
 
   group "scylla" {
     network {

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -57,48 +57,24 @@ variable "grapl_root" {
   description = "Where to find the Grapl repo on the host OS (where Nomad runs)."
 }
 
-variable "plugin_work_queue_db_hostname" {
-  type        = string
-  description = "The host for the local plugin work queue db"
+variable "plugin_work_queue_db" {
+  type = object({
+    hostname = string
+    port     = number
+    username = string
+    password = string
+  })
+  description = "Vars for the plugin-work-queue database"
 }
 
-variable "plugin_work_queue_db_port" {
-  type        = string
-  default     = "5432"
-  description = "The port for the local plugin_work_queue postgres"
-}
-
-variable "plugin_work_queue_db_username" {
-  type        = string
-  description = "The username for the local plugin_work_queue postgres"
-}
-
-variable "plugin_work_queue_db_password" {
-  type        = string
-  description = "The password for the local plugin_work_queue postgres"
-}
-
-
-
-variable "organization_management_db_hostname" {
-  type        = string
-  description = "The host for the local organization management  db"
-}
-
-variable "organization_management_db_port" {
-  type        = string
-  default     = "5432"
-  description = "The port for the local organization management postgres"
-}
-
-variable "organization_management_db_username" {
-  type        = string
-  description = "The username for the local organization management postgres"
-}
-
-variable "organization_management_db_password" {
-  type        = string
-  description = "The password for the local organization management postgres"
+variable "organization_management_db" {
+  type = object({
+    hostname = string
+    port     = number
+    username = string
+    password = string
+  })
+  description = "Vars for the Organization Management database"
 }
 
 locals {
@@ -196,18 +172,18 @@ job "integration-tests" {
 
         PLUGIN_WORK_QUEUE_BIND_ADDRESS = "0.0.0.0:${NOMAD_UPSTREAM_PORT_plugin-work-queue}"
 
-        PLUGIN_WORK_QUEUE_DB_HOSTNAME = "${var.plugin_work_queue_db_hostname}"
-        PLUGIN_WORK_QUEUE_DB_PORT     = "${var.plugin_work_queue_db_port}"
-        PLUGIN_WORK_QUEUE_DB_USERNAME = "${var.plugin_work_queue_db_username}"
-        PLUGIN_WORK_QUEUE_DB_PASSWORD = "${var.plugin_work_queue_db_password}"
+        PLUGIN_WORK_QUEUE_DB_HOSTNAME = var.plugin_work_queue_db.hostname
+        PLUGIN_WORK_QUEUE_DB_PORT     = var.plugin_work_queue.db_port
+        PLUGIN_WORK_QUEUE_DB_USERNAME = var.plugin_work_queue.db_username
+        PLUGIN_WORK_QUEUE_DB_PASSWORD = var.plugin_work_queue.db_password
 
         ORGANIZATION_MANAGEMENT_ADDRESS      = "http://0.0.0.0:${NOMAD_UPSTREAM_PORT_organization_management}"
         ORGANIZATION_MANAGEMENT_BIND_ADDRESS = "0.0.0.0:${NOMAD_UPSTREAM_PORT_organization_management}"
 
-        ORGANIZATION_MANAGEMENT_DB_HOSTNAME = "${var.organization_management_db_hostname}"
-        ORGANIZATION_MANAGEMENT_DB_PORT     = "${var.organization_management_db_port}"
-        ORGANIZATION_MANAGEMENT_DB_USERNAME = "${var.organization_management_db_username}"
-        ORGANIZATION_MANAGEMENT_DB_PASSWORD = "${var.organization_management_db_password}"
+        ORGANIZATION_MANAGEMENT_DB_HOSTNAME = var.organization_management_db.hostname
+        ORGANIZATION_MANAGEMENT_DB_PORT     = var.organization_management_db.port
+        ORGANIZATION_MANAGEMENT_DB_USERNAME = var.organization_management_db.username
+        ORGANIZATION_MANAGEMENT_DB_PASSWORD = var.organization_management_db.password
 
         NOMAD_SERVICE_ADDRESS = "${attr.unique.network.ip-address}:4646"
       }

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -173,9 +173,9 @@ job "integration-tests" {
         PLUGIN_WORK_QUEUE_BIND_ADDRESS = "0.0.0.0:${NOMAD_UPSTREAM_PORT_plugin-work-queue}"
 
         PLUGIN_WORK_QUEUE_DB_HOSTNAME = var.plugin_work_queue_db.hostname
-        PLUGIN_WORK_QUEUE_DB_PORT     = var.plugin_work_queue.db_port
-        PLUGIN_WORK_QUEUE_DB_USERNAME = var.plugin_work_queue.db_username
-        PLUGIN_WORK_QUEUE_DB_PASSWORD = var.plugin_work_queue.db_password
+        PLUGIN_WORK_QUEUE_DB_PORT     = var.plugin_work_queue_db.port
+        PLUGIN_WORK_QUEUE_DB_USERNAME = var.plugin_work_queue_db.username
+        PLUGIN_WORK_QUEUE_DB_PASSWORD = var.plugin_work_queue_db.password
 
         ORGANIZATION_MANAGEMENT_ADDRESS      = "http://0.0.0.0:${NOMAD_UPSTREAM_PORT_organization_management}"
         ORGANIZATION_MANAGEMENT_BIND_ADDRESS = "0.0.0.0:${NOMAD_UPSTREAM_PORT_organization_management}"

--- a/nomad/local/integration-tests.nomad
+++ b/nomad/local/integration-tests.nomad
@@ -64,7 +64,7 @@ variable "plugin_work_queue_db" {
     username = string
     password = string
   })
-  description = "Vars for the plugin-work-queue database"
+  description = "Vars for plugin-work-queue database"
 }
 
 variable "organization_management_db" {
@@ -74,7 +74,7 @@ variable "organization_management_db" {
     username = string
     password = string
   })
-  description = "Vars for the Organization Management database"
+  description = "Vars for organization-management database"
 }
 
 locals {

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -479,7 +479,7 @@ def main() -> None:
             nomad_agent_security_group_id=nomad_agent_security_group_id,
         )
 
-        organization_management_postgres = Postgres(
+        organization_management_db = Postgres(
             name="organization-management",
             subnet_ids=subnet_ids,
             vpc_id=vpc_id,
@@ -487,7 +487,7 @@ def main() -> None:
             nomad_agent_security_group_id=nomad_agent_security_group_id,
         )
 
-        plugin_registry_postgres = Postgres(
+        plugin_registry_db = Postgres(
             name="plugin-registry",
             subnet_ids=subnet_ids,
             vpc_id=vpc_id,
@@ -495,7 +495,7 @@ def main() -> None:
             nomad_agent_security_group_id=nomad_agent_security_group_id,
         )
 
-        plugin_work_queue_postgres = Postgres(
+        plugin_work_queue_db = Postgres(
             name="plugin-work-queue",
             subnet_ids=subnet_ids,
             vpc_id=vpc_id,
@@ -503,7 +503,7 @@ def main() -> None:
             nomad_agent_security_group_id=nomad_agent_security_group_id,
         )
 
-        uid_allocator_postgres = Postgres(
+        uid_allocator_db = Postgres(
             name="uid-allocator-db",
             subnet_ids=subnet_ids,
             vpc_id=vpc_id,
@@ -513,12 +513,12 @@ def main() -> None:
 
         pulumi.export(
             "organization-management-db",
-            organization_management_postgres.to_nomad_service_db_args(),
+            organization_management_db.to_nomad_service_db_args(),
         )
 
         pulumi.export(
             "plugin-work-queue-db",
-            plugin_work_queue_postgres.to_nomad_service_db_args(),
+            plugin_work_queue_db.to_nomad_service_db_args(),
         )
 
         # Not currently imported in integration tests:
@@ -530,12 +530,12 @@ def main() -> None:
         prod_grapl_core_vars: Final[NomadVars] = dict(
             # The vars with a leading underscore indicate that the hcl local version of the variable should be used
             # instead of the var version.
-            organization_management_db=organization_management_postgres.to_nomad_service_db_args(),
+            organization_management_db=organization_management_db.to_nomad_service_db_args(),
             pipeline_ingress_kafka_sasl_password=pipeline_ingress_kafka_credentials.api_secret,
             pipeline_ingress_kafka_sasl_username=pipeline_ingress_kafka_credentials.api_key,
-            plugin_registry_db=plugin_registry_postgres.to_nomad_service_db_args(),
-            plugin_work_queue_db=plugin_work_queue_postgres.to_nomad_service_db_args(),
-            uid_allocator_db=uid_allocator_postgres.to_nomad_service_db_args(),
+            plugin_registry_db=plugin_registry_db.to_nomad_service_db_args(),
+            plugin_work_queue_db=plugin_work_queue_db.to_nomad_service_db_args(),
+            uid_allocator_db=uid_allocator_db.to_nomad_service_db_args(),
             redis_endpoint=cache.endpoint,
             **nomad_inputs,
         )

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -412,16 +412,10 @@ def main() -> None:
         )
 
         local_grapl_core_vars: Final[NomadVars] = dict(
-            organization_management_db_hostname=organization_management_db.hostname,
-            organization_management_db_port=str(organization_management_db.port),
-            organization_management_db_username=organization_management_db.username,
-            organization_management_db_password=organization_management_db.password,
+            organization_management_db=organization_management_db.to_nomad_vars(),
             pipeline_ingress_kafka_sasl_username="fake",
             pipeline_ingress_kafka_sasl_password="fake",
-            plugin_registry_db_hostname=plugin_registry_db.hostname,
-            plugin_registry_db_port=str(plugin_registry_db.port),
-            plugin_registry_db_username=plugin_registry_db.username,
-            plugin_registry_db_password=plugin_registry_db.password,
+            plugin_registry_db=plugin_registry_db.to_nomad_vars(),
             plugin_work_queue_db_hostname=plugin_work_queue_db.hostname,
             plugin_work_queue_db_port=str(plugin_work_queue_db.port),
             plugin_work_queue_db_username=plugin_work_queue_db.username,

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -374,30 +374,18 @@ def main() -> None:
             port=5732,
         )
 
-        pulumi.export("plugin-work-queue-db-hostname", plugin_work_queue_db.hostname)
-        pulumi.export("plugin-work-queue-db-port", str(plugin_work_queue_db.port))
-        pulumi.export("plugin-work-queue-db-username", plugin_work_queue_db.username)
-        pulumi.export("plugin-work-queue-db-password", plugin_work_queue_db.password)
-
-        pulumi.export("uid-allocator-db-hostname", uid_allocator_db.hostname)
-        pulumi.export("uid-allocator-db-port", str(uid_allocator_db.port))
-        pulumi.export("uid-allocator-db-username", uid_allocator_db.username)
-        pulumi.export("uid-allocator-db-password", uid_allocator_db.password)
-
-        # TODO: ADD EXPORTS FOR PLUGIN-REGISTRY
+        pulumi.export(
+            "organization-management-db",
+            organization_management_db.to_nomad_service_db_args(),
+        )
 
         pulumi.export(
-            "organization-management-db-hostname", organization_management_db.hostname
+            "plugin-work-queue-db", plugin_work_queue_db.to_nomad_service_db_args()
         )
-        pulumi.export(
-            "organization-management-db-port", str(organization_management_db.port)
-        )
-        pulumi.export(
-            "organization-management-db-username", organization_management_db.username
-        )
-        pulumi.export(
-            "organization-management-db-password", organization_management_db.password
-        )
+
+        # Not currently imported in integration tests:
+        # - uid-allocator-db
+        # - plugin-registry-db
 
         redis_endpoint = f"redis://{config.HOST_IP_IN_NOMAD}:6379"
 
@@ -416,14 +404,8 @@ def main() -> None:
             pipeline_ingress_kafka_sasl_username="fake",
             pipeline_ingress_kafka_sasl_password="fake",
             plugin_registry_db=plugin_registry_db.to_nomad_service_db_args(),
-            plugin_work_queue_db_hostname=plugin_work_queue_db.hostname,
-            plugin_work_queue_db_port=str(plugin_work_queue_db.port),
-            plugin_work_queue_db_username=plugin_work_queue_db.username,
-            plugin_work_queue_db_password=plugin_work_queue_db.password,
-            uid_allocator_db_hostname=uid_allocator_db.hostname,
-            uid_allocator_db_port=str(uid_allocator_db.port),
-            uid_allocator_db_username=uid_allocator_db.username,
-            uid_allocator_db_password=uid_allocator_db.password,
+            plugin_work_queue_db=plugin_work_queue_db.to_nomad_service_db_args(),
+            uid_allocator_db=uid_allocator_db.to_nomad_service_db_args(),
             redis_endpoint=redis_endpoint,
             **nomad_inputs,
         )
@@ -530,47 +512,18 @@ def main() -> None:
         )
 
         pulumi.export(
-            "organization-management-db-hostname",
-            organization_management_postgres.host(),
-        )
-        pulumi.export(
-            "organization-management-db-port",
-            organization_management_postgres.port().apply(str),
-        )
-        pulumi.export(
-            "organization-management-db-username",
-            organization_management_postgres.username(),
-        )
-        pulumi.export(
-            "organization-management-db-password",
-            organization_management_postgres.password(),
+            "organization-management-db",
+            organization_management_postgres.to_nomad_service_db_args(),
         )
 
         pulumi.export(
-            "plugin-work-queue-db-hostname", plugin_work_queue_postgres.host()
-        )
-        pulumi.export(
-            "plugin-work-queue-db-port", plugin_work_queue_postgres.port().apply(str)
-        )
-        pulumi.export(
-            "plugin-work-queue-db-username",
-            plugin_work_queue_postgres.username(),
-        )
-        pulumi.export(
-            "plugin-work-queue-db-password",
-            plugin_work_queue_postgres.password(),
+            "plugin-work-queue-db",
+            plugin_work_queue_postgres.to_nomad_service_db_args(),
         )
 
-        pulumi.export("uid-allocator-db-hostname", uid_allocator_postgres.host())
-        pulumi.export("uid-allocator-db-port", uid_allocator_postgres.port().apply(str))
-        pulumi.export(
-            "uid-allocator-db-username",
-            uid_allocator_postgres.username(),
-        )
-        pulumi.export(
-            "uid-allocator-db-password",
-            uid_allocator_postgres.password(),
-        )
+        # Not currently imported in integration tests:
+        # - uid-allocator-db
+        # - plugin-registry-db
 
         pulumi.export("redis-endpoint", cache.endpoint)
 
@@ -578,20 +531,11 @@ def main() -> None:
             # The vars with a leading underscore indicate that the hcl local version of the variable should be used
             # instead of the var version.
             organization_management_db=organization_management_postgres.to_nomad_service_db_args(),
-            pipeline_ingress_kafka_sasl_username=pipeline_ingress_kafka_credentials.api_key,
             pipeline_ingress_kafka_sasl_password=pipeline_ingress_kafka_credentials.api_secret,
-            plugin_registry_db_hostname=plugin_registry_postgres.host(),
-            plugin_registry_db_port=plugin_registry_postgres.port().apply(str),
-            plugin_registry_db_username=plugin_registry_postgres.username(),
-            plugin_registry_db_password=plugin_registry_postgres.password(),
-            plugin_work_queue_db_hostname=plugin_work_queue_postgres.host(),
-            plugin_work_queue_db_port=plugin_work_queue_postgres.port().apply(str),
-            plugin_work_queue_db_username=plugin_work_queue_postgres.username(),
-            plugin_work_queue_db_password=plugin_work_queue_postgres.password(),
-            uid_allocator_db_hostname=uid_allocator_postgres.host(),
-            uid_allocator_db_port=uid_allocator_postgres.port().apply(str),
-            uid_allocator_db_username=uid_allocator_postgres.username(),
-            uid_allocator_db_password=uid_allocator_postgres.password(),
+            pipeline_ingress_kafka_sasl_username=pipeline_ingress_kafka_credentials.api_key,
+            plugin_registry_db=plugin_registry_postgres.to_nomad_service_db_args(),
+            plugin_work_queue_db=plugin_work_queue_postgres.to_nomad_service_db_args(),
+            uid_allocator_db=uid_allocator_postgres.to_nomad_service_db_args(),
             redis_endpoint=cache.endpoint,
             **nomad_inputs,
         )

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -412,10 +412,10 @@ def main() -> None:
         )
 
         local_grapl_core_vars: Final[NomadVars] = dict(
-            organization_management_db=organization_management_db.to_nomad_vars(),
+            organization_management_db=organization_management_db.to_nomad_service_db_args(),
             pipeline_ingress_kafka_sasl_username="fake",
             pipeline_ingress_kafka_sasl_password="fake",
-            plugin_registry_db=plugin_registry_db.to_nomad_vars(),
+            plugin_registry_db=plugin_registry_db.to_nomad_service_db_args(),
             plugin_work_queue_db_hostname=plugin_work_queue_db.hostname,
             plugin_work_queue_db_port=str(plugin_work_queue_db.port),
             plugin_work_queue_db_username=plugin_work_queue_db.username,
@@ -577,12 +577,7 @@ def main() -> None:
         prod_grapl_core_vars: Final[NomadVars] = dict(
             # The vars with a leading underscore indicate that the hcl local version of the variable should be used
             # instead of the var version.
-            organization_management_db_hostname=organization_management_postgres.host(),
-            organization_management_db_port=organization_management_postgres.port().apply(
-                str
-            ),
-            organization_management_db_username=organization_management_postgres.username(),
-            organization_management_db_password=organization_management_postgres.password(),
+            organization_management_db=organization_management_postgres.to_nomad_service_db_args(),
             pipeline_ingress_kafka_sasl_username=pipeline_ingress_kafka_credentials.api_key,
             pipeline_ingress_kafka_sasl_password=pipeline_ingress_kafka_credentials.api_secret,
             plugin_registry_db_hostname=plugin_registry_postgres.host(),

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -354,34 +354,49 @@ def main() -> None:
         #
         # There's not really a great way to deal with this duplication
         # at the moment, sadly.
-        postgres_db = LocalPostgresInstance(
-            name="postgres-db",
+        organization_management_db = LocalPostgresInstance(
+            name="organization-management-db",
+            port=5632,
+        )
+
+        plugin_registry_db = LocalPostgresInstance(
+            name="plugin-registry-db",
             port=5432,
         )
 
-        pulumi.export("plugin-work-queue-db-hostname", postgres_db.hostname)
-        pulumi.export("plugin-work-queue-db-port", str(postgres_db.port))
-        pulumi.export("plugin-work-queue-db-username", postgres_db.username)
-        pulumi.export("plugin-work-queue-db-password", postgres_db.password)
+        plugin_work_queue_db = LocalPostgresInstance(
+            name="plugin-work-queue-db",
+            port=5532,
+        )
 
-        pulumi.export("uid-allocator-db-hostname", postgres_db.hostname)
-        pulumi.export("uid-allocator-db-port", str(postgres_db.port))
-        pulumi.export("uid-allocator-db-username", postgres_db.username)
-        pulumi.export("uid-allocator-db-password", postgres_db.password)
+        uid_allocator_db = LocalPostgresInstance(
+            name="uid-allocator-db",
+            port=5732,
+        )
+
+        pulumi.export("plugin-work-queue-db-hostname", plugin_work_queue_db.hostname)
+        pulumi.export("plugin-work-queue-db-port", str(plugin_work_queue_db.port))
+        pulumi.export("plugin-work-queue-db-username", plugin_work_queue_db.username)
+        pulumi.export("plugin-work-queue-db-password", plugin_work_queue_db.password)
+
+        pulumi.export("uid-allocator-db-hostname", uid_allocator_db.hostname)
+        pulumi.export("uid-allocator-db-port", str(uid_allocator_db.port))
+        pulumi.export("uid-allocator-db-username", uid_allocator_db.username)
+        pulumi.export("uid-allocator-db-password", uid_allocator_db.password)
 
         # TODO: ADD EXPORTS FOR PLUGIN-REGISTRY
 
         pulumi.export(
-            "organization-management-db-hostname", postgres_db.hostname
+            "organization-management-db-hostname", organization_management_db.hostname
         )
         pulumi.export(
-            "organization-management-db-port", str(postgres_db.port)
+            "organization-management-db-port", str(organization_management_db.port)
         )
         pulumi.export(
-            "organization-management-db-username", postgres_db.username
+            "organization-management-db-username", organization_management_db.username
         )
         pulumi.export(
-            "organization-management-db-password", postgres_db.password
+            "organization-management-db-password", organization_management_db.password
         )
 
         redis_endpoint = f"redis://{config.HOST_IP_IN_NOMAD}:6379"
@@ -397,24 +412,24 @@ def main() -> None:
         )
 
         local_grapl_core_vars: Final[NomadVars] = dict(
-            organization_management_db_hostname=postgres_db.hostname,
-            organization_management_db_port=str(postgres_db.port),
-            organization_management_db_username=postgres_db.username,
-            organization_management_db_password=postgres_db.password,
+            organization_management_db_hostname=organization_management_db.hostname,
+            organization_management_db_port=str(organization_management_db.port),
+            organization_management_db_username=organization_management_db.username,
+            organization_management_db_password=organization_management_db.password,
             pipeline_ingress_kafka_sasl_username="fake",
             pipeline_ingress_kafka_sasl_password="fake",
-            plugin_registry_db_hostname=postgres_db.hostname,
-            plugin_registry_db_port=str(postgres_db.port),
-            plugin_registry_db_username=postgres_db.username,
-            plugin_registry_db_password=postgres_db.password,
-            plugin_work_queue_db_hostname=postgres_db.hostname,
-            plugin_work_queue_db_port=str(postgres_db.port),
-            plugin_work_queue_db_username=postgres_db.username,
-            plugin_work_queue_db_password=postgres_db.password,
-            uid_allocator_db_hostname=postgres_db.hostname,
-            uid_allocator_db_port=str(postgres_db.port),
-            uid_allocator_db_username=postgres_db.username,
-            uid_allocator_db_password=postgres_db.password,
+            plugin_registry_db_hostname=plugin_registry_db.hostname,
+            plugin_registry_db_port=str(plugin_registry_db.port),
+            plugin_registry_db_username=plugin_registry_db.username,
+            plugin_registry_db_password=plugin_registry_db.password,
+            plugin_work_queue_db_hostname=plugin_work_queue_db.hostname,
+            plugin_work_queue_db_port=str(plugin_work_queue_db.port),
+            plugin_work_queue_db_username=plugin_work_queue_db.username,
+            plugin_work_queue_db_password=plugin_work_queue_db.password,
+            uid_allocator_db_hostname=uid_allocator_db.hostname,
+            uid_allocator_db_port=str(uid_allocator_db.port),
+            uid_allocator_db_username=uid_allocator_db.username,
+            uid_allocator_db_password=uid_allocator_db.password,
             redis_endpoint=redis_endpoint,
             **nomad_inputs,
         )

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -354,49 +354,34 @@ def main() -> None:
         #
         # There's not really a great way to deal with this duplication
         # at the moment, sadly.
-        organization_management_db = LocalPostgresInstance(
-            name="organization-management-db",
-            port=5632,
-        )
-
-        plugin_registry_db = LocalPostgresInstance(
-            name="plugin-registry-db",
+        postgres_db = LocalPostgresInstance(
+            name="postgres-db",
             port=5432,
         )
 
-        plugin_work_queue_db = LocalPostgresInstance(
-            name="plugin-work-queue-db",
-            port=5532,
-        )
+        pulumi.export("plugin-work-queue-db-hostname", postgres_db.hostname)
+        pulumi.export("plugin-work-queue-db-port", str(postgres_db.port))
+        pulumi.export("plugin-work-queue-db-username", postgres_db.username)
+        pulumi.export("plugin-work-queue-db-password", postgres_db.password)
 
-        uid_allocator_db = LocalPostgresInstance(
-            name="uid-allocator-db",
-            port=5732,
-        )
-
-        pulumi.export("plugin-work-queue-db-hostname", plugin_work_queue_db.hostname)
-        pulumi.export("plugin-work-queue-db-port", str(plugin_work_queue_db.port))
-        pulumi.export("plugin-work-queue-db-username", plugin_work_queue_db.username)
-        pulumi.export("plugin-work-queue-db-password", plugin_work_queue_db.password)
-
-        pulumi.export("uid-allocator-db-hostname", uid_allocator_db.hostname)
-        pulumi.export("uid-allocator-db-port", str(uid_allocator_db.port))
-        pulumi.export("uid-allocator-db-username", uid_allocator_db.username)
-        pulumi.export("uid-allocator-db-password", uid_allocator_db.password)
+        pulumi.export("uid-allocator-db-hostname", postgres_db.hostname)
+        pulumi.export("uid-allocator-db-port", str(postgres_db.port))
+        pulumi.export("uid-allocator-db-username", postgres_db.username)
+        pulumi.export("uid-allocator-db-password", postgres_db.password)
 
         # TODO: ADD EXPORTS FOR PLUGIN-REGISTRY
 
         pulumi.export(
-            "organization-management-db-hostname", organization_management_db.hostname
+            "organization-management-db-hostname", postgres_db.hostname
         )
         pulumi.export(
-            "organization-management-db-port", str(organization_management_db.port)
+            "organization-management-db-port", str(postgres_db.port)
         )
         pulumi.export(
-            "organization-management-db-username", organization_management_db.username
+            "organization-management-db-username", postgres_db.username
         )
         pulumi.export(
-            "organization-management-db-password", organization_management_db.password
+            "organization-management-db-password", postgres_db.password
         )
 
         redis_endpoint = f"redis://{config.HOST_IP_IN_NOMAD}:6379"
@@ -412,24 +397,24 @@ def main() -> None:
         )
 
         local_grapl_core_vars: Final[NomadVars] = dict(
-            organization_management_db_hostname=organization_management_db.hostname,
-            organization_management_db_port=str(organization_management_db.port),
-            organization_management_db_username=organization_management_db.username,
-            organization_management_db_password=organization_management_db.password,
+            organization_management_db_hostname=postgres_db.hostname,
+            organization_management_db_port=str(postgres_db.port),
+            organization_management_db_username=postgres_db.username,
+            organization_management_db_password=postgres_db.password,
             pipeline_ingress_kafka_sasl_username="fake",
             pipeline_ingress_kafka_sasl_password="fake",
-            plugin_registry_db_hostname=plugin_registry_db.hostname,
-            plugin_registry_db_port=str(plugin_registry_db.port),
-            plugin_registry_db_username=plugin_registry_db.username,
-            plugin_registry_db_password=plugin_registry_db.password,
-            plugin_work_queue_db_hostname=plugin_work_queue_db.hostname,
-            plugin_work_queue_db_port=str(plugin_work_queue_db.port),
-            plugin_work_queue_db_username=plugin_work_queue_db.username,
-            plugin_work_queue_db_password=plugin_work_queue_db.password,
-            uid_allocator_db_hostname=uid_allocator_db.hostname,
-            uid_allocator_db_port=str(uid_allocator_db.port),
-            uid_allocator_db_username=uid_allocator_db.username,
-            uid_allocator_db_password=uid_allocator_db.password,
+            plugin_registry_db_hostname=postgres_db.hostname,
+            plugin_registry_db_port=str(postgres_db.port),
+            plugin_registry_db_username=postgres_db.username,
+            plugin_registry_db_password=postgres_db.password,
+            plugin_work_queue_db_hostname=postgres_db.hostname,
+            plugin_work_queue_db_port=str(postgres_db.port),
+            plugin_work_queue_db_username=postgres_db.username,
+            plugin_work_queue_db_password=postgres_db.password,
+            uid_allocator_db_hostname=postgres_db.hostname,
+            uid_allocator_db_port=str(postgres_db.port),
+            uid_allocator_db_username=postgres_db.username,
+            uid_allocator_db_password=postgres_db.password,
             redis_endpoint=redis_endpoint,
             **nomad_inputs,
         )

--- a/pulumi/infra/local/postgres.py
+++ b/pulumi/infra/local/postgres.py
@@ -2,12 +2,9 @@ from typing import Optional
 
 import pulumi_postgresql as postgresql
 from infra import config
-from infra.postgres import NomadServiceDbArgs
-from typing_extensions import TypedDict
+from infra.nomad_job import NomadServicePostgresDbArgs
 
 import pulumi
-
-
 
 
 class LocalPostgresInstance(pulumi.ComponentResource):
@@ -26,10 +23,14 @@ class LocalPostgresInstance(pulumi.ComponentResource):
 
         self.instance = postgresql.Database(name)
 
-    def to_nomad_service_db_args(self) -> pulumi.Output[NomadServiceDbArgs]:
-        return pulumi.Output.from_input(NomadServiceDbArgs({
-            "hostname": self.hostname,
-            "port": self.port,
-            "username": self.username,
-            "password": self.password,
-        }))
+    def to_nomad_service_db_args(self) -> pulumi.Output[NomadServicePostgresDbArgs]:
+        return pulumi.Output.from_input(
+            NomadServicePostgresDbArgs(
+                {
+                    "hostname": self.hostname,
+                    "port": self.port,
+                    "username": self.username,
+                    "password": self.password,
+                }
+            )
+        )

--- a/pulumi/infra/local/postgres.py
+++ b/pulumi/infra/local/postgres.py
@@ -2,8 +2,16 @@ from typing import Optional
 
 import pulumi_postgresql as postgresql
 from infra import config
+from typing_extensions import TypedDict
 
 import pulumi
+
+
+class PostgresDbArgs(TypedDict):
+    hostname: str
+    port: int
+    username: str
+    password: str
 
 
 class LocalPostgresInstance(pulumi.ComponentResource):
@@ -21,3 +29,11 @@ class LocalPostgresInstance(pulumi.ComponentResource):
         self.hostname = config.HOST_IP_IN_NOMAD
 
         self.instance = postgresql.Database(name)
+
+    def to_nomad_vars(self) -> pulumi.Output[PostgresDbArgs]:
+        return {
+            "hostname": self.hostname,
+            "port": self.port,
+            "username": self.username,
+            "password": self.password,
+        }

--- a/pulumi/infra/local/postgres.py
+++ b/pulumi/infra/local/postgres.py
@@ -2,16 +2,12 @@ from typing import Optional
 
 import pulumi_postgresql as postgresql
 from infra import config
+from infra.postgres import NomadServiceDbArgs
 from typing_extensions import TypedDict
 
 import pulumi
 
 
-class PostgresDbArgs(TypedDict):
-    hostname: str
-    port: int
-    username: str
-    password: str
 
 
 class LocalPostgresInstance(pulumi.ComponentResource):
@@ -30,10 +26,10 @@ class LocalPostgresInstance(pulumi.ComponentResource):
 
         self.instance = postgresql.Database(name)
 
-    def to_nomad_vars(self) -> pulumi.Output[PostgresDbArgs]:
-        return {
+    def to_nomad_service_db_args(self) -> pulumi.Output[NomadServiceDbArgs]:
+        return pulumi.Output.from_input(NomadServiceDbArgs({
             "hostname": self.hostname,
             "port": self.port,
             "username": self.username,
             "password": self.password,
-        }
+        }))

--- a/pulumi/infra/local/postgres.py
+++ b/pulumi/infra/local/postgres.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import pulumi_postgresql as postgresql
 from infra import config
-from infra.nomad_job import NomadServicePostgresDbArgs
+from infra.nomad_service_postgres import NomadServicePostgresDbArgs
 
 import pulumi
 

--- a/pulumi/infra/nomad_job.py
+++ b/pulumi/infra/nomad_job.py
@@ -4,17 +4,9 @@ from typing import Any, Mapping, Optional, Union, cast
 
 import pulumi_nomad as nomad
 from infra.config import STACK_NAME
-from typing_extensions import TypedDict
+from infra.nomad_service_postgres import NomadServicePostgresDbArgs
 
 import pulumi
-
-
-class NomadServicePostgresDbArgs(TypedDict):
-    hostname: str
-    port: int
-    username: str
-    password: str
-
 
 _ValidNomadVarTypePrimitives = Union[str, bool, int]
 _ValidNomadVarTypes = pulumi.Input[

--- a/pulumi/infra/nomad_job.py
+++ b/pulumi/infra/nomad_job.py
@@ -65,7 +65,7 @@ class NomadJob(pulumi.ComponentResource):
             else:
                 return val
 
-        return {k: dump_value(v) for (k, v) in vars.items()}
+        return {k: pulumi.Output.from_input(v).apply(dump_value) for (k, v) in vars.items()}
 
     def _fix_pulumi_preview(self, vars: NomadVars) -> NomadVars:
         """

--- a/pulumi/infra/nomad_service_postgres.py
+++ b/pulumi/infra/nomad_service_postgres.py
@@ -1,6 +1,4 @@
-from typing import Protocol
-
-from typing_extensions import TypedDict
+from typing_extensions import Protocol, TypedDict
 
 import pulumi
 

--- a/pulumi/infra/nomad_service_postgres.py
+++ b/pulumi/infra/nomad_service_postgres.py
@@ -1,4 +1,8 @@
+from typing import Protocol
+
 from typing_extensions import TypedDict
+
+import pulumi
 
 
 class NomadServicePostgresDbArgs(TypedDict):
@@ -6,3 +10,9 @@ class NomadServicePostgresDbArgs(TypedDict):
     port: int
     username: str
     password: str
+
+
+# a Pulumi resource that provides the above.
+class NomadServicePostgresResource(Protocol):
+    def to_nomad_service_db_args(self) -> pulumi.Output[NomadServicePostgresDbArgs]:
+        pass

--- a/pulumi/infra/nomad_service_postgres.py
+++ b/pulumi/infra/nomad_service_postgres.py
@@ -1,0 +1,8 @@
+from typing_extensions import TypedDict
+
+
+class NomadServicePostgresDbArgs(TypedDict):
+    hostname: str
+    port: int
+    username: str
+    password: str

--- a/pulumi/infra/postgres.py
+++ b/pulumi/infra/postgres.py
@@ -6,7 +6,7 @@ from typing import List, Optional, cast
 
 import pulumi_aws as aws
 import pulumi_random as random
-from infra.nomad_job import NomadServicePostgresDbArgs
+from infra.nomad_service_postgres import NomadServicePostgresDbArgs
 from packaging.version import parse as version_parse
 
 import pulumi
@@ -171,22 +171,6 @@ class Postgres(pulumi.ComponentResource):
             opts=pulumi.ResourceOptions(parent=self, delete_before_replace=True),
         )
 
-    def host(self) -> pulumi.Output[str]:
-        # Cast needed due to https://github.com/pulumi/pulumi/issues/7679
-        return cast(pulumi.Output[str], self._instance.address)
-
-    def port(self) -> pulumi.Output[int]:
-        # Cast needed due to https://github.com/pulumi/pulumi/issues/7679
-        return cast(pulumi.Output[int], self._instance.port)
-
-    def username(self) -> pulumi.Output[str]:
-        # Cast needed due to https://github.com/pulumi/pulumi/issues/7679
-        return cast(pulumi.Output[str], self._instance.username)
-
-    def password(self) -> pulumi.Output[str]:
-        # just to be safe...
-        return pulumi.Output.secret(self._instance.password)
-
     def to_nomad_service_db_args(self) -> pulumi.Output[NomadServicePostgresDbArgs]:
         return cast(
             pulumi.Output[NomadServicePostgresDbArgs],
@@ -195,5 +179,5 @@ class Postgres(pulumi.ComponentResource):
                 port=self._instance.port,
                 username=self._instance.username,
                 password=self._instance.password,
-            ).apply(lambda out: out),
+            ),
         )

--- a/pulumi/infra/postgres.py
+++ b/pulumi/infra/postgres.py
@@ -3,12 +3,19 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from typing import List, Optional, cast
+from typing_extensions import TypedDict
 
 import pulumi_aws as aws
 import pulumi_random as random
 from packaging.version import parse as version_parse
 
 import pulumi
+
+class NomadServiceDbArgs(TypedDict):
+    hostname: str
+    port: int
+    username: str
+    password: str
 
 
 @dataclass
@@ -185,3 +192,11 @@ class Postgres(pulumi.ComponentResource):
     def password(self) -> pulumi.Output[str]:
         # just to be safe...
         return pulumi.Output.secret(self._instance.password)
+
+    def to_nomad_service_db_args(self) -> pulumi.Output[NomadServiceDbArgs]:
+        return pulumi.Output.all(
+            hostname=self.host(),
+            port=self.port(),
+            username=self.username(),
+            password=self.password()
+        ).apply(NomadServiceDbArgs)

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -12,7 +12,7 @@ from infra.autotag import register_auto_tags
 from infra.docker_images import DockerImageId, DockerImageIdBuilder
 from infra.hashicorp_provider import get_nomad_provider_address
 from infra.kafka import Kafka
-from infra.nomad_job import NomadJob, NomadVars
+from infra.nomad_job import NomadJob, NomadServicePostgresDbArgs, NomadVars
 from infra.path import path_from_root
 
 import pulumi
@@ -167,14 +167,8 @@ def main() -> None:
             "schema_properties_table_name": grapl_stack.schema_properties_table_name,
             "test_user_name": grapl_stack.test_user_name,
             "test_user_password_secret_id": grapl_stack.test_user_password_secret_id,
-            "plugin_work_queue_db_hostname": grapl_stack.plugin_work_queue_db_hostname,
-            "plugin_work_queue_db_port": grapl_stack.plugin_work_queue_db_port,
-            "plugin_work_queue_db_username": grapl_stack.plugin_work_queue_db_username,
-            "plugin_work_queue_db_password": grapl_stack.plugin_work_queue_db_password,
-            "organization_management_db_hostname": grapl_stack.organization_management_db_hostname,
-            "organization_management_db_port": grapl_stack.organization_management_db_port,
-            "organization_management_db_username": grapl_stack.organization_management_db_username,
-            "organization_management_db_password": grapl_stack.organization_management_db_password,
+            "plugin_work_queue_db": grapl_stack.plugin_work_queue_db,
+            "organization_management_db": grapl_stack.organization_management_db,
         }
 
         integration_tests = NomadJob(
@@ -204,28 +198,11 @@ class GraplStack:
         self.sysmon_log_bucket = require_str("sysmon-log-bucket")
         self.test_user_name = require_str("test-user-name")
 
-        self.plugin_work_queue_db_hostname = require_str(
-            "plugin-work-queue-db-hostname"
+        self.plugin_work_queue_db = cast(
+            NomadServicePostgresDbArgs, ref.require_output("plugin-work-queue-db")
         )
-        self.plugin_work_queue_db_port = require_str("plugin-work-queue-db-port")
-        self.plugin_work_queue_db_username = require_str(
-            "plugin-work-queue-db-username"
-        )
-        self.plugin_work_queue_db_password = require_str(
-            "plugin-work-queue-db-password"
-        )
-
-        self.organization_management_db_hostname = require_str(
-            "organization-management-db-hostname"
-        )
-        self.organization_management_db_port = require_str(
-            "organization-management-db-port"
-        )
-        self.organization_management_db_username = require_str(
-            "organization-management-db-username"
-        )
-        self.organization_management_db_password = require_str(
-            "organization-management-db-password"
+        self.organization_management_db = cast(
+            NomadServicePostgresDbArgs, ref.require_output("organization-management-db")
         )
 
         self.pipeline_ingress_healthcheck_polling_interval_ms = require_str(

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -12,7 +12,8 @@ from infra.autotag import register_auto_tags
 from infra.docker_images import DockerImageId, DockerImageIdBuilder
 from infra.hashicorp_provider import get_nomad_provider_address
 from infra.kafka import Kafka
-from infra.nomad_job import NomadJob, NomadServicePostgresDbArgs, NomadVars
+from infra.nomad_job import NomadJob, NomadVars
+from infra.nomad_service_postgres import NomadServicePostgresDbArgs
 from infra.path import path_from_root
 
 import pulumi


### PR DESCRIPTION
Where once we had 4 Nomad vars per database, now we have 1.

That also means we can `pulumi.export` just 1 thing. 