### PR TITLE
Plugin Work Queue will now write GraphDescriptions to topic "generated-graphs"

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1290,6 +1290,13 @@ job "grapl-core" {
         # Hardcoded, but makes little sense to pipe up through Pulumi
         PLUGIN_WORK_QUEUE_HEALTHCHECK_POLLING_INTERVAL_MS = 5000
 
+        KAFKA_BOOTSTRAP_SERVERS   = var.kafka_bootstrap_servers
+        KAFKA_SASL_USERNAME       = var.kafka_credentials["plugin-work-queue"].sasl_username
+        KAFKA_SASL_PASSWORD       = var.kafka_credentials["plugin-work-queue"].sasl_password
+
+        KAFKA_PRODUCER_TOPIC_GENERATOR = "generated-graphs"
+        # KAFKA_PRODUCER_TOPIC_ANALYZER = "TODO"
+
         # common Rust env vars
         RUST_BACKTRACE = local.rust_backtrace
         RUST_LOG       = var.rust_log

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1290,9 +1290,9 @@ job "grapl-core" {
         # Hardcoded, but makes little sense to pipe up through Pulumi
         PLUGIN_WORK_QUEUE_HEALTHCHECK_POLLING_INTERVAL_MS = 5000
 
-        KAFKA_BOOTSTRAP_SERVERS   = var.kafka_bootstrap_servers
-        KAFKA_SASL_USERNAME       = var.kafka_credentials["plugin-work-queue"].sasl_username
-        KAFKA_SASL_PASSWORD       = var.kafka_credentials["plugin-work-queue"].sasl_password
+        KAFKA_BOOTSTRAP_SERVERS = var.kafka_bootstrap_servers
+        KAFKA_SASL_USERNAME     = var.kafka_credentials["plugin-work-queue"].sasl_username
+        KAFKA_SASL_PASSWORD     = var.kafka_credentials["plugin-work-queue"].sasl_password
 
         KAFKA_PRODUCER_TOPIC_GENERATOR = "generated-graphs"
         # KAFKA_PRODUCER_TOPIC_ANALYZER = "TODO"

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1294,8 +1294,8 @@ job "grapl-core" {
         KAFKA_SASL_USERNAME     = var.kafka_credentials["plugin-work-queue"].sasl_username
         KAFKA_SASL_PASSWORD     = var.kafka_credentials["plugin-work-queue"].sasl_password
 
-        KAFKA_PRODUCER_TOPIC_GENERATOR = "generated-graphs"
-        # KAFKA_PRODUCER_TOPIC_ANALYZER = "TODO"
+        GENERATOR_KAFKA_PRODUCER_TOPIC = "generated-graphs"
+        # ANALYZER_KAFKA_PRODUCER_TOPIC = "TODO"
 
         # common Rust env vars
         RUST_BACKTRACE = local.rust_backtrace

--- a/nomad/rust-integration-tests.nomad
+++ b/nomad/rust-integration-tests.nomad
@@ -188,8 +188,8 @@ job "rust-integration-tests" {
 
         KAFKA_BOOTSTRAP_SERVERS   = var.kafka_bootstrap_servers
         KAFKA_CONSUMER_GROUP_NAME = var.kafka_consumer_group
-        KAFKA_SASL_USERNAME  = var.kafka_credentials.sasl_username
-        KAFKA_SASL_PASSWORD  = var.kafka_credentials.sasl_password
+        KAFKA_SASL_USERNAME       = var.kafka_credentials.sasl_username
+        KAFKA_SASL_PASSWORD       = var.kafka_credentials.sasl_password
 
         NOMAD_SERVICE_ADDRESS = "${attr.unique.network.ip-address}:4646"
 

--- a/nomad/rust-integration-tests.nomad
+++ b/nomad/rust-integration-tests.nomad
@@ -188,8 +188,6 @@ job "rust-integration-tests" {
 
         KAFKA_BOOTSTRAP_SERVERS   = var.kafka_bootstrap_servers
         KAFKA_CONSUMER_GROUP_NAME = var.kafka_consumer_group
-        # (this is an invalid topic name, so it'd throw an error if consumed)
-        KAFKA_CONSUMER_TOPIC = "<replace me at integration test setup>"
         KAFKA_SASL_USERNAME  = var.kafka_credentials.sasl_username
         KAFKA_SASL_PASSWORD  = var.kafka_credentials.sasl_password
 

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -189,6 +189,7 @@ def main() -> None:
         "graph-merger",
         "node-identifier",
         "pipeline-ingress",
+        "plugin-work-queue",
     )
     kafka_service_credentials = {
         service: kafka.service_credentials(service).apply(

--- a/src/proto/graplinc/grapl/api/plugin_work_queue/v1beta1/plugin_work_queue.proto
+++ b/src/proto/graplinc/grapl/api/plugin_work_queue/v1beta1/plugin_work_queue.proto
@@ -81,7 +81,7 @@ message GetExecuteAnalyzerResponse {
 message AcknowledgeGeneratorRequest {
   // The request_id of the job that has been completed
   int64 request_id = 1;
-  // 'true' if success, 'false' if failure
+  // Some(GraphDescription) if generator ran successfully, None if it failed.
   optional graplinc.grapl.api.graph.v1beta1.GraphDescription graph_description = 2;
   // The plugin id of the plugin that completed the request
   graplinc.common.v1beta1.Uuid plugin_id = 3;
@@ -95,7 +95,8 @@ message AcknowledgeAnalyzerRequest {
   // The request_id of the job that has been completed
   int64 request_id = 1;
   // 'true' if success, 'false' if failure
-  bool success = 2;
+  // TODO: This will likely become an `optional GeneratedMessage` field like AcknowledgeGeneratorRequest
+  bool success = 2; 
   // The plugin id of the plugin that completed the request
   graplinc.common.v1beta1.Uuid plugin_id = 3;
 }

--- a/src/proto/graplinc/grapl/api/plugin_work_queue/v1beta1/plugin_work_queue.proto
+++ b/src/proto/graplinc/grapl/api/plugin_work_queue/v1beta1/plugin_work_queue.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package graplinc.grapl.api.plugin_work_queue.v1beta1;
 
 import "graplinc/common/v1beta1/types.proto";
+import "graplinc/grapl/api/graph/v1beta1/types.proto";
 
 // A job for a given plugin, for a given tenant, to be executed against `data`
 message ExecutionJob {
@@ -81,7 +82,7 @@ message AcknowledgeGeneratorRequest {
   // The request_id of the job that has been completed
   int64 request_id = 1;
   // 'true' if success, 'false' if failure
-  bool success = 2;
+  optional graplinc.grapl.api.graph.v1beta1.GraphDescription graph_description = 2;
   // The plugin id of the plugin that completed the request
   graplinc.common.v1beta1.Uuid plugin_id = 3;
 }

--- a/src/proto/graplinc/grapl/api/plugin_work_queue/v1beta1/plugin_work_queue.proto
+++ b/src/proto/graplinc/grapl/api/plugin_work_queue/v1beta1/plugin_work_queue.proto
@@ -96,7 +96,7 @@ message AcknowledgeAnalyzerRequest {
   int64 request_id = 1;
   // 'true' if success, 'false' if failure
   // TODO: This will likely become an `optional GeneratedMessage` field like AcknowledgeGeneratorRequest
-  bool success = 2; 
+  bool success = 2;
   // The plugin id of the plugin that completed the request
   graplinc.common.v1beta1.Uuid plugin_id = 3;
 }

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -3053,6 +3053,7 @@ dependencies = [
  "futures",
  "grapl-config",
  "grapl-utils",
+ "kafka",
  "rust-proto",
  "sqlx",
  "thiserror",

--- a/src/rust/graph-merger/tests/integration_test.rs
+++ b/src/rust/graph-merger/tests/integration_test.rs
@@ -3,7 +3,6 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use clap::Parser;
 use futures::StreamExt;
 use grapl_tracing::{
     setup_tracing,
@@ -91,10 +90,7 @@ impl AsyncTestContext for GraphMergerTestContext {
             .await
             .expect("could not configure gRPC client");
 
-        let consumer_config = ConsumerConfig {
-            topic: CONSUMER_TOPIC.to_string(),
-            ..ConsumerConfig::parse()
-        };
+        let consumer_config = ConsumerConfig::with_topic(CONSUMER_TOPIC);
 
         GraphMergerTestContext {
             pipeline_ingress_client,

--- a/src/rust/kafka/src/config.rs
+++ b/src/rust/kafka/src/config.rs
@@ -14,6 +14,17 @@ pub struct ConsumerConfig {
     pub topic: String,
 }
 
+impl ConsumerConfig {
+    // In some applications, where we need to produce to >1 topic,
+    // we'll specify the env-var containing the topic name instead of depending
+    // on the default KAFKA_PRODUCER_TOPIC.
+    pub fn with_topic(topic: &'static str) -> Self {
+        let app_args = std::env::args();
+        let extra_args = ["--topic".to_string(), topic.to_string()];
+        Self::parse_from(app_args.chain(extra_args.into_iter()))
+    }
+}
+
 #[derive(clap::Parser, Clone, Debug)]
 pub struct RetryConsumerConfig {
     #[clap(long, env = "KAFKA_BOOTSTRAP_SERVERS")]
@@ -48,7 +59,7 @@ impl ProducerConfig {
         let app_args = std::env::args();
         let topic = std::env::var(key).expect(key);
         let extra_args = ["--topic".to_string(), topic];
-        ProducerConfig::parse_from(app_args.chain(extra_args.into_iter()))
+        Self::parse_from(app_args.chain(extra_args.into_iter()))
     }
 }
 

--- a/src/rust/kafka/src/config.rs
+++ b/src/rust/kafka/src/config.rs
@@ -1,3 +1,5 @@
+use clap::Parser;
+
 #[derive(clap::Parser, Clone, Debug)]
 pub struct ConsumerConfig {
     #[clap(long, env = "KAFKA_BOOTSTRAP_SERVERS")]
@@ -26,7 +28,7 @@ pub struct RetryConsumerConfig {
     pub topic: String,
 }
 
-#[derive(clap::Parser, Clone, Debug)]
+#[derive(clap::Parser, Clone, Debug, Default)]
 pub struct ProducerConfig {
     #[clap(long, env = "KAFKA_BOOTSTRAP_SERVERS")]
     pub bootstrap_servers: String,
@@ -36,6 +38,16 @@ pub struct ProducerConfig {
     pub sasl_password: String,
     #[clap(long, env = "KAFKA_PRODUCER_TOPIC")]
     pub topic: String,
+}
+
+impl ProducerConfig {
+    // In some applications, where we need to produce to >1 topic,
+    // we'll specify the env-var containing the topic name instead of depending
+    // on the default KAFKA_PRODUCER_TOPIC.
+    pub fn with_topic_env_var(key: &'static str) -> Self {
+        let topic = std::env::var(key).expect(key);
+        ProducerConfig::parse_from(["--topic".to_string(), topic])
+    }
 }
 
 #[derive(clap::Parser, Clone, Debug)]
@@ -48,4 +60,4 @@ pub struct RetryProducerConfig {
     pub sasl_password: String,
     #[clap(long, env = "KAFKA_RETRY_TOPIC")]
     pub topic: String,
-}
+    

--- a/src/rust/kafka/src/config.rs
+++ b/src/rust/kafka/src/config.rs
@@ -79,4 +79,4 @@ pub struct RetryProducerConfig {
     pub sasl_password: String,
     #[clap(long, env = "KAFKA_RETRY_TOPIC")]
     pub topic: String,
-    
+}

--- a/src/rust/kafka/src/config.rs
+++ b/src/rust/kafka/src/config.rs
@@ -15,10 +15,10 @@ pub struct ConsumerConfig {
 }
 
 impl ConsumerConfig {
-    // In some test cases, where we need to consume from >1 topic,
-    // we'll manually specify the topic name in code instead of using
-    // the default KAFKA_CONSUMER_TOPIC.
-    // (Example: rust-integration-tests consumes from many topics)
+    /// In some test cases, where we need to consume from >1 topic,
+    /// we'll manually specify the topic name in code instead of using
+    /// the default KAFKA_CONSUMER_TOPIC.
+    /// (Example: rust-integration-tests consumes from many topics)
     pub fn with_topic(topic: &str) -> Self {
         let app_args = std::env::args();
         let extra_args = ["--topic".to_string(), topic.to_string()];
@@ -53,10 +53,10 @@ pub struct ProducerConfig {
 }
 
 impl ProducerConfig {
-    // In some applications, where we need to produce to >1 topic,
-    // we'll specify the env-var containing the topic name instead of depending
-    // on the default KAFKA_PRODUCER_TOPIC.
-    // (Example: plugin-work-queue produces to both generator and analyzer)
+    /// In some applications, where we need to produce to >1 topic,
+    /// we'll specify the env-var containing the topic name instead of depending
+    /// on the default KAFKA_PRODUCER_TOPIC.
+    /// (Example: plugin-work-queue produces to both generator and analyzer)
     pub fn with_topic_env_var(key: &'static str) -> Self {
         let topic = std::env::var(key).expect(key);
         Self::with_topic(&topic)

--- a/src/rust/kafka/src/config.rs
+++ b/src/rust/kafka/src/config.rs
@@ -45,8 +45,10 @@ impl ProducerConfig {
     // we'll specify the env-var containing the topic name instead of depending
     // on the default KAFKA_PRODUCER_TOPIC.
     pub fn with_topic_env_var(key: &'static str) -> Self {
+        let app_args = std::env::args();
         let topic = std::env::var(key).expect(key);
-        ProducerConfig::parse_from(["--topic".to_string(), topic])
+        let extra_args = ["--topic".to_string(), topic];
+        ProducerConfig::parse_from(app_args.chain(extra_args.into_iter()))
     }
 }
 

--- a/src/rust/kafka/src/config.rs
+++ b/src/rust/kafka/src/config.rs
@@ -15,10 +15,11 @@ pub struct ConsumerConfig {
 }
 
 impl ConsumerConfig {
-    // In some applications, where we need to produce to >1 topic,
-    // we'll specify the env-var containing the topic name instead of depending
-    // on the default KAFKA_PRODUCER_TOPIC.
-    pub fn with_topic(topic: &'static str) -> Self {
+    // In some test cases, where we need to consume from >1 topic,
+    // we'll manually specify the topic name in code instead of using
+    // the default KAFKA_CONSUMER_TOPIC.
+    // (Example: rust-integration-tests consumes from many topics)
+    pub fn with_topic(topic: &str) -> Self {
         let app_args = std::env::args();
         let extra_args = ["--topic".to_string(), topic.to_string()];
         Self::parse_from(app_args.chain(extra_args.into_iter()))
@@ -55,10 +56,15 @@ impl ProducerConfig {
     // In some applications, where we need to produce to >1 topic,
     // we'll specify the env-var containing the topic name instead of depending
     // on the default KAFKA_PRODUCER_TOPIC.
+    // (Example: plugin-work-queue produces to both generator and analyzer)
     pub fn with_topic_env_var(key: &'static str) -> Self {
-        let app_args = std::env::args();
         let topic = std::env::var(key).expect(key);
-        let extra_args = ["--topic".to_string(), topic];
+        Self::with_topic(&topic)
+    }
+
+    fn with_topic(topic: &str) -> Self {
+        let app_args = std::env::args();
+        let extra_args = ["--topic".to_string(), topic.to_string()];
         Self::parse_from(app_args.chain(extra_args.into_iter()))
     }
 }

--- a/src/rust/node-identifier/tests/integration_test.rs
+++ b/src/rust/node-identifier/tests/integration_test.rs
@@ -3,7 +3,6 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use clap::Parser;
 use futures::StreamExt;
 use grapl_tracing::{
     setup_tracing,
@@ -92,10 +91,7 @@ impl AsyncTestContext for NodeIdentifierTestContext {
             .await
             .expect("could not configure gRPC client");
 
-        let consumer_config = ConsumerConfig {
-            topic: CONSUMER_TOPIC.to_string(),
-            ..ConsumerConfig::parse()
-        };
+        let consumer_config = ConsumerConfig::with_topic(CONSUMER_TOPIC);
 
         NodeIdentifierTestContext {
             pipeline_ingress_client,

--- a/src/rust/pipeline-ingress/tests/integration_test.rs
+++ b/src/rust/pipeline-ingress/tests/integration_test.rs
@@ -3,7 +3,6 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use clap::Parser;
 use futures::StreamExt;
 use grapl_tracing::{
     setup_tracing,
@@ -73,10 +72,7 @@ impl AsyncTestContext for PipelineIngressTestContext {
             .await
             .expect("could not configure gRPC client");
 
-        let consumer_config = ConsumerConfig {
-            topic: CONSUMER_TOPIC.to_string(),
-            ..ConsumerConfig::parse()
-        };
+        let consumer_config = ConsumerConfig::with_topic(CONSUMER_TOPIC);
 
         PipelineIngressTestContext {
             grpc_client,

--- a/src/rust/plugin-execution-sidecar/src/plugin_executor.rs
+++ b/src/rust/plugin-execution-sidecar/src/plugin_executor.rs
@@ -52,6 +52,14 @@ where
                     .process_job(&self.config, job)
                     .await;
 
+                if let Err(e) = process_result.as_ref() {
+                    tracing::error!(
+                        message = "Error processing job",
+                        request_id = ?request_id,
+                        error = ?e,
+                    );
+                }
+
                 // Inform plugin-work-queue whether it worked or if we need
                 // to retry
                 self.plugin_work_processor

--- a/src/rust/plugin-execution-sidecar/src/work/generator_work_processor.rs
+++ b/src/rust/plugin-execution-sidecar/src/work/generator_work_processor.rs
@@ -71,12 +71,11 @@ impl PluginWorkProcessor for GeneratorWorkProcessor {
         request_id: RequestId,
     ) -> Result<(), PluginWorkProcessorError> {
         let plugin_id = config.plugin_id;
-        // TODO: Replace this with feeding the process-result back to Plugin Work Queue
-        let success = process_result.is_ok();
+        let graph_description = process_result.ok();
         let ack_request = AcknowledgeGeneratorRequest {
             plugin_id,
             request_id,
-            success,
+            graph_description,
         };
         pwq_client.acknowledge_generator(ack_request).await?;
         Ok(())

--- a/src/rust/plugin-work-queue/Cargo.toml
+++ b/src/rust/plugin-work-queue/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "3.0", default_features = false, features = [
 ] }
 grapl-config = { path = "../grapl-config" }
 grapl-utils = { path = "../grapl-utils" }
+kafka = { path = "../kafka" }
 rust-proto = { path = "../rust-proto" }
 thiserror = "1.0"
 tokio = { version = "1.17", features = ["full"] }

--- a/src/rust/plugin-work-queue/src/kafka_produce.rs
+++ b/src/rust/plugin-work-queue/src/kafka_produce.rs
@@ -1,0 +1,33 @@
+use std::time::SystemTime;
+
+use rust_proto::graplinc::grapl::{
+    api::graph::v1beta1::GraphDescription,
+    pipeline::{
+        v1beta1::Metadata,
+        v1beta2::Envelope,
+    },
+};
+
+pub fn generator_produce_graph_description(
+    graph_description: GraphDescription,
+) -> Envelope<GraphDescription> {
+    // We'd likely want to go look up in Plugin-Registry which Tenant ID this
+    // Plugin belongs to... and store that in an LRU cache... yikes!
+    let tenant_id = uuid::Uuid::new_v4(); // FIXME // TODO
+    let trace_id = uuid::Uuid::new_v4(); // FIXME // TODO
+    let retry_count = 0;
+    let created_time = SystemTime::now();
+    let last_updated_time = created_time;
+    let event_source_id = uuid::Uuid::new_v4(); // FIXME // TODO
+    Envelope::new(
+        Metadata::new(
+            tenant_id,
+            trace_id,
+            retry_count,
+            created_time,
+            last_updated_time,
+            event_source_id,
+        ),
+        graph_description,
+    )
+}

--- a/src/rust/plugin-work-queue/src/lib.rs
+++ b/src/rust/plugin-work-queue/src/lib.rs
@@ -1,10 +1,22 @@
 use std::net::SocketAddr;
 
+use kafka::config::ProducerConfig;
+
 pub mod client;
+mod kafka_produce;
 pub mod psql_queue;
 pub mod server;
 #[cfg(feature = "integration_tests")]
 pub mod test_utils;
+
+// Intentionally not clap::Parser, since ProducerConfigs are
+// manually constructed. Contains configs for all dependencies needed
+// to construct a PluginWorkQueue.
+pub struct ConfigUnion {
+    pub service_config: PluginWorkQueueServiceConfig,
+    pub db_config: PluginWorkQueueDbConfig,
+    pub generator_producer_config: ProducerConfig,
+}
 
 #[derive(clap::Parser, Clone, Debug)]
 pub struct PluginWorkQueueServiceConfig {
@@ -12,8 +24,6 @@ pub struct PluginWorkQueueServiceConfig {
     pub plugin_work_queue_bind_address: SocketAddr,
     #[clap(long, env)]
     pub plugin_work_queue_healthcheck_polling_interval_ms: u64,
-    #[clap(flatten)]
-    pub db_config: PluginWorkQueueDbConfig,
 }
 
 #[derive(clap::Parser, Clone, Debug)]

--- a/src/rust/plugin-work-queue/src/main.rs
+++ b/src/rust/plugin-work-queue/src/main.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let service_config = PluginWorkQueueServiceConfig::parse();
     let db_config = PluginWorkQueueDbConfig::parse();
     let generator_producer_config =
-        ProducerConfig::with_topic_env_var("KAFKA_PRODUCER_TOPIC_GENERATOR");
+        ProducerConfig::with_topic_env_var("GENERATOR_KAFKA_PRODUCER_TOPIC");
     // TODO let analyzer_producer_config = ...
     exec_service(ConfigUnion {
         service_config,

--- a/src/rust/plugin-work-queue/src/main.rs
+++ b/src/rust/plugin-work-queue/src/main.rs
@@ -1,13 +1,25 @@
 use clap::Parser;
+use kafka::config::ProducerConfig;
 use plugin_work_queue::{
     server::exec_service,
+    ConfigUnion,
+    PluginWorkQueueDbConfig,
     PluginWorkQueueServiceConfig,
 };
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (_env, _guard) = grapl_config::init_grapl_env!();
-    let config = PluginWorkQueueServiceConfig::parse();
-    exec_service(config).await?;
+    let service_config = PluginWorkQueueServiceConfig::parse();
+    let db_config = PluginWorkQueueDbConfig::parse();
+    let generator_producer_config =
+        ProducerConfig::with_topic_env_var("KAFKA_PRODUCER_TOPIC_GENERATOR");
+    // TODO let analyzer_producer_config = ...
+    exec_service(ConfigUnion {
+        service_config,
+        db_config,
+        generator_producer_config,
+    })
+    .await?;
     Ok(())
 }

--- a/src/rust/plugin-work-queue/src/server.rs
+++ b/src/rust/plugin-work-queue/src/server.rs
@@ -167,9 +167,12 @@ impl PluginWorkQueueApi for PluginWorkQueue {
         &self,
         request: v1beta1::AcknowledgeGeneratorRequest,
     ) -> Result<v1beta1::AcknowledgeGeneratorResponse, PluginWorkQueueError> {
-        let status = match request.success {
-            true => psql_queue::Status::Processed,
-            false => psql_queue::Status::Failed,
+        let status = match request.graph_description {
+            Some(_graph_description) => {
+                // TODO: KAFKA IT
+                psql_queue::Status::Processed
+            }
+            None => psql_queue::Status::Failed,
         };
         self.queue
             .ack_generator(request.request_id.into(), status)

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1.rs
@@ -22,7 +22,7 @@ use crate::{
     protobufs::graplinc::grapl::api::plugin_work_queue::v1beta1 as proto,
     serde_impl::ProtobufSerializable,
     type_url,
-    SerDeError,
+    SerDeError, graplinc::grapl::api::graph::v1beta1::GraphDescription,
 };
 
 #[derive(Clone, PartialEq)]
@@ -70,7 +70,7 @@ impl type_url::TypeUrl for ExecutionJob {
 #[derive(Debug, Clone, PartialEq)]
 pub struct AcknowledgeGeneratorRequest {
     pub request_id: i64,
-    pub success: bool,
+    pub graph_description: Option<GraphDescription>,
     pub plugin_id: uuid::Uuid,
 }
 
@@ -79,14 +79,14 @@ impl TryFrom<proto::AcknowledgeGeneratorRequest> for AcknowledgeGeneratorRequest
 
     fn try_from(value: proto::AcknowledgeGeneratorRequest) -> Result<Self, Self::Error> {
         let request_id = value.request_id;
-        let success = value.success;
+        let graph_description = value.graph_description.map(TryFrom::try_from?;
         let plugin_id = value
             .plugin_id
             .ok_or(Self::Error::MissingField("plugin_id"))?
             .into();
         Ok(Self {
             request_id,
-            success,
+            graph_description,
             plugin_id,
         })
     }
@@ -96,7 +96,7 @@ impl From<AcknowledgeGeneratorRequest> for proto::AcknowledgeGeneratorRequest {
     fn from(value: AcknowledgeGeneratorRequest) -> Self {
         Self {
             request_id: value.request_id,
-            success: value.success,
+            graph_description: value.graph_description.into(),
             plugin_id: Some(value.plugin_id.into()),
         }
     }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1.rs
@@ -19,10 +19,11 @@ pub use crate::graplinc::grapl::api::plugin_work_queue::{
     },
 };
 use crate::{
+    graplinc::grapl::api::graph::v1beta1::GraphDescription,
     protobufs::graplinc::grapl::api::plugin_work_queue::v1beta1 as proto,
     serde_impl::ProtobufSerializable,
     type_url,
-    SerDeError, graplinc::grapl::api::graph::v1beta1::GraphDescription,
+    SerDeError,
 };
 
 #[derive(Clone, PartialEq)]
@@ -79,7 +80,7 @@ impl TryFrom<proto::AcknowledgeGeneratorRequest> for AcknowledgeGeneratorRequest
 
     fn try_from(value: proto::AcknowledgeGeneratorRequest) -> Result<Self, Self::Error> {
         let request_id = value.request_id;
-        let graph_description = value.graph_description.map(TryFrom::try_from?;
+        let graph_description = value.graph_description.map(TryInto::try_into).transpose()?;
         let plugin_id = value
             .plugin_id
             .ok_or(Self::Error::MissingField("plugin_id"))?
@@ -96,7 +97,7 @@ impl From<AcknowledgeGeneratorRequest> for proto::AcknowledgeGeneratorRequest {
     fn from(value: AcknowledgeGeneratorRequest) -> Self {
         Self {
             request_id: value.request_id,
-            graph_description: value.graph_description.into(),
+            graph_description: value.graph_description.map(Into::into),
             plugin_id: Some(value.plugin_id.into()),
         }
     }

--- a/src/rust/rust-proto/tests/test_utils/strategies.rs
+++ b/src/rust/rust-proto/tests/test_utils/strategies.rs
@@ -934,12 +934,12 @@ pub mod plugin_work_queue {
     prop_compose! {
         pub fn acknowledge_generator_requests()(
             request_id in any::<i64>(),
-            success in any::<bool>(),
+            graph_description in proptest::option::of(graph::graph_descriptions()),
             plugin_id in uuids(),
         ) -> native::AcknowledgeGeneratorRequest {
             native::AcknowledgeGeneratorRequest {
                 request_id,
-                success,
+                graph_description,
                 plugin_id,
             }
         }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
.never made an issue for this

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
We discovered https://github.com/grapl-security/grapl/pull/1811 would not work because of too many producers. 
Now, when a plugin sidecar acknowledges its work to PWQ, PWQ will write the generated graph to a kafka topic

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
not quite there yet. SOON! We need the generator-dispatcher in order for work to show up in a generator.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
