### PR TITLE
Postgres client abstraction that safely handles credentials, removes boilerplate

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1112,9 +1112,8 @@ job "grapl-core" {
         ORGANIZATION_MANAGEMENT_BIND_ADDRESS = "0.0.0.0:${NOMAD_PORT_organization-management-port}"
         RUST_BACKTRACE                       = local.rust_backtrace
         RUST_LOG                             = var.rust_log
-        ORGANIZATION_MANAGEMENT_DB_HOSTNAME  = var.organization_management_db.hostname
+        ORGANIZATION_MANAGEMENT_DB_ADDRESS   = "${var.organization_management_db.hostname}:${var.organization_management_db.port}"
         ORGANIZATION_MANAGEMENT_DB_PASSWORD  = var.organization_management_db.password
-        ORGANIZATION_MANAGEMENT_DB_PORT      = var.organization_management_db.port
         ORGANIZATION_MANAGEMENT_DB_USERNAME  = var.organization_management_db.username
 
         ORGANIZATION_MANAGEMENT_HEALTHCHECK_POLLING_INTERVAL_MS = var.organization_management_healthcheck_polling_interval_ms
@@ -1227,9 +1226,8 @@ job "grapl-core" {
         AWS_REGION                                      = var.aws_region
         NOMAD_SERVICE_ADDRESS                           = "${attr.unique.network.ip-address}:4646"
         PLUGIN_REGISTRY_BIND_ADDRESS                    = "0.0.0.0:${NOMAD_PORT_plugin-registry-port}"
-        PLUGIN_REGISTRY_DB_HOSTNAME                     = var.plugin_registry_db.hostname
+        PLUGIN_REGISTRY_DB_ADDRESS                      = "${var.plugin_registry_db.hostname}:${var.plugin_registry_db.port}"
         PLUGIN_REGISTRY_DB_PASSWORD                     = var.plugin_registry_db.password
-        PLUGIN_REGISTRY_DB_PORT                         = var.plugin_registry_db.port
         PLUGIN_REGISTRY_DB_USERNAME                     = var.plugin_registry_db.username
         PLUGIN_BOOTSTRAP_CONTAINER_IMAGE                = var.container_images["plugin-bootstrap"]
         PLUGIN_REGISTRY_KERNEL_ARTIFACT_URL             = var.plugin_registry_kernel_artifact_url
@@ -1301,9 +1299,8 @@ job "grapl-core" {
 
       env {
         PLUGIN_WORK_QUEUE_BIND_ADDRESS = "0.0.0.0:${NOMAD_PORT_plugin-work-queue-port}"
-        PLUGIN_WORK_QUEUE_DB_HOSTNAME  = var.plugin_work_queue_db.hostname
+        PLUGIN_WORK_QUEUE_DB_ADDRESS   = "${var.plugin_work_queue_db.hostname}:${var.plugin_work_queue_db.port}"
         PLUGIN_WORK_QUEUE_DB_PASSWORD  = var.plugin_work_queue_db.password
-        PLUGIN_WORK_QUEUE_DB_PORT      = var.plugin_work_queue_db.port
         PLUGIN_WORK_QUEUE_DB_USERNAME  = var.plugin_work_queue_db.username
         # Hardcoded, but makes little sense to pipe up through Pulumi
         PLUGIN_WORK_QUEUE_HEALTHCHECK_POLLING_INTERVAL_MS = 5000
@@ -1417,9 +1414,8 @@ job "grapl-core" {
 
       env {
         EVENT_SOURCE_BIND_ADDRESS = "0.0.0.0:${NOMAD_PORT_event-source-port}"
-        EVENT_SOURCE_DB_HOSTNAME  = var.event_source_db.hostname
+        EVENT_SOURCE_DB_ADDRESS   = "${var.event_source_db.hostname}:${var.event_source_db.port}"
         EVENT_SOURCE_DB_PASSWORD  = var.event_source_db.password
-        EVENT_SOURCE_DB_PORT      = var.event_source_db.port
         EVENT_SOURCE_DB_USERNAME  = var.event_source_db.username
         # Hardcoded, but makes little sense to pipe up through Pulumi
         EVENT_SOURCE_HEALTHCHECK_POLLING_INTERVAL_MS = 5000

--- a/nomad/rust-integration-tests.nomad
+++ b/nomad/rust-integration-tests.nomad
@@ -193,9 +193,8 @@ job "rust-integration-tests" {
 
         ORGANIZATION_MANAGEMENT_BIND_ADDRESS   = "0.0.0.0:1004" # not used but required due to clap
         ORGANIZATION_MANAGEMENT_CLIENT_ADDRESS = "http://${NOMAD_UPSTREAM_ADDR_organization-management}"
-        ORGANIZATION_MANAGEMENT_DB_HOSTNAME    = var.organization_management_db.hostname
+        ORGANIZATION_MANAGEMENT_DB_ADDRESS     = "${var.organization_management_db.hostname}:${var.organization_management_db.port}"
         ORGANIZATION_MANAGEMENT_DB_PASSWORD    = var.organization_management_db.password
-        ORGANIZATION_MANAGEMENT_DB_PORT        = var.organization_management_db.port
         ORGANIZATION_MANAGEMENT_DB_USERNAME    = var.organization_management_db.username
 
         ORGANIZATION_MANAGEMENT_HEALTHCHECK_POLLING_INTERVAL_MS = 5000
@@ -213,8 +212,7 @@ job "rust-integration-tests" {
 
         NOMAD_SERVICE_ADDRESS = "${attr.unique.network.ip-address}:4646"
 
-        PLUGIN_WORK_QUEUE_DB_HOSTNAME = var.plugin_work_queue_db.hostname
-        PLUGIN_WORK_QUEUE_DB_PORT     = var.plugin_work_queue_db.port
+        PLUGIN_WORK_QUEUE_DB_ADDRESS  = "${var.plugin_work_queue_db.hostname}:${var.plugin_work_queue_db.port}"
         PLUGIN_WORK_QUEUE_DB_USERNAME = var.plugin_work_queue_db.username
         PLUGIN_WORK_QUEUE_DB_PASSWORD = var.plugin_work_queue_db.password
       }

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1477,6 +1477,7 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "clap 3.2.13",
+ "grapl-config",
  "grapl-tracing",
  "grapl-utils",
  "rust-proto",
@@ -1702,6 +1703,7 @@ dependencies = [
  "bytes",
  "clap 3.2.13",
  "futures",
+ "grapl-config",
  "grapl-tracing",
  "kafka",
  "moka 0.9.2",
@@ -1833,8 +1835,10 @@ name = "grapl-config"
 version = "0.0.2"
 dependencies = [
  "async-trait",
+ "clap 3.2.13",
  "color-eyre",
  "eyre",
+ "grapl-utils",
  "log",
  "rusoto_cloudwatch",
  "rusoto_core",
@@ -1842,6 +1846,9 @@ dependencies = [
  "rusoto_dynamodb",
  "rusoto_s3",
  "rusoto_sqs",
+ "secrecy",
+ "sqlx",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -2934,6 +2941,7 @@ dependencies = [
  "argon2",
  "async-trait",
  "clap 3.2.13",
+ "grapl-config",
  "grapl-tracing",
  "grapl-utils",
  "rust-proto",
@@ -3264,6 +3272,7 @@ dependencies = [
  "chrono",
  "clap 3.2.13",
  "futures",
+ "grapl-config",
  "grapl-tracing",
  "grapl-utils",
  "kafka",

--- a/src/rust/event-source/Cargo.toml
+++ b/src/rust/event-source/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 grapl-tracing = { path = "../grapl-tracing" }
+grapl-config = { path = "../grapl-config" }
 grapl-utils = { path = "../grapl-utils" }
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }
 uuid = { version = "1.0", features = ["serde", "v4"] }

--- a/src/rust/event-source/src/config.rs
+++ b/src/rust/event-source/src/config.rs
@@ -29,11 +29,19 @@ pub struct EventSourceServiceConfig {
 #[derive(Parser, Clone, Debug)]
 pub struct EventSourceDbConfig {
     #[clap(long, env)]
-    pub event_source_db_hostname: String,
-    #[clap(long, env)]
-    pub event_source_db_port: u16,
+    pub event_source_db_address: String,
     #[clap(long, env)]
     pub event_source_db_username: String,
     #[clap(long, env)]
-    pub event_source_db_password: String,
+    pub event_source_db_password: grapl_config::SecretString,
+}
+
+impl grapl_config::ToPostgresUrl for EventSourceDbConfig {
+    fn to_postgres_url(self) -> grapl_config::PostgresUrl {
+        grapl_config::PostgresUrl {
+            address: self.event_source_db_address,
+            username: self.event_source_db_username,
+            password: self.event_source_db_password,
+        }
+    }
 }

--- a/src/rust/event-source/src/db.rs
+++ b/src/rust/event-source/src/db.rs
@@ -1,6 +1,3 @@
 mod client;
 mod types;
-pub use client::{
-    EventSourceDbClient,
-    EventSourceDbError,
-};
+pub use client::EventSourceDbClient;

--- a/src/rust/event-source/src/error.rs
+++ b/src/rust/event-source/src/error.rs
@@ -1,11 +1,11 @@
 use rust_proto::protocol::status::Status;
 
-use crate::db::EventSourceDbError;
-
 #[derive(thiserror::Error, Debug)]
 pub enum EventSourceError {
-    #[error("DbError")]
-    DbError(#[from] EventSourceDbError),
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    #[error(transparent)]
+    DbInit(#[from] grapl_config::PostgresDbInitError),
 }
 
 impl From<EventSourceError> for Status {

--- a/src/rust/event-source/src/main.rs
+++ b/src/rust/event-source/src/main.rs
@@ -1,4 +1,3 @@
-use clap::Parser;
 use event_source::{
     config::EventSourceConfig,
     server::exec_service,
@@ -10,7 +9,7 @@ const SERVICE_NAME: &'static str = "event-source";
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = setup_tracing(SERVICE_NAME)?;
-    let config = EventSourceConfig::parse();
+    let config = EventSourceConfig::from_env_vars();
     exec_service(config).await?;
     Ok(())
 }

--- a/src/rust/generator-dispatcher/Cargo.toml
+++ b/src/rust/generator-dispatcher/Cargo.toml
@@ -30,6 +30,7 @@ async-trait = "0.1"
 bytes = "1.0"
 plugin-work-queue = { path = "../plugin-work-queue", features = ["test-utils"] }
 test-context = "0.1"
+grapl-config = { path = "../grapl-config" }
 
 [features]
 integration_tests = []

--- a/src/rust/generator-dispatcher/tests/test_utils/context.rs
+++ b/src/rust/generator-dispatcher/tests/test_utils/context.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use grapl_config::PostgresClient;
 use grapl_tracing::{
     setup_tracing,
     WorkerGuard,
@@ -65,9 +66,10 @@ impl AsyncTestContext for GeneratorDispatcherTestContext {
         .await
         .expect("pipeline_ingress_client");
 
-        let plugin_work_queue_psql_client = PsqlQueue::try_from(PluginWorkQueueDbConfig::parse())
-            .await
-            .expect("plugin_work_queue");
+        let plugin_work_queue_psql_client =
+            PsqlQueue::init_with_config(PluginWorkQueueDbConfig::parse())
+                .await
+                .expect("plugin_work_queue");
 
         GeneratorDispatcherTestContext {
             event_source_client,

--- a/src/rust/grapl-config/Cargo.toml
+++ b/src/rust/grapl-config/Cargo.toml
@@ -36,3 +36,19 @@ tokio = { version = "1.17", features = [
 color-eyre = "0.6"
 eyre = "0.6"
 async-trait = "0.1"
+clap = { version = "3.0", default_features = false, features = [
+  "std",
+  "env",
+  "derive"
+] }
+secrecy = "0.8"
+sqlx = { version = "0.6", features = [
+  "chrono",
+  "migrate",
+  "offline",
+  "postgres",
+  "runtime-tokio-rustls",
+  "uuid",
+] }
+thiserror = "1.0"
+grapl-utils = { path = "../grapl-utils" }

--- a/src/rust/grapl-config/src/lib.rs
+++ b/src/rust/grapl-config/src/lib.rs
@@ -3,6 +3,17 @@ use std::str::FromStr;
 use rusoto_core::Region;
 
 pub mod env_helpers;
+mod postgres;
+pub use postgres::{
+    PostgresClient,
+    PostgresDbInitError,
+    PostgresUrl,
+    ToPostgresUrl,
+};
+pub use secrecy::{
+    Secret,
+    SecretString,
+};
 
 pub fn region() -> Region {
     let region_override_endpoint = std::env::var("AWS_REGION_ENDPOINT_OVERRIDE");

--- a/src/rust/grapl-config/src/postgres.rs
+++ b/src/rust/grapl-config/src/postgres.rs
@@ -1,0 +1,119 @@
+use grapl_utils::future_ext::GraplFutureExt;
+use secrecy::ExposeSecret;
+
+#[derive(Debug, Clone)]
+pub struct PostgresUrl {
+    pub address: String,
+    pub username: String,
+    pub password: super::SecretString,
+}
+
+impl std::fmt::Display for PostgresUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "postgresql://{username}:<REDACTED>@{address}",
+            username = self.username,
+            address = self.address
+        )
+    }
+}
+
+impl PostgresUrl {
+    /// Connect to Postgres with a timeout of 5 seconds.
+    pub async fn connect(&self) -> Result<sqlx::Pool<sqlx::Postgres>, PostgresDbInitError> {
+        let timeout = std::time::Duration::from_secs(5);
+
+        self.connect_with_timeout(timeout).await
+    }
+
+    /// Connect to Postgres with the supplied timeout.
+    #[tracing::instrument]
+    pub async fn connect_with_timeout(
+        &self,
+        timeout: std::time::Duration,
+    ) -> Result<sqlx::Pool<sqlx::Postgres>, PostgresDbInitError> {
+        tracing::info!(message = "Connecting to database", postgres_url =% self, ?timeout);
+
+        let pool = sqlx::PgPool::connect(
+            format!(
+                "postgresql://{username}:{password}@{address}",
+                username = self.username,
+                password = self.password.expose_secret(),
+                address = self.address
+            )
+            .as_str(),
+        )
+        .timeout(timeout)
+        .await
+        .map_err(|_| PostgresDbInitError::Timeout { timeout })??;
+
+        Ok(pool)
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum PostgresDbInitError {
+    #[error("sqlx migration error: {0}")]
+    MigrateError(#[from] sqlx::migrate::MigrateError),
+    #[error("unable to connect: {0}")]
+    Sqlx(#[from] sqlx::Error),
+    #[error("connection timeout after {timeout:?}")]
+    Timeout { timeout: std::time::Duration },
+}
+
+/// A trait for deriving a PostgresUrl, which is used by the PostgresClient trait. This is
+/// intended to be used by Postgres configs.
+///
+/// Ideally we could have a single Postgres config type that all Postgres clients could use,
+/// instead of needing this trait, but we can't exactly do that right now while keeping consistent
+/// with Grapl's use of clap derive for argument processing.
+///
+/// The clap::Parser derive macro does not support supllied prefixes when flattening a config
+/// structure. This means all fields of the Postgres config would need to be same across all uses
+/// of it (ex: DB_ADDRESS). At the time of this writing that wouldn't be a problem for running our
+/// services themselves, because 1) we don't have any services that uses multiple Postgres servers,
+/// and 2) we could set the common name in our grapl-core.nomad for each service (ex: DB_USERNAME
+/// = var.example.username). However, our Rust integration tests are all running in a single
+/// environment, and those tests need to use the same config builders as the services themselves.
+/// So for now we need to have the argument variable names include uniqueness, such as prefixing
+/// with the service's name (EXAMPLE_DB_HOSTNAME), meaning we can't use a common config. It looks
+/// like this issue is being tracked at https://github.com/clap-rs/clap/issues/3513.
+///
+/// We could stray from using clap for this and have code that takes a prefix for loading Postgres
+/// environment configs, but this isn't great for a couple reasons:
+/// 1. It hides required arguments for a service in a different package. Some services have a
+///    src/config.rs, which clearly defines all the parameters for the service. But by not using
+///    clap here we'd break that for users, and we'd break the help formatter produced by clap when
+///    one of the clap arguments are not supplied.
+/// 2. Clap has good error reporting when required arguments are not supplied. We'd have to
+///    recreate that, which isn't a big deal, but still.
+pub trait ToPostgresUrl {
+    fn to_postgres_url(self) -> PostgresUrl;
+}
+
+#[async_trait::async_trait]
+pub trait PostgresClient {
+    type Config: ToPostgresUrl + Send + std::fmt::Debug;
+    type Error: From<PostgresDbInitError>;
+
+    fn new(pool: sqlx::Pool<sqlx::Postgres>) -> Self;
+
+    /// Initialize the Postgres client by connecting to Postrges and running a migration on the server.
+    #[tracing::instrument]
+    async fn init_with_config(config: Self::Config) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        let postgres_url = config.to_postgres_url();
+        let pool = postgres_url.connect().await?;
+
+        Self::migrate(&pool).await.map_err(|e| e.into())?;
+
+        Ok(Self::new(pool))
+    }
+
+    /// Run a migration to initialize a Postgres
+    async fn migrate(pool: &sqlx::Pool<sqlx::Postgres>) -> Result<(), sqlx::migrate::MigrateError>;
+}

--- a/src/rust/organization-management/Cargo.toml
+++ b/src/rust/organization-management/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 async-trait = "0.1"
 grapl-tracing = { path = "../grapl-tracing" }
+grapl-config = { path = "../grapl-config" }
 grapl-utils = { path = "../grapl-utils" }
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }
 uuid = { version = "1.0", features = ["serde", "v4"] }

--- a/src/rust/organization-management/src/lib.rs
+++ b/src/rust/organization-management/src/lib.rs
@@ -9,11 +9,19 @@ pub struct OrganizationManagementServiceConfig {
     #[clap(long, env)]
     pub organization_management_healthcheck_polling_interval_ms: u64,
     #[clap(long, env)]
-    pub organization_management_db_hostname: String,
-    #[clap(long, env)]
-    pub organization_management_db_port: u16,
+    pub organization_management_db_address: String,
     #[clap(long, env)]
     pub organization_management_db_username: String,
     #[clap(long, env)]
-    pub organization_management_db_password: String,
+    pub organization_management_db_password: grapl_config::SecretString,
+}
+
+impl grapl_config::ToPostgresUrl for OrganizationManagementServiceConfig {
+    fn to_postgres_url(self) -> grapl_config::PostgresUrl {
+        grapl_config::PostgresUrl {
+            address: self.organization_management_db_address,
+            username: self.organization_management_db_username,
+            password: self.organization_management_db_password,
+        }
+    }
 }

--- a/src/rust/organization-management/tests/test_create_organization.rs
+++ b/src/rust/organization-management/tests/test_create_organization.rs
@@ -1,9 +1,7 @@
 #![cfg(feature = "integration_tests")]
 
-use std::time::Duration;
-
 use clap::Parser;
-use grapl_utils::future_ext::GraplFutureExt;
+use grapl_config::ToPostgresUrl;
 use organization_management::OrganizationManagementServiceConfig;
 use rust_proto::{
     client_factory::{
@@ -22,17 +20,7 @@ async fn test_create_organization() -> Result<(), Box<dyn std::error::Error>> {
 
     let service_config = OrganizationManagementServiceConfig::parse();
 
-    let postgres_address = format!(
-        "postgresql://{}:{}@{}:{}",
-        service_config.organization_management_db_username,
-        service_config.organization_management_db_password,
-        service_config.organization_management_db_hostname,
-        service_config.organization_management_db_port,
-    );
-
-    let pool = sqlx::PgPool::connect(&postgres_address)
-        .timeout(Duration::from_secs(5))
-        .await??;
+    let pool = service_config.to_postgres_url().connect().await?;
 
     let client_config = OrganizationManagementClientConfig::parse();
     let mut client = build_grpc_client_with_options(

--- a/src/rust/organization-management/tests/test_create_user.rs
+++ b/src/rust/organization-management/tests/test_create_user.rs
@@ -1,9 +1,7 @@
 #![cfg(feature = "integration_tests")]
 
-use std::time::Duration;
-
 use clap::Parser;
-use grapl_utils::future_ext::GraplFutureExt;
+use grapl_config::ToPostgresUrl;
 use organization_management::OrganizationManagementServiceConfig;
 use rust_proto::{
     client_factory::{
@@ -25,17 +23,7 @@ async fn test_create_user() -> Result<(), Box<dyn std::error::Error>> {
 
     let service_config = OrganizationManagementServiceConfig::parse();
 
-    let postgres_address = format!(
-        "postgresql://{}:{}@{}:{}",
-        service_config.organization_management_db_username,
-        service_config.organization_management_db_password,
-        service_config.organization_management_db_hostname,
-        service_config.organization_management_db_port,
-    );
-
-    let pool = sqlx::PgPool::connect(&postgres_address)
-        .timeout(Duration::from_secs(5))
-        .await??;
+    let pool = service_config.to_postgres_url().connect().await?;
 
     let client_config = OrganizationManagementClientConfig::parse();
     let mut client = build_grpc_client_with_options(

--- a/src/rust/plugin-work-queue/Cargo.toml
+++ b/src/rust/plugin-work-queue/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "3.0", default_features = false, features = [
   "derive"
 ] }
 grapl-tracing = { path = "../grapl-tracing" }
+grapl-config = { path = "../grapl-config" }
 grapl-utils = { path = "../grapl-utils" }
 kafka = { path = "../kafka" }
 rust-proto = { path = "../rust-proto" }

--- a/src/rust/plugin-work-queue/src/lib.rs
+++ b/src/rust/plugin-work-queue/src/lib.rs
@@ -27,11 +27,19 @@ pub struct PluginWorkQueueServiceConfig {
 #[derive(clap::Parser, Clone, Debug)]
 pub struct PluginWorkQueueDbConfig {
     #[clap(long, env)]
-    pub plugin_work_queue_db_hostname: String,
-    #[clap(long, env)]
-    pub plugin_work_queue_db_port: u16,
+    pub plugin_work_queue_db_address: String,
     #[clap(long, env)]
     pub plugin_work_queue_db_username: String,
     #[clap(long, env)]
-    pub plugin_work_queue_db_password: String,
+    pub plugin_work_queue_db_password: grapl_config::SecretString,
+}
+
+impl grapl_config::ToPostgresUrl for PluginWorkQueueDbConfig {
+    fn to_postgres_url(self) -> grapl_config::PostgresUrl {
+        grapl_config::PostgresUrl {
+            address: self.plugin_work_queue_db_address,
+            username: self.plugin_work_queue_db_username,
+            password: self.plugin_work_queue_db_password,
+        }
+    }
 }


### PR DESCRIPTION
### Which issue does this PR correspond to?

This relates to https://github.com/grapl-security/issue-tracker/issues/990 and is a follow up to https://github.com/grapl-security/grapl/pull/1848.

### What changes does this PR make to Grapl? Why?

This has all services using Postgres use a secrets type for safer handling of Postgres credentials.

Additionally, this provides a Postgres client trait that intends to reduce boilerplate with some default implementations. A trait is used in-part so users can override the default functionality.

This also introduces a trait, `ToPostgresUrl`, to be used with Postgres service configs. The need for this trait is somewhat unfortunate, and we can probably move away from it and allow all services to use a common Postgres config type if/when clap::Praser derive macro supports supplied prefixes when `flatten`ing configs. The following code comment in this PR explains details of this situation:

> /// Ideally we could have a single Postgres config type that all Postgres clients could use,
/// instead of needing this trait, but we can't exactly do that right now while keeping consistent
/// with Grapl's use of clap derive for argument processing.
///
/// The clap::Parser derive macro does not support supllied prefixes when flattening a config
/// structure. This means all fields of the Postgres config would need to be same across all uses
/// of it (ex: DB_ADDRESS). At the time of this writing that wouldn't be a problem for running our
/// services themselves, because 1) we don't have any services that uses multiple Postgres servers,
/// and 2) we could set the common name in our grapl-core.nomad for each service (ex: DB_USERNAME
/// = var.example.username). However, our Rust integration tests are all running in a single
/// environment, and those tests need to use the same config builders as the services themselves.
/// So for now we need to have the argument variable names include uniqueness, such as prefixing
/// with the service's name (EXAMPLE_DB_HOSTNAME), meaning we can't use a common config. It looks
/// like this issue is being tracked at https://github.com/clap-rs/clap/issues/3513.
/// 
/// We could stray from using clap for this and have code that takes a prefix for loading Postgres
/// environment configs, but this isn't great for a couple reasons:
/// 1. It hides required arguments for a service in a different package. Some services have a
///    src/config.rs, which clearly defines all the parameters for the service. But by not using
///    clap here we'd break that for users, and we'd break the help formatter produced by clap when
///    one of the clap arguments are not supplied.
/// 2. Clap has good error reporting when required arguments are not supplied. We'd have to
///    recreate that, which isn't a big deal, but still.

### How were these changes tested?

Rust integration tests