### PR TITLE
Plugin-execution-sidecar now has a Producer and produces messages to `generated-graphs`

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1132,6 +1132,11 @@ job "grapl-core" {
         PLUGIN_REGISTRY_BUCKET_AWS_ACCOUNT_ID           = var.plugin_registry_bucket_aws_account_id
         PLUGIN_REGISTRY_BUCKET_NAME                     = var.plugin_registry_bucket_name
 
+        # Some vars that are forwarded to plugin-execution-sidecar
+        PLUGIN_EXECUTION_KAFKA_BOOTSTRAP_SERVERS = var.kafka_bootstrap_servers
+        PLUGIN_EXECUTION_KAFKA_SASL_USERNAME     = var.kafka_credentials["plugin-execution"].sasl_username
+        PLUGIN_EXECUTION_KAFKA_SASL_PASSWORD     = var.kafka_credentials["plugin-execution"].sasl_password
+
         # common Rust env vars
         RUST_BACKTRACE                  = local.rust_backtrace
         RUST_LOG                        = var.rust_log

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -186,6 +186,7 @@ def main() -> None:
         "graph-merger",
         "node-identifier",
         "pipeline-ingress",
+        "plugin-execution",
     )
     kafka_service_credentials = {
         service: kafka.service_credentials(service).apply(

--- a/pulumi/infra/log_levels.py
+++ b/pulumi/infra/log_levels.py
@@ -7,6 +7,7 @@ RUST_LOG_LEVELS = ",".join(
         "hyper=WARN",
         "rusoto_core=WARN",
         "rustls=WARN",
+        "tower=WARN",
     ]
 )
 PY_LOG_LEVEL = "DEBUG"

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -3017,6 +3017,7 @@ dependencies = [
  "async-trait",
  "clap 3.1.18",
  "grapl-config",
+ "kafka",
  "plugin-work-queue",
  "rust-proto",
  "tokio",

--- a/src/rust/plugin-execution-sidecar/Cargo.toml
+++ b/src/rust/plugin-execution-sidecar/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "3.0", default_features = false, features = [
   "derive"
 ] }
 grapl-config = { path = "../grapl-config" }
+kafka = { path = "../kafka" }
 plugin-work-queue = { path = "../plugin-work-queue" }
 rust-proto = { path = "../rust-proto" }
 tokio = { version = "1.17", features = ["macros", "rt", "rt-multi-thread"] }

--- a/src/rust/plugin-execution-sidecar/generator-execution-sidecar.rs
+++ b/src/rust/plugin-execution-sidecar/generator-execution-sidecar.rs
@@ -12,9 +12,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let plugin_executor_config = PluginExecutorConfig::parse();
     let producer_config = ProducerConfig::parse();
 
-    let generator_work_processor =
-        GeneratorWorkProcessor::new(&plugin_executor_config, producer_config).await?;
-    let mut plugin_executor =
-        PluginExecutor::new(plugin_executor_config, generator_work_processor).await?;
+    let generator_work_processor = GeneratorWorkProcessor::new(&plugin_executor_config).await?;
+    let mut plugin_executor = PluginExecutor::new(
+        plugin_executor_config,
+        producer_config,
+        generator_work_processor,
+    )
+    .await?;
     plugin_executor.main_loop().await
 }

--- a/src/rust/plugin-execution-sidecar/generator-execution-sidecar.rs
+++ b/src/rust/plugin-execution-sidecar/generator-execution-sidecar.rs
@@ -1,4 +1,7 @@
+use clap::Parser;
+use kafka::config::ProducerConfig;
 use plugin_execution_sidecar::{
+    config::PluginExecutorConfig,
     plugin_executor::PluginExecutor,
     work::GeneratorWorkProcessor,
 };
@@ -6,7 +9,12 @@ use plugin_execution_sidecar::{
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (_env, _guard) = grapl_config::init_grapl_env!();
-    let generator_work_processor = GeneratorWorkProcessor::new().await?;
-    let mut plugin_executor = PluginExecutor::new(generator_work_processor).await?;
+    let plugin_executor_config = PluginExecutorConfig::parse();
+    let producer_config = ProducerConfig::parse();
+
+    let generator_work_processor =
+        GeneratorWorkProcessor::new(&plugin_executor_config, producer_config).await?;
+    let mut plugin_executor =
+        PluginExecutor::new(plugin_executor_config, generator_work_processor).await?;
     plugin_executor.main_loop().await
 }

--- a/src/rust/plugin-execution-sidecar/src/config.rs
+++ b/src/rust/plugin-execution-sidecar/src/config.rs
@@ -2,4 +2,7 @@
 pub struct PluginExecutorConfig {
     #[clap(long, env = "PLUGIN_EXECUTOR_PLUGIN_ID")]
     pub plugin_id: uuid::Uuid,
+
+    #[clap(long, env = "PLUGIN_EXECUTOR_TENANT_ID")]
+    pub tenant_id: uuid::Uuid,
 }

--- a/src/rust/plugin-execution-sidecar/src/lib.rs
+++ b/src/rust/plugin-execution-sidecar/src/lib.rs
@@ -1,4 +1,4 @@
-mod config;
+pub mod config;
 pub mod plugin_executor;
 mod sidecar_client;
 pub mod work;

--- a/src/rust/plugin-execution-sidecar/src/work/plugin_work_processor.rs
+++ b/src/rust/plugin-execution-sidecar/src/work/plugin_work_processor.rs
@@ -4,6 +4,8 @@ use rust_proto::graplinc::grapl::api::plugin_work_queue::v1beta1::{
     PluginWorkQueueServiceClientError,
 };
 
+use crate::config::PluginExecutorConfig;
+
 pub type RequestId = i64;
 
 // Abstract out between Get[Generator/Analyzer]ExecutionResponse,
@@ -18,17 +20,21 @@ pub trait PluginWorkProcessor {
 
     async fn get_work(
         &self,
+        config: &PluginExecutorConfig,
         pwq_client: &mut PluginWorkQueueServiceClient,
-        plugin_id: uuid::Uuid,
     ) -> Result<Self::Work, PluginWorkQueueServiceClientError>;
 
     async fn ack_work(
         &self,
+        config: &PluginExecutorConfig,
         pwq_client: &mut PluginWorkQueueServiceClient,
-        plugin_id: uuid::Uuid,
         request_id: RequestId,
         success: bool,
     ) -> Result<(), PluginWorkQueueServiceClientError>;
 
-    async fn process_job(&mut self, work: ExecutionJob) -> Result<(), Box<dyn std::error::Error>>;
+    async fn process_job(
+        &mut self,
+        config: &PluginExecutorConfig,
+        work: ExecutionJob,
+    ) -> Result<(), Box<dyn std::error::Error>>;
 }

--- a/src/rust/plugin-execution-sidecar/src/work/plugin_work_processor.rs
+++ b/src/rust/plugin-execution-sidecar/src/work/plugin_work_processor.rs
@@ -1,7 +1,14 @@
+use kafka::Producer;
 use plugin_work_queue::client::PluginWorkQueueServiceClient;
-use rust_proto::graplinc::grapl::api::plugin_work_queue::v1beta1::{
-    ExecutionJob,
-    PluginWorkQueueServiceClientError,
+use rust_proto::{
+    graplinc::grapl::{
+        api::plugin_work_queue::v1beta1::{
+            ExecutionJob,
+            PluginWorkQueueServiceClientError,
+        },
+        pipeline::v1beta2::Envelope,
+    },
+    SerDe,
 };
 
 use crate::config::PluginExecutorConfig;
@@ -17,6 +24,7 @@ pub trait Workload {
 #[async_trait::async_trait]
 pub trait PluginWorkProcessor {
     type Work: Workload;
+    type ProducedMessage: SerDe;
 
     async fn get_work(
         &self,
@@ -35,6 +43,7 @@ pub trait PluginWorkProcessor {
     async fn process_job(
         &mut self,
         config: &PluginExecutorConfig,
+        producer: &Producer<Envelope<Self::ProducedMessage>>,
         work: ExecutionJob,
     ) -> Result<(), Box<dyn std::error::Error>>;
 }

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -207,7 +207,7 @@ mod tests {
             plugin_id: arbitrary_uuid,
             tenant_id: arbitrary_uuid,
             display_name: "arbitrary".to_owned(),
-            plugin_type: "analyzer".to_owned(),
+            plugin_type: "generator".to_owned(),
             event_source_id: None,
             artifact_s3_key: "arbitrary".to_owned(),
         };

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -76,7 +76,7 @@ pub struct PluginRegistryDbConfig {
     plugin_registry_db_password: String,
 }
 
-#[derive(clap::Parser, Debug)]
+#[derive(clap::Parser, Clone, Debug)]
 pub struct PluginRegistryServiceConfig {
     #[clap(long, env = "PLUGIN_REGISTRY_BUCKET_AWS_ACCOUNT_ID")]
     pub bucket_aws_account_id: String,
@@ -100,7 +100,22 @@ pub struct PluginRegistryServiceConfig {
         default_value = "250"
     )]
     pub artifact_size_limit_mb: usize,
-    // --- Pass through a couple env vars also used for this binary
+    #[clap(flatten)]
+    pub passthrough_vars: PluginExecutionPassthroughVars,
+}
+
+#[derive(clap::Parser, Clone, Debug, Default)]
+pub struct PluginExecutionPassthroughVars {
+    #[clap(long, env = "PLUGIN_EXECUTION_KAFKA_BOOTSTRAP_SERVERS")]
+    pub kafka_bootstrap_servers: String,
+    #[clap(long, env = "PLUGIN_EXECUTION_KAFKA_SASL_USERNAME")]
+    pub kafka_sasl_username: String,
+    #[clap(long, env = "PLUGIN_EXECUTION_KAFKA_SASL_PASSWORD")]
+    pub kafka_sasl_password: String,
+
+    // Pass through a couple env vars also used for the plugin-registry service
+    // Since they're used in both ways - locally for this service, and the
+    // spawned plugins - I decided against prefixing PLUGIN_EXECUTION_.
     #[clap(long, env)]
     pub rust_log: String,
     #[clap(long, env)]

--- a/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
@@ -118,7 +118,8 @@ job "grapl-plugin" {
       }
 
       env {
-        PLUGIN_EXECUTOR_PLUGIN_ID = "${var.plugin_id}"
+        PLUGIN_EXECUTOR_PLUGIN_ID = var.plugin_id
+        PLUGIN_EXECUTOR_TENANT_ID = var.tenant_id
 
         // FYI: the upstream plugin's address is discovered at runtime, not
         // env{}, because the upstream's name is based on ${PLUGIN_ID}.

--- a/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
@@ -49,6 +49,23 @@ variable "otel_exporter_jaeger_agent_port" {
   description = "Jaeger configuration"
 }
 
+variable "kafka_bootstrap_servers" {
+  type        = string
+  description = "The URL(s) (possibly comma-separated) of the Kafka bootstrap servers."
+}
+
+variable "kafka_sasl_username" {
+  type = string
+}
+
+variable "kafka_sasl_password" {
+  type = string
+}
+
+variable "kafka_producer_topic" {
+  type = string
+}
+
 job "grapl-plugin" {
   datacenters = ["dc1"]
   namespace   = "plugin-${var.plugin_id}"
@@ -125,6 +142,11 @@ job "grapl-plugin" {
         // env{}, because the upstream's name is based on ${PLUGIN_ID}.
 
         PLUGIN_WORK_QUEUE_CLIENT_ADDRESS = "http://${NOMAD_UPSTREAM_ADDR_plugin-work-queue}"
+
+        KAFKA_BOOTSTRAP_SERVERS = var.kafka_bootstrap_servers
+        KAFKA_SASL_USERNAME     = var.kafka_sasl_username
+        KAFKA_SASL_PASSWORD     = var.kafka_sasl_password
+        KAFKA_PRODUCER_TOPIC    = var.kafka_producer_topic
 
         RUST_LOG       = var.rust_log
         RUST_BACKTRACE = 1

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
@@ -39,6 +39,18 @@ impl PluginType {
     }
 }
 
+impl TryFrom<&str> for PluginType {
+    type Error = SerDeError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "generator" => Ok(PluginType::Generator),
+            "analyzer" => Ok(PluginType::Analyzer),
+            _ => Err(SerDeError::UnknownVariant("PluginType")),
+        }
+    }
+}
+
 impl TryFrom<proto::PluginType> for PluginType {
     type Error = SerDeError;
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/977

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Previously the `plugin-execution-sidecar` would not push messages to Kafka. Now it does. 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
CI. No messages flow through to the producer quite just yet, unfortunately, but this should be exercised once generator-dispatcher is ready to go.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
