### PR TITLE
add a configurable delay to the retry processor

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -943,6 +943,7 @@ job "grapl-core" {
         KAFKA_SASL_PASSWORD       = var.kafka_credentials["generator-dispatcher-retry"].sasl_password
         KAFKA_CONSUMER_GROUP_NAME = var.kafka_consumer_groups["generator-dispatcher-retry"]
         KAFKA_RETRY_TOPIC         = "raw-logs-retry"
+        KAFKA_RETRY_DELAY_MS      = "5000"
         KAFKA_PRODUCER_TOPIC      = "raw-logs"
 
         # TODO: should equal number of raw-logs-retry partitions

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -645,7 +645,7 @@ job "grapl-core" {
         WORKER_POOL_SIZE = 10
 
         GENERATOR_IDS_CACHE_CAPACITY            = 10000
-        GENERATOR_IDS_CACHE_TTL_MS              = 500
+        GENERATOR_IDS_CACHE_TTL_MS              = 5000
         GENERATOR_IDS_CACHE_UPDATER_POOL_SIZE   = 10
         GENERATOR_IDS_CACHE_UPDATER_QUEUE_DEPTH = 1000
 
@@ -943,7 +943,7 @@ job "grapl-core" {
         KAFKA_SASL_PASSWORD       = var.kafka_credentials["generator-dispatcher-retry"].sasl_password
         KAFKA_CONSUMER_GROUP_NAME = var.kafka_consumer_groups["generator-dispatcher-retry"]
         KAFKA_RETRY_TOPIC         = "raw-logs-retry"
-        KAFKA_RETRY_DELAY_MS      = "5000"
+        KAFKA_RETRY_DELAY_MS      = 500
         KAFKA_PRODUCER_TOPIC      = "raw-logs"
 
         # TODO: should equal number of raw-logs-retry partitions

--- a/src/rust/kafka/src/config.rs
+++ b/src/rust/kafka/src/config.rs
@@ -38,6 +38,8 @@ pub struct RetryConsumerConfig {
     pub consumer_group_name: String,
     #[clap(long, env = "KAFKA_RETRY_TOPIC")]
     pub topic: String,
+    #[clap(long, env = "KAFKA_RETRY_DELAY_MS")]
+    pub delay_ms: u64,
 }
 
 #[derive(clap::Parser, Clone, Debug)]

--- a/src/rust/kafka/src/lib.rs
+++ b/src/rust/kafka/src/lib.rs
@@ -379,6 +379,12 @@ impl BytesConsumer {
                         let message_ts = SystemTime::UNIX_EPOCH + Duration::from_millis(millis);
                         let target = message_ts + Duration::from_millis(self.delay_ms);
 
+                        // If the current time is greater than the target time
+                        // we delay for the duration between the current time
+                        // and the target time. In other words, if the target
+                        // time has elapsed we continue without delay, otherwise
+                        // we wait long enough for it to have elapsed and then
+                        // continue.
                         if let Err(e) = target.elapsed() {
                             let duration = e.duration();
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
NA
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
This PR adds a configurable `KAFKA_RETRY_DELAY_MS` to the retry processors.
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Automated tests, inspected the generator-dispatcher-retry logs and checked that indeed the retry app is delaying: 
```json
{"timestamp":"2022-08-02T00:31:41.473688Z","level":"DEBUG","fields":{"message":"Processed Kafka message"},"target":"kafka_retry","span":{"name":"handler"},"spans":[{"name":"handler"}]}

{"timestamp":"2022-08-02T00:31:41.473775Z","level":"DEBUG","fields":{"message":"delaying kafka message consumption","kafka_timestamp":"2022-08-02T00:31:41.339+00:00","delay_ms":"5000","delay_duration_ms":"4865"},"target":"kafka","span":{"name":"handler"},"spans":[{"name":"handler"}]}

{"timestamp":"2022-08-02T00:31:46.347642Z","level":"DEBUG","fields":{"message":"Processed Kafka message"},"target":"kafka_retry","span":{"name":"handler"},"spans":[{"name":"handler"}]}

{"timestamp":"2022-08-02T00:31:46.347705Z","level":"DEBUG","fields":{"message":"delaying kafka message consumption","kafka_timestamp":"2022-08-02T00:31:41.474+00:00","delay_ms":"5000","delay_duration_ms":"126"},"target":"kafka","span":{"name":"handler"},"spans":[{"name":"handler"}]}

{"timestamp":"2022-08-02T00:31:46.481840Z","level":"DEBUG","fields":{"message":"Processed Kafka message"},"target":"kafka_retry","span":{"name":"handler"},"spans":[{"name":"handler"}]}
```
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
