### PR TITLE
Upgrade to a different curl

### DIFF
--- a/Dockerfile.pulumi
+++ b/Dockerfile.pulumi
@@ -4,7 +4,7 @@ FROM python:${PYTHON_VERSION}-slim-bullseye as grapl-local-pulumi
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
        build-essential=12.9 \
-       curl=7.74.0-1.3+deb11u1 \
+       curl=7.74.0-1.3+deb11u2 \
        unzip=6.0-26 \
     && rm -rf /var/lib/apt/lists/* \
     && adduser \

--- a/scylladb/Dockerfile
+++ b/scylladb/Dockerfile
@@ -4,7 +4,7 @@ ENV HWLOC_VERSION="2.7.1"
 # At least one of the install-recommends is necessary in order for hwloc to compile.
 # hadolint ignore=DL3015
 RUN apt-get update \
-    && apt-get -y install curl=7.74.0-1.3+deb11u1 \
+    && apt-get -y install curl=7.74.0-1.3+deb11u2 \
     libssl-dev=1.1.1n-0+deb11u3 \
     ca-certificates=20210119  \
     gcc=4:10.2.1-1 \

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends \
         bash=5.1-2+deb11u1 \
         libstdc++6=10.2.1-6 \
-        curl=7.74.0-1.3+deb11u1 \
+        curl=7.74.0-1.3+deb11u2 \
     && rm -rf /var/lib/apt/lists/* \
     && adduser \
         --disabled-password \
@@ -50,7 +50,7 @@ USER root
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
         build-essential=12.9 \
-        curl=7.74.0-1.3+deb11u1 \
+        curl=7.74.0-1.3+deb11u2 \
         unzip=6.0-26 \
         python3-dev=3.9.2-3 \
     && rm -rf /var/lib/apt/lists/* \

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -19,7 +19,7 @@ SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-base-apt \
     apt-get update \
     && apt-get install --yes --no-install-recommends \
-        curl=7.74.0-1.3+deb11u1 \
+        curl=7.74.0-1.3+deb11u2 \
         jq=1.6-2.1 \
         unzip=6.0-26 \
     && apt-get install --yes --no-install-recommends \

--- a/src/rust/build-env.Dockerfile
+++ b/src/rust/build-env.Dockerfile
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-build-en
         perl=5.32.1-4+deb11u2 \
         pkg-config=0.29.2-1 \
         tcl=8.6.11+1 \
-        curl=7.74.0-1.3+deb11u1 \
+        curl=7.74.0-1.3+deb11u2 \
         unzip=6.0-26
 EOF
 


### PR DESCRIPTION
seeing this on firecracker_rootfs
#0 1.457 The following packages have unmet dependencies:
#0 1.503  curl : Depends: libcurl4 (= 7.74.0-1.3+deb11u1) but 7.74.0-1.3+deb11u2 is to be installed

just updating it everywhere i see deb11u1