### PR TITLE
Move 'scan_for_plugin_message_in_pwq()` to PluginWorkQueue's test-utils

### DIFF
--- a/src/rust/generator-dispatcher/Cargo.toml
+++ b/src/rust/generator-dispatcher/Cargo.toml
@@ -28,9 +28,7 @@ uuid = { version = "1.0", features = ["v4"] }
 [dev-dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-plugin-work-queue = { path = "../plugin-work-queue", features = [
-  "test-utils"
-] }
+plugin-work-queue = { path = "../plugin-work-queue", features = ["test-utils"] }
 test-context = "0.1"
 
 [features]

--- a/src/rust/generator-dispatcher/Cargo.toml
+++ b/src/rust/generator-dispatcher/Cargo.toml
@@ -29,7 +29,7 @@ uuid = { version = "1.0", features = ["v4"] }
 async-trait = "0.1"
 bytes = "1.0"
 plugin-work-queue = { path = "../plugin-work-queue", features = [
-  "integration_tests"
+  "test-utils"
 ] }
 test-context = "0.1"
 

--- a/src/rust/generator-dispatcher/tests/generator_dispatcher_integration_tests.rs
+++ b/src/rust/generator-dispatcher/tests/generator_dispatcher_integration_tests.rs
@@ -3,9 +3,7 @@
 mod test_utils;
 
 use bytes::Bytes;
-use plugin_work_queue::{
-    test_utils::scan_for_plugin_message_in_pwq,
-};
+use plugin_work_queue::test_utils::scan_for_plugin_message_in_pwq;
 use rust_proto::graplinc::grapl::api::{
     event_source::v1beta1::CreateEventSourceRequest,
     pipeline_ingress::v1beta1::PublishRawLogRequest,

--- a/src/rust/plugin-work-queue/Cargo.toml
+++ b/src/rust/plugin-work-queue/Cargo.toml
@@ -42,4 +42,6 @@ futures = "0.3"
 tracing-subscriber = "0.3"
 
 [features]
+default = []
+test-utils = []
 integration_tests = []

--- a/src/rust/plugin-work-queue/src/lib.rs
+++ b/src/rust/plugin-work-queue/src/lib.rs
@@ -5,7 +5,7 @@ use kafka::config::ProducerConfig;
 mod kafka_produce;
 pub mod psql_queue;
 pub mod server;
-#[cfg(feature = "integration_tests")]
+#[cfg(feature = "test-utils")]
 pub mod test_utils;
 
 // Intentionally not clap::Parser, since ProducerConfigs are

--- a/src/rust/plugin-work-queue/src/psql_queue.rs
+++ b/src/rust/plugin-work-queue/src/psql_queue.rs
@@ -82,7 +82,7 @@ impl PsqlQueue {
         Ok(Self::new(pool))
     }
 
-    #[instrument(skip(pipeline_message), err)]
+    #[instrument(skip(self, pipeline_message), err)]
     pub async fn put_generator_message(
         &self,
         plugin_id: Uuid,
@@ -106,7 +106,7 @@ impl PsqlQueue {
         Ok(())
     }
 
-    #[instrument(skip(pipeline_message), err)]
+    #[instrument(skip(self, pipeline_message), err)]
     pub async fn put_analyzer_message(
         &self,
         plugin_id: Uuid,
@@ -130,7 +130,7 @@ impl PsqlQueue {
         Ok(())
     }
 
-    #[instrument(err)]
+    #[instrument(skip(self), err)]
     pub async fn get_generator_message(&self) -> Result<Option<Message>, PsqlQueueError> {
         // This function does a few things
         // 1. It attempts to get a message from the queue
@@ -179,7 +179,7 @@ impl PsqlQueue {
         Ok(request.map(|request| Message { request }))
     }
 
-    #[instrument(err)]
+    #[instrument(skip(self), err)]
     pub async fn get_analyzer_message(&self) -> Result<Option<Message>, PsqlQueueError> {
         // `get_message` does a few things
         // 1. It attempts to get a message from the queue
@@ -228,7 +228,7 @@ impl PsqlQueue {
         Ok(request.map(|request| Message { request }))
     }
 
-    #[instrument(err)]
+    #[instrument(skip(self), err)]
     pub async fn ack_generator(
         &self,
         execution_key: ExecutionId,
@@ -253,7 +253,7 @@ impl PsqlQueue {
         Ok(())
     }
 
-    #[instrument(err)]
+    #[instrument(skip(self), err)]
     pub async fn ack_analyzer(
         &self,
         execution_key: ExecutionId,

--- a/src/rust/plugin-work-queue/src/test_utils.rs
+++ b/src/rust/plugin-work-queue/src/test_utils.rs
@@ -59,3 +59,39 @@ impl PsqlQueueTestExtensions for PsqlQueue {
         Ok(generator_messages)
     }
 }
+
+use std::time::Duration;
+
+use tracing::Instrument;
+
+pub async fn scan_for_plugin_message_in_pwq(
+    psql_queue: PsqlQueue,
+    plugin_id: uuid::Uuid,
+) -> Option<NextExecutionRequest> {
+    tracing::info!("creating plugin-work-queue scan thread");
+    let scan_thread = tokio::task::spawn(async move {
+        let scan_for_generator_job = async move {
+            while let Ok(generator_messages) =
+                psql_queue.get_all_generator_messages(plugin_id).await
+            {
+                if let Some(message) = generator_messages.first() {
+                    return Some(message.clone());
+                } else {
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                }
+            }
+            None
+        };
+
+        tokio::time::timeout(Duration::from_secs(30), scan_for_generator_job)
+            .await
+            .expect("failed to consume expected message within 30s")
+    });
+
+    tracing::info!("waiting for scan_thread to complete");
+    let matching_job = scan_thread
+        .instrument(tracing::debug_span!("scan_thread"))
+        .await
+        .expect("could not join scan_thread");
+    matching_job
+}

--- a/src/rust/plugin-work-queue/src/test_utils.rs
+++ b/src/rust/plugin-work-queue/src/test_utils.rs
@@ -1,3 +1,6 @@
+use std::time::Duration;
+
+use tracing::Instrument;
 use uuid::Uuid;
 
 use crate::psql_queue::{
@@ -59,10 +62,6 @@ impl PsqlQueueTestExtensions for PsqlQueue {
         Ok(generator_messages)
     }
 }
-
-use std::time::Duration;
-
-use tracing::Instrument;
 
 pub async fn scan_for_plugin_message_in_pwq(
     psql_queue: PsqlQueue,


### PR DESCRIPTION
Also, change the feature to "test-utils"; Depending on another package's "integration_tests" was an antipattern that was causing code to unexpectedly run.