### PR TITLE
KafkaTopicScanner: test util to search for matching Kafka messages in a stream.

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2314,7 +2314,9 @@ dependencies = [
  "rdkafka",
  "rust-proto",
  "thiserror",
+ "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/src/rust/graph-merger/Cargo.toml
+++ b/src/rust/graph-merger/Cargo.toml
@@ -51,5 +51,6 @@ tracing = "0.1"
 uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
+kafka = { path = "../kafka", features = ["test-utils"] }
 rust-proto-clients = { path = "../rust-proto-clients" }
 test-context = "0.1"

--- a/src/rust/graph-merger/tests/integration_test.rs
+++ b/src/rust/graph-merger/tests/integration_test.rs
@@ -8,7 +8,7 @@ use grapl_tracing::{
 };
 use kafka::{
     config::ConsumerConfig,
-    test_utils::topic_contains::KafkaTopicScanner,
+    test_utils::topic_scanner::KafkaTopicScanner,
 };
 use rust_proto::graplinc::grapl::{
     api::{

--- a/src/rust/graph-merger/tests/integration_test.rs
+++ b/src/rust/graph-merger/tests/integration_test.rs
@@ -1,18 +1,14 @@
 #![cfg(feature = "integration_tests")]
 
-use std::time::Duration;
-
 use bytes::Bytes;
 use clap::Parser;
-use futures::StreamExt;
 use grapl_tracing::{
     setup_tracing,
     WorkerGuard,
 };
 use kafka::{
     config::ConsumerConfig,
-    Consumer,
-    ConsumerError,
+    test_utils::topic_contains::KafkaTopicScanner,
 };
 use rust_proto::graplinc::grapl::{
     api::{
@@ -38,7 +34,6 @@ use test_context::{
     test_context,
     AsyncTestContext,
 };
-use tokio::sync::oneshot;
 use tracing::Instrument;
 use uuid::Uuid;
 
@@ -91,83 +86,52 @@ impl AsyncTestContext for GraphMergerTestContext {
 
 #[test_context(GraphMergerTestContext)]
 #[tokio::test]
-async fn test_sysmon_event_produces_merged_graph(ctx: &mut GraphMergerTestContext) {
+async fn test_sysmon_event_produces_merged_graph(
+    ctx: &mut GraphMergerTestContext,
+) -> Result<(), Box<dyn std::error::Error>> {
     let event_source_id = Uuid::new_v4();
     let tenant_id = Uuid::new_v4();
 
-    tracing::info!("configuring kafka consumer");
-    let kafka_consumer =
-        Consumer::new(ctx.consumer_config.clone()).expect("could not configure kafka consumer");
+    let kafka_scanner = KafkaTopicScanner::new(ctx.consumer_config.clone())?
+        .contains(move |envelope: &Envelope<MergedGraph>| -> bool {
+            let metadata = &envelope.metadata;
+            let merged_graph = &envelope.inner_message;
+            if metadata.tenant_id == tenant_id && metadata.event_source_id == event_source_id {
+                let parent_process = find_node(
+                    merged_graph,
+                    "process_id",
+                    ImmutableUintProp { prop: 6132 }.into(),
+                )
+                .expect("parent process missing");
 
-    // we'll use this channel to communicate that the consumer is ready to
-    // consume messages
-    let (tx, rx) = oneshot::channel::<()>();
+                let child_process = find_node(
+                    merged_graph,
+                    "process_id",
+                    ImmutableUintProp { prop: 5752 }.into(),
+                )
+                .expect("child process missing");
 
-    tracing::info!("creating kafka subscriber thread");
-    let kafka_subscriber = tokio::task::spawn(async move {
-        let stream = kafka_consumer.stream();
-
-        // notify the consumer that we're ready to receive messages
-        tx.send(())
-            .expect("failed to notify sender that consumer is consuming");
-
-        let contains_expected = stream.any(
-            |res: Result<Envelope<MergedGraph>, ConsumerError>| async move {
-                let envelope = res.expect("error consuming message from kafka");
-                let metadata = envelope.metadata;
-                let merged_graph = envelope.inner_message;
-
-                tracing::debug!(message = "consumed kafka message");
-
-                if metadata.tenant_id == tenant_id && metadata.event_source_id == event_source_id {
-                    let parent_process = find_node(
-                        &merged_graph,
-                        "process_id",
-                        ImmutableUintProp { prop: 6132 }.into(),
-                    )
-                    .expect("parent process missing");
-
-                    let child_process = find_node(
-                        &merged_graph,
-                        "process_id",
-                        ImmutableUintProp { prop: 5752 }.into(),
-                    )
-                    .expect("child process missing");
-
-                    // NOTE: here, unlike node-identifier, we expect the edge
-                    // connecting the parent and child proceses to be *absent*
-                    // in the message emitted to the merged-graphs topic. The
-                    // reason for this is that downstream services (analyzers)
-                    // don't operate on edges, just nodes. So the view of the
-                    // graph diverges at the graph-merger--we now tell one story
-                    // in our Kafka messages and a totally different story in
-                    // Dgraph. This is confusing and we should fix it:
-                    //
-                    // https://app.zenhub.com/workspaces/grapl-6036cbd36bacff000ef314f2/issues/grapl-security/issue-tracker/950
-                    !merged_graph
-                        .edges
-                        .get(parent_process.get_node_key())
-                        .iter()
-                        .flat_map(|edge_list| edge_list.edges.iter())
-                        .any(|edge| edge.to_node_key == child_process.get_node_key())
-                } else {
-                    false
-                }
-            },
-        );
-
-        tracing::info!("consuming kafka messages for 30s");
-        assert!(
-            tokio::time::timeout(Duration::from_secs(30), contains_expected)
-                .await
-                .expect("failed to consume expected message within 30s")
-        );
-    });
-
-    // wait for the kafka consumer to start consuming
-    tracing::info!("waiting for kafka consumer to report ready");
-    rx.await
-        .expect("failed to receive notification that consumer is consuming");
+                // NOTE: here, unlike node-identifier, we expect the edge
+                // connecting the parent and child proceses to be *absent*
+                // in the message emitted to the merged-graphs topic. The
+                // reason for this is that downstream services (analyzers)
+                // don't operate on edges, just nodes. So the view of the
+                // graph diverges at the graph-merger--we now tell one story
+                // in our Kafka messages and a totally different story in
+                // Dgraph. This is confusing and we should fix it:
+                //
+                // https://app.zenhub.com/workspaces/grapl-6036cbd36bacff000ef314f2/issues/grapl-security/issue-tracker/950
+                !merged_graph
+                    .edges
+                    .get(parent_process.get_node_key())
+                    .iter()
+                    .flat_map(|edge_list| edge_list.edges.iter())
+                    .any(|edge| edge.to_node_key == child_process.get_node_key())
+            } else {
+                false
+            }
+        })
+        .await?;
 
     let log_event: Bytes = r#"
 <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
@@ -224,9 +188,11 @@ async fn test_sysmon_event_produces_merged_graph(ctx: &mut GraphMergerTestContex
         .await
         .expect("received error response");
 
-    tracing::info!("waiting for kafka_subscriber to complete");
-    kafka_subscriber
-        .instrument(tracing::debug_span!("kafka_subscriber"))
-        .await
-        .expect("could not join kafka subscriber");
+    tracing::info!("waiting for kafka_scanner to complete");
+    kafka_scanner
+        .get_listen_result()
+        .instrument(tracing::debug_span!("kafka_scanner"))
+        .await??;
+
+    Ok(())
 }

--- a/src/rust/kafka/Cargo.toml
+++ b/src/rust/kafka/Cargo.toml
@@ -23,5 +23,15 @@ rdkafka = { version = "0.28", features = [
   "zstd"
 ] }
 rust-proto = { path = "../rust-proto", version = "*" }
+tokio = { version = "1.17", features = [
+  "macros",
+  "rt",
+  "rt-multi-thread"
+], optional = true }
 thiserror = "1.0"
 tracing = "0.1"
+uuid = { version = "1.0", features = ["v4"], optional = true }
+
+[features]
+default = []
+test-utils = ["tokio", "uuid"]

--- a/src/rust/kafka/src/lib.rs
+++ b/src/rust/kafka/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod config;
 
+#[cfg(feature = "test-utils")]
+pub mod test_utils;
+
 use std::marker::PhantomData;
 
 use bytes::{

--- a/src/rust/kafka/src/test_utils.rs
+++ b/src/rust/kafka/src/test_utils.rs
@@ -1,0 +1,1 @@
+pub mod topic_scanner;

--- a/src/rust/kafka/src/test_utils/topic_scanner.rs
+++ b/src/rust/kafka/src/test_utils/topic_scanner.rs
@@ -108,7 +108,8 @@ where
                 timeout = ?self.timeout,
             );
             let matched_predicate = tokio::time::timeout(self.timeout, matched_predicate).await?;
-            Ok(matched_predicate.expect("Can't occur - if this were None we'd have the above timeout"))
+            Ok(matched_predicate
+                .expect("Can't occur - if this were None we'd have the above timeout"))
         });
 
         // wait for the kafka consumer to start consuming

--- a/src/rust/kafka/src/test_utils/topic_scanner.rs
+++ b/src/rust/kafka/src/test_utils/topic_scanner.rs
@@ -1,0 +1,130 @@
+use std::time::Duration;
+
+use futures::StreamExt;
+use rust_proto::{
+    graplinc::grapl::pipeline::v1beta2::Envelope,
+    SerDe,
+};
+use tokio::{
+    sync::{
+        oneshot,
+        oneshot::error::RecvError,
+    },
+    task::JoinError,
+    time::error::Elapsed,
+};
+
+use crate::{
+    config::ConsumerConfig,
+    ConfigurationError,
+    Consumer,
+    ConsumerError,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum KafkaTopicContainsError {
+    #[error("Timed out looking for a message matching this predicate: {0}")]
+    KafkaTopicContainsElapsed(#[from] Elapsed),
+    #[error("RecvError: failed to receive notification that consumer is consuming")]
+    RecvError(#[from] RecvError),
+    #[error("JoinError: could not join kafka subscriber")]
+    JoinError(#[from] JoinError),
+}
+
+/// Usage:
+/// 1. Construct a KafkaTopicScanner
+/// 2. Call `.contains*().await`
+/// 3. Kick off an event that'll result in logs showing up in Kafka
+/// 4. Call `.get_listen_result().await` to wait for the first matching element
+pub struct KafkaTopicScanner<T>
+where
+    T: SerDe + Send + Sync + 'static,
+{
+    consumer: Consumer<Envelope<T>>,
+    timeout: Duration,
+}
+
+impl<T> KafkaTopicScanner<T>
+where
+    T: SerDe + Send + Sync,
+{
+    pub fn new(consumer_config: ConsumerConfig) -> Result<Self, ConfigurationError> {
+        let consumer = Consumer::new(consumer_config)?;
+        let timeout = Duration::from_secs(30); // hardcoded for now, whatever
+        Ok(Self { consumer, timeout })
+    }
+
+    pub async fn contains_for_tenant(
+        self,
+        tenant_id: uuid::Uuid,
+        mut predicate: impl FnMut(&T) -> bool + Send + Sync + 'static,
+    ) -> Result<
+        ScanReadyToGetResult<Result<Envelope<T>, KafkaTopicContainsError>>,
+        KafkaTopicContainsError,
+    > {
+        let tenant_eq_predicate = move |envelope: &Envelope<T>| {
+            envelope.metadata.tenant_id == tenant_id && predicate(&envelope.inner_message)
+        };
+        self.contains(tenant_eq_predicate).await
+    }
+
+    pub async fn contains(
+        self,
+        predicate: impl FnMut(&Envelope<T>) -> bool + Send + Sync + 'static,
+    ) -> Result<
+        ScanReadyToGetResult<Result<Envelope<T>, KafkaTopicContainsError>>,
+        KafkaTopicContainsError,
+    > {
+        // we'll use this channel to communicate that the consumer is ready to
+        // consume messages
+        let (tx, rx) = oneshot::channel::<()>();
+
+        let predicate = std::sync::Arc::new(std::sync::Mutex::new(predicate));
+
+        tracing::info!("creating kafka subscriber thread");
+        let kafka_subscriber = tokio::task::spawn(async move {
+            let stream = Box::pin(self.consumer.stream());
+
+            // notify the consumer that we're ready to receive messages
+            tx.send(())
+                .expect("failed to notify sender that consumer is consuming");
+
+            let mut filtered_stream = Box::pin(stream.filter_map(
+                move |res: Result<Envelope<T>, ConsumerError>| {
+                    let predicate = predicate.clone();
+                    async move {
+                        let envelope = res.expect("error consuming message from kafka");
+                        match predicate.clone().lock().expect("locking")(&envelope) {
+                            true => Some(envelope.clone()),
+                            false => None,
+                        }
+                    }
+                },
+            ));
+            let matched_predicate = filtered_stream.next();
+
+            tracing::info!(
+                message = "Consuming kafka messages",
+                timeout = ?self.timeout,
+            );
+            let matched_predicate = tokio::time::timeout(self.timeout, matched_predicate).await?;
+            Ok(matched_predicate.expect("Can't occur - if this were None we'd have the above timeout"))
+        });
+
+        // wait for the kafka consumer to start consuming
+        tracing::info!("waiting for kafka consumer to report ready");
+        rx.await?;
+        Ok(ScanReadyToGetResult {
+            listen_result: kafka_subscriber,
+        })
+    }
+}
+
+pub struct ScanReadyToGetResult<T> {
+    listen_result: tokio::task::JoinHandle<T>,
+}
+impl<T> ScanReadyToGetResult<T> {
+    pub async fn get_listen_result(self) -> Result<T, KafkaTopicContainsError> {
+        Ok(self.listen_result.await?)
+    }
+}

--- a/src/rust/node-identifier/Cargo.toml
+++ b/src/rust/node-identifier/Cargo.toml
@@ -30,7 +30,7 @@ grapl-config = { path = "../grapl-config" }
 grapl-tracing = { path = "../grapl-tracing" }
 hex = "0.4"
 hmap = "0.1"
-kafka = { path = "../kafka", version = "*" }
+kafka = { path = "../kafka" }
 rusoto_core = { version = "0.47", default_features = false, features = [
   "rustls"
 ] }
@@ -57,6 +57,7 @@ uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
 async-trait = "0.1"
+kafka = { path = "../kafka", features = ["test-utils"] }
 rand = "0.8"
 rust-proto-clients = { path = "../rust-proto-clients" }
 test-context = "0.1"

--- a/src/rust/node-identifier/tests/integration_test.rs
+++ b/src/rust/node-identifier/tests/integration_test.rs
@@ -8,7 +8,7 @@ use grapl_tracing::{
 };
 use kafka::{
     config::ConsumerConfig,
-    test_utils::topic_contains::KafkaTopicScanner,
+    test_utils::topic_scanner::KafkaTopicScanner,
 };
 use rust_proto::graplinc::grapl::{
     api::{

--- a/src/rust/node-identifier/tests/integration_test.rs
+++ b/src/rust/node-identifier/tests/integration_test.rs
@@ -1,18 +1,14 @@
 #![cfg(feature = "integration_tests")]
 
-use std::time::Duration;
-
 use bytes::Bytes;
 use clap::Parser;
-use futures::StreamExt;
 use grapl_tracing::{
     setup_tracing,
     WorkerGuard,
 };
 use kafka::{
     config::ConsumerConfig,
-    Consumer,
-    ConsumerError,
+    test_utils::topic_contains::KafkaTopicScanner,
 };
 use rust_proto::graplinc::grapl::{
     api::{
@@ -38,7 +34,6 @@ use test_context::{
     test_context,
     AsyncTestContext,
 };
-use tokio::sync::oneshot;
 use tracing::Instrument;
 use uuid::Uuid;
 
@@ -92,76 +87,48 @@ impl AsyncTestContext for NodeIdentifierTestContext {
 
 #[test_context(NodeIdentifierTestContext)]
 #[tokio::test]
-async fn test_sysmon_event_produces_identified_graph(ctx: &mut NodeIdentifierTestContext) {
+async fn test_sysmon_event_produces_identified_graph(
+    ctx: &mut NodeIdentifierTestContext,
+) -> Result<(), Box<dyn std::error::Error>> {
     let event_source_id = Uuid::new_v4();
     let tenant_id = Uuid::new_v4();
 
-    tracing::info!("configuring kafka consumer");
-    let kafka_consumer =
-        Consumer::new(ctx.consumer_config.clone()).expect("could not configure kafka consumer");
+    let kafka_scanner = KafkaTopicScanner::new(ctx.consumer_config.clone())?
+        .contains(move |envelope: &Envelope<IdentifiedGraph>| -> bool {
+            let metadata = &envelope.metadata;
+            let identified_graph = &envelope.inner_message;
 
-    // we'll use this channel to communicate that the consumer is ready to
-    // consume messages
-    let (tx, rx) = oneshot::channel::<()>();
+            tracing::debug!(message = "consumed kafka message");
 
-    tracing::info!("creating kafka subscriber thread");
-    let kafka_subscriber = tokio::task::spawn(async move {
-        let stream = kafka_consumer.stream();
+            if metadata.tenant_id == tenant_id && metadata.event_source_id == event_source_id {
+                let parent_process = find_node(
+                    identified_graph,
+                    "process_id",
+                    ImmutableUintProp { prop: 6132 }.into(),
+                )
+                .expect("parent process missing");
 
-        // notify the consumer that we're ready to receive messages
-        tx.send(())
-            .expect("failed to notify sender that consumer is consuming");
+                let child_process = find_node(
+                    identified_graph,
+                    "process_id",
+                    ImmutableUintProp { prop: 5752 }.into(),
+                )
+                .expect("child process missing");
 
-        let contains_expected = stream.any(
-            |res: Result<Envelope<IdentifiedGraph>, ConsumerError>| async move {
-                let envelope = res.expect("error consuming message from kafka");
-                let metadata = envelope.metadata;
-                let identified_graph = envelope.inner_message;
+                let parent_to_child_edge = identified_graph
+                    .edges
+                    .get(parent_process.get_node_key())
+                    .iter()
+                    .flat_map(|edge_list| edge_list.edges.iter())
+                    .find(|edge| edge.to_node_key == child_process.get_node_key())
+                    .expect("missing edge from parent to child");
 
-                tracing::debug!(message = "consumed kafka message");
-
-                if metadata.tenant_id == tenant_id && metadata.event_source_id == event_source_id {
-                    let parent_process = find_node(
-                        &identified_graph,
-                        "process_id",
-                        ImmutableUintProp { prop: 6132 }.into(),
-                    )
-                    .expect("parent process missing");
-
-                    let child_process = find_node(
-                        &identified_graph,
-                        "process_id",
-                        ImmutableUintProp { prop: 5752 }.into(),
-                    )
-                    .expect("child process missing");
-
-                    let parent_to_child_edge = identified_graph
-                        .edges
-                        .get(parent_process.get_node_key())
-                        .iter()
-                        .flat_map(|edge_list| edge_list.edges.iter())
-                        .find(|edge| edge.to_node_key == child_process.get_node_key())
-                        .expect("missing edge from parent to child");
-
-                    parent_to_child_edge.edge_name == "children"
-                } else {
-                    false
-                }
-            },
-        );
-
-        tracing::info!("consuming kafka messages for 30s");
-        assert!(
-            tokio::time::timeout(Duration::from_millis(30000), contains_expected)
-                .await
-                .expect("failed to consume expected message within 30s")
-        );
-    });
-
-    // wait for the kafka consumer to start consuming
-    tracing::info!("waiting for kafka consumer to report ready");
-    rx.await
-        .expect("failed to receive notification that consumer is consuming");
+                parent_to_child_edge.edge_name == "children"
+            } else {
+                false
+            }
+        })
+        .await?;
 
     let log_event: Bytes = r#"
 <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
@@ -218,9 +185,11 @@ async fn test_sysmon_event_produces_identified_graph(ctx: &mut NodeIdentifierTes
         .await
         .expect("received error response");
 
-    tracing::info!("waiting for kafka_subscriber to complete");
-    kafka_subscriber
-        .instrument(tracing::debug_span!("kafka_subscriber"))
-        .await
-        .expect("could not join kafka subscriber");
+    tracing::info!("waiting for kafka_scanner to complete");
+    kafka_scanner
+        .get_listen_result()
+        .instrument(tracing::debug_span!("kafka_scanner"))
+        .await??;
+
+    Ok(())
 }

--- a/src/rust/pipeline-ingress/Cargo.toml
+++ b/src/rust/pipeline-ingress/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "3.0", default_features = false, features = [
   "derive"
 ] }
 grapl-tracing = { path = "../grapl-tracing" }
-kafka = { path = "../kafka", version = "*" }
+kafka = { path = "../kafka" }
 rust-proto = { path = "../rust-proto", version = "*" }
 tokio = { version = "1.17", features = ["macros", "rt", "rt-multi-thread"] }
 thiserror = "1.0"
@@ -22,6 +22,7 @@ uuid = { version = "1.0", features = ["v4"] }
 [dev-dependencies]
 bytes = "1.1"
 futures = "0.3"
+kafka = { path = "../kafka", features = ["test-utils"] }
 rust-proto-clients = { path = "../rust-proto-clients" }
 test-context = "0.1"
 tokio = { version = "1.17", features = ["macros", "rt"] }

--- a/src/rust/pipeline-ingress/tests/integration_test.rs
+++ b/src/rust/pipeline-ingress/tests/integration_test.rs
@@ -1,18 +1,14 @@
 #![cfg(feature = "integration_tests")]
 
-use std::time::Duration;
-
 use bytes::Bytes;
 use clap::Parser;
-use futures::StreamExt;
 use grapl_tracing::{
     setup_tracing,
     WorkerGuard,
 };
 use kafka::{
     config::ConsumerConfig,
-    Consumer,
-    ConsumerError,
+    test_utils::topic_contains::KafkaTopicScanner,
 };
 use rust_proto::graplinc::grapl::{
     api::pipeline_ingress::v1beta1::{
@@ -33,7 +29,6 @@ use test_context::{
     test_context,
     AsyncTestContext,
 };
-use tokio::sync::oneshot;
 use tracing::Instrument;
 use uuid::Uuid;
 
@@ -72,54 +67,26 @@ impl AsyncTestContext for PipelineIngressTestContext {
 
 #[test_context(PipelineIngressTestContext)]
 #[tokio::test]
-async fn test_publish_raw_log_sends_message_to_kafka(ctx: &mut PipelineIngressTestContext) {
+async fn test_publish_raw_log_sends_message_to_kafka(
+    ctx: &mut PipelineIngressTestContext,
+) -> Result<(), Box<dyn std::error::Error>> {
     let event_source_id = Uuid::new_v4();
     let tenant_id = Uuid::new_v4();
     let log_event: Bytes = "test".into();
 
-    tracing::info!("configuring kafka consumer");
+    let kafka_scanner = KafkaTopicScanner::new(ctx.consumer_config.clone())?
+        .contains(move |envelope: &Envelope<RawLog>| -> bool {
+            let metadata = &envelope.metadata;
+            let raw_log = &envelope.inner_message;
+            let expected_log_event: Bytes = "test".into();
 
-    let kafka_consumer =
-        Consumer::new(ctx.consumer_config.clone()).expect("could not configure kafka consumer");
+            tracing::debug!(message = "consumed kafka message");
 
-    // we'll use this channel to communicate that the consumer is ready to
-    // consume messages
-    let (tx, rx) = oneshot::channel::<()>();
-
-    tracing::info!("creating kafka subscriber thread");
-    let kafka_subscriber = tokio::task::spawn(async move {
-        let stream = kafka_consumer.stream();
-
-        // notify the consumer that we're ready to receive messages
-        tx.send(())
-            .expect("failed to notify sender that consumer is consuming");
-
-        let contains_expected =
-            stream.any(|res: Result<Envelope<RawLog>, ConsumerError>| async move {
-                let envelope = res.expect("error consuming message from kafka");
-                let metadata = envelope.metadata;
-                let raw_log = envelope.inner_message;
-                let expected_log_event: Bytes = "test".into();
-
-                tracing::debug!(message = "consumed kafka message");
-
-                metadata.tenant_id == tenant_id
-                    && metadata.event_source_id == event_source_id
-                    && raw_log.log_event == expected_log_event
-            });
-
-        tracing::info!("consuming kafka messages for 30s");
-        assert!(
-            tokio::time::timeout(Duration::from_millis(30000), contains_expected)
-                .await
-                .expect("failed to consume expected message within 30s")
-        );
-    });
-
-    // wait for the kafka consumer to start consuming
-    tracing::info!("waiting for kafka consumer to report ready");
-    rx.await
-        .expect("failed to receive notification that consumer is consuming");
+            metadata.tenant_id == tenant_id
+                && metadata.event_source_id == event_source_id
+                && raw_log.log_event == expected_log_event
+        })
+        .await?;
 
     tracing::info!("sending publish_raw_log request");
     ctx.grpc_client
@@ -131,9 +98,10 @@ async fn test_publish_raw_log_sends_message_to_kafka(ctx: &mut PipelineIngressTe
         .await
         .expect("received error response");
 
-    tracing::info!("waiting for kafka_subscriber to complete");
-    kafka_subscriber
-        .instrument(tracing::debug_span!("kafka_subscriber"))
-        .await
-        .expect("could not join kafka subscriber");
+    tracing::info!("waiting for kafka_scanner to complete");
+    kafka_scanner
+        .get_listen_result()
+        .instrument(tracing::debug_span!("kafka_scanner"))
+        .await??;
+    Ok(())
 }

--- a/src/rust/pipeline-ingress/tests/integration_test.rs
+++ b/src/rust/pipeline-ingress/tests/integration_test.rs
@@ -8,7 +8,7 @@ use grapl_tracing::{
 };
 use kafka::{
     config::ConsumerConfig,
-    test_utils::topic_contains::KafkaTopicScanner,
+    test_utils::topic_scanner::KafkaTopicScanner,
 };
 use rust_proto::graplinc::grapl::{
     api::pipeline_ingress::v1beta1::{


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
We have this delightful ability with Kafka tests to "listen in" on the topics between our services and make sure that progress has been made between Service A -> Service B -> Service C.

However, it's currently medium-complex copy-pasted tokio rx/tx complex stuff. 
Test utilities should be ergonomic and reusable, hence: KafkaTopicScanner obfuscates that all away.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
its all tests

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
