### PR TITLE
Add protos and rust-proto structs for the GetPluginHealth RPCs

### DIFF
--- a/src/proto/graplinc/grapl/api/plugin_registry/v1beta1/plugin_registry.proto
+++ b/src/proto/graplinc/grapl/api/plugin_registry/v1beta1/plugin_registry.proto
@@ -78,6 +78,22 @@ message DeployPluginRequest {
 // A response indicating that a plugin has been deployed
 message DeployPluginResponse {}
 
+message GetPluginHealthRequest {
+  graplinc.common.v1beta1.Uuid plugin_id = 1;
+}
+
+message GetPluginHealthResponse {
+  enum PluginHealthStatus {
+    UNKNOWN = 0;
+    NOT_DEPLOYED = 1;
+    // These map to https://www.nomadproject.io/api-docs/jobs#status
+    PENDING = 2;
+    RUNNING = 3;
+    DEAD = 4;
+  }
+  PluginHealthStatus health_status = 1;
+}
+
 // A request to disable a deployed plugin
 message TearDownPluginRequest {
   // The identity of the plugin to be disabled
@@ -121,6 +137,9 @@ service PluginRegistryService {
 
   // turn on a particular plugin's code
   rpc DeployPlugin(DeployPluginRequest) returns (DeployPluginResponse);
+
+  // Get the health of a given deployed plugin ID
+  rpc GetPluginHealth(GetPluginHealthRequest) returns (GetPluginHealthResponse);
 
   // turn off a particular plugin's code
   rpc TearDownPlugin(TearDownPluginRequest) returns (TearDownPluginResponse);

--- a/src/proto/graplinc/grapl/api/plugin_registry/v1beta1/plugin_registry.proto
+++ b/src/proto/graplinc/grapl/api/plugin_registry/v1beta1/plugin_registry.proto
@@ -84,12 +84,12 @@ message GetPluginHealthRequest {
 
 message GetPluginHealthResponse {
   enum PluginHealthStatus {
-    UNKNOWN = 0;
-    NOT_DEPLOYED = 1;
+    PLUGIN_HEALTH_STATUS_UNSPECIFIED = 0;
+    PLUGIN_HEALTH_STATUS_NOT_DEPLOYED = 1;
     // These map to https://www.nomadproject.io/api-docs/jobs#status
-    PENDING = 2;
-    RUNNING = 3;
-    DEAD = 4;
+    PLUGIN_HEALTH_STATUS_PENDING = 2;
+    PLUGIN_HEALTH_STATUS_RUNNING = 3;
+    PLUGIN_HEALTH_STATUS_DEAD = 4;
   }
   PluginHealthStatus health_status = 1;
 }

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -16,6 +16,8 @@ use rust_proto::{
         GetAnalyzersForTenantResponse,
         GetGeneratorsForEventSourceRequest,
         GetGeneratorsForEventSourceResponse,
+        GetPluginHealthRequest,
+        GetPluginHealthResponse,
         GetPluginRequest,
         GetPluginResponse,
         PluginMetadata,
@@ -264,6 +266,14 @@ impl PluginRegistryApi for PluginRegistry {
         &self,
         _request: GetAnalyzersForTenantRequest,
     ) -> Result<GetAnalyzersForTenantResponse, Self::Error> {
+        todo!()
+    }
+
+    #[tracing::instrument(skip(self, _request), err)]
+    async fn get_plugin_health(
+        &self,
+        _request: GetPluginHealthRequest,
+    ) -> Result<GetPluginHealthResponse, Self::Error> {
         todo!()
     }
 }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
@@ -697,7 +697,7 @@ impl TryFrom<PluginHealthStatusProto> for PluginHealthStatus {
 
     fn try_from(value: PluginHealthStatusProto) -> Result<Self, Self::Error> {
         match value {
-            PluginHealthStatusProto::Unknown => {
+            PluginHealthStatusProto::Unspecified => {
                 Err(SerDeError::UnknownVariant("PluginHealthStatus"))
             }
             PluginHealthStatusProto::NotDeployed => Ok(PluginHealthStatus::NotDeployed),

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
@@ -639,3 +639,119 @@ impl From<TearDownPluginResponse> for proto::TearDownPluginResponse {
 impl ProtobufSerializable for TearDownPluginResponse {
     type ProtobufMessage = proto::TearDownPluginResponse;
 }
+
+//
+// GetPluginHealthRequest
+//
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GetPluginHealthRequest {
+    pub plugin_id: uuid::Uuid,
+}
+
+impl type_url::TypeUrl for GetPluginHealthRequest {
+    const TYPE_URL: &'static str =
+        "graplsecurity.com/graplinc.grapl.api.plugin_registry.v1beta1.GetPluginHealthRequest";
+}
+
+impl TryFrom<proto::GetPluginHealthRequest> for GetPluginHealthRequest {
+    type Error = SerDeError;
+
+    fn try_from(value: proto::GetPluginHealthRequest) -> Result<Self, Self::Error> {
+        let plugin_id = value
+            .plugin_id
+            .ok_or(SerDeError::MissingField("CreatePluginResponse.plugin_id"))?
+            .into();
+        Ok(Self { plugin_id })
+    }
+}
+
+impl From<GetPluginHealthRequest> for proto::GetPluginHealthRequest {
+    fn from(value: GetPluginHealthRequest) -> Self {
+        Self {
+            plugin_id: Some(value.plugin_id.into()),
+        }
+    }
+}
+
+impl ProtobufSerializable for GetPluginHealthRequest {
+    type ProtobufMessage = proto::GetPluginHealthRequest;
+}
+
+//
+// PluginHealthStatus
+//
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PluginHealthStatus {
+    NotDeployed,
+    // These map to https://www.nomadproject.io/api-docs/jobs#status
+    Pending,
+    Running,
+    Dead,
+}
+
+use proto::get_plugin_health_response::PluginHealthStatus as PluginHealthStatusProto;
+impl TryFrom<PluginHealthStatusProto> for PluginHealthStatus {
+    type Error = SerDeError;
+
+    fn try_from(value: PluginHealthStatusProto) -> Result<Self, Self::Error> {
+        match value {
+            PluginHealthStatusProto::Unknown => {
+                Err(SerDeError::UnknownVariant("PluginHealthStatus"))
+            }
+            PluginHealthStatusProto::NotDeployed => Ok(PluginHealthStatus::NotDeployed),
+            PluginHealthStatusProto::Pending => Ok(PluginHealthStatus::Pending),
+            PluginHealthStatusProto::Running => Ok(PluginHealthStatus::Running),
+            PluginHealthStatusProto::Dead => Ok(PluginHealthStatus::Dead),
+        }
+    }
+}
+
+impl From<PluginHealthStatus> for PluginHealthStatusProto {
+    fn from(value: PluginHealthStatus) -> Self {
+        match value {
+            PluginHealthStatus::NotDeployed => PluginHealthStatusProto::NotDeployed,
+            PluginHealthStatus::Pending => PluginHealthStatusProto::Pending,
+            PluginHealthStatus::Running => PluginHealthStatusProto::Running,
+            PluginHealthStatus::Dead => PluginHealthStatusProto::Dead,
+        }
+    }
+}
+
+//
+// GetPluginHealthResponse
+//
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GetPluginHealthResponse {
+    pub health_status: PluginHealthStatus,
+}
+
+impl type_url::TypeUrl for GetPluginHealthResponse {
+    const TYPE_URL: &'static str =
+        "graplsecurity.com/graplinc.grapl.api.plugin_registry.v1beta1.GetPluginHealthResponse";
+}
+
+impl TryFrom<proto::GetPluginHealthResponse> for GetPluginHealthResponse {
+    type Error = SerDeError;
+
+    fn try_from(value: proto::GetPluginHealthResponse) -> Result<Self, Self::Error> {
+        // Note that the `.some_enum()` has parens after!
+        let health_status = value.health_status().try_into()?;
+        Ok(Self { health_status })
+    }
+}
+
+impl From<GetPluginHealthResponse> for proto::GetPluginHealthResponse {
+    fn from(value: GetPluginHealthResponse) -> Self {
+        let health_status: PluginHealthStatusProto = value.health_status.into();
+        Self {
+            health_status: health_status as i32,
+        }
+    }
+}
+
+impl ProtobufSerializable for GetPluginHealthResponse {
+    type ProtobufMessage = proto::GetPluginHealthResponse;
+}

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_server.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_server.rs
@@ -34,6 +34,8 @@ use crate::{
         GetAnalyzersForTenantResponse,
         GetGeneratorsForEventSourceRequest,
         GetGeneratorsForEventSourceResponse,
+        GetPluginHealthRequest,
+        GetPluginHealthResponse,
         GetPluginRequest,
         GetPluginResponse,
         TearDownPluginRequest,
@@ -78,6 +80,11 @@ pub trait PluginRegistryApi {
         &self,
         request: TearDownPluginRequest,
     ) -> Result<TearDownPluginResponse, Self::Error>;
+
+    async fn get_plugin_health(
+        &self,
+        request: GetPluginHealthRequest,
+    ) -> Result<GetPluginHealthResponse, Self::Error>;
 
     async fn get_generators_for_event_source(
         &self,
@@ -149,6 +156,12 @@ where
         request: Request<proto::DeployPluginRequest>,
     ) -> Result<Response<proto::DeployPluginResponse>, tonic::Status> {
         execute_rpc!(self, request, deploy_plugin)
+    }
+    async fn get_plugin_health(
+        &self,
+        request: Request<proto::GetPluginHealthRequest>,
+    ) -> Result<Response<proto::GetPluginHealthResponse>, tonic::Status> {
+        execute_rpc!(self, request, get_plugin_health)
     }
 
     async fn tear_down_plugin(

--- a/src/rust/rust-proto/tests/proto_serde_tests.rs
+++ b/src/rust/rust-proto/tests/proto_serde_tests.rs
@@ -377,6 +377,20 @@ mod plugin_registry {
             check_encode_decode_invariant(value)
         }
 
+        #[test]
+        fn test_serde_get_plugin_health_requests(
+            value in pr_strats::get_plugin_health_requests()
+        ) {
+            check_encode_decode_invariant(value)
+        }
+
+        #[test]
+        fn test_serde_get_plugin_health_responses(
+            value in pr_strats::get_plugin_health_responses()
+        ) {
+            check_encode_decode_invariant(value)
+        }
+
     }
 }
 

--- a/src/rust/rust-proto/tests/test_utils/strategies.rs
+++ b/src/rust/rust-proto/tests/test_utils/strategies.rs
@@ -694,8 +694,11 @@ pub mod plugin_registry {
         GetAnalyzersForTenantResponse,
         GetGeneratorsForEventSourceRequest,
         GetGeneratorsForEventSourceResponse,
+        GetPluginHealthRequest,
+        GetPluginHealthResponse,
         GetPluginRequest,
         GetPluginResponse,
+        PluginHealthStatus,
         PluginMetadata,
         PluginType,
         TearDownPluginRequest,
@@ -843,6 +846,37 @@ pub mod plugin_registry {
 
     pub fn tear_down_plugin_responses() -> impl Strategy<Value = TearDownPluginResponse> {
         Just(TearDownPluginResponse {})
+    }
+
+    prop_compose! {
+        pub fn get_plugin_health_requests()(
+            plugin_id in uuids()
+        ) -> GetPluginHealthRequest {
+            GetPluginHealthRequest{
+                plugin_id
+            }
+        }
+    }
+
+    pub fn plugin_health_statuses() -> BoxedStrategy<PluginHealthStatus> {
+        prop_oneof![
+            // For cases without data, `Just` is all you need
+            Just(PluginHealthStatus::NotDeployed),
+            Just(PluginHealthStatus::Pending),
+            Just(PluginHealthStatus::Running),
+            Just(PluginHealthStatus::Dead),
+        ]
+        .boxed()
+    }
+
+    prop_compose! {
+        pub fn get_plugin_health_responses()(
+            health_status in plugin_health_statuses()
+        ) -> GetPluginHealthResponse{
+            GetPluginHealthResponse{
+                health_status
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
Beginning to implement the RPC described in this RFC change: https://github.com/grapl-security/grapl-rfcs/pull/18

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Adds a new endpoint to plugin-registry to examine a given plugin's health.
Not implemented yet.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
make test-unit-rust

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
