### PR TITLE
[just for CI] Prove funkiness around sysmon-generator - why does it have so much incoming data for a single test tenant-id?

### DIFF
--- a/src/rust/generators/sysmon-generator/src/main_legacy.rs
+++ b/src/rust/generators/sysmon-generator/src/main_legacy.rs
@@ -90,6 +90,8 @@ async fn event_handler(
         envelope.inner_message.log_event.as_ref(),
     )?)?;
 
+    tracing::info!(message = "Incoming raw_log", tenant_id =? envelope.metadata.tenant_id);
+
     match models::generate_graph_from_event(&sysmon_event)? {
         Some(graph_description) => Ok(Some(Envelope::new(
             Metadata::create_from(envelope.metadata),

--- a/src/rust/graph-merger/src/main.rs
+++ b/src/rust/graph-merger/src/main.rs
@@ -94,6 +94,7 @@ async fn handler(
             let graph_merger = graph_merger.clone();
             async move {
                 let envelope = event?;
+                tracing::info!(message = "Incoming data", tenant_id =? envelope.metadata.tenant_id);
                 match graph_merger
                     .lock()
                     .await

--- a/src/rust/graph-merger/tests/integration_test.rs
+++ b/src/rust/graph-merger/tests/integration_test.rs
@@ -93,6 +93,7 @@ async fn test_sysmon_event_produces_merged_graph(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let event_source_id = Uuid::new_v4();
     let tenant_id = Uuid::new_v4();
+    tracing::debug!(message = "Test metadata", tenant_id = ?tenant_id, event_source_id = ?event_source_id);
 
     let kafka_scanner = KafkaTopicScanner::new(ctx.consumer_config.clone())?
         .contains(move |envelope: &Envelope<MergedGraph>| -> bool {

--- a/src/rust/kafka/src/test_utils/topic_scanner.rs
+++ b/src/rust/kafka/src/test_utils/topic_scanner.rs
@@ -50,7 +50,7 @@ where
 {
     pub fn new(consumer_config: ConsumerConfig) -> Result<Self, ConfigurationError> {
         let consumer = Consumer::new(consumer_config)?;
-        let timeout = Duration::from_secs(30); // hardcoded for now, whatever
+        let timeout = Duration::from_secs(150); // hardcoded for now, whatever
         Ok(Self { consumer, timeout })
     }
 

--- a/src/rust/kafka/src/test_utils/topic_scanner.rs
+++ b/src/rust/kafka/src/test_utils/topic_scanner.rs
@@ -50,7 +50,7 @@ where
 {
     pub fn new(consumer_config: ConsumerConfig) -> Result<Self, ConfigurationError> {
         let consumer = Consumer::new(consumer_config)?;
-        let timeout = Duration::from_secs(150); // hardcoded for now, whatever
+        let timeout = Duration::from_secs(30); // hardcoded for now, whatever
         Ok(Self { consumer, timeout })
     }
 

--- a/src/rust/node-identifier/src/main.rs
+++ b/src/rust/node-identifier/src/main.rs
@@ -76,6 +76,8 @@ async fn handler() -> Result<(), NodeIdentifierError> {
             async move {
                 let envelope = event?;
 
+                tracing::info!(message = "Incoming data", tenant_id =? envelope.metadata.tenant_id);
+
                 match identifier.handle_event(envelope.inner_message).await {
                     Ok(identified_graph) => Ok(Some(Envelope::new(
                         Metadata::create_from(envelope.metadata),

--- a/src/rust/node-identifier/tests/integration_test.rs
+++ b/src/rust/node-identifier/tests/integration_test.rs
@@ -94,13 +94,14 @@ async fn test_sysmon_event_produces_identified_graph(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let event_source_id = Uuid::new_v4();
     let tenant_id = Uuid::new_v4();
+    tracing::debug!(message = "Test metadata", tenant_id = ?tenant_id, event_source_id = ?event_source_id);
 
     let kafka_scanner = KafkaTopicScanner::new(ctx.consumer_config.clone())?
         .contains(move |envelope: &Envelope<IdentifiedGraph>| -> bool {
             let metadata = &envelope.metadata;
             let identified_graph = &envelope.inner_message;
 
-            tracing::debug!(message = "consumed kafka message");
+            tracing::debug!(message = "consumed kafka message", tenant_id = ?metadata.tenant_id, event_source_id = ?metadata.event_source_id);
 
             if metadata.tenant_id == tenant_id && metadata.event_source_id == event_source_id {
                 let parent_process = find_node(


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
