### PR TITLE
rust-proto: merge two traits together. Remove NamedService, only Connectable

### DIFF
--- a/src/rust/rust-proto/src/client_factory/build_grpc_client.rs
+++ b/src/rust/rust-proto/src/client_factory/build_grpc_client.rs
@@ -11,7 +11,6 @@ use crate::{
         service_client::{
             ConnectError,
             Connectable,
-            NamedService,
         },
     },
 };

--- a/src/rust/rust-proto/src/client_factory/grpc_client_config.rs
+++ b/src/rust/rust-proto/src/client_factory/grpc_client_config.rs
@@ -1,12 +1,9 @@
-use crate::protocol::service_client::{
-    Connectable,
-    NamedService,
-};
+use crate::protocol::service_client::Connectable;
 
 pub struct GenericGrpcClientConfig {
     pub address: String,
 }
 
 pub trait GrpcClientConfig: clap::Parser + Into<GenericGrpcClientConfig> {
-    type Client: NamedService + Connectable;
+    type Client: Connectable;
 }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/event_source/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/event_source/v1beta1/client.rs
@@ -11,7 +11,6 @@ use crate::{
         service_client::{
             ConnectError,
             Connectable,
-            NamedService,
         },
         status::Status,
     },
@@ -40,6 +39,8 @@ pub struct EventSourceServiceClient {
 
 #[async_trait::async_trait]
 impl Connectable for EventSourceServiceClient {
+    const SERVICE_NAME: &'static str = "graplinc.grapl.api.event_source.v1beta1.EventSourceService";
+
     #[tracing::instrument(err)]
     async fn connect(endpoint: Endpoint) -> Result<Self, ConnectError> {
         Ok(EventSourceServiceClient {
@@ -81,8 +82,4 @@ impl EventSourceServiceClient {
             .await?;
         Ok(response.into_inner().try_into()?)
     }
-}
-
-impl NamedService for EventSourceServiceClient {
-    const SERVICE_NAME: &'static str = "graplinc.grapl.api.event_source.v1beta1.EventSourceService";
 }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/organization_management/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/organization_management/v1beta1.rs
@@ -197,10 +197,9 @@ pub mod client {
     use tonic::Request;
     use crate::protocol::endpoint::Endpoint;
 
-    use crate::protocol::service_client::{ConnectError, NamedService};
     use crate::{
         protobufs::graplinc::grapl::api::organization_management::v1beta1::organization_management_service_client::OrganizationManagementServiceClient as OrganizationManagementServiceClientProto,
-        protocol::{service_client::Connectable},
+        protocol::{service_client::Connectable, service_client::ConnectError},
         SerDeError,
     };
 
@@ -225,13 +224,10 @@ pub mod client {
         proto_client: OrganizationManagementServiceClientProto<tonic::transport::Channel>,
     }
 
-    impl NamedService for OrganizationManagementClient {
-        const SERVICE_NAME: &'static str =
-            "graplinc.grapl.api.organization_management.v1beta1.OrganizationManagementService";
-    }
-
     #[async_trait::async_trait]
     impl Connectable for OrganizationManagementClient {
+        const SERVICE_NAME: &'static str =
+            "graplinc.grapl.api.organization_management.v1beta1.OrganizationManagementService";
         async fn connect(endpoint: Endpoint) -> Result<Self, ConnectError> {
             Ok(OrganizationManagementClient {
                 proto_client: OrganizationManagementServiceClientProto::connect(endpoint).await?,

--- a/src/rust/rust-proto/src/graplinc/grapl/api/pipeline_ingress/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/pipeline_ingress/v1beta1/client.rs
@@ -7,7 +7,6 @@ use crate::protocol::{
     service_client::{
         ConnectError,
         Connectable,
-        NamedService,
     },
 };
 /// This module contains the gRPC client for the pipeline ingress API. We
@@ -38,6 +37,9 @@ pub struct PipelineIngressClient {
 
 #[async_trait::async_trait]
 impl Connectable for PipelineIngressClient {
+    const SERVICE_NAME: &'static str =
+        "graplinc.grapl.api.pipeline_ingress.v1beta1.PipelineIngressService";
+
     #[tracing::instrument(err)]
     async fn connect(endpoint: Endpoint) -> Result<Self, ConnectError> {
         Ok(PipelineIngressClient {
@@ -61,9 +63,4 @@ impl PipelineIngressClient {
             )
             .await
     }
-}
-
-impl NamedService for PipelineIngressClient {
-    const SERVICE_NAME: &'static str =
-        "graplinc.grapl.api.pipeline_ingress.v1beta1.PipelineIngressService";
 }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_bootstrap/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_bootstrap/v1beta1.rs
@@ -167,7 +167,7 @@ pub mod client {
 
     use crate::{
         protobufs::graplinc::grapl::api::plugin_bootstrap::v1beta1::plugin_bootstrap_service_client::PluginBootstrapServiceClient as PluginBootstrapServiceClientProto,
-        protocol::{service_client::{Connectable, ConnectError, NamedService}},
+        protocol::{service_client::{Connectable, ConnectError}},
         SerDeError,
     };
 
@@ -191,13 +191,11 @@ pub mod client {
         proto_client: PluginBootstrapServiceClientProto<tonic::transport::Channel>,
     }
 
-    impl NamedService for PluginBootstrapClient {
-        const SERVICE_NAME: &'static str =
-            "graplinc.grapl.api.plugin_bootstrap.v1beta1.PluginBootstrapService";
-    }
-
     #[async_trait::async_trait]
     impl Connectable for PluginBootstrapClient {
+        const SERVICE_NAME: &'static str =
+            "graplinc.grapl.api.plugin_bootstrap.v1beta1.PluginBootstrapService";
+
         #[tracing::instrument(err)]
         async fn connect(endpoint: Endpoint) -> Result<Self, ConnectError> {
             Ok(PluginBootstrapClient {

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -15,7 +15,6 @@ use crate::{
         service_client::{
             ConnectError,
             Connectable,
-            NamedService,
         },
         status::Status,
     },
@@ -37,6 +36,9 @@ pub struct PluginRegistryServiceClient {
 
 #[async_trait::async_trait]
 impl Connectable for PluginRegistryServiceClient {
+    const SERVICE_NAME: &'static str =
+        "graplinc.grapl.api.plugin_registry.v1beta1.PluginRegistryService";
+
     #[tracing::instrument(err)]
     async fn connect(endpoint: Endpoint) -> Result<Self, ConnectError> {
         Ok(PluginRegistryServiceClient {
@@ -172,9 +174,4 @@ impl PluginRegistryServiceClient {
             .map_err(Status::from)?;
         todo!()
     }
-}
-
-impl NamedService for PluginRegistryServiceClient {
-    const SERVICE_NAME: &'static str =
-        "graplinc.grapl.api.plugin_registry.v1beta1.PluginRegistryService";
 }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/generators/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/generators/v1beta1/client.rs
@@ -11,7 +11,6 @@ use crate::{
         service_client::{
             ConnectError,
             Connectable,
-            NamedService,
         },
         status::Status,
     },
@@ -32,6 +31,9 @@ pub struct GeneratorServiceClient {
 }
 #[async_trait::async_trait]
 impl Connectable for GeneratorServiceClient {
+    const SERVICE_NAME: &'static str =
+        "graplinc.grapl.api.plugin_sdk.generators.v1beta1.GeneratorService";
+
     #[tracing::instrument(err)]
     async fn connect(endpoint: Endpoint) -> Result<Self, ConnectError> {
         Ok(GeneratorServiceClient {
@@ -53,9 +55,4 @@ impl GeneratorServiceClient {
         let response = native::RunGeneratorResponse::try_from(response.into_inner())?;
         Ok(response)
     }
-}
-
-impl NamedService for GeneratorServiceClient {
-    const SERVICE_NAME: &'static str =
-        "graplinc.grapl.api.plugin_sdk.generators.v1beta1.GeneratorService";
 }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1_client.rs
@@ -10,7 +10,6 @@ use crate::{
         service_client::{
             ConnectError,
             Connectable,
-            NamedService,
         },
     },
     SerDeError,
@@ -31,6 +30,9 @@ pub struct PluginWorkQueueServiceClient {
 
 #[async_trait::async_trait]
 impl Connectable for PluginWorkQueueServiceClient {
+    const SERVICE_NAME: &'static str =
+        "graplinc.grapl.api.plugin_work_queue.v1beta1.PluginWorkQueueService";
+
     #[tracing::instrument(err)]
     async fn connect(endpoint: Endpoint) -> Result<Self, ConnectError> {
         Ok(Self {
@@ -123,9 +125,4 @@ impl PluginWorkQueueServiceClient {
             .await?;
         Ok(response.into_inner().try_into()?)
     }
-}
-
-impl NamedService for PluginWorkQueueServiceClient {
-    const SERVICE_NAME: &'static str =
-        "graplinc.grapl.api.plugin_work_queue.v1beta1.PluginWorkQueueService";
 }

--- a/src/rust/rust-proto/src/protocol/service_client.rs
+++ b/src/rust/rust-proto/src/protocol/service_client.rs
@@ -3,16 +3,12 @@ use tokio::time::error::Elapsed;
 use super::healthcheck::HealthcheckError;
 use crate::protocol::endpoint::Endpoint;
 
-/// Equivalent to the NamedService trait in tonic for server constructs.
-/// Pass this NAME to e.g. a healthcheck client.
-pub trait NamedService {
-    const SERVICE_NAME: &'static str;
-}
-// TODO: Merge NamedService into Connectable
-
 /// Every service should implement Connectable.
 #[async_trait::async_trait]
 pub trait Connectable {
+    /// Pass this NAME to e.g. a healthcheck client.
+    const SERVICE_NAME: &'static str;
+
     async fn connect(endpoint: Endpoint) -> Result<Self, ConnectError>
     where
         Self: Sized;


### PR DESCRIPTION
These two traits are used together always, so I merged them