### PR TITLE
update merge pipeline to account for renamed integration testing stack

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -105,7 +105,7 @@ steps:
           artifact_file: all_artifacts.json
           stacks:
             - grapl/grapl/testing
-            - grapl/integration-tests/testing
+            - grapl/rust-integration-tests/testing
     env:
       # We're going to be doing some git manipulation, so it's best if
       # we have a clean slate.


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?

https://app.zenhub.com/workspaces/grapl-6036cbd36bacff000ef314f2/issues/grapl-security/issue-tracker/368

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

The pipeline updates I merged yesterday renamed the integration testing stack from `integration-tests` to `rust-integration-tests` which broke the merge pipeline. This should fix it.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

Automated tests.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
