### PR TITLE
automatically attach pipeline metadata to tracing span

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2339,6 +2339,7 @@ name = "kafka"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "chrono",
  "clap 3.2.13",
  "futures",
  "rdkafka",

--- a/src/rust/kafka/Cargo.toml
+++ b/src/rust/kafka/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 bytes = "1.1"
+chrono = "0.4"
 clap = { version = "3.0", default_features = false, features = [
   "std",
   "env",

--- a/src/rust/kafka/src/lib.rs
+++ b/src/rust/kafka/src/lib.rs
@@ -3,11 +3,18 @@ pub mod config;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
 
-use std::marker::PhantomData;
+use std::{
+    marker::PhantomData,
+    time::SystemTime,
+};
 
 use bytes::{
     Bytes,
     BytesMut,
+};
+use chrono::{
+    DateTime,
+    Utc,
 };
 use config::{
     ConsumerConfig,
@@ -44,6 +51,12 @@ use rust_proto::{
 use secrecy::ExposeSecret;
 use thiserror::Error;
 use tracing::Instrument;
+
+/// helper function to format a timestamp as ISO-8601 (useful for logging)
+fn format_iso8601(timestamp: SystemTime) -> String {
+    let datetime: DateTime<Utc> = timestamp.into();
+    datetime.to_rfc3339()
+}
 
 //
 // Kafka configurations
@@ -310,8 +323,8 @@ impl<T: SerDe> Consumer<T> {
                         trace_id =% envelope.trace_id(),
                         event_source_id =% envelope.event_source_id(),
                         retry_count =% envelope.retry_count(),
-                        created_time =? envelope.created_time(),
-                        last_updated_time =? envelope.last_updated_time(),
+                        created_time = format_iso8601(envelope.created_time()),
+                        last_updated_time = format_iso8601(envelope.last_updated_time()),
                     );
 
                     (span, envelope)

--- a/src/rust/kafka/src/test_utils/topic_scanner.rs
+++ b/src/rust/kafka/src/test_utils/topic_scanner.rs
@@ -21,7 +21,6 @@ use crate::{
     config::ConsumerConfig,
     ConfigurationError,
     Consumer,
-    ConsumerError,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -43,7 +42,7 @@ pub struct KafkaTopicScanner<T>
 where
     T: SerDe + Send + Sync + 'static,
 {
-    consumer: Consumer<Envelope<T>>,
+    consumer: Consumer<T>,
     timeout: Duration,
 }
 
@@ -91,24 +90,25 @@ where
             let stream = Box::pin(self.consumer.stream());
 
             let tx_mutex = Mutex::new(Some(tx));
-            let mut filtered_stream = Box::pin(stream.filter_map(
-                move |res: Result<Envelope<T>, ConsumerError>| {
-                    if let Some(tx) = tx_mutex.lock().expect("failed to acquire tx lock").take() {
-                        // notify the consumer that we're ready to receive messages
-                        tx.send(())
-                            .expect("failed to notify sender that consumer is consuming");
-                    }
+            let mut filtered_stream = Box::pin(stream.filter_map(move |res| {
+                if let Some(tx) = tx_mutex.lock().expect("failed to acquire tx lock").take() {
+                    // notify the consumer that we're ready to receive messages
+                    tx.send(())
+                        .expect("failed to notify sender that consumer is consuming");
+                }
 
-                    let predicate = predicate.clone();
-                    async move {
-                        let envelope = res.expect("error consuming message from kafka");
-                        match predicate.clone().lock().expect("locking")(envelope.clone()) {
-                            true => Some(envelope),
-                            false => None,
+                let predicate = predicate.clone();
+                async move {
+                    let (_, envelope) = res.expect("error consuming message from kafka");
+                    match predicate.clone().lock().expect("locking")(envelope.clone()) {
+                        true => {
+                            tracing::debug!("predicate matched");
+                            Some(envelope)
                         }
+                        false => None,
                     }
-                },
-            ));
+                }
+            }));
             let matched_predicate = filtered_stream.next();
 
             tracing::info!(

--- a/src/rust/node-identifier/src/main.rs
+++ b/src/rust/node-identifier/src/main.rs
@@ -62,7 +62,7 @@ async fn handler() -> Result<(), NodeIdentifierError> {
 
     // TODO: also construct a stream processor for retries
 
-    let stream_processor: StreamProcessor<Envelope<GraphDescription>, Envelope<IdentifiedGraph>> =
+    let stream_processor: StreamProcessor<GraphDescription, IdentifiedGraph> =
         StreamProcessor::new(consumer_config, producer_config)?;
 
     tracing::info!(message = "Kafka StreamProcessor configured successfully");

--- a/src/rust/pipeline-ingress/src/main.rs
+++ b/src/rust/pipeline-ingress/src/main.rs
@@ -54,11 +54,11 @@ impl From<IngressApiError> for Status {
 }
 
 struct IngressApi {
-    producer: Producer<Envelope<RawLog>>,
+    producer: Producer<RawLog>,
 }
 
 impl IngressApi {
-    fn new(producer: Producer<Envelope<RawLog>>) -> Self {
+    fn new(producer: Producer<RawLog>) -> Self {
         IngressApi { producer }
     }
 }
@@ -135,7 +135,7 @@ async fn handler() -> Result<(), ConfigurationError> {
         message = "configuring kafka producer",
         producer_config = ?producer_config,
     );
-    let producer: Producer<Envelope<RawLog>> = Producer::new(producer_config)?;
+    let producer: Producer<RawLog> = Producer::new(producer_config)?;
     tracing::info!(message = "kafka producer configured successfully",);
 
     tracing::info!(

--- a/src/rust/plugin-work-queue/src/server.rs
+++ b/src/rust/plugin-work-queue/src/server.rs
@@ -69,7 +69,7 @@ impl From<PluginWorkQueueError> for Status {
 #[derive(Clone)]
 pub struct PluginWorkQueue {
     queue: PsqlQueue,
-    generator_producer: Producer<Envelope<GraphDescription>>,
+    generator_producer: Producer<GraphDescription>,
 }
 
 impl PluginWorkQueue {

--- a/src/rust/rust-proto/src/lib.rs
+++ b/src/rust/rust-proto/src/lib.rs
@@ -224,7 +224,7 @@ pub(crate) mod type_url {
 }
 
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum SerDeError {
     #[error("failed to serialize {0}")]
     EncodingFailed(#[from] EncodeError),


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
NA
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
This PR refactors the `kafka` library a little bit to automatically instrument things with a `tracing::Span` that includes all the Envelope metadata.

The biggest consequence here is that now the `Producer<U>`, `Consumer<T>`, and `StreamProcessor<T, U>` now all require that `T` and `U` are Envelopes. This isn't a terrible imposition, because that's how they're already being used.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Automated tests

now see a bunch of nice metadata in the logs: 
```json
{
  "timestamp": "2022-08-01T22:55:01.267407Z",
  "level": "DEBUG",
  "fields": {
    "message": "predicate matched"
  },
  "target": "kafka::test_utils::topic_scanner",
  "span": {
    "created_time": "2022-08-01T22:55:01.258892697+00:00",
    "event_source_id": "a187dab6-e00a-4787-b3d9-62b6511b8f0a",
    "last_updated_time": "2022-08-01T22:55:01.258892697+00:00",
    "retry_count": "0",
    "tenant_id": "2ae0e22d-9e1b-4f6c-8030-be43a088a19e",
    "trace_id": "a5933277-4668-4393-a6e9-b3d5fcec0032",
    "name": "envelope_span"
  },
  "spans": [
    {
      "created_time": "2022-08-01T22:55:01.258892697+00:00",
      "event_source_id": "a187dab6-e00a-4787-b3d9-62b6511b8f0a",
      "last_updated_time": "2022-08-01T22:55:01.258892697+00:00",
      "retry_count": "0",
      "tenant_id": "2ae0e22d-9e1b-4f6c-8030-be43a088a19e",
      "trace_id": "a5933277-4668-4393-a6e9-b3d5fcec0032",
      "name": "envelope_span"
    }
  ]
}
```

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
