### PR TITLE
Ensure consistent use of `DOCKER_BUILDX_BAKE` Make macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,9 @@ ifdef WITH_TRACING
 buildx_builder_args := --builder=grapl-tracing-builder
 endif
 
-# Helper macro to make using the HCL file for builds less
-# verbose. Once we get rid of docker-compose.yml, we can just use
-# `docker buildx bake`, since it will pick up the HCL file
-# automatically.
-DOCKER_BUILDX_BAKE_HCL := docker buildx bake --file=docker-bake.hcl $(buildx_builder_args)
+# Helper macro to invoke buildx with standard arguments. Prefer this
+# over invoking `docker buildx bake` directly.
+DOCKER_BUILDX_BAKE := docker buildx bake $(buildx_builder_args)
 
 COMPOSE_PROJECT_INTEGRATION_TESTS := grapl-integration_tests
 COMPOSE_PROJECT_INTEGRATION_TESTS_NEW := grapl-integration_tests_new
@@ -145,8 +143,7 @@ help: ## Print this help
 
 .PHONY: build-test-unit-js
 build-test-unit-js:
-	docker buildx bake \
-		--file ./test/docker-compose.unit-tests-js.yml $(buildx_builder_args)
+	$(DOCKER_BUILDX_BAKE) --file ./test/docker-compose.unit-tests-js.yml
 
 # Build Service Images and their Prerequisites
 ########################################################################
@@ -203,28 +200,28 @@ build-image-prerequisites: build-grapl-service-prerequisites build-e2e-pex-files
 .PHONY: build-local-infrastructure
 build-local-infrastructure: build-grapl-service-prerequisites
 	@echo "--- Building the Grapl SaaS service images and local-only images"
-	$(DOCKER_BUILDX_BAKE_HCL) local-infrastructure
+	$(DOCKER_BUILDX_BAKE) local-infrastructure
 
 .PHONY: build-test-e2e
 build-test-e2e: build-e2e-pex-files
 	@echo "--- Building e2e testing image"
-	$(DOCKER_BUILDX_BAKE_HCL) e2e-tests
+	$(DOCKER_BUILDX_BAKE) e2e-tests
 
 .PHONY: build-test-integration
 build-test-integration:
 	@echo "--- Building integration test images"
-	docker buildx bake integration-tests $(buildx_builder_args)
+	$(DOCKER_BUILDX_BAKE) integration-tests
 
 .PHONY: build-test-integration-new
 build-test-integration-new:
 	@echo "--- Building \"new\" integration test images"
-	docker buildx bake rust-integration-tests-new $(buildx_builder_args)
+	$(DOCKER_BUILDX_BAKE) rust-integration-tests-new
 
 ########################################################################
 
 .PHONY: build-prettier-image
 build-prettier-image:
-	docker buildx bake --file ./docker-compose.check.yml prettier $(buildx_builder_args)
+	$(DOCKER_BUILDX_BAKE) --file ./docker-compose.check.yml prettier
 
 .PHONY: graplctl
 graplctl: ## Build graplctl and install it to ./bin
@@ -515,7 +512,7 @@ stop: ## docker compose stop - stops (but preserves) the containers
 # Will only work as expected as long as tag is "dev".
 .PHONY: restart-web-ui
 restart-web-ui: build-engagement-view  ## Rebuild web-ui image, and restart web-ui task in Nomad
-	$(DOCKER_BUILDX_BAKE_HCL) grapl-web-ui
+	$(DOCKER_BUILDX_BAKE) grapl-web-ui
 	source ./nomad/lib/nomad_cli_tools.sh
 	nomad alloc restart "$$(nomad_get_alloc_id_for_task grapl-core web-ui)"
 
@@ -669,7 +666,7 @@ dist/plugin-bootstrap-init: _export-rust-build-artifacts-to-dist  ## Build the P
 
 .PHONY: _export-rust-build-artifacts-to-dist
 _export-rust-build-artifacts-to-dist: | dist  ## Copy all specified Rust binary artifacts to dist/
-	$(DOCKER_BUILDX_BAKE_HCL) export-rust-build-artifacts-to-dist
+	$(DOCKER_BUILDX_BAKE) export-rust-build-artifacts-to-dist
 
 # TODO: Would be nice to be able to specify the input file prerequisites of
 # this target, once `dist/plugin-bootstrap-init` is non-PHONY


### PR DESCRIPTION
Not all our Makefile targets were using our `DOCKER_BUILDX_BAKE_HCL` macro; now they do.

Additionally, since according to https://github.com/docker/buildx/issues/936 we don't actually need to specify our `docker-bake.hcl` file explicitly, we rename the macro to simply `DOCKER_BUILDX_BAKE`.
