### PR TITLE
Make build-rootfs packer do retries for debootstrap

### DIFF
--- a/firecracker/rootfs/build-rootfs.pkr.hcl
+++ b/firecracker/rootfs/build-rootfs.pkr.hcl
@@ -146,6 +146,8 @@ build {
       "PLUGIN_BOOTSTRAP_INIT_ARTIFACTS_DIR=${local.init_artifacts_dir_remote}",
       "SIZE_MB=${local.image_size_mb}",
     ]
+    # The `debootstrap` in this script is unfortunately pretty flaky.
+    max_retries = 2
   }
 
   # Grab the output from EC2 and copy it over into the Packer Host OS's `dist/`

--- a/firecracker/rootfs/scripts/create_rootfs_image.sh
+++ b/firecracker/rootfs/scripts/create_rootfs_image.sh
@@ -40,6 +40,12 @@ sudo mount -t ext4 \
     -o loop,rw \
     "${IMAGE}" "${MOUNT_POINT}"
 
+# (Automatically unmount the image, in case we need to retry)
+unmount_image() {
+    sudo umount "${MOUNT_POINT}"
+}
+trap unmount_image EXIT
+
 # Let anybody write to the mount point.
 sudo chmod 777 "${MOUNT_POINT}"
 
@@ -79,7 +85,6 @@ sudo debootstrap --include apt,nano "${DEBIAN_VERSION}" \
 # Tar the image into $OUTPUT_DIR; this will be scp'd
 # back to the Packer Host OS by Packer
 ########################################
-sudo umount "${MOUNT_POINT}"
 
 # NOTE about tar: If you specify the full path of the image,
 #   the tar will contain that full nested path of directories.


### PR DESCRIPTION
The `debootstrap` in this image is unfortunately pretty flaky when downloading.

Example:
https://buildkite.com/grapl/grapl-verify/builds/4004#01825af7-73b1-4c0a-b4da-d30a54c0c90d

Common failure scenarios that are totally retriable:
```
  | amazon-ebs.grapl-build-rootfs: I: Validating liblzma5 5.2.5-2.1~deb11u1
  | amazon-ebs.grapl-build-rootfs: I: Retrieving zlib1g 1:1.2.11.dfsg-2+deb11u1
  | amazon-ebs.grapl-build-rootfs: I: Validating zlib1g 1:1.2.11.dfsg-2+deb11u1
  | amazon-ebs.grapl-build-rootfs: E: Couldn't download packages: apt
  | ==> amazon-ebs.grapl-build-rootfs: Provisioning step had errors: Running the cleanup provisioner, if present...
```

```
  | amazon-ebs.grapl-build-rootfs: I: Retrieving liblzma5 5.2.5-2.1~deb11u1
  | amazon-ebs.grapl-build-rootfs: I: Validating liblzma5 5.2.5-2.1~deb11u1
  | amazon-ebs.grapl-build-rootfs: I: Retrieving zlib1g 1:1.2.11.dfsg-2+deb11u1
  | amazon-ebs.grapl-build-rootfs: I: Validating zlib1g 1:1.2.11.dfsg-2+deb11u1
  | amazon-ebs.grapl-build-rootfs: E: Couldn't download packages: debconf
  | ==> amazon-ebs.grapl-build-rootfs: Provisioning step had errors: Running the cleanup provisioner, if present...
```