### PR TITLE
Update Localstack to `localstack-light:1.0.1`

### DIFF
--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -133,10 +133,7 @@ job "grapl-local-infra" {
       driver = "docker"
 
       config {
-        # https://github.com/localstack/localstack/issues/5824
-        # The bugfix we need is only available post-14.3 in latest starting May 23
-        # Hence pinning by sha, not tag
-        image = "localstack/localstack-light@sha256:a64dbc0b4e05f3647d8f1a09eb743e3d213402312858fb4146a7571a4a4ee6be"
+        image = "localstack/localstack-light:1.0.1"
 
         # Was running into this: https://github.com/localstack/localstack/issues/1349
         memory_hard_limit = 2048


### PR DESCRIPTION
While doing some unrelated version bumps elsewhere, I discovered that
a new release of Localstack had been made, allowing us to pin to a
specific tag, rather than a SHA256 checksum.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
