### PR TITLE
Steal some good Config changes from abandoned kafka-in-plugin-executor branch 

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -3019,6 +3019,7 @@ dependencies = [
  "grapl-config",
  "plugin-work-queue",
  "rust-proto",
+ "thiserror",
  "tokio",
  "tonic 0.7.2",
  "tracing",

--- a/src/rust/plugin-execution-sidecar/Cargo.toml
+++ b/src/rust/plugin-execution-sidecar/Cargo.toml
@@ -22,6 +22,7 @@ clap = { version = "3.0", default_features = false, features = [
 grapl-config = { path = "../grapl-config" }
 plugin-work-queue = { path = "../plugin-work-queue" }
 rust-proto = { path = "../rust-proto" }
+thiserror = "1.0"
 tokio = { version = "1.17", features = ["macros", "rt", "rt-multi-thread"] }
 # TODO: Add a `rust-proto` wrapper around tonic Endpoint
 # Remove tonic dependency once satisfied

--- a/src/rust/plugin-execution-sidecar/generator-execution-sidecar.rs
+++ b/src/rust/plugin-execution-sidecar/generator-execution-sidecar.rs
@@ -1,4 +1,6 @@
+use clap::Parser;
 use plugin_execution_sidecar::{
+    config::PluginExecutorConfig,
     plugin_executor::PluginExecutor,
     work::GeneratorWorkProcessor,
 };
@@ -6,7 +8,10 @@ use plugin_execution_sidecar::{
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (_env, _guard) = grapl_config::init_grapl_env!();
+    let plugin_executor_config = PluginExecutorConfig::parse();
+
     let generator_work_processor = GeneratorWorkProcessor::new().await?;
-    let mut plugin_executor = PluginExecutor::new(generator_work_processor).await?;
+    let mut plugin_executor =
+        PluginExecutor::new(plugin_executor_config, generator_work_processor).await?;
     plugin_executor.main_loop().await
 }

--- a/src/rust/plugin-execution-sidecar/src/lib.rs
+++ b/src/rust/plugin-execution-sidecar/src/lib.rs
@@ -1,4 +1,4 @@
-mod config;
+pub mod config;
 pub mod plugin_executor;
 mod sidecar_client;
 pub mod work;

--- a/src/rust/plugin-execution-sidecar/src/plugin_executor.rs
+++ b/src/rust/plugin-execution-sidecar/src/plugin_executor.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use clap::Parser;
 use plugin_work_queue::client::{
     FromEnv as pwq_from_env,
     PluginWorkQueueServiceClient,
@@ -17,22 +16,23 @@ use crate::{
 pub struct PluginExecutor<P: PluginWorkProcessor> {
     plugin_work_processor: P,
     plugin_work_queue_client: PluginWorkQueueServiceClient,
-    plugin_id: uuid::Uuid,
+    config: PluginExecutorConfig,
 }
 
 impl<P> PluginExecutor<P>
 where
     P: PluginWorkProcessor,
 {
-    pub async fn new(plugin_work_processor: P) -> Result<Self, Box<dyn std::error::Error>> {
-        let PluginExecutorConfig { plugin_id } = PluginExecutorConfig::parse();
-
+    pub async fn new(
+        config: PluginExecutorConfig,
+        plugin_work_processor: P,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         let plugin_work_queue_client = PluginWorkQueueServiceClient::from_env().await?;
 
         Ok(Self {
             plugin_work_processor,
             plugin_work_queue_client,
-            plugin_id,
+            config,
         })
     }
 
@@ -41,23 +41,25 @@ where
         // Continually scan for new work for this Plugin.
         while let Ok(work) = self
             .plugin_work_processor
-            .get_work(&mut self.plugin_work_queue_client, self.plugin_id)
+            .get_work(&self.config, &mut self.plugin_work_queue_client)
             .await
         {
             let request_id = work.request_id();
             if let Some(job) = work.maybe_job() {
                 // Process the job
-                let process_result = self.plugin_work_processor.process_job(job).await;
-                let success = process_result.is_ok();
+                let process_result = self
+                    .plugin_work_processor
+                    .process_job(&self.config, job)
+                    .await;
 
                 // Inform plugin-work-queue whether it worked or if we need
                 // to retry
                 self.plugin_work_processor
                     .ack_work(
+                        &self.config,
                         &mut self.plugin_work_queue_client,
-                        self.plugin_id,
+                        process_result,
                         request_id,
-                        success,
                     )
                     .await?;
             } else {

--- a/src/rust/plugin-execution-sidecar/src/work/generator_work_processor.rs
+++ b/src/rust/plugin-execution-sidecar/src/work/generator_work_processor.rs
@@ -1,5 +1,6 @@
 use plugin_work_queue::client::PluginWorkQueueServiceClient;
 use rust_proto::graplinc::grapl::api::{
+    graph::v1beta1::GraphDescription,
     plugin_sdk::generators::v1beta1::{
         client::{
             GeneratorServiceClient,
@@ -12,18 +13,21 @@ use rust_proto::graplinc::grapl::api::{
         ExecutionJob,
         GetExecuteGeneratorRequest,
         GetExecuteGeneratorResponse,
-        PluginWorkQueueServiceClientError,
     },
 };
 
 use super::{
     plugin_work_processor::{
+        PluginWorkProcessorError,
         RequestId,
         Workload,
     },
     PluginWorkProcessor,
 };
-use crate::sidecar_client::generator_client::FromEnv;
+use crate::{
+    config::PluginExecutorConfig,
+    sidecar_client::generator_client::FromEnv,
+};
 
 impl Workload for GetExecuteGeneratorResponse {
     fn request_id(&self) -> i64 {
@@ -50,41 +54,48 @@ impl GeneratorWorkProcessor {
 #[async_trait::async_trait]
 impl PluginWorkProcessor for GeneratorWorkProcessor {
     type Work = GetExecuteGeneratorResponse;
+    type ProducedMessage = GraphDescription;
 
     async fn get_work(
         &self,
+        config: &PluginExecutorConfig,
         pwq_client: &mut PluginWorkQueueServiceClient,
-        plugin_id: uuid::Uuid,
-    ) -> Result<Self::Work, PluginWorkQueueServiceClientError> {
+    ) -> Result<Self::Work, PluginWorkProcessorError> {
+        let plugin_id = config.plugin_id;
         let get_request = GetExecuteGeneratorRequest { plugin_id };
-        pwq_client.get_execute_generator(get_request).await
+        Ok(pwq_client.get_execute_generator(get_request).await?)
     }
 
     async fn ack_work(
         &self,
+        config: &PluginExecutorConfig,
         pwq_client: &mut PluginWorkQueueServiceClient,
-        plugin_id: uuid::Uuid,
+        process_result: Result<Self::ProducedMessage, PluginWorkProcessorError>,
         request_id: RequestId,
-        success: bool,
-    ) -> Result<(), PluginWorkQueueServiceClientError> {
+    ) -> Result<(), PluginWorkProcessorError> {
+        let plugin_id = config.plugin_id;
+        // TODO: Replace this with feeding the process-result back to Plugin Work Queue
+        let success = process_result.is_ok();
         let ack_request = AcknowledgeGeneratorRequest {
             plugin_id,
             request_id,
             success,
         };
-        pwq_client
-            .acknowledge_generator(ack_request)
-            .await
-            .map(|_| ())
+        // TODO: forward _request_id
+        pwq_client.acknowledge_generator(ack_request).await?;
+        Ok(())
     }
 
-    async fn process_job(&mut self, job: ExecutionJob) -> Result<(), Box<dyn std::error::Error>> {
-        let _run_generator_response = self
+    async fn process_job(
+        &mut self,
+        _config: &PluginExecutorConfig,
+        job: ExecutionJob,
+    ) -> Result<Self::ProducedMessage, PluginWorkProcessorError> {
+        let run_generator_response = self
             .generator_service_client
             .run_generator(RunGeneratorRequest { data: job.data })
             .await?;
 
-        //kafka_stream.put(generated_graphs).await.unwrap();
-        Ok(()) // TODO replace with above
+        Ok(run_generator_response.generated_graph.graph_description)
     }
 }

--- a/src/rust/plugin-execution-sidecar/src/work/generator_work_processor.rs
+++ b/src/rust/plugin-execution-sidecar/src/work/generator_work_processor.rs
@@ -81,7 +81,6 @@ impl PluginWorkProcessor for GeneratorWorkProcessor {
             request_id,
             success,
         };
-        // TODO: forward _request_id
         pwq_client.acknowledge_generator(ack_request).await?;
         Ok(())
     }

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -76,7 +76,7 @@ pub struct PluginRegistryDbConfig {
     plugin_registry_db_password: String,
 }
 
-#[derive(clap::Parser, Debug)]
+#[derive(clap::Parser, Clone, Debug)]
 pub struct PluginRegistryServiceConfig {
     #[clap(long, env = "PLUGIN_REGISTRY_BUCKET_AWS_ACCOUNT_ID")]
     pub bucket_aws_account_id: String,
@@ -100,7 +100,15 @@ pub struct PluginRegistryServiceConfig {
         default_value = "250"
     )]
     pub artifact_size_limit_mb: usize,
-    // --- Pass through a couple env vars also used for this binary
+    #[clap(flatten)]
+    pub passthrough_vars: PluginExecutionPassthroughVars,
+}
+
+#[derive(clap::Parser, Clone, Debug, Default)]
+pub struct PluginExecutionPassthroughVars {
+    // Pass through a couple env vars also used for the plugin-registry service
+    // Since they're used in both ways - locally for this service, and the
+    // spawned plugins - I decided against prefixing PLUGIN_EXECUTION_.
     #[clap(long, env)]
     pub rust_log: String,
     #[clap(long, env)]

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
@@ -39,6 +39,18 @@ impl PluginType {
     }
 }
 
+impl TryFrom<&str> for PluginType {
+    type Error = SerDeError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "generator" => Ok(PluginType::Generator),
+            "analyzer" => Ok(PluginType::Analyzer),
+            _ => Err(SerDeError::UnknownVariant("PluginType")),
+        }
+    }
+}
+
 impl TryFrom<proto::PluginType> for PluginType {
     type Error = SerDeError;
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Steal some otherwise positive changes from https://github.com/grapl-security/grapl/pull/1811 where we pass around the config object instead of a bare Plugin ID, among other things. 
Also, hook it up so the Plugin Work Processor can feed the result of `process_job` into `ack`. 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
CI

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
