### PR TITLE
Implement and test GetPluginHealth

### DIFF
--- a/src/rust/plugin-executor/src/generator_client.rs
+++ b/src/rust/plugin-executor/src/generator_client.rs
@@ -41,7 +41,7 @@ impl FromEnv<GeneratorServiceClient, GeneratorServiceClientError> for GeneratorS
             endpoint.clone(),
             Self::SERVICE_NAME,
             Duration::from_millis(10000),
-            Duration::from_millis(500),
+            Duration::from_millis(5000),
         )
         .await
         .expect("Generator plugin never reported healthy");

--- a/src/rust/plugin-registry/src/error.rs
+++ b/src/rust/plugin-registry/src/error.rs
@@ -86,6 +86,7 @@ impl From<PluginRegistryServiceError> for Status {
                 // Since it's regarding user input, we can de-anonymize this message
                 Status::invalid_argument(format!("Unexpected input to Stream RPC: {e}"))
             }
+            Error::DeploymentStateError(_) => Status::internal("Deployment state error."),
         }
     }
 }

--- a/src/rust/plugin-registry/src/error.rs
+++ b/src/rust/plugin-registry/src/error.rs
@@ -51,6 +51,8 @@ pub enum PluginRegistryServiceError {
     NomadJobAllocationError,
     #[error("StreamInputError {0}")]
     StreamInputError(&'static str),
+    #[error("DeploymentStateError {0}")]
+    DeploymentStateError(String),
     // TODO: These errs are meant to be human-readable and are not directly
     // sent over the wire, so add {0}s to them!
 }

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use nomad_client_gen::models;
 
 use super::{
+    plugin_nomad_job,
     s3_url::get_s3_url,
     service::PluginRegistryServiceConfig,
 };
@@ -129,12 +130,12 @@ pub async fn deploy_plugin(
     service_config: &PluginRegistryServiceConfig,
 ) -> Result<(), PluginRegistryServiceError> {
     // --- Convert HCL to JSON Job model
-    let job_name = "grapl-plugin"; // Matches what's in `plugin.nomad`
+    let job_name = plugin_nomad_job::job_name();
 
     let job = get_job(&plugin, service_config, cli, &HARDCODED_PLUGIN_RUNTIME)?;
 
     // --- Deploy namespace
-    let namespace_name = format!("plugin-{id}", id = plugin.plugin_id);
+    let namespace_name = plugin_nomad_job::namespace_name(&plugin.plugin_id);
     let namespace_description = format!("Plugin for {name}", name = plugin.display_name);
     client
         .create_update_namespace(models::Namespace {

--- a/src/rust/plugin-registry/src/server/get_plugin_health.rs
+++ b/src/rust/plugin-registry/src/server/get_plugin_health.rs
@@ -1,0 +1,14 @@
+use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::PluginHealthStatus;
+
+use crate::{
+    db::client::PluginRegistryDbClient,
+    nomad::client::NomadClient,
+};
+
+pub fn get_plugin_health(
+    client: &NomadClient,
+    db_client: &PluginRegistryDbClient,
+    plugin_id: uuid::Uuid,
+) -> PluginHealthStatus {
+    todo!()
+}

--- a/src/rust/plugin-registry/src/server/get_plugin_health.rs
+++ b/src/rust/plugin-registry/src/server/get_plugin_health.rs
@@ -25,7 +25,7 @@ pub async fn get_plugin_health(
                     Ok(PluginHealthStatus::Dead)
                 }
                 PluginDeploymentStatus::Success => {
-                    query_nomad_for_health(&nomad_client, plugin_id).await
+                    query_nomad_for_health(nomad_client, plugin_id).await
                 }
             }
         }

--- a/src/rust/plugin-registry/src/server/get_plugin_health.rs
+++ b/src/rust/plugin-registry/src/server/get_plugin_health.rs
@@ -1,14 +1,55 @@
 use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::PluginHealthStatus;
 
+use super::plugin_nomad_job;
 use crate::{
-    db::client::PluginRegistryDbClient,
+    db::{
+        client::PluginRegistryDbClient,
+        models::PluginDeploymentStatus,
+    },
+    error::PluginRegistryServiceError,
     nomad::client::NomadClient,
 };
 
-pub fn get_plugin_health(
-    client: &NomadClient,
+pub async fn get_plugin_health(
+    nomad_client: &NomadClient,
     db_client: &PluginRegistryDbClient,
     plugin_id: uuid::Uuid,
-) -> PluginHealthStatus {
-    todo!()
+) -> Result<PluginHealthStatus, PluginRegistryServiceError> {
+    let plugin_deployment = db_client.get_plugin_deployment(&plugin_id).await;
+    match plugin_deployment {
+        Err(_) => Ok(PluginHealthStatus::NotDeployed),
+        Ok(deploy) => {
+            match deploy.status {
+                PluginDeploymentStatus::Fail => {
+                    // Perhaps this should be a different Status?
+                    Ok(PluginHealthStatus::Dead)
+                }
+                PluginDeploymentStatus::Success => {
+                    query_nomad_for_health(&nomad_client, plugin_id).await
+                }
+            }
+        }
+    }
+}
+
+async fn query_nomad_for_health(
+    nomad_client: &NomadClient,
+    plugin_id: uuid::Uuid,
+) -> Result<PluginHealthStatus, PluginRegistryServiceError> {
+    let job_name = plugin_nomad_job::job_name().to_owned();
+    let namespace_name = plugin_nomad_job::namespace_name(&plugin_id);
+    let job = nomad_client.get_job(job_name, Some(namespace_name)).await?;
+    match job.status {
+        Some(status) => match status.as_str() {
+            "pending" => Ok(PluginHealthStatus::Pending),
+            "running" => Ok(PluginHealthStatus::Running),
+            "dead" => Ok(PluginHealthStatus::Dead),
+            other => Err(PluginRegistryServiceError::DeploymentStateError(format!(
+                "Unknown state {other}"
+            ))),
+        },
+        _ => Err(PluginRegistryServiceError::DeploymentStateError(
+            "No State for this job? Is this even possible?".to_owned(),
+        )),
+    }
 }

--- a/src/rust/plugin-registry/src/server/mod.rs
+++ b/src/rust/plugin-registry/src/server/mod.rs
@@ -1,4 +1,5 @@
 mod create_plugin;
 mod deploy_plugin;
+mod get_plugin_health;
 mod s3_url;
 pub mod service;

--- a/src/rust/plugin-registry/src/server/mod.rs
+++ b/src/rust/plugin-registry/src/server/mod.rs
@@ -1,5 +1,6 @@
 mod create_plugin;
 mod deploy_plugin;
 mod get_plugin_health;
+mod plugin_nomad_job;
 mod s3_url;
 pub mod service;

--- a/src/rust/plugin-registry/src/server/plugin_nomad_job.rs
+++ b/src/rust/plugin-registry/src/server/plugin_nomad_job.rs
@@ -1,0 +1,12 @@
+
+/// A centralized place for constants and common patterns done on the
+/// `plugin.nomad` (and hax_docker equivalent)
+
+pub fn job_name() -> &'static str {
+    // Matches what's in `plugin.nomad`
+    "grapl-plugin"
+}
+
+pub fn namespace_name(plugin_id: &uuid::Uuid) -> String {
+    format!("plugin-{plugin_id}")
+}

--- a/src/rust/plugin-registry/src/server/plugin_nomad_job.rs
+++ b/src/rust/plugin-registry/src/server/plugin_nomad_job.rs
@@ -1,4 +1,3 @@
-
 /// A centralized place for constants and common patterns done on the
 /// `plugin.nomad` (and hax_docker equivalent)
 

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -32,7 +32,10 @@ use rust_proto::{
 use tokio::net::TcpListener;
 use tonic::async_trait;
 
-use super::create_plugin::upload_stream_multipart_to_s3;
+use super::{
+    create_plugin::upload_stream_multipart_to_s3,
+    get_plugin_health,
+};
 use crate::{
     db::{
         client::{
@@ -269,12 +272,17 @@ impl PluginRegistryApi for PluginRegistry {
         todo!()
     }
 
-    #[tracing::instrument(skip(self, _request), err)]
+    #[tracing::instrument(skip(self, request), err)]
     async fn get_plugin_health(
         &self,
-        _request: GetPluginHealthRequest,
+        request: GetPluginHealthRequest,
     ) -> Result<GetPluginHealthResponse, Self::Error> {
-        todo!()
+        let health_status = get_plugin_health::get_plugin_health(
+            &self.nomad_client,
+            &self.db_client,
+            request.plugin_id,
+        );
+        Ok(GetPluginHealthResponse { health_status })
     }
 }
 

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -281,7 +281,8 @@ impl PluginRegistryApi for PluginRegistry {
             &self.nomad_client,
             &self.db_client,
             request.plugin_id,
-        );
+        )
+        .await?;
         Ok(GetPluginHealthResponse { health_status })
     }
 }

--- a/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
@@ -54,6 +54,11 @@ job "grapl-plugin" {
   namespace   = "plugin-${var.plugin_id}"
   type        = "service"
 
+  reschedule {
+    # Make this a one-shot job
+    attempts = 0
+  }
+
   # We'll want to make sure we have the opposite constraint on other services
   # This is set in the Nomad agent's `client` stanza:
   # https://www.nomadproject.io/docs/configuration/client#meta
@@ -129,6 +134,11 @@ job "grapl-plugin" {
     }
 
     // TODO: task "tenant-plugin-graph-query-sidecar"
+
+    restart {
+      attempts = 1
+      delay    = "5s"
+    }
   }
 
   group "plugin" {
@@ -139,10 +149,6 @@ job "grapl-plugin" {
       //   servers = local.dns_servers
       // }
       port "plugin" {}
-    }
-
-    restart {
-      attempts = 1
     }
 
     count = var.plugin_count
@@ -218,6 +224,11 @@ EOF
         RUST_LOG       = var.rust_log
         RUST_BACKTRACE = 1
       }
+    }
+
+    restart {
+      attempts = 1
+      delay    = "5s"
     }
   }
 }

--- a/src/rust/plugin-registry/tests/test_create_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_create_plugin.rs
@@ -27,7 +27,7 @@ async fn test_create_plugin() -> Result<(), Box<dyn std::error::Error>> {
     let event_source_id = uuid::Uuid::new_v4();
 
     let meta = PluginMetadata {
-        tenant_id: tenant_id.clone(),
+        tenant_id,
         display_name: display_name.clone(),
         plugin_type: PluginType::Generator,
         event_source_id: Some(event_source_id),
@@ -47,7 +47,7 @@ async fn test_create_plugin() -> Result<(), Box<dyn std::error::Error>> {
 
     let get_response: GetPluginResponse = client
         .get_plugin(GetPluginRequest {
-            plugin_id: plugin_id.clone(),
+            plugin_id,
             tenant_id,
         })
         .timeout(std::time::Duration::from_secs(5))

--- a/src/rust/plugin-registry/tests/test_create_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_create_plugin.rs
@@ -47,7 +47,7 @@ async fn test_create_plugin() -> Result<(), Box<dyn std::error::Error>> {
 
     let get_response: GetPluginResponse = client
         .get_plugin(GetPluginRequest {
-            plugin_id,
+            plugin_id: plugin_id.clone(),
             tenant_id,
         })
         .timeout(std::time::Duration::from_secs(5))
@@ -62,5 +62,6 @@ async fn test_create_plugin() -> Result<(), Box<dyn std::error::Error>> {
         get_response.plugin_metadata.event_source_id,
         Some(event_source_id)
     );
+
     Ok(())
 }

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "integration_tests")]
 
+use std::time::Duration;
+
 use bytes::Bytes;
 use grapl_utils::future_ext::GraplFutureExt;
 use plugin_registry::client::FromEnv;
@@ -100,7 +102,11 @@ async fn test_deploy_sysmon_generator() -> Result<(), Box<dyn std::error::Error>
         .timeout(std::time::Duration::from_secs(5))
         .await??;
 
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
     // Ensure that a now-deployed plugin is now Running
+    // If it's Pending, it's possible the agent is out of mem or disk
+    // and was unable to allocate it.
     assert_health(&mut client, &plugin_id, PluginHealthStatus::Running).await?;
 
     Ok(())

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -37,7 +37,7 @@ async fn test_deploy_example_generator() -> Result<(), Box<dyn std::error::Error
         let display_name = uuid::Uuid::new_v4().to_string();
         let artifact = get_example_generator()?;
         let metadata = PluginMetadata {
-            tenant_id: tenant_id.clone(),
+            tenant_id,
             display_name: display_name.clone(),
             plugin_type: PluginType::Generator,
             event_source_id: Some(event_source_id.clone()),
@@ -75,7 +75,7 @@ async fn test_deploy_sysmon_generator() -> Result<(), Box<dyn std::error::Error>
         let display_name = "sysmon-generator";
         let artifact = get_sysmon_generator()?;
         let metadata = PluginMetadata {
-            tenant_id: tenant_id.clone(),
+            tenant_id,
             display_name: display_name.to_owned(),
             plugin_type: PluginType::Generator,
             event_source_id: Some(event_source_id.clone()),
@@ -93,12 +93,10 @@ async fn test_deploy_sysmon_generator() -> Result<(), Box<dyn std::error::Error>
     let plugin_id = create_response.plugin_id;
 
     // Ensure that an un-deployed plugin is NotDeployed
-    assert_health(&mut client, &plugin_id, PluginHealthStatus::NotDeployed).await?;
+    assert_health(&mut client, plugin_id, PluginHealthStatus::NotDeployed).await?;
 
     let _deploy_response = client
-        .deploy_plugin(DeployPluginRequest {
-            plugin_id: plugin_id.clone(),
-        })
+        .deploy_plugin(DeployPluginRequest { plugin_id })
         .timeout(std::time::Duration::from_secs(5))
         .await??;
 
@@ -107,7 +105,7 @@ async fn test_deploy_sysmon_generator() -> Result<(), Box<dyn std::error::Error>
     // Ensure that a now-deployed plugin is now Running
     // If it's Pending, it's possible the agent is out of mem or disk
     // and was unable to allocate it.
-    assert_health(&mut client, &plugin_id, PluginHealthStatus::Running).await?;
+    assert_health(&mut client, plugin_id, PluginHealthStatus::Running).await?;
 
     Ok(())
 }
@@ -121,13 +119,11 @@ fn assert_contains(input: &str, expected_substr: &str) {
 
 async fn assert_health(
     client: &mut PluginRegistryServiceClient,
-    plugin_id: &uuid::Uuid,
+    plugin_id: uuid::Uuid,
     expected: PluginHealthStatus,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let get_health_response: GetPluginHealthResponse = client
-        .get_plugin_health(GetPluginHealthRequest {
-            plugin_id: plugin_id.clone(),
-        })
+        .get_plugin_health(GetPluginHealthRequest { plugin_id })
         .timeout(std::time::Duration::from_secs(5))
         .await??;
 

--- a/src/rust/plugin-registry/tests/test_get_generators_for_event_source.rs
+++ b/src/rust/plugin-registry/tests/test_get_generators_for_event_source.rs
@@ -25,20 +25,21 @@ async fn test_get_generators_for_event_source() -> Result<(), Box<dyn std::error
     let event_source_id = uuid::Uuid::new_v4();
 
     let generator1_metadata = PluginMetadata {
-        tenant_id: tenant_id.clone(),
+        tenant_id,
         display_name: generator1_display_name.clone(),
         plugin_type: PluginType::Generator,
         event_source_id: Some(event_source_id),
     };
+
     let generator2_metadata = PluginMetadata {
-        tenant_id: tenant_id.clone(),
+        tenant_id,
         display_name: generator2_display_name.clone(),
         plugin_type: PluginType::Generator,
         event_source_id: Some(event_source_id),
     };
 
     let analyzer_metadata = PluginMetadata {
-        tenant_id: tenant_id.clone(),
+        tenant_id,
         display_name: analyzer_display_name.clone(),
         plugin_type: PluginType::Analyzer,
         event_source_id: None,

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -114,6 +114,18 @@ impl PluginRegistryServiceClient {
         todo!()
     }
 
+    pub async fn get_plugin_health(
+        &mut self,
+        request: native::GetPluginHealthRequest,
+    ) -> Result<native::GetPluginHealthResponse, PluginRegistryServiceClientError> {
+        let response = self
+            .proto_client
+            .get_plugin_health(proto::GetPluginHealthRequest::from(request))
+            .await?;
+        let response = native::GetPluginHealthResponse::try_from(response.into_inner())?;
+        Ok(response)
+    }
+
     /// Given information about an event source, return all generators that handle that event source
     #[tracing::instrument(skip(self, request), err)]
     pub async fn get_generators_for_event_source(


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/grapl/pull/1803
https://github.com/grapl-security/grapl-rfcs/pull/18

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Adds a GetPluginHealth implementation to plugin-registry. This endpoint lets you get a snapshot of the health of a given plugin.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I added a test around the sysmon deployment.
We may actually want to add some sort of reverse-engineered monitoring of the "deployment" construct - this is [not really well documented](https://github.com/hashicorp/nomad/issues/13731) but is [how the Nomad Job Run cli works](https://github.com/hashicorp/nomad/pull/10661/files#diff-80f5ef80d69e464881311f147a40e6ff244e516afa3d85733327ee34d6f8b164R242).

In general, the RFC explicitly states we need to get something more robust going on for plugin monitoring, but this is a decent first stab. 

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
tests