### PR TITLE
Remove all bare get_grpc_client in tests; only with_options

### DIFF
--- a/src/rust/graph-merger/tests/integration_test.rs
+++ b/src/rust/graph-merger/tests/integration_test.rs
@@ -30,8 +30,9 @@ use rust_proto::graplinc::grapl::{
     pipeline::v1beta2::Envelope,
 };
 use rust_proto_clients::{
-    get_grpc_client,
+    get_grpc_client_with_options,
     services::PipelineIngressClientConfig,
+    GetGrpcClientOptions,
 };
 use test_context::{
     test_context,
@@ -68,7 +69,15 @@ impl AsyncTestContext for GraphMergerTestContext {
         let _guard = setup_tracing(SERVICE_NAME).expect("setup_tracing");
 
         let client_config = PipelineIngressClientConfig::parse();
-        let pipeline_ingress_client = get_grpc_client(client_config).await.expect("client");
+        let pipeline_ingress_client = get_grpc_client_with_options(
+            client_config,
+            GetGrpcClientOptions {
+                perform_healthcheck: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("pipeline_ingress_client");
 
         let consumer_config = ConsumerConfig::with_topic(CONSUMER_TOPIC);
 

--- a/src/rust/organization-management/tests/test_create_organization.rs
+++ b/src/rust/organization-management/tests/test_create_organization.rs
@@ -7,8 +7,9 @@ use grapl_utils::future_ext::GraplFutureExt;
 use organization_management::OrganizationManagementServiceConfig;
 use rust_proto::graplinc::grapl::api::organization_management::v1beta1::CreateOrganizationRequest;
 use rust_proto_clients::{
-    get_grpc_client,
+    get_grpc_client_with_options,
     services::OrganizationManagementClientConfig,
+    GetGrpcClientOptions,
 };
 
 #[test_log::test(tokio::test)]
@@ -32,7 +33,14 @@ async fn test_create_organization() -> Result<(), Box<dyn std::error::Error>> {
         .await??;
 
     let client_config = OrganizationManagementClientConfig::parse();
-    let mut client = get_grpc_client(client_config).await?;
+    let mut client = get_grpc_client_with_options(
+        client_config,
+        GetGrpcClientOptions {
+            perform_healthcheck: true,
+            ..Default::default()
+        },
+    )
+    .await?;
 
     let organization_display_name = uuid::Uuid::new_v4().to_string();
     let admin_username = "test user".to_string();

--- a/src/rust/pipeline-ingress/tests/integration_test.rs
+++ b/src/rust/pipeline-ingress/tests/integration_test.rs
@@ -51,7 +51,7 @@ impl AsyncTestContext for PipelineIngressTestContext {
         let _guard = setup_tracing("pipeline-ingress-integration-tests").expect("setup_tracing");
 
         let client_config = PipelineIngressClientConfig::parse();
-        let grpc_client = get_grpc_client_with_options(
+        let pipeline_ingress_client = get_grpc_client_with_options(
             client_config,
             GetGrpcClientOptions {
                 perform_healthcheck: true,
@@ -59,11 +59,11 @@ impl AsyncTestContext for PipelineIngressTestContext {
             },
         )
         .await
-        .expect("client");
+        .expect("pipeline_ingress_client");
         let consumer_config = ConsumerConfig::with_topic(CONSUMER_TOPIC);
 
         PipelineIngressTestContext {
-            grpc_client,
+            grpc_client: pipeline_ingress_client,
             consumer_config,
             _guard,
         }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
Followup to https://github.com/grapl-security/grapl/pull/1826


<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
I noticed a connection error occured in test_sysmon_event_produces_merged_graph today; the healthcheck would avoid this scenario, theoretically.

I changed all other bare `get_grpc_client`s to the options form as well, Just In Case(tm). 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
its all tests
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
