### PR TITLE
Rust dockerfile will expose error messages at integration test time

### DIFF
--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -153,6 +153,18 @@ RUN mkdir --parents "${TEST_DIR}"
 RUN --mount=type=cache,target="${CARGO_TARGET_DIR}",sharing=locked \
     --mount=type=cache,target="${REGISTRY_CACHE_TARGET}",sharing=locked \
     --mount=type=cache,target="${RUSTUP_CACHE_TARGET}",sharing=locked \
+<<EOF
+    # First, run cargo test without --message-format=json; this will expose
+    # errors to the developer over stdout/err in human-readable format.
+    # (These two `cargo tests` could be merged, with a jq 
+    # search over .reason == "compiler-message" )
+    cargo test \
+        --features "${RUST_INTEGRATION_TEST_FEATURES}" \
+        --no-run \
+        --test "*"
+
+    # Run cargo test again - everything's already compiled - but this time, 
+    # the message is used as input to the jq script
     cargo test \
         --features "${RUST_INTEGRATION_TEST_FEATURES}" \
         --no-run \
@@ -162,6 +174,7 @@ RUN --mount=type=cache,target="${CARGO_TARGET_DIR}",sharing=locked \
         xargs \
           --replace="{}" \
           cp "{}" "${TEST_DIR}/"
+EOF
 
 
 # integration tests distribution

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -156,8 +156,6 @@ RUN --mount=type=cache,target="${CARGO_TARGET_DIR}",sharing=locked \
 <<EOF
     # First, run cargo test without --message-format=json; this will expose
     # errors to the developer over stdout/err in human-readable format.
-    # (These two `cargo tests` could be merged, with a jq 
-    # search over .reason == "compiler-message" )
     cargo test \
         --features "${RUST_INTEGRATION_TEST_FEATURES}" \
         --no-run \


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
```
[wimax]()
  [11:35 AM]()
Has anybody found a way to get either docker buildx or cargo to spit out more information when you encounter the following during a make build-test-integration?
#34 43.33 error: could not compile `generator-dispatcher` due to 3 previous errors
progress=plain doesn't do it; I'm hoping a make docker-clean-all + progress=plain will
[11:36](https://grapl-internal.slack.com/archives/C0174A8QV2S/p1658504161441869)
¯\_(ツ)_/¯


[wimax]()
  [11:50 AM]()
actually, i may have an idea
```
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
