### PR TITLE
Internal 719 get generator rpc

### DIFF
--- a/src/proto/graplinc/grapl/api/plugin_registry/v1beta1/plugin_registry.proto
+++ b/src/proto/graplinc/grapl/api/plugin_registry/v1beta1/plugin_registry.proto
@@ -15,31 +15,8 @@ enum PluginType {
 }
 
 // A basic representation of a plugin
-message Plugin {
-  // unique identifier for this plugin
-  graplinc.common.v1beta1.Uuid plugin_id = 1;
-
-  // The string value to display to a user, non-empty
-  string display_name = 2;
-
-  // The type of the plugin
-  PluginType plugin_type = 3;
-
-  // The executable binary for this plugin
-  bytes plugin_binary = 4;
-}
-
-message CreatePluginRequest {
-  oneof inner {
-    CreatePluginRequestMetadata metadata = 1;
-    // Chunks of the plugin binary
-    bytes chunk = 2;
-  }
-}
-
-// A request to create a plugin entry
-message CreatePluginRequestMetadata {
-  // Tenant that is deploying this plugin
+message PluginMetadata {
+  // The platform tenant this plugin belongs to
   graplinc.common.v1beta1.Uuid tenant_id = 1;
 
   // The string value to display to a user, non-empty
@@ -47,6 +24,26 @@ message CreatePluginRequestMetadata {
 
   // The type of the plugin
   PluginType plugin_type = 3;
+
+  // Optional event source id to associate with this plugin. The semantics of
+  // this field are that it is:
+  //
+  // - present for a plugin of type PLUGIN_TYPE_GENERATOR
+  // - absent otherwise
+  //
+  // Attempting to create a plugin of type PLUGIN_TYPE_GENERATOR without
+  // specifying an event_source_id will result in an error.
+  graplinc.common.v1beta1.Uuid event_source_id = 4;
+}
+
+message CreatePluginRequest {
+  oneof inner {
+    // Preamble containing important information about the plugin.
+    PluginMetadata metadata = 1;
+    // Chunks of the plugin binary--these are streamed in-order after the
+    // PluginMetadata preamble.
+    bytes chunk = 2;
+  }
 }
 
 // A Response to a plugin entry being created
@@ -59,14 +56,17 @@ message CreatePluginResponse {
 message GetPluginRequest {
   // The identity of the plugin
   graplinc.common.v1beta1.Uuid plugin_id = 1;
-  // The tenant for which the plugin belongs to
+  // The platform tenant this plugin belongs to
   graplinc.common.v1beta1.Uuid tenant_id = 2;
 }
 
 // A response containing the request plugin
 message GetPluginResponse {
-  // The requested plugin
-  Plugin plugin = 1;
+  // unique identifier for this plugin
+  graplinc.common.v1beta1.Uuid plugin_id = 1;
+
+  // The requested plugin's metadata
+  PluginMetadata plugin_metadata = 2;
 }
 
 // A request to deploy an existing plugin

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -437,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "atoi"
-version = "0.4.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616896e05fc0e2649463a93a15183c6a16bf03413a7af88ef1285ddedfa9cda5"
+checksum = "d7c57d12312ff59c811c0643f4d80830505833c9ffaebd193d819392b265be8e"
 dependencies = [
  "num-traits",
 ]
@@ -935,18 +935,18 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
+checksum = "53757d12b596c16c78b83458d732a5d1a17ab3f53f2f7412f6fb57cc8a140ab3"
 dependencies = [
  "crc-catalog",
 ]
 
 [[package]]
 name = "crc-catalog"
-version = "1.1.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
+checksum = "2d0165d2900ae6778e36e80bbc4da3b5eefccee9ba939761f9c2882a5d9af3ff"
 
 [[package]]
 name = "crc32fast"
@@ -1904,12 +1904,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.7.0"
+name = "hashbrown"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 dependencies = [
- "hashbrown",
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452c155cb93fecdfb02a73dd57b5d8e442c2063bd7aac72f1bc5e4263a43086"
+dependencies = [
+ "hashbrown 0.12.1",
 ]
 
 [[package]]
@@ -2132,7 +2141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -2317,7 +2326,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8015d95cb7b2ddd3c0d32ca38283ceb1eea09b4713ee380bceb942d85a244228"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -2492,7 +2501,7 @@ dependencies = [
  "metrics",
  "prost 0.9.0",
  "prost-derive 0.9.0",
- "quanta",
+ "quanta 0.9.3",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2506,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.7.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e1a0803406a47496169480f26cab92e78936c1180ad439ee18d36478c1509c"
+checksum = "975fa04238144061e7f8df9746b2e9cd93ef85881da5548d842a7c6a4b614415"
 dependencies = [
  "async-io",
  "async-lock",
@@ -2519,7 +2528,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.1",
- "quanta",
+ "quanta 0.10.0",
  "scheduled-thread-pool",
  "skeptic",
  "smallvec",
@@ -3359,6 +3368,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafd74c340a0a7e79415981ede3460df16b530fd071541901a57416eea950b17"
+dependencies = [
+ "crossbeam-utils 0.8.8",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3637,7 +3662,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.22.3",
+ "webpki-roots",
  "winreg 0.10.1",
 ]
 
@@ -4201,9 +4226,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.5.13"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551873805652ba0d912fec5bbb0f8b4cdd96baf8e2ebf5970e5671092966019b"
+checksum = "1f82cbe94f41641d6c410ded25bbf5097c240cefdf8e3b06d04198d0a96af6a4"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -4211,9 +4236,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.5.13"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48c61941ccf5ddcada342cd59e3e5173b007c509e1e8e990dafc830294d9dc5"
+checksum = "6b69bf218860335ddda60d6ce85ee39f6cf6e5630e300e19757d1de15886a093"
 dependencies = [
  "ahash",
  "atoi",
@@ -4245,7 +4270,8 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rand 0.8.5",
- "rustls 0.19.1",
+ "rustls 0.20.6",
+ "rustls-pemfile 1.0.0",
  "serde",
  "serde_json",
  "sha-1",
@@ -4258,16 +4284,15 @@ dependencies = [
  "tokio-stream",
  "url",
  "uuid",
- "webpki 0.21.4",
- "webpki-roots 0.21.1",
+ "webpki-roots",
  "whoami",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.5.13"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0fba2b0cae21fc00fe6046f8baa4c7fcb49e379f0f592b04696607f69ed2e1"
+checksum = "f40c63177cf23d356b159b60acd27c54af7423f1736988502e36bae9a712118f"
 dependencies = [
  "dotenv",
  "either",
@@ -4287,20 +4312,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.5.13"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db708cd3e459078f85f39f96a00960bd841f66ee2a669e90bf36907f5a79aae"
+checksum = "874e93a365a598dc3dadb197565952cb143ae4aa716f7bcc933a8d836f6bf89f"
 dependencies = [
  "once_cell",
  "tokio",
- "tokio-rustls 0.22.0",
+ "tokio-rustls 0.23.4",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stringprep"
@@ -4993,10 +5012,6 @@ name = "triomphe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda0abf5a9b5ad4a5ac1393956ae03fb57033749d3983e2cac9afbfd5ae04ec2"
-dependencies = [
- "serde",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "trust-dns-proto"
@@ -5152,9 +5167,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom 0.2.6",
  "serde",
@@ -5332,15 +5347,6 @@ checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
-dependencies = [
- "webpki 0.21.4",
 ]
 
 [[package]]

--- a/src/rust/derive-dynamic-node/Cargo.toml
+++ b/src/rust/derive-dynamic-node/Cargo.toml
@@ -21,4 +21,4 @@ serde = "1.0.130"
 serde_json = "1.0.72"
 serde_derive = "1.0.130"
 log = "0.4.14"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }

--- a/src/rust/endpoint-plugin/Cargo.toml
+++ b/src/rust/endpoint-plugin/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 rust-proto = { path = "../rust-proto", version = "*" }
 derive-dynamic-node = { path = "../derive-dynamic-node" }
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }
 thiserror = "1.0.30"

--- a/src/rust/event-source/Cargo.toml
+++ b/src/rust/event-source/Cargo.toml
@@ -8,8 +8,8 @@ async-trait = "0.1"
 grapl-config = { path = "../grapl-config" }
 grapl-utils = { path = "../grapl-utils" }
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }
-uuid = { version = "0.8", features = ["serde", "v4"] }
-sqlx = { version = "0.5", features = [
+uuid = { version = "1.0", features = ["serde", "v4"] }
+sqlx = { version = "0.6", features = [
   "chrono",
   "migrate",
   "offline",

--- a/src/rust/generator-dispatcher/Cargo.toml
+++ b/src/rust/generator-dispatcher/Cargo.toml
@@ -21,7 +21,7 @@ plugin-work-queue = { path = "../plugin-work-queue" }
 rust-proto = { path = "../rust-proto" }
 tokio = { version = "1.17", features = ["macros", "rt", "rt-multi-thread"] }
 tracing = "0.1.29"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/src/rust/generators/osquery-generator/Cargo.toml
+++ b/src/rust/generators/osquery-generator/Cargo.toml
@@ -29,4 +29,4 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.16"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }

--- a/src/rust/generators/sysmon-generator/Cargo.toml
+++ b/src/rust/generators/sysmon-generator/Cargo.toml
@@ -34,7 +34,7 @@ tracing = "0.1.29"
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.16"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/src/rust/graph-merger/Cargo.toml
+++ b/src/rust/graph-merger/Cargo.toml
@@ -55,7 +55,7 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.16"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
 test-context = "0.1"

--- a/src/rust/node-identifier/Cargo.toml
+++ b/src/rust/node-identifier/Cargo.toml
@@ -60,7 +60,7 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.16"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/src/rust/organization-management/Cargo.toml
+++ b/src/rust/organization-management/Cargo.toml
@@ -15,8 +15,8 @@ async-trait = "0.1"
 grapl-config = { path = "../grapl-config" }
 grapl-utils = { path = "../grapl-utils" }
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }
-uuid = { version = "0.8", features = ["serde", "v4"] }
-sqlx = { version = "0.5", features = [
+uuid = { version = "1.0", features = ["serde", "v4"] }
+sqlx = { version = "0.6", features = [
   "runtime-tokio-rustls",
   "postgres",
   "offline",

--- a/src/rust/pipeline-ingress/Cargo.toml
+++ b/src/rust/pipeline-ingress/Cargo.toml
@@ -24,7 +24,7 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.16"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
 bytes = "1.1"

--- a/src/rust/plugin-bootstrap/Cargo.toml
+++ b/src/rust/plugin-bootstrap/Cargo.toml
@@ -27,7 +27,7 @@ rust-proto = { path = "../rust-proto" }
 thiserror = "1.0"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }
 futures = "0.3"
 
 [features]

--- a/src/rust/plugin-registry/Cargo.toml
+++ b/src/rust/plugin-registry/Cargo.toml
@@ -24,7 +24,7 @@ grapl-utils = { path = "../grapl-utils" }
 rust-proto = { path = "../rust-proto" }
 nomad-client-gen = { path = "../nomad-client-gen" }
 serde_json = "1.0.72"
-sqlx = { version = "0.5", features = [
+sqlx = { version = "0.6", features = [
   "chrono",
   "migrate",
   "offline",
@@ -44,7 +44,7 @@ rusoto_core = { version = "0.47.0", default_features = false, features = [
 rusoto_s3 = { version = "0.47.0", default_features = false, features = [
   "rustls"
 ] }
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }
 futures = "0.3"
 
 [dev-dependencies]

--- a/src/rust/plugin-registry/migrations/20220629221304_plugin_event_source.sql
+++ b/src/rust/plugin-registry/migrations/20220629221304_plugin_event_source.sql
@@ -1,0 +1,12 @@
+-- Add migration script here
+
+-- The event_source_id will be absent for analyzers, present for generators. In
+-- the get_generators_for_event_source query we filter on both event_source_id
+-- and plugin_type to ensure we won't erroneously return data for some 3rd
+-- plugin type should we add one in the future. The event_source_plugin_type_ix
+-- will also be useful at that future time if we need to implement a similar
+-- query for that 3rd plugin type.
+ALTER TABLE plugins
+      ADD COLUMN event_source_id uuid DEFAULT NULL;
+
+CREATE INDEX event_source_plugin_type_ix ON plugins (event_source_id, plugin_type);

--- a/src/rust/plugin-registry/sqlx-data.json
+++ b/src/rust/plugin-registry/sqlx-data.json
@@ -1,80 +1,47 @@
 {
   "db": "PostgreSQL",
-  "59991d338dfedafd140ece1f94cec67df8734490a5ccca581ae9c1d0507f003d": {
-    "query": "\n            INSERT INTO plugin_deployment (\n                plugin_id,\n                status\n            )\n            VALUES ($1::uuid, $2);\n            ",
+  "0f04a764a6348444101c900b5f63e5f96b7480c679de5d732a12ae732b856aed": {
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
-          {
-            "Custom": {
-              "name": "plugin_deployment_status",
-              "kind": {
-                "Enum": [
-                  "fail",
-                  "success"
-                ]
-              }
-            }
-          }
+          "Varchar",
+          "Varchar",
+          "Uuid",
+          "Varchar",
+          "Uuid"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\n                INSERT INTO plugins (\n                    plugin_id,\n                    plugin_type,\n                    display_name,\n                    tenant_id,\n                    artifact_s3_key,\n                    event_source_id\n                )\n                VALUES ($1::uuid, $2, $3, $4::uuid, $5, $6::uuid)\n                ON CONFLICT DO NOTHING;\n                "
   },
-  "5a1b633a47279ec559e797b2d76abb94d85ebf1853cb7b7e9fa4d3b6f633d5f8": {
-    "query": "\n            SELECT\n                id,\n                plugin_id,\n                deploy_time,\n                status AS \"status: PluginDeploymentStatus\"\n            FROM plugin_deployment\n            WHERE plugin_id = $1\n            ORDER BY id desc limit 1;\n            ",
+  "28c021bb5a0f5ccde835369e727619efb41b97cf81ddda62ed368af95a6dcc06": {
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Int4"
-        },
-        {
-          "ordinal": 1,
           "name": "plugin_id",
+          "ordinal": 0,
           "type_info": "Uuid"
-        },
-        {
-          "ordinal": 2,
-          "name": "deploy_time",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 3,
-          "name": "status: PluginDeploymentStatus",
-          "type_info": {
-            "Custom": {
-              "name": "plugin_deployment_status",
-              "kind": {
-                "Enum": [
-                  "fail",
-                  "success"
-                ]
-              }
-            }
-          }
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
-          "Uuid"
+          "Uuid",
+          "Text"
         ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\n            SELECT\n            plugin_id\n            FROM plugins\n            WHERE event_source_id = $1 AND plugin_type = $2;\n            "
   },
-  "c57567e93fa4914365fffaf15b1a6937f28b5ee1e8ed28d569ee66035926cd0e": {
-    "query": "\n            INSERT INTO plugins (\n                plugin_id,\n                plugin_type,\n                display_name,\n                tenant_id,\n                artifact_s3_key\n            )\n            VALUES ($1::uuid, $2, $3, $4::uuid, $5)\n            ON CONFLICT DO NOTHING;\n            ",
+  "2ca595f8a559bd468593dc0adc0149c79e062d9c4910342f82c9d7d9cd80ea0f": {
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Uuid",
@@ -83,52 +50,129 @@
           "Uuid",
           "Varchar"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "\n                INSERT INTO plugins (\n                    plugin_id,\n                    plugin_type,\n                    display_name,\n                    tenant_id,\n                    artifact_s3_key\n                )\n                VALUES ($1::uuid, $2, $3, $4::uuid, $5)\n                ON CONFLICT DO NOTHING;\n                "
   },
-  "d31a831ff688cfe70f5ba3fc527acac049d9312d8a58888dddca697db188a4cc": {
-    "query": "\n            SELECT\n            plugin_id,\n            tenant_id,\n            display_name,\n            plugin_type,\n            artifact_s3_key\n            FROM plugins\n            WHERE plugin_id = $1\n            ",
+  "59991d338dfedafd140ece1f94cec67df8734490a5ccca581ae9c1d0507f003d": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "fail",
+                  "success"
+                ]
+              },
+              "name": "plugin_deployment_status"
+            }
+          }
+        ]
+      }
+    },
+    "query": "\n            INSERT INTO plugin_deployment (\n                plugin_id,\n                status\n            )\n            VALUES ($1::uuid, $2);\n            "
+  },
+  "5a1b633a47279ec559e797b2d76abb94d85ebf1853cb7b7e9fa4d3b6f633d5f8": {
     "describe": {
       "columns": [
         {
+          "name": "id",
           "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
           "name": "plugin_id",
-          "type_info": "Uuid"
-        },
-        {
           "ordinal": 1,
-          "name": "tenant_id",
           "type_info": "Uuid"
         },
         {
+          "name": "deploy_time",
           "ordinal": 2,
-          "name": "display_name",
-          "type_info": "Varchar"
+          "type_info": "Timestamptz"
         },
         {
+          "name": "status: PluginDeploymentStatus",
           "ordinal": 3,
-          "name": "plugin_type",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 4,
-          "name": "artifact_s3_key",
-          "type_info": "Varchar"
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "fail",
+                  "success"
+                ]
+              },
+              "name": "plugin_deployment_status"
+            }
+          }
         }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false
       ],
       "parameters": {
         "Left": [
           "Uuid"
         ]
-      },
+      }
+    },
+    "query": "\n            SELECT\n                id,\n                plugin_id,\n                deploy_time,\n                status AS \"status: PluginDeploymentStatus\"\n            FROM plugin_deployment\n            WHERE plugin_id = $1\n            ORDER BY id desc limit 1;\n            "
+  },
+  "cd302b0299a3919aa7fcd34ec60877e8a3189560b9485dc9f75b3ca0368afcc8": {
+    "describe": {
+      "columns": [
+        {
+          "name": "plugin_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "tenant_id",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "display_name",
+          "ordinal": 2,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "plugin_type",
+          "ordinal": 3,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "artifact_s3_key",
+          "ordinal": 4,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "event_source_id",
+          "ordinal": 5,
+          "type_info": "Uuid"
+        }
+      ],
       "nullable": [
         false,
         false,
         false,
         false,
-        false
-      ]
-    }
+        false,
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n            SELECT\n            plugin_id,\n            tenant_id,\n            display_name,\n            plugin_type,\n            artifact_s3_key,\n            event_source_id\n            FROM plugins\n            WHERE plugin_id = $1\n            "
   }
 }

--- a/src/rust/plugin-registry/src/db/client.rs
+++ b/src/rust/plugin-registry/src/db/client.rs
@@ -4,6 +4,7 @@ use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::PluginType;
 use super::models::{
     PluginDeploymentRow,
     PluginDeploymentStatus,
+    PluginIdRow,
     PluginRow,
 };
 
@@ -15,9 +16,30 @@ pub struct DbCreatePluginArgs {
     pub tenant_id: uuid::Uuid,
     pub display_name: String,
     pub plugin_type: PluginType,
+    pub event_source_id: Option<uuid::Uuid>,
 }
 
 impl PluginRegistryDbClient {
+    #[tracing::instrument(skip(self), err)]
+    pub async fn get_generators_for_event_source(
+        &self,
+        event_source_id: &uuid::Uuid,
+    ) -> Result<Vec<PluginIdRow>, sqlx::Error> {
+        sqlx::query_as!(
+            PluginIdRow,
+            r"
+            SELECT
+            plugin_id
+            FROM plugins
+            WHERE event_source_id = $1 AND plugin_type = $2;
+            ",
+            event_source_id,
+            PluginType::Generator.type_name(),
+        )
+        .fetch_all(&self.pool)
+        .await
+    }
+
     #[tracing::instrument(skip(self), err)]
     pub async fn get_plugin(&self, plugin_id: &uuid::Uuid) -> Result<PluginRow, sqlx::Error> {
         sqlx::query_as!(
@@ -28,7 +50,8 @@ impl PluginRegistryDbClient {
             tenant_id,
             display_name,
             plugin_type,
-            artifact_s3_key
+            artifact_s3_key,
+            event_source_id
             FROM plugins
             WHERE plugin_id = $1
             ",
@@ -68,24 +91,46 @@ impl PluginRegistryDbClient {
         args: DbCreatePluginArgs,
         s3_key: &str,
     ) -> Result<(), sqlx::Error> {
-        sqlx::query!(
-            r"
-            INSERT INTO plugins (
+        match args.event_source_id {
+            Some(event_source_id) => sqlx::query!(
+                r"
+                INSERT INTO plugins (
+                    plugin_id,
+                    plugin_type,
+                    display_name,
+                    tenant_id,
+                    artifact_s3_key,
+                    event_source_id
+                )
+                VALUES ($1::uuid, $2, $3, $4::uuid, $5, $6::uuid)
+                ON CONFLICT DO NOTHING;
+                ",
                 plugin_id,
-                plugin_type,
-                display_name,
-                tenant_id,
-                artifact_s3_key
-            )
-            VALUES ($1::uuid, $2, $3, $4::uuid, $5)
-            ON CONFLICT DO NOTHING;
-            ",
-            plugin_id,
-            &args.plugin_type.type_name(),
-            &args.display_name,
-            &args.tenant_id,
-            s3_key,
-        )
+                &args.plugin_type.type_name(),
+                &args.display_name,
+                &args.tenant_id,
+                s3_key,
+                event_source_id,
+            ),
+            None => sqlx::query!(
+                r"
+                INSERT INTO plugins (
+                    plugin_id,
+                    plugin_type,
+                    display_name,
+                    tenant_id,
+                    artifact_s3_key
+                )
+                VALUES ($1::uuid, $2, $3, $4::uuid, $5)
+                ON CONFLICT DO NOTHING;
+                ",
+                plugin_id,
+                &args.plugin_type.type_name(),
+                &args.display_name,
+                &args.tenant_id,
+                s3_key,
+            ),
+        }
         .execute(&self.pool)
         .await
         .map(|_| ()) // Toss result

--- a/src/rust/plugin-registry/src/db/models.rs
+++ b/src/rust/plugin-registry/src/db/models.rs
@@ -4,12 +4,18 @@ use sqlx::types::chrono::{
 };
 
 #[derive(sqlx::FromRow)]
+pub struct PluginIdRow {
+    pub plugin_id: uuid::Uuid,
+}
+
+#[derive(sqlx::FromRow)]
 pub struct PluginRow {
     pub plugin_id: uuid::Uuid,
     pub tenant_id: uuid::Uuid,
     pub display_name: String,
     pub plugin_type: String,
     pub artifact_s3_key: String,
+    pub event_source_id: Option<uuid::Uuid>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, sqlx::Type)]
@@ -32,7 +38,7 @@ impl<T, E> From<&Result<T, E>> for PluginDeploymentStatus {
 /// consumed anywhere.
 #[derive(sqlx::FromRow)]
 pub struct PluginDeploymentRow {
-    pub id: i32,
+    pub id: i64,
     pub plugin_id: uuid::Uuid,
     pub deploy_time: DateTime<Utc>,
     pub status: PluginDeploymentStatus,

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -185,6 +185,7 @@ mod tests {
             tenant_id: arbitrary_uuid,
             display_name: "arbitrary".to_owned(),
             plugin_type: "analyzer".to_owned(),
+            event_source_id: None,
             artifact_s3_key: "arbitrary".to_owned(),
         };
         let service_config = arbitrary_service_config();

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -5,15 +5,10 @@ use std::{
 
 use futures::StreamExt;
 use grapl_config::env_helpers::FromEnv;
-use rusoto_s3::{
-    GetObjectRequest,
-    S3Client,
-    S3,
-};
+use rusoto_s3::S3Client;
 use rust_proto::{
     graplinc::grapl::api::plugin_registry::v1beta1::{
         CreatePluginRequest,
-        CreatePluginRequestMetadata,
         CreatePluginResponse,
         DeployPluginRequest,
         DeployPluginResponse,
@@ -23,7 +18,7 @@ use rust_proto::{
         GetGeneratorsForEventSourceResponse,
         GetPluginRequest,
         GetPluginResponse,
-        Plugin,
+        PluginMetadata,
         PluginRegistryApi,
         PluginRegistryServer,
         PluginType,
@@ -32,10 +27,7 @@ use rust_proto::{
     },
     protocol::healthcheck::HealthcheckStatus,
 };
-use tokio::{
-    io::AsyncReadExt,
-    net::TcpListener,
-};
+use tokio::net::TcpListener;
 use tonic::async_trait;
 
 use super::create_plugin::upload_stream_multipart_to_s3;
@@ -127,10 +119,11 @@ impl PluginRegistryApi for PluginRegistry {
 
         let mut request = request;
 
-        let CreatePluginRequestMetadata {
+        let PluginMetadata {
             tenant_id,
             display_name,
             plugin_type,
+            event_source_id,
         } = match request.next().await {
             Some(CreatePluginRequest::Metadata(m)) => m,
             _ => {
@@ -172,6 +165,7 @@ impl PluginRegistryApi for PluginRegistry {
                     tenant_id,
                     display_name,
                     plugin_type,
+                    event_source_id,
                 },
                 &s3_key,
             )
@@ -186,44 +180,23 @@ impl PluginRegistryApi for PluginRegistry {
         request: GetPluginRequest,
     ) -> Result<GetPluginResponse, Self::Error> {
         let PluginRow {
-            artifact_s3_key,
+            artifact_s3_key: _,
             plugin_type,
             plugin_id,
             display_name,
-            tenant_id: _,
+            tenant_id,
+            event_source_id,
         } = self.db_client.get_plugin(&request.plugin_id).await?;
 
-        let s3_key: String = artifact_s3_key;
         let plugin_type: PluginType = try_from(&plugin_type)?;
 
-        let get_object_output = self
-            .s3
-            .get_object(GetObjectRequest {
-                bucket: self.config.bucket_name.clone(),
-                key: s3_key.clone(),
-                expected_bucket_owner: Some(self.config.bucket_aws_account_id.clone()),
-                ..Default::default()
-            })
-            .await?;
-
-        let stream = get_object_output
-            .body
-            .ok_or(PluginRegistryServiceError::EmptyObject)?;
-
-        let mut plugin_binary = Vec::new();
-
-        // read the whole file
-        stream
-            .into_async_read()
-            .read_to_end(&mut plugin_binary)
-            .await?;
-
         let response = GetPluginResponse {
-            plugin: Plugin {
-                plugin_id,
+            plugin_id,
+            plugin_metadata: PluginMetadata {
+                tenant_id,
                 display_name,
                 plugin_type,
-                plugin_binary,
+                event_source_id,
             },
         };
 
@@ -262,12 +235,20 @@ impl PluginRegistryApi for PluginRegistry {
         todo!()
     }
 
-    #[tracing::instrument(skip(self, _request), err)]
+    #[tracing::instrument(skip(self, request), err)]
     async fn get_generators_for_event_source(
         &self,
-        _request: GetGeneratorsForEventSourceRequest,
+        request: GetGeneratorsForEventSourceRequest,
     ) -> Result<GetGeneratorsForEventSourceResponse, Self::Error> {
-        todo!()
+        Ok(GetGeneratorsForEventSourceResponse {
+            plugin_ids: self
+                .db_client
+                .get_generators_for_event_source(&request.event_source_id)
+                .await?
+                .iter()
+                .map(|row| row.plugin_id)
+                .collect(),
+        })
     }
 
     #[allow(dead_code)]
@@ -329,9 +310,9 @@ fn generate_artifact_s3_key(
 ) -> String {
     format!(
         "plugins/tenant_id_{}/plugin_type-{}/{}.bin",
-        tenant_id.to_hyphenated(),
+        tenant_id.as_hyphenated(),
         plugin_type.type_name(),
-        plugin_id.to_hyphenated(),
+        plugin_id.as_hyphenated(),
     )
 }
 

--- a/src/rust/plugin-registry/tests/test_create_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_create_plugin.rs
@@ -3,9 +3,9 @@
 use grapl_utils::future_ext::GraplFutureExt;
 use plugin_registry::client::FromEnv;
 use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::{
-    CreatePluginRequestMetadata,
     GetPluginRequest,
     GetPluginResponse,
+    PluginMetadata,
     PluginRegistryServiceClient,
     PluginType,
 };
@@ -23,10 +23,13 @@ async fn test_create_plugin() -> Result<(), Box<dyn std::error::Error>> {
 
     let display_name = uuid::Uuid::new_v4().to_string();
 
-    let meta = CreatePluginRequestMetadata {
+    let event_source_id = uuid::Uuid::new_v4();
+
+    let meta = PluginMetadata {
         tenant_id: tenant_id.clone(),
         display_name: display_name.clone(),
         plugin_type: PluginType::Generator,
+        event_source_id: Some(event_source_id),
     };
 
     let single_chunk = b"dummy vec for now".to_vec();
@@ -45,8 +48,15 @@ async fn test_create_plugin() -> Result<(), Box<dyn std::error::Error>> {
         })
         .timeout(std::time::Duration::from_secs(5))
         .await??;
-    assert_eq!(get_response.plugin.plugin_id, plugin_id);
-    assert_eq!(get_response.plugin.plugin_type, PluginType::Generator);
-    assert_eq!(get_response.plugin.display_name, display_name);
+    assert_eq!(get_response.plugin_id, plugin_id);
+    assert_eq!(
+        get_response.plugin_metadata.plugin_type,
+        PluginType::Generator
+    );
+    assert_eq!(get_response.plugin_metadata.display_name, display_name);
+    assert_eq!(
+        get_response.plugin_metadata.event_source_id,
+        Some(event_source_id)
+    );
     Ok(())
 }

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -3,8 +3,8 @@
 use grapl_utils::future_ext::GraplFutureExt;
 use plugin_registry::client::FromEnv;
 use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::{
-    CreatePluginRequestMetadata,
     DeployPluginRequest,
+    PluginMetadata,
     PluginRegistryServiceClient,
     PluginRegistryServiceClientError,
     PluginType,
@@ -21,14 +21,16 @@ async fn test_deploy_plugin() -> Result<(), Box<dyn std::error::Error>> {
     let mut client = PluginRegistryServiceClient::from_env().await?;
 
     let tenant_id = uuid::Uuid::new_v4();
+    let event_source_id = uuid::Uuid::new_v4();
 
     let create_response = {
         let display_name = uuid::Uuid::new_v4().to_string();
         let artifact = get_example_generator()?;
-        let metadata = CreatePluginRequestMetadata {
+        let metadata = PluginMetadata {
             tenant_id: tenant_id.clone(),
             display_name: display_name.clone(),
             plugin_type: PluginType::Generator,
+            event_source_id: Some(event_source_id.clone()),
         };
 
         client

--- a/src/rust/plugin-registry/tests/test_get_generators_for_event_source.rs
+++ b/src/rust/plugin-registry/tests/test_get_generators_for_event_source.rs
@@ -1,0 +1,83 @@
+#![cfg(feature = "integration_tests")]
+
+use grapl_utils::future_ext::GraplFutureExt;
+use plugin_registry::client::FromEnv;
+use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::{
+    GetGeneratorsForEventSourceRequest,
+    PluginMetadata,
+    PluginRegistryServiceClient,
+    PluginType,
+};
+
+#[test_log::test(tokio::test)]
+async fn test_get_generators_for_event_source() -> Result<(), Box<dyn std::error::Error>> {
+    tracing::debug!(
+        env=?std::env::args(),
+    );
+
+    let mut client = PluginRegistryServiceClient::from_env().await?;
+
+    let tenant_id = uuid::Uuid::new_v4();
+    let generator1_display_name = "my first generator".to_string();
+    let generator2_display_name = "my second generator".to_string();
+    let analyzer_display_name = "my analyzer".to_string();
+    let event_source_id = uuid::Uuid::new_v4();
+
+    let generator1_metadata = PluginMetadata {
+        tenant_id: tenant_id.clone(),
+        display_name: generator1_display_name.clone(),
+        plugin_type: PluginType::Generator,
+        event_source_id: Some(event_source_id),
+    };
+    let generator2_metadata = PluginMetadata {
+        tenant_id: tenant_id.clone(),
+        display_name: generator2_display_name.clone(),
+        plugin_type: PluginType::Generator,
+        event_source_id: Some(event_source_id),
+    };
+
+    let analyzer_metadata = PluginMetadata {
+        tenant_id: tenant_id.clone(),
+        display_name: analyzer_display_name.clone(),
+        plugin_type: PluginType::Analyzer,
+        event_source_id: None,
+    };
+
+    let chunk = b"chonk".to_vec();
+
+    let create_generator1_response = client
+        .create_plugin(generator1_metadata, chunk.clone().into_iter())
+        .timeout(std::time::Duration::from_secs(5))
+        .await??;
+    let generator1_plugin_id = create_generator1_response.plugin_id;
+
+    let create_generator2_response = client
+        .create_plugin(generator2_metadata, chunk.clone().into_iter())
+        .timeout(std::time::Duration::from_secs(5))
+        .await??;
+    let generator2_plugin_id = create_generator2_response.plugin_id;
+
+    let create_analyzer_response = client
+        .create_plugin(analyzer_metadata, chunk.clone().into_iter())
+        .timeout(std::time::Duration::from_secs(5))
+        .await??;
+    let analyzer_plugin_id = create_analyzer_response.plugin_id;
+
+    let generators_for_event_source_response = client
+        .get_generators_for_event_source(GetGeneratorsForEventSourceRequest { event_source_id })
+        .timeout(std::time::Duration::from_secs(5))
+        .await??;
+
+    assert_eq!(generators_for_event_source_response.plugin_ids.len(), 2);
+    assert!(generators_for_event_source_response
+        .plugin_ids
+        .contains(&generator1_plugin_id));
+    assert!(generators_for_event_source_response
+        .plugin_ids
+        .contains(&generator2_plugin_id));
+    assert!(!generators_for_event_source_response
+        .plugin_ids
+        .contains(&analyzer_plugin_id));
+
+    Ok(())
+}

--- a/src/rust/plugin-sdk/generator-sdk/Cargo.toml
+++ b/src/rust/plugin-sdk/generator-sdk/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/examples/example_generator.rs"
 [dependencies]
 async-trait = "0.1"
 consul-connect = { path = "../../consul-connect" }
-moka = { version = "0.7", features = ["future"] }
+moka = { version = "0.8", features = ["future"] }
 rust-proto = { path = "../../rust-proto" }
 serde = { version = "1.0.136", features = ["derive"] }
 clap = { version = "3.0", default_features = false, features = [
@@ -22,7 +22,7 @@ clap = { version = "3.0", default_features = false, features = [
 thiserror = "1.0.30"
 tokio = { version = "1.17", features = ["full"] }
 tracing = "0.1.29"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }
 
 [features]
 internal = ["client"]

--- a/src/rust/plugin-work-queue/Cargo.toml
+++ b/src/rust/plugin-work-queue/Cargo.toml
@@ -25,8 +25,8 @@ thiserror = "1.0.30"
 tokio = { version = "1.17", features = ["full"] }
 tonic-health = "0.5.0"
 tracing = "0.1.29"
-uuid = { version = "0.8", features = ["v4"] }
-sqlx = { version = "0.5", features = [
+uuid = { version = "1.0", features = ["v4"] }
+sqlx = { version = "0.6", features = [
   "chrono",
   "migrate",
   "postgres",

--- a/src/rust/rust-proto/Cargo.toml
+++ b/src/rust/rust-proto/Cargo.toml
@@ -18,7 +18,7 @@ tokio-stream = { version = "0.1.8", features = ["net"] }
 tonic = { version = "0.7", features = ["default", "compression", "tls"] }
 tonic-health = "0.6"
 tracing = "0.1"
-uuid = { version = "0.8.2", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }
 
 [build-dependencies]
 tonic-build = { version = "0.7", features = ["default", "compression"] }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -61,7 +61,7 @@ impl PluginRegistryServiceClient {
     /// Simplified wrapper function for create_plugin
     pub async fn create_plugin(
         &mut self,
-        metadata: native::CreatePluginRequestMetadata,
+        metadata: native::PluginMetadata,
         plugin_artifact: impl Sized + Iterator<Item = u8> + Send + 'static,
     ) -> Result<native::CreatePluginResponse, PluginRegistryServiceClientError> {
         // Split the artifact up into 5MB chunks
@@ -119,12 +119,17 @@ impl PluginRegistryServiceClient {
         &mut self,
         request: native::GetGeneratorsForEventSourceRequest,
     ) -> Result<native::GetGeneratorsForEventSourceResponse, PluginRegistryServiceClientError> {
-        self.proto_client
+        let response = self
+            .proto_client
             .get_generators_for_event_source(proto::GetGeneratorsForEventSourceRequest::from(
                 request,
             ))
             .await?;
-        todo!()
+
+        let response =
+            native::GetGeneratorsForEventSourceResponse::try_from(response.into_inner())?;
+
+        Ok(response)
     }
 
     /// Given information about a tenant, return all analyzers for that tenant

--- a/src/rust/rust-proto/tests/proto_serde_tests.rs
+++ b/src/rust/rust-proto/tests/proto_serde_tests.rs
@@ -320,9 +320,8 @@ mod plugin_registry {
     use super::*;
 
     proptest! {
-        // For the record, codec
         #[test]
-        fn test_serde_plugins(value in pr_strats::plugins()) {
+        fn test_serde_plugin_metadatas(value in pr_strats::plugin_metadatas()) {
             check_encode_decode_invariant(value)
         }
 
@@ -352,8 +351,6 @@ mod plugin_registry {
         fn test_serde_deploy_plugin_responses(value in pr_strats::deploy_plugin_responses()) {
             check_encode_decode_invariant(value)
         }
-
-        //
 
         #[test]
         fn test_serde_get_generators_for_event_source_requests(value in pr_strats::get_generators_for_event_source_requests()) {

--- a/src/rust/sysmon-parser/Cargo.toml
+++ b/src/rust/sysmon-parser/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "0.4" }
 derive-into-owned = "0.2"
 memchr = "2"
 thiserror = "1.0"
-uuid = "0.8"
+uuid = "1.0"
 xmlparser = "0.13"
 serde = { version = "1.0", default-features = false, features = [
   "derive"


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://app.zenhub.com/workspaces/grapl-6036cbd36bacff000ef314f2/issues/grapl-security/issue-tracker/719
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

This PR makes some protocol buffer updates to simplify the plugin-registry's data model. We've consolidated the concept of `PluginMetadata` and removed the ability to download the plugin binary via RPC because it'll never be used.

This PR also implements the `GetGeneratorsForEventSource` RPC method, which necessitated a database schema migration to add `event_source_id` to the `plugins` table and associated updates to the data access layer.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

Automated tests.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
