### PR TITLE
use rust_integration_tests in the provision pipeline

### DIFF
--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -52,7 +52,7 @@ steps:
 
   - wait
 
-  - label: ":pulumi: Preview grapl/integration-tests/testing environment changes in Staging account"
+  - label: ":pulumi: Preview grapl/rust-integration-tests/testing environment changes in Staging account"
     plugins:
       - grapl-security/vault-login#v0.1.3
       - grapl-security/vault-env#v0.1.0:
@@ -60,14 +60,14 @@ steps:
             - PULUMI_ACCESS_TOKEN
       - grapl-security/pulumi#v0.1.5:
           command: preview
-          project_dir: pulumi/integration_tests
+          project_dir: pulumi/rust_integration_tests
           stack: grapl/testing
     agents:
       queue: "pulumi-staging"
 
   - wait
 
-  - label: ":pulumi: Update grapl/integration-tests/testing environment in Staging account"
+  - label: ":pulumi: Update grapl/rust-integration-tests/testing environment in Staging account"
     plugins:
       - grapl-security/vault-login#v0.1.3
       - grapl-security/vault-env#v0.1.0:
@@ -75,7 +75,7 @@ steps:
             - PULUMI_ACCESS_TOKEN
       - grapl-security/pulumi#v0.1.5:
           command: update
-          project_dir: pulumi/integration_tests
+          project_dir: pulumi/rust_integration_tests
           stack: grapl/testing
     agents:
       queue: "pulumi-staging"


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?

NA

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

This PR fixes the provision pipeline to point to the new `rust_integration_tests` folder instead of the previous (and now nonexistent) `integration_tests` folder.
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

Automated tests (post-merge).

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
