### PR TITLE
Remove opentelemetry during prod, in Rust

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -629,8 +629,8 @@ job "grapl-core" {
         KAFKA_CONSUMER_TOPIC      = "raw-logs"
         KAFKA_PRODUCER_TOPIC      = "generated-graphs"
 
-        RUST_BACKTRACE                  = local.rust_backtrace
-        RUST_LOG                        = var.rust_log
+        RUST_BACKTRACE = local.rust_backtrace
+        RUST_LOG       = var.rust_log
       }
     }
 
@@ -1163,10 +1163,11 @@ job "grapl-core" {
         PLUGIN_EXECUTION_IMAGE                          = var.container_images["generator-execution-sidecar"] # TODO: add support for analyzer too
         PLUGIN_REGISTRY_BUCKET_AWS_ACCOUNT_ID           = var.plugin_registry_bucket_aws_account_id
         PLUGIN_REGISTRY_BUCKET_NAME                     = var.plugin_registry_bucket_name
+        PLUGIN_EXECUTION_OBSERVABILITY_ENV_VARS         = var.observability_env_vars
 
         # common Rust env vars
-        RUST_BACKTRACE                  = local.rust_backtrace
-        RUST_LOG                        = var.rust_log
+        RUST_BACKTRACE = local.rust_backtrace
+        RUST_LOG       = var.rust_log
       }
 
       resources {
@@ -1233,8 +1234,8 @@ job "grapl-core" {
         PLUGIN_WORK_QUEUE_HEALTHCHECK_POLLING_INTERVAL_MS = 5000
 
         # common Rust env vars
-        RUST_BACKTRACE                  = local.rust_backtrace
-        RUST_LOG                        = var.rust_log
+        RUST_BACKTRACE = local.rust_backtrace
+        RUST_LOG       = var.rust_log
       }
     }
 
@@ -1281,13 +1282,13 @@ job "grapl-core" {
       }
 
       env {
-        UID_ALLOCATOR_BIND_ADDRESS      = "0.0.0.0:${NOMAD_PORT_uid-allocator-port}"
-        UID_ALLOCATOR_DB_HOSTNAME       = var.uid_allocator_db.hostname
-        UID_ALLOCATOR_DB_PASSWORD       = var.uid_allocator_db.password
-        UID_ALLOCATOR_DB_PORT           = var.uid_allocator_db.port
-        UID_ALLOCATOR_DB_USERNAME       = var.uid_allocator_db.username
-        RUST_BACKTRACE                  = local.rust_backtrace
-        RUST_LOG                        = var.rust_log
+        UID_ALLOCATOR_BIND_ADDRESS = "0.0.0.0:${NOMAD_PORT_uid-allocator-port}"
+        UID_ALLOCATOR_DB_HOSTNAME  = var.uid_allocator_db.hostname
+        UID_ALLOCATOR_DB_PASSWORD  = var.uid_allocator_db.password
+        UID_ALLOCATOR_DB_PORT      = var.uid_allocator_db.port
+        UID_ALLOCATOR_DB_USERNAME  = var.uid_allocator_db.username
+        RUST_BACKTRACE             = local.rust_backtrace
+        RUST_LOG                   = var.rust_log
       }
     }
 
@@ -1342,8 +1343,8 @@ job "grapl-core" {
         EVENT_SOURCE_HEALTHCHECK_POLLING_INTERVAL_MS = 5000
 
         # common Rust env vars
-        RUST_BACKTRACE                  = local.rust_backtrace
-        RUST_LOG                        = var.rust_log
+        RUST_BACKTRACE = local.rust_backtrace
+        RUST_LOG       = var.rust_log
       }
     }
 

--- a/nomad/grapl-provision.nomad
+++ b/nomad/grapl-provision.nomad
@@ -18,6 +18,14 @@ weird nomad state parse error.
 EOF
 }
 
+variable "observability_env_vars" {
+  type        = string
+  description = <<EOF
+With local-grapl, we have to inject env vars for Opentelemetry.
+In prod, this is currently disabled.
+EOF
+}
+
 variable "container_images" {
   type        = map(string)
   description = <<EOF
@@ -58,18 +66,6 @@ variable "test_user_password_secret_id" {
 variable "py_log_level" {
   type        = string
   description = "Controls the logging behavior of Python-based services."
-}
-
-variable "tracing_endpoint" {
-  type = string
-  # if nothing is passed in we default to "${attr.unique.network.ip-address}" in locals.
-  # Using a variable isn't allowed here though :(
-  default = ""
-}
-
-locals {
-  tracing_endpoint        = (var.tracing_endpoint == "") ? "http://${attr.unique.network.ip-address}" : var.tracing_endpoint
-  tracing_zipkin_endpoint = "${local.tracing_endpoint}:9411/api/v2/spans"
 }
 
 job "grapl-provision" {
@@ -114,6 +110,12 @@ EOF
         env         = true
       }
 
+      template {
+        data        = var.observability_env_vars
+        destination = "observability.env"
+        env         = true
+      }
+
       env {
         # This is a hack, because IDK how to share locals across files.
         # It's fine if `provision` only hits one alpha.
@@ -128,7 +130,6 @@ EOF
         GRAPL_TEST_USER_NAME               = var.test_user_name
         GRAPL_TEST_USER_PASSWORD_SECRET_ID = var.test_user_password_secret_id
         GRAPL_LOG_LEVEL                    = var.py_log_level
-        OTEL_EXPORTER_ZIPKIN_ENDPOINT      = local.tracing_zipkin_endpoint
       }
     }
 

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -30,6 +30,7 @@ from infra.kafka import Credential, Kafka
 from infra.local.postgres import LocalPostgresInstance
 from infra.nomad_job import NomadJob, NomadVars
 from infra.nomad_service_postgres import NomadServicePostgresResource
+from infra.observability_env_vars import observability_env_vars_for_local
 from infra.path import path_from_root
 from infra.postgres import Postgres
 
@@ -203,6 +204,8 @@ def main() -> None:
         service: kafka.consumer_group(service) for service in kafka_consumer_services
     }
 
+    observability_env_vars = observability_env_vars_for_local()
+
     # These are shared across both local and prod deployments.
     nomad_inputs: Final[NomadVars] = dict(
         aws_env_vars_for_local=aws_env_vars_for_local,
@@ -212,6 +215,7 @@ def main() -> None:
         kafka_bootstrap_servers=kafka.bootstrap_servers(),
         kafka_credentials=kafka_service_credentials,
         kafka_consumer_groups=kafka_consumer_groups,
+        observability_env_vars=observability_env_vars,
         organization_management_healthcheck_polling_interval_ms=organization_management_healthcheck_polling_interval_ms,
         pipeline_ingress_healthcheck_polling_interval_ms=pipeline_ingress_healthcheck_polling_interval_ms,
         plugin_registry_bucket_aws_account_id=config.AWS_ACCOUNT_ID,
@@ -236,6 +240,7 @@ def main() -> None:
                 "aws_env_vars_for_local",
                 "aws_region",
                 "container_images",
+                "observability_env_vars",
                 "py_log_level",
                 "schema_properties_table_name",
                 "schema_table_name",

--- a/pulumi/infra/observability_env_vars.py
+++ b/pulumi/infra/observability_env_vars.py
@@ -1,5 +1,5 @@
 from infra import config
-import pulumi_aws as aws
+
 
 def observability_env_vars_for_local() -> str:
     # We currently use both the zipkin v2 endpoint for consul, python and typescript instrumentation and the jaeger udp
@@ -12,7 +12,9 @@ def observability_env_vars_for_local() -> str:
     # gets passed in to a template{} stanza.
     otel_host = '{{ env "attr.unique.network.ip-address" }}'
     otel_port = 6831  # compare with nomad/local/observability.nomad
-    zipkin_endpoint = 'http://{{ env "attr.unique.network.ip-address" }}:9411/api/v2/spans'
+    zipkin_endpoint = (
+        'http://{{ env "attr.unique.network.ip-address" }}:9411/api/v2/spans'
+    )
 
     return f"""
         OTEL_EXPORTER_JAEGER_AGENT_HOST = {otel_host}

--- a/pulumi/infra/observability_env_vars.py
+++ b/pulumi/infra/observability_env_vars.py
@@ -1,0 +1,21 @@
+from infra import config
+import pulumi_aws as aws
+
+def observability_env_vars_for_local() -> str:
+    # We currently use both the zipkin v2 endpoint for consul, python and typescript instrumentation and the jaeger udp
+    # agent endpoint for rust instrumentation. These will be consolidated in the future
+
+    if not config.LOCAL_GRAPL:
+        return "DUMMY_VAR_FOR_PROD = TRUE"
+
+    # These use the weird Mustache {{}} tags because this interpolation eventually
+    # gets passed in to a template{} stanza.
+    otel_host = '{{ env "attr.unique.network.ip-address" }}'
+    otel_port = 6831  # compare with nomad/local/observability.nomad
+    zipkin_endpoint = 'http://{{ env "attr.unique.network.ip-address" }}:9411/api/v2/spans'
+
+    return f"""
+        OTEL_EXPORTER_JAEGER_AGENT_HOST = {otel_host}
+        OTEL_EXPORTER_JAEGER_AGENT_PORT = {otel_port}
+        OTEL_EXPORTER_ZIPKIN_ENDPOINT   = {zipkin_endpoint}
+    """

--- a/src/rust/grapl-tracing/src/setup_tracing.rs
+++ b/src/rust/grapl-tracing/src/setup_tracing.rs
@@ -14,6 +14,11 @@ pub enum SetupTracingError {
     TraceError(#[from] opentelemetry::trace::TraceError),
 }
 
+fn otel_jaeger_enabled() -> bool {
+    // If this environment variable isn't set, don't bother hooking up Jaeger
+    std::env::var("OTEL_EXPORTER_JAEGER_AGENT_HOST").is_ok()
+}
+
 pub fn setup_tracing(service_name: &str) -> Result<WorkerGuard, SetupTracingError> {
     let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stdout());
 
@@ -24,22 +29,26 @@ pub fn setup_tracing(service_name: &str) -> Result<WorkerGuard, SetupTracingErro
 
     // initialize tracing layer
     global::set_text_map_propagator(TraceContextPropagator::new());
-    let tracer = opentelemetry_jaeger::new_pipeline()
+    let jaeger_tracer = opentelemetry_jaeger::new_pipeline()
         .with_service_name(service_name)
         .install_batch(opentelemetry::runtime::Tokio)?;
 
     // register a subscriber
     let filter = EnvFilter::from_default_env();
     {
-        let registry = tracing_subscriber::registry().with(filter).with(log_layer);
+        // Builder pattern is difficult here
+        let registry = Box::new(tracing_subscriber::registry()
+            .with(filter)
+            .with(log_layer));
+        if otel_jaeger_enabled() {
+            registry.with(tracing_opentelemetry::layer().with_tracer(jaeger_tracer)).init();
+            tracing::warn!("Skipping Jaeger tracer");
+        } else {
+            registry.init();
+        }
+    };
 
-        let registry = registry.with(tracing_opentelemetry::layer().with_tracer(tracer));
-
-        registry
-    }
-    .init();
-
-    tracing::info!("logger configured successfully");
+    tracing::info!("Tracer configured successfully");
 
     Ok(guard)
 }

--- a/src/rust/grapl-tracing/src/setup_tracing.rs
+++ b/src/rust/grapl-tracing/src/setup_tracing.rs
@@ -30,11 +30,14 @@ pub fn setup_tracing(service_name: &str) -> Result<WorkerGuard, SetupTracingErro
 
     // register a subscriber
     let filter = EnvFilter::from_default_env();
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(log_layer)
-        .with(tracing_opentelemetry::layer().with_tracer(tracer))
-        .init();
+    {
+        let registry = tracing_subscriber::registry().with(filter).with(log_layer);
+
+        let registry = registry.with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+        registry
+    }
+    .init();
 
     tracing::info!("logger configured successfully");
 

--- a/src/rust/grapl-tracing/src/setup_tracing.rs
+++ b/src/rust/grapl-tracing/src/setup_tracing.rs
@@ -37,11 +37,11 @@ pub fn setup_tracing(service_name: &str) -> Result<WorkerGuard, SetupTracingErro
     let filter = EnvFilter::from_default_env();
     {
         // Builder pattern is difficult here
-        let registry = Box::new(tracing_subscriber::registry()
-            .with(filter)
-            .with(log_layer));
+        let registry = Box::new(tracing_subscriber::registry().with(filter).with(log_layer));
         if otel_jaeger_enabled() {
-            registry.with(tracing_opentelemetry::layer().with_tracer(jaeger_tracer)).init();
+            registry
+                .with(tracing_opentelemetry::layer().with_tracer(jaeger_tracer))
+                .init();
             tracing::warn!("Skipping Jaeger tracer");
         } else {
             registry.init();

--- a/src/rust/grapl-tracing/src/setup_tracing.rs
+++ b/src/rust/grapl-tracing/src/setup_tracing.rs
@@ -42,9 +42,9 @@ pub fn setup_tracing(service_name: &str) -> Result<WorkerGuard, SetupTracingErro
             registry
                 .with(tracing_opentelemetry::layer().with_tracer(jaeger_tracer))
                 .init();
-            tracing::warn!("Skipping Jaeger tracer");
         } else {
             registry.init();
+            tracing::warn!("Skipping Jaeger tracer");
         }
     };
 

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -74,14 +74,7 @@ pub fn get_job(
                 ("tenant_id", plugin.tenant_id.to_string()),
                 // Passthrough vars
                 ("rust_log", passthru.rust_log),
-                (
-                    "otel_exporter_jaeger_agent_host",
-                    passthru.otel_exporter_jaeger_agent_host,
-                ),
-                (
-                    "otel_exporter_jaeger_agent_port",
-                    passthru.otel_exporter_jaeger_agent_port,
-                ),
+                ("observability_env_vars", passthru.observability_env_vars),
             ]);
             cli.parse_hcl2(job_file_hcl, job_file_vars)
         }

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -106,15 +106,13 @@ pub struct PluginRegistryServiceConfig {
 
 #[derive(clap::Parser, Clone, Debug, Default)]
 pub struct PluginExecutionPassthroughVars {
+    #[clap(long, env = "PLUGIN_EXECUTION_OBSERVABILITY_ENV_VARS")]
+    pub observability_env_vars: String,
     // Pass through a couple env vars also used for the plugin-registry service
     // Since they're used in both ways - locally for this service, and the
     // spawned plugins - I decided against prefixing PLUGIN_EXECUTION_.
     #[clap(long, env)]
     pub rust_log: String,
-    #[clap(long, env)]
-    pub otel_exporter_jaeger_agent_host: String,
-    #[clap(long, env)]
-    pub otel_exporter_jaeger_agent_port: String,
 }
 
 pub struct PluginRegistry {


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
none, followup to https://github.com/grapl-security/grapl/pull/1817

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
We were seeing in CI that grapl-core failed to deploy due to 
> OpenTelemetry trace error occurred. Exporter jaeger encountered the following error(s): thrift agent failed with not open

This gates the rust opentelemetry stuff behind "does the OTEL_EXPORTER_JAEGER_AGENT_HOST env var exist?"

I then standardized how we feed in the otel jaeger/zipkin stuff into services. It'll populate those env vars in local but not in prod, just like aws_env_vars_for_local. 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I overrode `observability_env_vars_for_local` locally so it'd look like prod; stuff started up!

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
