### PR TITLE
Update `libssl-dev` to `1.1.1n-0+deb11u3`

### DIFF
--- a/scylladb/Dockerfile
+++ b/scylladb/Dockerfile
@@ -5,7 +5,7 @@ ENV HWLOC_VERSION="2.7.1"
 # hadolint ignore=DL3015
 RUN apt-get update \
     && apt-get -y install curl=7.74.0-1.3+deb11u1 \
-    libssl-dev=1.1.1n-0+deb11u2 \
+    libssl-dev=1.1.1n-0+deb11u3 \
     ca-certificates=20210119  \
     gcc=4:10.2.1-1 \
     cmake=3.18.4-2+deb11u1 \

--- a/src/js/graphql_endpoint/Dockerfile
+++ b/src/js/graphql_endpoint/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && apt-get --yes install --no-install-recommends \
         build-essential=12.9 \
         libffi-dev=3.3-6 \
-        libssl-dev=1.1.1n-0+deb11u2 \
+        libssl-dev=1.1.1n-0+deb11u3 \
         python3=3.9.2-3 \
         zip=3.0-12 \
     && rm -rf /var/lib/apt/lists/* \

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-base-apt
     && apt-get install --yes --no-install-recommends \
         build-essential=12.9 \
         cmake=3.18.4-2+deb11u1 \
-        libssl-dev=1.1.1n-0+deb11u2 \
+        libssl-dev=1.1.1n-0+deb11u3 \
         perl=5.32.1-4+deb11u2 \
         pkg-config=0.29.2-1 \
         tcl=8.6.11+1
@@ -108,7 +108,7 @@ FROM base AS tarpaulin
 RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-tarpaulin-apt \
     apt-get update \
     && apt-get install --yes --no-install-recommends \
-        libssl-dev=1.1.1n-0+deb11u2 \
+        libssl-dev=1.1.1n-0+deb11u3 \
         pkg-config=0.29.2-1
 
 # For test coverage reports
@@ -381,4 +381,3 @@ FROM rust-dist AS uid-allocator-deploy
 
 COPY --from=build /outputs/uid-allocator /
 ENTRYPOINT ["/uid-allocator"]
-

--- a/src/rust/build-env.Dockerfile
+++ b/src/rust/build-env.Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-build-en
     apt-get install --yes --no-install-recommends \
         build-essential=12.9 \
         cmake=3.18.4-2+deb11u1 \
-        libssl-dev=1.1.1n-0+deb11u2 \
+        libssl-dev=1.1.1n-0+deb11u3 \
         perl=5.32.1-4+deb11u2 \
         pkg-config=0.29.2-1 \
         tcl=8.6.11+1 \


### PR DESCRIPTION
`1.1.1n-0+deb11u2` is no longer available.