### PR TITLE
Use secrecy::SecretString for kafka passwords

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2336,6 +2336,7 @@ dependencies = [
  "futures",
  "rdkafka",
  "rust-proto",
+ "secrecy",
  "thiserror",
  "tokio",
  "tracing",

--- a/src/rust/kafka/Cargo.toml
+++ b/src/rust/kafka/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1.17", features = [
 thiserror = "1.0"
 tracing = "0.1"
 uuid = { version = "1.0", features = ["v4"], optional = true }
+secrecy = "0.8.0"
 
 [features]
 default = []

--- a/src/rust/kafka/src/config.rs
+++ b/src/rust/kafka/src/config.rs
@@ -7,7 +7,7 @@ pub struct ConsumerConfig {
     #[clap(long, env = "KAFKA_SASL_USERNAME")]
     pub sasl_username: String,
     #[clap(long, env = "KAFKA_SASL_PASSWORD")]
-    pub sasl_password: String,
+    pub sasl_password: secrecy::SecretString,
     #[clap(long, env = "KAFKA_CONSUMER_GROUP_NAME")]
     pub consumer_group_name: String,
     #[clap(long, env = "KAFKA_CONSUMER_TOPIC")]
@@ -33,21 +33,21 @@ pub struct RetryConsumerConfig {
     #[clap(long, env = "KAFKA_SASL_USERNAME")]
     pub sasl_username: String,
     #[clap(long, env = "KAFKA_SASL_PASSWORD")]
-    pub sasl_password: String,
+    pub sasl_password: secrecy::SecretString,
     #[clap(long, env = "KAFKA_CONSUMER_GROUP_NAME")]
     pub consumer_group_name: String,
     #[clap(long, env = "KAFKA_RETRY_TOPIC")]
     pub topic: String,
 }
 
-#[derive(clap::Parser, Clone, Debug, Default)]
+#[derive(clap::Parser, Clone, Debug)]
 pub struct ProducerConfig {
     #[clap(long, env = "KAFKA_BOOTSTRAP_SERVERS")]
     pub bootstrap_servers: String,
     #[clap(long, env = "KAFKA_SASL_USERNAME")]
     pub sasl_username: String,
     #[clap(long, env = "KAFKA_SASL_PASSWORD")]
-    pub sasl_password: String,
+    pub sasl_password: secrecy::SecretString,
     #[clap(long, env = "KAFKA_PRODUCER_TOPIC")]
     pub topic: String,
 }
@@ -76,7 +76,7 @@ pub struct RetryProducerConfig {
     #[clap(long, env = "KAFKA_SASL_USERNAME")]
     pub sasl_username: String,
     #[clap(long, env = "KAFKA_SASL_PASSWORD")]
-    pub sasl_password: String,
+    pub sasl_password: secrecy::SecretString,
     #[clap(long, env = "KAFKA_RETRY_TOPIC")]
     pub topic: String,
 }


### PR DESCRIPTION
### Which issue does this PR correspond to?

https://github.com/grapl-security/issue-tracker/issues/990

### What changes does this PR make to Grapl? Why?

Some services using the kafka package were found to be logging Confluent Cloud credentials to standard out, exposing them in places they shouldn't. Ex: https://github.com/grapl-security/grapl/blob/e17fb9154c030d6f0ee9e987291f93682791419b/src/rust/generators/sysmon-generator/src/main_legacy.rs#L46-L53

This changes the Rust kafka package to use https://docs.rs/secrecy/0.8.0/secrecy/type.SecretString.html# for storing credentials, as opposed to using std Strings. This prevents accidentally leaking via Display because it does not implement that trait, and although SecretString does implement Debug, what's returned is not the secret value, but something like `Secret([REDACTED alloc::string::String])` instead.


### How were these changes tested?

Currently testing via Rust integration tests.

I verified the instance where I noticed the issue now prints the redacted string example I posted above. 👍 
