### PR TITLE
Prevent a race condition in generator-dispatcher integration tests.

### DIFF
--- a/nomad/integration-tests-new.nomad
+++ b/nomad/integration-tests-new.nomad
@@ -56,6 +56,16 @@ variable "rust_log" {
   description = "Controls the logging behavior of Rust-based services."
 }
 
+variable "plugin_work_queue_db" {
+  type = object({
+    hostname = string
+    port     = number
+    username = string
+    password = string
+  })
+  description = "Vars for plugin-work-queue database"
+}
+
 job "integration-tests-new" {
   datacenters = ["dc1"]
   type        = "batch"
@@ -140,6 +150,11 @@ job "integration-tests-new" {
         KAFKA_CONSUMER_TOPIC = "<replace me at integration test setup>"
 
         NOMAD_SERVICE_ADDRESS = "${attr.unique.network.ip-address}:4646"
+
+        PLUGIN_WORK_QUEUE_DB_HOSTNAME = var.plugin_work_queue_db.hostname
+        PLUGIN_WORK_QUEUE_DB_PORT     = var.plugin_work_queue_db.port
+        PLUGIN_WORK_QUEUE_DB_USERNAME = var.plugin_work_queue_db.username
+        PLUGIN_WORK_QUEUE_DB_PASSWORD = var.plugin_work_queue_db.password
       }
 
       resources {

--- a/pulumi/integration_tests/__main__.py
+++ b/pulumi/integration_tests/__main__.py
@@ -99,6 +99,7 @@ def main() -> None:
         ),
         "kafka_bootstrap_servers": kafka.bootstrap_servers(),
         "pipeline_ingress_healthcheck_polling_interval_ms": grapl_stack.pipeline_ingress_healthcheck_polling_interval_ms,
+        "plugin_work_queue_db": grapl_stack.plugin_work_queue_db,
     }
 
     integration_tests_new = NomadJob(

--- a/src/rust/bin/generate_sqlx_data.sh
+++ b/src/rust/bin/generate_sqlx_data.sh
@@ -37,18 +37,18 @@ start_postgres() {
 
 stop_postgres() {
     echo -e "\n--- Stopping Postgres"
-    docker stop "${CONTAINER_NAME}" || true
+    docker rm --force "${CONTAINER_NAME}" || true
 }
 
 sqlx_prepare() {
     local -r which_rust_lib="${1}"
 
+    echo -e "\n--- Sqlx Prepare on ${which_rust_lib}"
     start_postgres
-    echo -e "\n --- Sqlx Prepare on ${which_rust_lib}"
     (
         cd "${which_rust_lib}"
         DATABASE_URL="${DB_URL}" cargo sqlx migrate run
-        DATABASE_URL="${DB_URL}" cargo sqlx prepare -- --lib
+        DATABASE_URL="${DB_URL}" cargo sqlx prepare -- --lib --all-features
     )
     stop_postgres
 }

--- a/src/rust/generator-dispatcher/Cargo.toml
+++ b/src/rust/generator-dispatcher/Cargo.toml
@@ -31,6 +31,9 @@ opentelemetry-jaeger = { version = "0.15", features = [
   "collector_client",
   "rt-tokio"
 ] }
+plugin-work-queue = { path = "../plugin-work-queue", features = [
+  "new_integration_tests"
+] }
 test-context = "0.1"
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.16"

--- a/src/rust/generator-dispatcher/tests/test_utils/context.rs
+++ b/src/rust/generator-dispatcher/tests/test_utils/context.rs
@@ -1,12 +1,13 @@
 use std::time::Duration;
 
+use clap::Parser;
 use opentelemetry::{
     global,
     sdk::propagation::TraceContextPropagator,
 };
-use plugin_work_queue::client::{
-    FromEnv,
-    PluginWorkQueueServiceClient,
+use plugin_work_queue::{
+    psql_queue::PsqlQueue,
+    PluginWorkQueueDbConfig,
 };
 use rust_proto_new::{
     graplinc::grapl::api::pipeline_ingress::v1beta1::client::PipelineIngressClient,
@@ -21,7 +22,7 @@ use tracing_subscriber::{
 
 pub struct GeneratorDispatcherTestContext {
     pub pipeline_ingress_client: PipelineIngressClient,
-    pub plugin_work_queue_client: PluginWorkQueueServiceClient,
+    pub plugin_work_queue_psql_client: PsqlQueue,
     pub _guard: WorkerGuard,
 }
 
@@ -74,13 +75,13 @@ impl AsyncTestContext for GeneratorDispatcherTestContext {
             .await
             .expect("could not configure gRPC client");
 
-        let plugin_work_queue_client = PluginWorkQueueServiceClient::from_env()
+        let plugin_work_queue_psql_client = PsqlQueue::try_from(PluginWorkQueueDbConfig::parse())
             .await
-            .expect("plugin-work-queue client");
+            .expect("plugin_work_queue");
 
         GeneratorDispatcherTestContext {
             pipeline_ingress_client,
-            plugin_work_queue_client,
+            plugin_work_queue_psql_client,
             _guard,
         }
     }

--- a/src/rust/plugin-work-queue/Cargo.toml
+++ b/src/rust/plugin-work-queue/Cargo.toml
@@ -42,3 +42,4 @@ tracing-subscriber = "0.3"
 
 [features]
 integration = []
+new_integration_tests = []

--- a/src/rust/plugin-work-queue/sqlx-data.json
+++ b/src/rust/plugin-work-queue/sqlx-data.json
@@ -1,213 +1,189 @@
 {
   "db": "PostgreSQL",
   "0089d32b4d7af35f29f3b496c63735fcc8a7290efe7f996db4595735eafdae7f": {
-    "query": "\n            UPDATE plugin_work_queue.analyzer_plugin_executions\n            SET\n                try_count  = plugin_work_queue.analyzer_plugin_executions.try_count + 1,\n                last_updated = CURRENT_TIMESTAMP,\n                visible_after  = CURRENT_TIMESTAMP + INTERVAL '10 seconds'\n            FROM (\n                 SELECT execution_key, plugin_id, pipeline_message, current_status, creation_time, visible_after, tenant_id\n                 FROM plugin_work_queue.analyzer_plugin_executions\n                 WHERE current_status = 'enqueued'\n                   AND creation_time >= (CURRENT_TIMESTAMP - INTERVAL '1 day')\n                   AND visible_after <= CURRENT_TIMESTAMP\n                 ORDER BY creation_time ASC\n                 FOR UPDATE SKIP LOCKED\n                 LIMIT 1\n             ) AS next_execution\n             WHERE plugin_work_queue.analyzer_plugin_executions.execution_key = next_execution.execution_key\n             RETURNING\n                 next_execution.execution_key AS \"execution_key!: ExecutionId\",\n                 next_execution.plugin_id,\n                 next_execution.pipeline_message,\n                 next_execution.tenant_id\n        ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "execution_key!: ExecutionId",
+          "ordinal": 0,
           "type_info": "Int8"
         },
         {
-          "ordinal": 1,
           "name": "plugin_id",
+          "ordinal": 1,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 2,
           "name": "pipeline_message",
+          "ordinal": 2,
           "type_info": "Bytea"
         },
         {
-          "ordinal": 3,
           "name": "tenant_id",
+          "ordinal": 3,
           "type_info": "Uuid"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n            UPDATE plugin_work_queue.analyzer_plugin_executions\n            SET\n                try_count  = plugin_work_queue.analyzer_plugin_executions.try_count + 1,\n                last_updated = CURRENT_TIMESTAMP,\n                visible_after  = CURRENT_TIMESTAMP + INTERVAL '10 seconds'\n            FROM (\n                 SELECT execution_key, plugin_id, pipeline_message, current_status, creation_time, visible_after, tenant_id\n                 FROM plugin_work_queue.analyzer_plugin_executions\n                 WHERE current_status = 'enqueued'\n                   AND creation_time >= (CURRENT_TIMESTAMP - INTERVAL '1 day')\n                   AND visible_after <= CURRENT_TIMESTAMP\n                 ORDER BY creation_time ASC\n                 FOR UPDATE SKIP LOCKED\n                 LIMIT 1\n             ) AS next_execution\n             WHERE plugin_work_queue.analyzer_plugin_executions.execution_key = next_execution.execution_key\n             RETURNING\n                 next_execution.execution_key AS \"execution_key!: ExecutionId\",\n                 next_execution.plugin_id,\n                 next_execution.pipeline_message,\n                 next_execution.tenant_id\n        "
   },
   "1ec0c84f3f890741c183d7ede697e7e7cf7c7ed8d92bb5e8a46f01cbfe44ab73": {
-    "query": "\n            INSERT INTO plugin_work_queue.analyzer_plugin_executions (\n                plugin_id,\n                pipeline_message,\n                tenant_id,\n                current_status,\n                try_count\n            )\n            VALUES( $1::UUID, $2, $3::UUID, 'enqueued', -1 )\n        ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
           "Bytea",
           "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\n            INSERT INTO plugin_work_queue.analyzer_plugin_executions (\n                plugin_id,\n                pipeline_message,\n                tenant_id,\n                current_status,\n                try_count\n            )\n            VALUES( $1::UUID, $2, $3::UUID, 'enqueued', -1 )\n        "
   },
   "34822afa8bef4e4faf115130b855398f9e7396d74bd4a0ed476c6dd5c9128f9b": {
-    "query": "\n                UPDATE plugin_work_queue.generator_plugin_executions\n                SET current_status = $2,\n                    last_updated = CASE\n                        WHEN current_status != 'processed'\n                            THEN CURRENT_TIMESTAMP\n                            ELSE last_updated\n                        END\n                WHERE execution_key = $1\n            ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Int8",
           {
             "Custom": {
-              "name": "status",
               "kind": {
                 "Enum": [
                   "enqueued",
                   "failed",
                   "processed"
                 ]
-              }
+              },
+              "name": "status"
             }
           }
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\n                UPDATE plugin_work_queue.generator_plugin_executions\n                SET current_status = $2,\n                    last_updated = CASE\n                        WHEN current_status != 'processed'\n                            THEN CURRENT_TIMESTAMP\n                            ELSE last_updated\n                        END\n                WHERE execution_key = $1\n            "
   },
-  "4eb941c37568614ac5423f5f86bb214b0cdc08c8099db32b07437c036cd4f231": {
-    "query": "SELECT current_status AS \"current_status: Status\"\n            FROM plugin_work_queue.generator_plugin_executions\n            WHERE plugin_id = $1\n            LIMIT 1;",
+  "69200cbb16091543b1524070b3d2a73cf1304fe02427335f04625f293b2b2242": {
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
-          "name": "current_status: Status",
-          "type_info": {
-            "Custom": {
-              "name": "status",
-              "kind": {
-                "Enum": [
-                  "enqueued",
-                  "failed",
-                  "processed"
-                ]
-              }
-            }
-          }
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "c061b6bffb5339055486d7c40a5aa87353e30bf328521b6061e2cab1296c8bf1": {
-    "query": "\n            INSERT INTO plugin_work_queue.generator_plugin_executions (\n                plugin_id,\n                pipeline_message,\n                tenant_id,\n                current_status,\n                try_count\n            )\n            VALUES( $1::UUID, $2, $3::UUID, 'enqueued', -1 )\n        ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Bytea",
-          "Uuid"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "cf69be06c1e04833cd7b84256bdd7ebe396558b5720082b78882b1abc6be6195": {
-    "query": "\n            UPDATE plugin_work_queue.generator_plugin_executions\n            SET\n                try_count  = try_count + 1,\n                last_updated = CURRENT_TIMESTAMP,\n                visible_after  = CURRENT_TIMESTAMP + INTERVAL '10 seconds'\n            FROM (\n                 SELECT execution_key, plugin_id, pipeline_message, current_status, creation_time, visible_after, tenant_id\n                 FROM plugin_work_queue.generator_plugin_executions\n                 WHERE current_status = 'enqueued'\n                   AND creation_time >= (CURRENT_TIMESTAMP - INTERVAL '1 day')\n                   AND visible_after <= CURRENT_TIMESTAMP\n                 ORDER BY creation_time ASC\n                 FOR UPDATE SKIP LOCKED\n                 LIMIT 1\n             ) AS next_execution\n             WHERE plugin_work_queue.generator_plugin_executions.execution_key = next_execution.execution_key\n             RETURNING\n                 next_execution.execution_key AS \"execution_key!: ExecutionId\",\n                 next_execution.plugin_id,\n                 next_execution.pipeline_message,\n                 next_execution.tenant_id\n        ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
           "name": "execution_key!: ExecutionId",
+          "ordinal": 0,
           "type_info": "Int8"
         },
         {
-          "ordinal": 1,
           "name": "plugin_id",
+          "ordinal": 1,
           "type_info": "Uuid"
         },
         {
-          "ordinal": 2,
           "name": "pipeline_message",
+          "ordinal": 2,
           "type_info": "Bytea"
         },
         {
-          "ordinal": 3,
           "name": "tenant_id",
+          "ordinal": 3,
           "type_info": "Uuid"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false,
         false,
         false
-      ]
-    }
-  },
-  "ecc678ab358f2bd49afed2c2d5880aa61bcf73066ab0bdfdcb123d10ffac4827": {
-    "query": "SELECT current_status AS \"current_status: Status\"\n            FROM plugin_work_queue.generator_plugin_executions\n            WHERE execution_key = $1",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "current_status: Status",
-          "type_info": {
-            "Custom": {
-              "name": "status",
-              "kind": {
-                "Enum": [
-                  "enqueued",
-                  "failed",
-                  "processed"
-                ]
-              }
-            }
-          }
-        }
       ],
       "parameters": {
         "Left": [
-          "Int8"
+          "Uuid"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\n            SELECT\n                 execution_key AS \"execution_key!: ExecutionId\",\n                 plugin_id,\n                 pipeline_message,\n                 tenant_id\n            FROM plugin_work_queue.generator_plugin_executions\n            WHERE tenant_id = $1\n            "
   },
-  "f71b00154ecb7c5ac2d507c4dcae96e35bcc7a3a246af12cf02d077211ee155d": {
-    "query": "\n                UPDATE plugin_work_queue.analyzer_plugin_executions\n                SET current_status = $2,\n                    last_updated = CASE\n                        WHEN current_status != 'processed'\n                            THEN CURRENT_TIMESTAMP\n                            ELSE last_updated\n                        END\n                WHERE execution_key = $1\n            ",
+  "c061b6bffb5339055486d7c40a5aa87353e30bf328521b6061e2cab1296c8bf1": {
     "describe": {
       "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Bytea",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n            INSERT INTO plugin_work_queue.generator_plugin_executions (\n                plugin_id,\n                pipeline_message,\n                tenant_id,\n                current_status,\n                try_count\n            )\n            VALUES( $1::UUID, $2, $3::UUID, 'enqueued', -1 )\n        "
+  },
+  "cf69be06c1e04833cd7b84256bdd7ebe396558b5720082b78882b1abc6be6195": {
+    "describe": {
+      "columns": [
+        {
+          "name": "execution_key!: ExecutionId",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "plugin_id",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "pipeline_message",
+          "ordinal": 2,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "tenant_id",
+          "ordinal": 3,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n            UPDATE plugin_work_queue.generator_plugin_executions\n            SET\n                try_count  = try_count + 1,\n                last_updated = CURRENT_TIMESTAMP,\n                visible_after  = CURRENT_TIMESTAMP + INTERVAL '10 seconds'\n            FROM (\n                 SELECT execution_key, plugin_id, pipeline_message, current_status, creation_time, visible_after, tenant_id\n                 FROM plugin_work_queue.generator_plugin_executions\n                 WHERE current_status = 'enqueued'\n                   AND creation_time >= (CURRENT_TIMESTAMP - INTERVAL '1 day')\n                   AND visible_after <= CURRENT_TIMESTAMP\n                 ORDER BY creation_time ASC\n                 FOR UPDATE SKIP LOCKED\n                 LIMIT 1\n             ) AS next_execution\n             WHERE plugin_work_queue.generator_plugin_executions.execution_key = next_execution.execution_key\n             RETURNING\n                 next_execution.execution_key AS \"execution_key!: ExecutionId\",\n                 next_execution.plugin_id,\n                 next_execution.pipeline_message,\n                 next_execution.tenant_id\n        "
+  },
+  "f71b00154ecb7c5ac2d507c4dcae96e35bcc7a3a246af12cf02d077211ee155d": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Int8",
           {
             "Custom": {
-              "name": "status",
               "kind": {
                 "Enum": [
                   "enqueued",
                   "failed",
                   "processed"
                 ]
-              }
+              },
+              "name": "status"
             }
           }
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\n                UPDATE plugin_work_queue.analyzer_plugin_executions\n                SET current_status = $2,\n                    last_updated = CASE\n                        WHEN current_status != 'processed'\n                            THEN CURRENT_TIMESTAMP\n                            ELSE last_updated\n                        END\n                WHERE execution_key = $1\n            "
   }
 }

--- a/src/rust/plugin-work-queue/src/lib.rs
+++ b/src/rust/plugin-work-queue/src/lib.rs
@@ -3,13 +3,21 @@ use std::net::SocketAddr;
 pub mod client;
 pub mod psql_queue;
 pub mod server;
+#[cfg(feature = "new_integration_tests")]
+pub mod test_utils;
 
-#[derive(clap::Parser, Debug)]
+#[derive(clap::Parser, Clone, Debug)]
 pub struct PluginWorkQueueServiceConfig {
     #[clap(long, env)]
     pub plugin_work_queue_bind_address: SocketAddr,
     #[clap(long, env)]
     pub plugin_work_queue_healthcheck_polling_interval_ms: u64,
+    #[clap(flatten)]
+    pub db_config: PluginWorkQueueDbConfig,
+}
+
+#[derive(clap::Parser, Clone, Debug)]
+pub struct PluginWorkQueueDbConfig {
     #[clap(long, env)]
     pub plugin_work_queue_db_hostname: String,
     #[clap(long, env)]

--- a/src/rust/plugin-work-queue/src/server.rs
+++ b/src/rust/plugin-work-queue/src/server.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use grapl_utils::future_ext::GraplFutureExt;
 use rust_proto_new::{
     graplinc::grapl::api::plugin_work_queue::{
         v1beta1,
@@ -80,21 +79,9 @@ impl PluginWorkQueue {
     pub async fn try_from(
         service_config: &PluginWorkQueueServiceConfig,
     ) -> Result<Self, PluginWorkQueueInitError> {
-        let postgres_address = format!(
-            "postgresql://{}:{}@{}:{}",
-            service_config.plugin_work_queue_db_username,
-            service_config.plugin_work_queue_db_password,
-            service_config.plugin_work_queue_db_hostname,
-            service_config.plugin_work_queue_db_port,
-        );
-
-        let plugin_work_queue: PluginWorkQueue = PluginWorkQueue::from(
-            sqlx::PgPool::connect(&postgres_address)
-                .timeout(std::time::Duration::from_secs(5))
-                .await??,
-        );
-
-        Ok(plugin_work_queue)
+        Ok(Self::from(
+            PsqlQueue::try_from(service_config.db_config.clone()).await?,
+        ))
     }
 }
 #[async_trait::async_trait]

--- a/src/rust/plugin-work-queue/src/test_utils.rs
+++ b/src/rust/plugin-work-queue/src/test_utils.rs
@@ -1,0 +1,62 @@
+use uuid::Uuid;
+
+use crate::psql_queue::{
+    ExecutionId,
+    NextExecutionRequest,
+    PsqlQueue,
+    PsqlQueueError,
+};
+
+/// This module is meant to be used by integration tests in other crates.
+///
+/// ## Example use case
+/// So I've introduced a new service 'generator-dispatcher' which:
+/// - pops logs off raw-logs
+/// - sticks them in plugin-work-queue
+///
+/// The reasonable integration test for this would, then, be:
+/// - insert a log into raw-logs
+/// - read jobs in plugin-work-queue to ensure a matching one lives in there
+///
+/// The problem is this:
+/// - We have two concurrent and competing binaries that are calling get_execute_generator:
+///   this integration test, and generator-executor.
+/// - Generator-executor could potentially mark the job as 'acknowledged', hiding
+///   the job from the integration test - it's a race condition.
+///
+/// As such, I'm exposing a test-only utilities suite that will let a
+/// downstream integration test inspect jobs that are already acknowledged, too.
+
+#[async_trait::async_trait]
+pub trait PsqlQueueTestExtensions {
+    /// Get all generator messages regardless of state
+    async fn get_all_generator_messages(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Vec<NextExecutionRequest>, PsqlQueueError>;
+}
+
+#[async_trait::async_trait]
+impl PsqlQueueTestExtensions for PsqlQueue {
+    async fn get_all_generator_messages(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Vec<NextExecutionRequest>, PsqlQueueError> {
+        let generator_messages = sqlx::query_as!(
+            NextExecutionRequest,
+            r#"
+            SELECT
+                 execution_key AS "execution_key!: ExecutionId",
+                 plugin_id,
+                 pipeline_message,
+                 tenant_id
+            FROM plugin_work_queue.generator_plugin_executions
+            WHERE tenant_id = $1
+            "#,
+            tenant_id
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(generator_messages)
+    }
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?

None
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Introduce a test utils extension to PsqlQueue so integration tests can
    make assertions against not-publicly-exposed data/APIs. Prevent a
    race condition between our generator-dispatcher integration tests and
    our pipeline services.

```
/// This module is meant to be used by integration tests in other crates.
///
/// ## Example use case
/// So I've introduced a new service 'generator-dispatcher' which:
/// - pops logs off raw-logs
/// - sticks them in plugin-work-queue
///
/// The reasonable integration test for this would, then, be:
/// - insert a log into raw-logs
/// - read jobs in plugin-work-queue to ensure a matching one lives in there
///
/// The problem is this:
/// - We have two concurrent and competing binaries that are calling get_execute_generator:
///   this integration test, and generator-executor.
/// - Generator-executor could potentially mark the job as 'acknowledged', hiding
///   the job from the integration test - it's a race condition.
///
/// As such, I'm exposing a test-only utilities suite that will let a
/// downstream integration test inspect jobs that are already acknowledged, too.
```

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
its all tests baby
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
