### PR TITLE
Centralize Kafka credential and consumer-groups creation/access in Pulumi<->Nomad.

### DIFF
--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -26,7 +26,7 @@ from infra.hashicorp_provider import (
     get_consul_provider_address,
     get_nomad_provider_address,
 )
-from infra.kafka import Kafka
+from infra.kafka import Credential, Kafka
 from infra.local.postgres import LocalPostgresInstance
 from infra.nomad_job import NomadJob, NomadVars
 from infra.nomad_service_postgres import NomadServicePostgresResource
@@ -189,20 +189,18 @@ def main() -> None:
     pulumi.export("aws-env-vars-for-local", aws_env_vars_for_local)
 
     kafka_services = (
-        "graph-generator",
         "generator-dispatcher",
+        "graph-generator",
         "node-identifier",
         "pipeline-ingress",
     )
     kafka_service_credentials = {
-        service: kafka.service_credentials(service).apply(
-            lambda creds: creds.to_nomad_service_creds()
-        )
+        service: kafka.service_credentials(service).apply(Credential.to_nomad_service_creds)
         for service in kafka_services
     }
     kafka_consumer_services = (
-        "graph-generator",
         "generator-dispatcher",
+        "graph-generator",
         "node-identifier",
     )
     kafka_consumer_groups = {

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -188,12 +188,26 @@ def main() -> None:
     aws_env_vars_for_local = _get_aws_env_vars_for_local()
     pulumi.export("aws-env-vars-for-local", aws_env_vars_for_local)
 
-    pipeline_ingress_kafka_credentials = kafka.service_credentials("pipeline-ingress")
-    generator_dispatcher_kafka_credentials = kafka.service_credentials(
-        "generator-dispatcher"
+    kafka_services = (
+        "graph-generator",
+        "generator-dispatcher",
+        "node-identifier",
+        "pipeline-ingress",
     )
-    graph_generator_kafka_credentials = kafka.service_credentials("graph-generator")
-    node_identifier_kafka_credentials = kafka.service_credentials("node-identifier")
+    kafka_service_credentials = {
+        service: kafka.service_credentials(service).apply(
+            lambda creds: creds.to_nomad_service_creds()
+        )
+        for service in kafka_services
+    }
+    kafka_consumer_services = (
+        "graph-generator",
+        "generator-dispatcher",
+        "node-identifier",
+    )
+    kafka_consumer_groups = {
+        service: kafka.consumer_group(service) for service in kafka_consumer_services
+    }
 
     # These are shared across both local and prod deployments.
     nomad_inputs: Final[NomadVars] = dict(
@@ -202,22 +216,11 @@ def main() -> None:
         aws_region=aws.get_region().name,
         container_images=_container_images(artifacts),
         dns_server=config.CONSUL_DNS_IP,
-        generator_dispatcher_kafka_consumer_group=kafka.consumer_group(
-            "generator-dispatcher"
-        ),
-        generator_dispatcher_kafka_sasl_password=generator_dispatcher_kafka_credentials.api_secret,
-        generator_dispatcher_kafka_sasl_username=generator_dispatcher_kafka_credentials.api_key,
-        graph_generator_kafka_consumer_group=kafka.consumer_group("graph-generator"),
-        graph_generator_kafka_sasl_password=graph_generator_kafka_credentials.api_secret,
-        graph_generator_kafka_sasl_username=graph_generator_kafka_credentials.api_key,
         kafka_bootstrap_servers=kafka.bootstrap_servers(),
+        kafka_credentials=kafka_service_credentials,
+        kafka_consumer_groups=kafka_consumer_groups,
         model_plugins_bucket=model_plugins_bucket.bucket,
-        node_identifier_kafka_consumer_group=kafka.consumer_group("node-identifier"),
-        node_identifier_kafka_sasl_password=node_identifier_kafka_credentials.api_secret,
-        node_identifier_kafka_sasl_username=node_identifier_kafka_credentials.api_key,
         pipeline_ingress_healthcheck_polling_interval_ms=pipeline_ingress_healthcheck_polling_interval_ms,
-        pipeline_ingress_kafka_sasl_password=pipeline_ingress_kafka_credentials.api_secret,
-        pipeline_ingress_kafka_sasl_username=pipeline_ingress_kafka_credentials.api_key,
         plugin_registry_bucket_aws_account_id=config.AWS_ACCOUNT_ID,
         plugin_registry_bucket_name=plugin_registry_bucket.bucket,
         plugin_registry_kernel_artifact_url=firecracker_s3objs.kernel_s3obj_url,
@@ -290,10 +293,6 @@ def main() -> None:
     plugin_registry_db: NomadServicePostgresResource
     plugin_work_queue_db: NomadServicePostgresResource
     uid_allocator_db: NomadServicePostgresResource
-
-    pipeline_ingress_kafka_credentials = kafka.service_credentials("pipeline-ingress")
-    graph_generator_kafka_credentials = kafka.service_credentials("graph-generator")
-    node_identifier_kafka_credentials = kafka.service_credentials("node-identifier")
 
     if config.LOCAL_GRAPL:
         ###################################

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -195,7 +195,9 @@ def main() -> None:
         "pipeline-ingress",
     )
     kafka_service_credentials = {
-        service: kafka.service_credentials(service).apply(Credential.to_nomad_service_creds)
+        service: kafka.service_credentials(service).apply(
+            Credential.to_nomad_service_creds
+        )
         for service in kafka_services
     }
     kafka_consumer_services = (

--- a/pulumi/infra/kafka.py
+++ b/pulumi/infra/kafka.py
@@ -7,8 +7,14 @@ from infra import config
 from pulumi.stack_reference import StackReference
 from pulumi_kafka import Provider
 from pulumi_kafka import Topic as KafkaTopic
+from typing_extensions import TypedDict
 
 import pulumi
+
+
+class NomadServiceKafkaCredentials(TypedDict):
+    sasl_username: str
+    sasl_password: str
 
 
 @dataclasses.dataclass
@@ -23,6 +29,12 @@ class Credential:
             service_account_id=data["service_account_id"],
             api_key=data["api_key"],
             api_secret=data["api_secret"],
+        )
+
+    def to_nomad_service_creds(self) -> NomadServiceKafkaCredentials:
+        return NomadServiceKafkaCredentials(
+            sasl_username=self.api_key,
+            sasl_password=self.api_secret,
         )
 
 

--- a/pulumi/infra/nomad_job.py
+++ b/pulumi/infra/nomad_job.py
@@ -1,9 +1,10 @@
 import json
 from pathlib import Path
-from typing import Any, Mapping, Optional, Union, cast
+from typing import Any, Dict, Mapping, Optional, Union, cast
 
 import pulumi_nomad as nomad
 from infra.config import STACK_NAME
+from infra.kafka import NomadServiceKafkaCredentials
 from infra.nomad_service_postgres import NomadServicePostgresDbArgs
 
 import pulumi
@@ -12,8 +13,10 @@ _ValidNomadVarTypePrimitives = Union[str, bool, int]
 _ValidNomadVarTypes = pulumi.Input[
     Union[
         _ValidNomadVarTypePrimitives,
-        Mapping[str, _ValidNomadVarTypePrimitives],
-        NomadServicePostgresDbArgs,  # Upsettingly, this is a Mapping[str, object]
+        Mapping[str, pulumi.Input[_ValidNomadVarTypePrimitives]],
+        # Upsettingly, TypedDicts are a Mapping[str, object]
+        NomadServicePostgresDbArgs,
+        Mapping[str, pulumi.Input[NomadServiceKafkaCredentials]],
     ]
 ]
 NomadVars = Mapping[str, Optional[_ValidNomadVarTypes]]
@@ -53,7 +56,8 @@ class NomadJob(pulumi.ComponentResource):
             f.close()
             return jobspec
 
-    def _json_dump_complex_types(self, vars: NomadVars) -> NomadVars:
+    @staticmethod
+    def _json_dump_complex_types(vars: NomadVars) -> NomadVars:
         """
         Nomad accepts input of lists and maps, but the Nomad/Pulumi plugin doesn't
         convert them correctly.
@@ -73,7 +77,7 @@ class NomadJob(pulumi.ComponentResource):
             elif isinstance(val, dict):
                 return json.dumps({k: escape_str_value(v) for (k, v) in val.items()})
             else:
-                return cast(_ValidNomadVarTypePrimitives, val)
+                return val
 
         return {
             k: pulumi.Output.from_input(v).apply(dump_value) for (k, v) in vars.items()

--- a/pulumi/infra/nomad_job.py
+++ b/pulumi/infra/nomad_job.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional, Union, cast
+from typing import Any, Mapping, Optional, Union, cast
 
 import pulumi_nomad as nomad
 from infra.config import STACK_NAME

--- a/pulumi/infra/nomad_job.py
+++ b/pulumi/infra/nomad_job.py
@@ -77,7 +77,7 @@ class NomadJob(pulumi.ComponentResource):
             elif isinstance(val, dict):
                 return json.dumps({k: escape_str_value(v) for (k, v) in val.items()})
             else:
-                return val
+                return cast(_ValidNomadVarTypePrimitives, val)
 
         return {
             k: pulumi.Output.from_input(v).apply(dump_value) for (k, v) in vars.items()


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
none
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Drastically reduces the number of variables passed into Nomad having to do with Kafka from
num kafka services * 3 (username, password, consumer_group_name)
to
2.

Centralizes where they are made, making it very simple to add new services that consume Kafka. 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
make test-integration-new

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
