### PR TITLE
[grapl-web-ui] Migrate to clap for argument processing.

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1894,6 +1894,7 @@ dependencies = [
  "argon2",
  "awc",
  "chrono",
+ "clap 3.2.13",
  "eyre",
  "futures-util",
  "grapl-config",

--- a/src/rust/grapl-web-ui/Cargo.toml
+++ b/src/rust/grapl-web-ui/Cargo.toml
@@ -47,6 +47,11 @@ rusoto_dynamodb = { version = "0.47", default_features = false, features = [
 jsonwebtoken-google = "0.1"
 secrecy = { version = "0.8", features = ["serde"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+clap = { version = "3", default_features = false, features = [
+  "std",
+  "env",
+  "derive"
+] }
 
 [dev-dependencies]
 uuid = { version = "1.0", features = ["v4"] }

--- a/src/rust/grapl-web-ui/src/config.rs
+++ b/src/rust/grapl-web-ui/src/config.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use grapl_config::env_helpers::FromEnv;
 use rand::Rng;
 use rusoto_dynamodb::DynamoDbClient;
@@ -9,30 +10,13 @@ pub(crate) const SESSION_TOKEN: &'static str = "SESSION_TOKEN";
 pub(crate) const SESSION_TOKEN_LENGTH: usize = 32;
 pub(crate) const SESSION_EXPIRATION_TIMEOUT_DAYS: i64 = 1;
 
-fn get_env_var(name: &'static str) -> Result<String, ConfigError> {
-    std::env::var(name).map_err(|source| ConfigError::EnvironmentVariable {
-        variable_name: name,
-        source,
-    })
-}
-
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum ConfigError {
-    #[error("unable to get required environment variable `{variable_name}`: {source}")]
-    EnvironmentVariable {
-        variable_name: &'static str,
-        source: std::env::VarError,
-    },
-    #[error("unable to parse URL for '{variable_name}' with '{value}': {source}")]
-    UrlParse {
-        variable_name: &'static str,
-        value: String,
-        source: url::ParseError,
-    },
+    #[error(transparent)]
+    Clap(#[from] clap::Error),
     #[error(transparent)]
     BindAddress(#[from] std::io::Error),
-    #[error("ConfigBuilder missing TcpListener")]
-    MissingTcpListener,
 }
 
 pub struct Config {
@@ -45,74 +29,42 @@ pub struct Config {
     pub google_client_id: String,
 }
 
-pub struct ConfigBuilder {
-    pub dynamodb_client: DynamoDbClient,
-    pub listener: Option<std::net::TcpListener>,
-    pub session_key: [u8; KEY_SIZE],
-    pub user_auth_table_name: String,
-    pub user_session_table_name: String,
-    pub graphql_endpoint: GraphQlEndpointUrl,
-    pub google_client_id: String,
-}
-
-impl ConfigBuilder {
-    #[tracing::instrument(err)]
+impl Config {
     pub fn from_env() -> Result<Self, ConfigError> {
-        let listener = std::env::var("GRAPL_WEB_UI_BIND_ADDRESS")
-            .ok()
-            .map(std::net::TcpListener::bind)
-            .transpose()?;
+        let builder = ConfigBuilder::try_parse()?;
 
-        let user_auth_table_name = get_env_var("GRAPL_USER_AUTH_TABLE")?;
-        let user_session_table_name = get_env_var("GRAPL_USER_SESSION_TABLE")?;
+        let listener = std::net::TcpListener::bind(builder.bind_address)?;
+
+        let dynamodb_client = DynamoDbClient::from_env();
 
         // generate a random key for encrypting user state.
         let session_key = rand::thread_rng().gen::<[u8; KEY_SIZE]>();
 
-        let dynamodb_client = DynamoDbClient::from_env();
-
-        let graphql_endpoint = get_env_var("GRAPL_GRAPHQL_ENDPOINT")
-            .map(|url| {
-                url::Url::parse(url.as_str()).map_err(|source| ConfigError::UrlParse {
-                    variable_name: "GRAPL_GRAPHQL_ENDPOINT",
-                    value: url,
-                    source,
-                })
-            })?
-            .map(GraphQlEndpointUrl::from)?;
-
-        let google_client_id = get_env_var("GRAPL_GOOGLE_CLIENT_ID")?;
-
-        Ok(ConfigBuilder {
+        let config = Config {
             dynamodb_client,
             listener,
             session_key,
-            user_auth_table_name,
-            user_session_table_name,
-            graphql_endpoint,
-            google_client_id,
-        })
-    }
-
-    pub fn with_listener(mut self, listener: std::net::TcpListener) -> Self {
-        self.listener = Some(listener);
-
-        self
-    }
-
-    pub fn build(self) -> Result<Config, ConfigError> {
-        let config = Config {
-            dynamodb_client: self.dynamodb_client,
-            listener: self
-                .listener
-                .ok_or_else(|| ConfigError::MissingTcpListener)?,
-            session_key: self.session_key,
-            user_auth_table_name: self.user_auth_table_name,
-            user_session_table_name: self.user_session_table_name,
-            graphql_endpoint: self.graphql_endpoint,
-            google_client_id: self.google_client_id,
+            user_auth_table_name: builder.user_auth_table_name,
+            user_session_table_name: builder.user_session_table_name,
+            graphql_endpoint: builder.graphql_endpoint,
+            google_client_id: builder.google_client_id,
         };
 
         Ok(config)
     }
+}
+
+#[derive(clap::Parser, Debug)]
+#[clap(name = "grapl-web-ui", about = "Grapl web")]
+pub struct ConfigBuilder {
+    #[clap(env = "GRAPL_WEB_UI_BIND_ADDRESS")]
+    pub bind_address: String,
+    #[clap(env = "GRAPL_USER_AUTH_TABLE")]
+    pub user_auth_table_name: String,
+    #[clap(env = "GRAPL_USER_SESSION_TABLE")]
+    pub user_session_table_name: String,
+    #[clap(env = "GRAPL_GRAPHQL_ENDPOINT")]
+    pub graphql_endpoint: GraphQlEndpointUrl,
+    #[clap(env = "GRAPL_GOOGLE_CLIENT_ID")]
+    pub google_client_id: String,
 }

--- a/src/rust/grapl-web-ui/src/graphql.rs
+++ b/src/rust/grapl-web-ui/src/graphql.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 // We have a new type for this to differentiate between the URL for this backend service and that
 // for others
 #[derive(Clone, Debug)]
@@ -9,10 +11,20 @@ impl From<url::Url> for GraphQlEndpointUrl {
     }
 }
 
-impl std::ops::Deref for GraphQlEndpointUrl {
-    type Target = url::Url;
+impl FromStr for GraphQlEndpointUrl {
+    type Err = url::ParseError;
 
-    fn deref(&self) -> &Self::Target {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<url::Url>().map(GraphQlEndpointUrl::from)
+    }
+}
+
+impl GraphQlEndpointUrl {
+    pub fn inner(self) -> url::Url {
+        self.0
+    }
+
+    pub fn get_ref(&self) -> &url::Url {
         &self.0
     }
 }

--- a/src/rust/grapl-web-ui/src/lib.rs
+++ b/src/rust/grapl-web-ui/src/lib.rs
@@ -10,7 +10,7 @@ use actix_web::{
     App,
     HttpServer,
 };
-pub use config::ConfigBuilder;
+pub use config::Config;
 pub use graphql::GraphQlEndpointUrl;
 
 pub fn run(config: config::Config) -> Result<Server, std::io::Error> {

--- a/src/rust/grapl-web-ui/src/main.rs
+++ b/src/rust/grapl-web-ui/src/main.rs
@@ -2,7 +2,7 @@
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (_env, _guard) = grapl_config::init_grapl_env!();
 
-    let config = grapl_web_ui::ConfigBuilder::from_env()?.build()?;
+    let config = grapl_web_ui::Config::from_env()?;
 
     grapl_web_ui::run(config)?.await?;
 

--- a/src/rust/grapl-web-ui/src/routes/api/graphql.rs
+++ b/src/rust/grapl-web-ui/src/routes/api/graphql.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use actix_web::{
     post,
     web,
@@ -23,7 +21,7 @@ pub(crate) async fn handler(
     _user: crate::authn::AuthenticatedUser,
 ) -> Result<HttpResponse> {
     // Strip "api/graphQlEndpoint" from the request URL before forwarding.
-    let backend_endpoint = backend_endpoint.get_ref().deref().clone();
+    let backend_endpoint = backend_endpoint.get_ref().get_ref().clone();
     let backend_path = path.into_inner();
     let mut backend_url = backend_endpoint;
     backend_url.set_path(backend_path.as_str());

--- a/src/rust/grapl-web-ui/tests/api/config.rs
+++ b/src/rust/grapl-web-ui/tests/api/config.rs
@@ -1,7 +1,6 @@
+use clap::Parser;
 use grapl_config::env_helpers::FromEnv;
 use rusoto_dynamodb::DynamoDbClient;
-
-type Result<T> = std::result::Result<T, TestConfigError>;
 
 pub struct TestConfig {
     pub dynamodb_client: DynamoDbClient,
@@ -10,47 +9,28 @@ pub struct TestConfig {
     pub endpoint_address: url::Url,
 }
 
-#[derive(thiserror::Error, Debug)]
-pub enum TestConfigError {
-    #[error("unable to get required environment variable `{variable_name}`: {source}")]
-    EnvironmentVariable {
-        variable_name: &'static str,
-        source: std::env::VarError,
-    },
-    #[error("unable to parse URL for '{variable_name}' with '{value}': {source}")]
-    UrlParse {
-        variable_name: &'static str,
-        value: String,
-        source: url::ParseError,
-    },
-}
-
-fn get_env_var(name: &'static str) -> Result<String> {
-    std::env::var(name).map_err(|source| TestConfigError::EnvironmentVariable {
-        variable_name: name,
-        source,
-    })
-}
-
 impl TestConfig {
-    pub fn from_env() -> Result<Self> {
+    pub fn from_env() -> Result<Self, clap::Error> {
+        let builder = TestConfigBuilder::try_parse()?;
+
         let dynamodb_client = DynamoDbClient::from_env();
-        let user_auth_table_name = get_env_var("GRAPL_USER_AUTH_TABLE")?;
-        let user_session_table_name = get_env_var("GRAPL_USER_SESSION_TABLE")?;
-        let endpoint_address_str = get_env_var("GRAPL_WEB_UI_ENDPOINT_ADDRESS")?;
-        let endpoint_address = url::Url::parse(endpoint_address_str.as_str()).map_err(|e| {
-            TestConfigError::UrlParse {
-                variable_name: "GRAPL_WEB_UI_ENDPOINT_ADDRESS",
-                value: endpoint_address_str,
-                source: e,
-            }
-        })?;
 
         Ok(Self {
             dynamodb_client,
-            user_auth_table_name,
-            user_session_table_name,
-            endpoint_address,
+            user_auth_table_name: builder.user_auth_table_name,
+            user_session_table_name: builder.user_session_table_name,
+            endpoint_address: builder.endpoint_address,
         })
     }
+}
+
+#[derive(clap::Parser)]
+#[clap(name = "grapl-web-ui tests", about = "Grapl web integration tests")]
+pub struct TestConfigBuilder {
+    #[clap(env = "GRAPL_USER_AUTH_TABLE")]
+    pub user_auth_table_name: String,
+    #[clap(env = "GRAPL_USER_SESSION_TABLE")]
+    pub user_session_table_name: String,
+    #[clap(env = "GRAPL_WEB_UI_ENDPOINT_ADDRESS")]
+    pub endpoint_address: url::Url,
 }


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This migrates to using clap for env var argument processing for both the main app and the integration tests, which makes for less code here and makes it more consistent with other grapl packages.

### How were these changes tested?

The Rust integration tests should cover these changes.