### PR TITLE
Split up CreatePlugin into CreateAnalyzer, CreateGenerator

### DIFF
--- a/src/js/engagement_view/build-env.Dockerfile
+++ b/src/js/engagement_view/build-env.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-bullseye
+FROM node:16-bullseye-slim
 
 SHELL ["/bin/bash", "-c"]
 

--- a/src/proto/graplinc/grapl/api/plugin_registry/v1beta1/plugin_registry.proto
+++ b/src/proto/graplinc/grapl/api/plugin_registry/v1beta1/plugin_registry.proto
@@ -29,24 +29,39 @@ message Plugin {
   bytes plugin_binary = 4;
 }
 
-message CreatePluginRequest {
+message CreateGeneratorRequest {
   oneof inner {
-    CreatePluginRequestMetadata metadata = 1;
-    // Chunks of the plugin binary
+    CreateGeneratorRequestMetadata metadata = 1;
+    // Chunks of the generator binary
     bytes chunk = 2;
   }
 }
 
-// A request to create a plugin entry
-message CreatePluginRequestMetadata {
-  // Tenant that is deploying this plugin
+message CreateGeneratorRequestMetadata {
+  // Tenant that is deploying this Generator
   graplinc.common.v1beta1.Uuid tenant_id = 1;
 
   // The string value to display to a user, non-empty
   string display_name = 2;
 
-  // The type of the plugin
-  PluginType plugin_type = 3;
+  // The Event Sources that should be input in to this Generator
+  repeated graplinc.common.v1beta1.Uuid event_sources = 3;
+}
+
+message CreateAnalyzerRequest {
+  oneof inner {
+    CreateAnalyzerRequestMetadata metadata = 1;
+    // Chunks of the analyzer binary
+    bytes chunk = 2;
+  }
+}
+
+message CreateAnalyzerRequestMetadata {
+  // Tenant that is deploying this plugin
+  graplinc.common.v1beta1.Uuid tenant_id = 1;
+
+  // The string value to display to a user, non-empty
+  string display_name = 2;
 }
 
 // A Response to a plugin entry being created
@@ -114,7 +129,10 @@ message GetAnalyzersForTenantResponse {
 // A service that manages the state of plugins
 service PluginRegistryService {
   // create a new plugin
-  rpc CreatePlugin(stream CreatePluginRequest) returns (CreatePluginResponse);
+  rpc CreateGenerator(stream CreateGeneratorRequest) returns (CreatePluginResponse);
+
+  // create a new plugin
+  rpc CreateAnalyzer(stream CreateAnalyzerRequest) returns (CreatePluginResponse);
 
   // retrieve the plugin corresponding to the given plugin_id
   rpc GetPlugin(GetPluginRequest) returns (GetPluginResponse);

--- a/src/rust/plugin-registry/src/server/create_plugin.rs
+++ b/src/rust/plugin-registry/src/server/create_plugin.rs
@@ -15,7 +15,9 @@ use rusoto_s3::{
 };
 use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::{
     CreateAnalyzerRequest,
+    CreateAnalyzerRequestMetadata,
     CreateGeneratorRequest,
+    CreateGeneratorRequestMetadata,
 };
 
 use super::service::PluginRegistryServiceConfig;
@@ -100,6 +102,36 @@ impl TryToChunk for CreateGeneratorRequest {
             CreateGeneratorRequest::Chunk(c) => Ok(c),
             _ => Err(PluginRegistryServiceError::StreamInputError(
                 "Expected request 1..N to be Chunk",
+            )),
+        }
+    }
+}
+
+pub(crate) trait TryIntoMetadata<T> {
+    fn try_into_metadata(self) -> Result<T, PluginRegistryServiceError>;
+}
+
+impl TryIntoMetadata<CreateAnalyzerRequestMetadata> for Option<CreateAnalyzerRequest> {
+    fn try_into_metadata(
+        self,
+    ) -> Result<CreateAnalyzerRequestMetadata, PluginRegistryServiceError> {
+        match self {
+            Some(CreateAnalyzerRequest::Metadata(m)) => Ok(m),
+            _ => Err(PluginRegistryServiceError::StreamInputError(
+                "Expected request 0 to be Metadata",
+            )),
+        }
+    }
+}
+
+impl TryIntoMetadata<CreateGeneratorRequestMetadata> for Option<CreateGeneratorRequest> {
+    fn try_into_metadata(
+        self,
+    ) -> Result<CreateGeneratorRequestMetadata, PluginRegistryServiceError> {
+        match self {
+            Some(CreateGeneratorRequest::Metadata(m)) => Ok(m),
+            _ => Err(PluginRegistryServiceError::StreamInputError(
+                "Expected request 0 to be Metadata",
             )),
         }
     }

--- a/src/rust/plugin-registry/src/server/create_plugin.rs
+++ b/src/rust/plugin-registry/src/server/create_plugin.rs
@@ -13,7 +13,10 @@ use rusoto_s3::{
     UploadPartRequest,
     S3,
 };
-use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::CreatePluginRequest;
+use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::{
+    CreateAnalyzerRequest,
+    CreateGeneratorRequest,
+};
 
 use super::service::PluginRegistryServiceConfig;
 use crate::{

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -12,6 +12,7 @@ use rusoto_s3::{
 };
 use rust_proto::{
     graplinc::grapl::api::plugin_registry::v1beta1::{
+        CreateAnalyzerRequest,
         CreatePluginRequest,
         CreatePluginRequestMetadata,
         CreatePluginResponse,
@@ -119,9 +120,9 @@ impl PluginRegistryApi for PluginRegistry {
 
     // TODO: This function is so long I'm gonna split it out into its own file soon.
     #[tracing::instrument(skip(self, request), err)]
-    async fn create_plugin(
+    async fn create_analyzer(
         &self,
-        request: futures::channel::mpsc::Receiver<CreatePluginRequest>,
+        request: futures::channel::mpsc::Receiver<CreateAnalyzerRequest>,
     ) -> Result<CreatePluginResponse, Self::Error> {
         let start_time = std::time::SystemTime::now();
 
@@ -158,7 +159,7 @@ impl PluginRegistryApi for PluginRegistry {
                 .unwrap_or_default();
 
             tracing::info!(
-                message = "CreatePlugin benchmark",
+                message = "CreateAnalyzer benchmark",
                 display_name = ?display_name,
                 duration_millis = ?total_duration.as_millis(),
                 stream_length_bytes = multipart_upload.stream_length,

--- a/src/rust/plugin-registry/tests/test_create_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_create_plugin.rs
@@ -3,17 +3,16 @@
 use grapl_utils::future_ext::GraplFutureExt;
 use plugin_registry::client::FromEnv;
 use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::{
-    CreatePluginRequestMetadata,
+    CreateAnalyzerRequestMetadata,
     GetPluginRequest,
     GetPluginResponse,
     PluginRegistryServiceClient,
-    PluginType,
 };
 
 /// For now, this is just a smoke test. This test can and should evolve as
 /// the service matures.
 #[test_log::test(tokio::test)]
-async fn test_create_plugin() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_create_analyzer() -> Result<(), Box<dyn std::error::Error>> {
     tracing::debug!(
         env=?std::env::args(),
     );
@@ -23,16 +22,15 @@ async fn test_create_plugin() -> Result<(), Box<dyn std::error::Error>> {
 
     let display_name = uuid::Uuid::new_v4().to_string();
 
-    let meta = CreatePluginRequestMetadata {
+    let meta = CreateAnalyzerRequestMetadata {
         tenant_id: tenant_id.clone(),
         display_name: display_name.clone(),
-        plugin_type: PluginType::Generator,
     };
 
     let single_chunk = b"dummy vec for now".to_vec();
 
     let response = client
-        .create_plugin(meta, single_chunk.into_iter())
+        .create_analyzer(meta, single_chunk.into_iter())
         .timeout(std::time::Duration::from_secs(5))
         .await??;
 
@@ -46,7 +44,6 @@ async fn test_create_plugin() -> Result<(), Box<dyn std::error::Error>> {
         .timeout(std::time::Duration::from_secs(5))
         .await??;
     assert_eq!(get_response.plugin.plugin_id, plugin_id);
-    assert_eq!(get_response.plugin.plugin_type, PluginType::Generator);
     assert_eq!(get_response.plugin.display_name, display_name);
     Ok(())
 }

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -3,11 +3,10 @@
 use grapl_utils::future_ext::GraplFutureExt;
 use plugin_registry::client::FromEnv;
 use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::{
-    CreatePluginRequestMetadata,
+    CreateAnalyzerRequestMetadata,
     DeployPluginRequest,
     PluginRegistryServiceClient,
     PluginRegistryServiceClientError,
-    PluginType,
 };
 
 pub const SMALL_TEST_BINARY: &'static [u8] = include_bytes!("./small_test_binary.sh");
@@ -17,7 +16,7 @@ fn get_example_generator() -> Result<Vec<u8>, std::io::Error> {
 }
 
 #[test_log::test(tokio::test)]
-async fn test_deploy_plugin() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_deploy_analyzer() -> Result<(), Box<dyn std::error::Error>> {
     let mut client = PluginRegistryServiceClient::from_env().await?;
 
     let tenant_id = uuid::Uuid::new_v4();
@@ -25,14 +24,13 @@ async fn test_deploy_plugin() -> Result<(), Box<dyn std::error::Error>> {
     let create_response = {
         let display_name = uuid::Uuid::new_v4().to_string();
         let artifact = get_example_generator()?;
-        let metadata = CreatePluginRequestMetadata {
+        let metadata = CreateAnalyzerRequestMetadata {
             tenant_id: tenant_id.clone(),
             display_name: display_name.clone(),
-            plugin_type: PluginType::Generator,
         };
 
         client
-            .create_plugin(metadata, artifact.into_iter())
+            .create_analyzer(metadata, artifact.into_iter())
             .timeout(std::time::Duration::from_secs(5))
             .await??
     };

--- a/src/rust/rust-proto/tests/proto_serde_tests.rs
+++ b/src/rust/rust-proto/tests/proto_serde_tests.rs
@@ -327,7 +327,12 @@ mod plugin_registry {
         }
 
         #[test]
-        fn test_serde_create_plugin_requests(value in pr_strats::create_plugin_requests()) {
+        fn test_serde_create_analyzer_requests(value in pr_strats::create_analyzer_requests()) {
+            check_encode_decode_invariant(value)
+        }
+
+        #[test]
+        fn test_serde_create_generator_requests(value in pr_strats::create_generator_requests()) {
             check_encode_decode_invariant(value)
         }
 

--- a/src/rust/rust-proto/tests/test_utils/strategies.rs
+++ b/src/rust/rust-proto/tests/test_utils/strategies.rs
@@ -693,8 +693,10 @@ pub mod event_source {
 
 pub mod plugin_registry {
     use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::{
-        CreatePluginRequest,
-        CreatePluginRequestMetadata,
+        CreateAnalyzerRequest,
+        CreateAnalyzerRequestMetadata,
+        CreateGeneratorRequest,
+        CreateGeneratorRequestMetadata,
         CreatePluginResponse,
         DeployPluginRequest,
         DeployPluginResponse,
@@ -737,23 +739,42 @@ pub mod plugin_registry {
         }
     }
 
-    pub fn create_plugin_requests() -> impl Strategy<Value = CreatePluginRequest> {
+    pub fn create_analyzer_requests() -> impl Strategy<Value = CreateAnalyzerRequest> {
         prop_oneof![
-            any::<Vec<u8>>().prop_map(CreatePluginRequest::Chunk),
-            create_plugin_request_metadatas().prop_map(CreatePluginRequest::Metadata)
+            any::<Vec<u8>>().prop_map(CreateAnalyzerRequest::Chunk),
+            create_analyzer_request_metadatas().prop_map(CreateAnalyzerRequest::Metadata)
         ]
     }
 
     prop_compose! {
-        pub fn create_plugin_request_metadatas()(
+        pub fn create_analyzer_request_metadatas()(
             tenant_id in uuids(),
             display_name in string_not_empty(),
-            plugin_type in plugin_types(),
-        ) -> CreatePluginRequestMetadata {
-            CreatePluginRequestMetadata {
+        ) -> CreateAnalyzerRequestMetadata {
+            CreateAnalyzerRequestMetadata {
                 tenant_id,
                 display_name,
-                plugin_type,
+            }
+        }
+    }
+
+    pub fn create_generator_requests() -> impl Strategy<Value = CreateGeneratorRequest> {
+        prop_oneof![
+            any::<Vec<u8>>().prop_map(CreateGeneratorRequest::Chunk),
+            create_generator_request_metadatas().prop_map(CreateGeneratorRequest::Metadata)
+        ]
+    }
+
+    prop_compose! {
+        pub fn create_generator_request_metadatas()(
+            tenant_id in uuids(),
+            display_name in string_not_empty(),
+            event_sources in vec_of_uuids(),
+        ) -> CreateGeneratorRequestMetadata {
+            CreateGeneratorRequestMetadata {
+                tenant_id,
+                display_name,
+                event_sources,
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
Related to https://app.zenhub.com/workspaces/grapl-6036cbd36bacff000ef314f2/issues/grapl-security/issue-tracker/719
https://github.com/grapl-security/issue-tracker/issues/719

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Split up CreatePlugin into two mostly-duplicate RPCs: CreateAnalyzer and CreateGenerator.
Currently they are functionally exactly the same; a followup PR will implement the following
```
        // TODO: A DB client call that adds a one-to-many for event sources
        // that are associated with this Generator
```

which will then let us properly implement GetEventSourcesForGenerator

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
existing test cases updated for analyzer

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
