### PR TITLE
'client-executor' crate for performing retries on grpc clients; port Plugin Registry to this pattern

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,6 +58,7 @@ BUILD @christophermaier
 /src/rust/.cargo/audit.toml @colin-grapl @inickles-grapl
 /src/rust/Cargo.lock @christophermaier
 /src/rust/Cargo.toml @christophermaier
+/src/rust/client-executor/ @colin-grapl
 /src/rust/consul-connect/ @colin-grapl @wimax-grapl
 /src/rust/derive-dynamic-node/ @colin-grapl
 /src/rust/e2e-tests/ @wimax-grapl

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -822,6 +822,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "client-executor"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "pin-project",
+ "recloser",
+ "thiserror",
+ "tokio",
+ "tokio-retry",
+ "tracing",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1032,20 @@ checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
  "cast",
  "itertools 0.10.3",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch 0.9.9",
+ "crossbeam-queue",
+ "crossbeam-utils 0.8.10",
 ]
 
 [[package]]
@@ -3762,6 +3789,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "recloser"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a33de4aab243767d610c4619ea8156202a59b27fb7c94a140f486c96d41d6ef"
+dependencies = [
+ "crossbeam",
+ "pin-project",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4865,6 +4902,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -4072,6 +4072,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "clap 3.2.13",
+ "client-executor",
  "futures",
  "grapl-utils",
  "proptest",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "./derive-dynamic-node",
+  "./client-executor",
   "./consul-connect",
   "./e2e-tests",
   "./endpoint-plugin",

--- a/src/rust/client-executor/Cargo.toml
+++ b/src/rust/client-executor/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "client-executor"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+futures = "0.3.21"
+pin-project = "1.0.11"
+recloser = "1.0.0"
+tokio = { version = "1.20.0", features = ["full"] }
+tokio-retry = "0.3.0"
+thiserror = "1.0.31"
+tracing = "0.1.35"

--- a/src/rust/client-executor/src/action.rs
+++ b/src/rust/client-executor/src/action.rs
@@ -1,0 +1,23 @@
+use std::future::Future;
+
+/// An action can be run multiple times and produces a future.
+pub trait Action {
+    /// The future that this action produces.
+    type Future: Future<Output = Result<Self::Item, Self::Error>>;
+    /// The item that the future may resolve with.
+    type Item;
+    /// The error that the future may resolve with.
+    type Error: std::error::Error;
+
+    fn run(&mut self) -> Self::Future;
+}
+
+impl<R, E: std::error::Error, T: Future<Output = Result<R, E>>, F: FnMut() -> T> Action for F {
+    type Item = R;
+    type Error = E;
+    type Future = T;
+
+    fn run(&mut self) -> Self::Future {
+        self()
+    }
+}

--- a/src/rust/client-executor/src/lib.rs
+++ b/src/rust/client-executor/src/lib.rs
@@ -44,7 +44,7 @@ pub enum Error<E: std::error::Error> {
     Rejected,
     /// A timeout for an underlying call has occurred
     #[error("Elapsed")]
-    Elapsed(Elapsed),
+    Elapsed,
 }
 
 #[pin_project(project = ExecuteStateProj)]
@@ -119,7 +119,7 @@ where
         match this.future.poll(cx) {
             Poll::Ready(Ok(Ok(p))) => Poll::Ready(Ok(p)),
             Poll::Ready(Ok(Err(e))) => Poll::Ready(Err(Error::Inner(e))),
-            Poll::Ready(Err(e @ Elapsed { .. })) => Poll::Ready(Err(Error::Elapsed(e))),
+            Poll::Ready(Err(Elapsed { .. })) => Poll::Ready(Err(Error::Elapsed)),
             Poll::Pending => Poll::Pending,
         }
     }

--- a/src/rust/client-executor/src/lib.rs
+++ b/src/rust/client-executor/src/lib.rs
@@ -1,0 +1,419 @@
+use std::{
+    future::Future,
+    iter::{
+        IntoIterator,
+        Iterator,
+    },
+    num::NonZeroUsize,
+    pin::Pin,
+    task::{
+        Context,
+        Poll,
+    },
+};
+
+use action::Action;
+use pin_project::pin_project;
+use recloser::{
+    AnyError,
+    AsyncRecloser,
+    Recloser,
+    RecloserBuilder,
+    RecloserFuture,
+};
+use tokio::time::{
+    error::Elapsed,
+    sleep_until,
+    timeout,
+    Duration,
+    Instant,
+    Sleep,
+    Timeout,
+};
+pub use tokio_retry::strategy;
+
+pub mod action;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error<E: std::error::Error> {
+    /// An error occurred while executing the underlying future
+    #[error(transparent)]
+    Inner(E),
+    /// A rejected call is returned immediately when the circuit is opened
+    #[error("Reject")]
+    Rejected,
+    /// A timeout for an underlying call has occurred
+    #[error("Elapsed")]
+    Elapsed(Elapsed),
+}
+
+#[pin_project(project = ExecuteStateProj)]
+enum ExecuteState<A>
+where
+    A: Action,
+{
+    Running(#[pin] RecloserFuture<TryTimeout<<A as action::Action>::Future>, AnyError>),
+    Sleeping(#[pin] Sleep),
+}
+
+impl<A: Action> ExecuteState<A> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> ExecuteFuturePoll<A> {
+        match self.project() {
+            ExecuteStateProj::Running(future) => match future.poll(cx) {
+                Poll::Ready(Ok(p)) => ExecuteFuturePoll::Running(Poll::Ready(Ok(p))),
+                Poll::Ready(Err(recloser::Error::Rejected)) => {
+                    ExecuteFuturePoll::Running(Poll::Ready(Err(Error::Rejected)))
+                }
+                Poll::Ready(Err(recloser::Error::Inner(e))) => {
+                    ExecuteFuturePoll::Running(Poll::Ready(Err(e)))
+                }
+                Poll::Pending => ExecuteFuturePoll::Running(Poll::Pending),
+            },
+            ExecuteStateProj::Sleeping(future) => ExecuteFuturePoll::Sleeping(future.poll(cx)),
+        }
+    }
+}
+
+enum ExecuteFuturePoll<A>
+where
+    A: Action,
+{
+    Running(Poll<ActionResult<A>>),
+    Sleeping(Poll<()>),
+}
+
+pub type ActionResult<A> = Result<<A as Action>::Item, Error<<A as Action>::Error>>;
+
+/// Internal helper Future that flattens timeout errors into crate::Error
+#[pin_project]
+struct TryTimeout<F>
+where
+    F: Future,
+{
+    #[pin]
+    future: Timeout<F>,
+    timeout: Duration,
+}
+
+impl<F> TryTimeout<F>
+where
+    F: Future,
+{
+    fn new(t: Duration, future: F) -> Self {
+        TryTimeout {
+            future: timeout(t, future),
+            timeout: t,
+        }
+    }
+}
+
+impl<F, T, E> Future for TryTimeout<F>
+where
+    F: Future<Output = Result<T, E>>,
+    E: std::error::Error,
+{
+    type Output = Result<T, Error<E>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.future.poll(cx) {
+            Poll::Ready(Ok(Ok(p))) => Poll::Ready(Ok(p)),
+            Poll::Ready(Ok(Err(e))) => Poll::Ready(Err(Error::Inner(e))),
+            Poll::Ready(Err(e @ Elapsed { .. })) => Poll::Ready(Err(Error::Elapsed(e))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Future that drives multiple attempts at an action via a retry strategy.
+/// All executions go through a circuit breaker.
+#[pin_project]
+pub struct Execution<'a, I, A>
+where
+    I: Iterator<Item = Duration>,
+    A: Action,
+{
+    strategy: I,
+    #[pin]
+    state: ExecuteState<A>,
+    recloser: &'a AsyncRecloser,
+    timeout: Duration,
+    action: A,
+}
+
+impl<'a, I, A> Execution<'a, I, A>
+where
+    I: Iterator<Item = Duration>,
+    A: Action,
+{
+    fn attempt(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<ActionResult<A>> {
+        let future = {
+            let this = self.as_mut().project();
+
+            this.recloser
+                .call(TryTimeout::new(this.timeout.clone(), this.action.run()))
+        };
+        self.as_mut()
+            .project()
+            .state
+            .set(ExecuteState::Running(future));
+        self.poll(cx)
+    }
+
+    fn retry(
+        mut self: Pin<&mut Self>,
+        err: Error<A::Error>,
+        cx: &mut Context,
+    ) -> Result<Poll<ActionResult<A>>, Error<<A as Action>::Error>> {
+        match self.as_mut().project().strategy.next() {
+            None => {
+                tracing::debug!(message="No more retries", error=?err);
+                Err(err)
+            }
+            Some(duration) => {
+                tracing::debug!(message="Retrying", sleep_for=%duration.as_millis(), error=?err);
+                let deadline = Instant::now() + duration;
+                let future = sleep_until(deadline);
+                self.as_mut()
+                    .project()
+                    .state
+                    .set(ExecuteState::Sleeping(future));
+                Ok(self.poll(cx))
+            }
+        }
+    }
+}
+
+impl<'a, I, A> Future for Execution<'a, I, A>
+where
+    I: Iterator<Item = Duration>,
+    A: Action,
+{
+    type Output = ActionResult<A>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        match self.as_mut().project().state.poll(cx) {
+            ExecuteFuturePoll::Running(poll_result) => match poll_result {
+                Poll::Ready(Ok(ok)) => Poll::Ready(Ok(ok)),
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Err(err)) => match self.retry(err, cx) {
+                    Ok(poll) => poll,
+                    Err(err) => Poll::Ready(Err(err)),
+                },
+            },
+            ExecuteFuturePoll::Sleeping(poll_result) => match poll_result {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(_) => self.attempt(cx),
+            },
+        }
+    }
+}
+
+/// Based on https://resilience4j.readme.io/docs/circuitbreaker
+pub struct ExecutorConfig {
+    builder: RecloserBuilder,
+    timeout: Duration,
+}
+
+impl ExecutorConfig {
+    /// Creates a new `ExecutorConfig` from a `timeout`. Note that the `timeout`
+    /// is *not* a global timeout, but will be applied to each individual call
+    /// of the underlying future.
+    /// The rest of the parameters - threshold, closed_len, etc, are initialized
+    /// to defaults.
+    pub fn new(timeout: Duration) -> Self {
+        let builder = Recloser::custom()
+            .error_rate(0.5)
+            .closed_len(100)
+            .half_open_len(10)
+            .open_wait(Duration::from_secs(5));
+        ExecutorConfig { builder, timeout }
+    }
+
+    /// The timeout for the individual executions of the future
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// The threshold for opening the circuit, expressed as a float between 0 and 1.0.
+    /// The state of the CircuitBreaker changes from CLOSED to OPEN when the failure rate
+    /// is equal or greater than `threshold`.
+    /// For example when more than 50% (`0.5f32`) of the recorded calls have failed.
+    pub fn threshold(mut self, threshold: f32) -> Self {
+        self.builder = self.builder.error_rate(threshold);
+        self
+    }
+
+    /// How many calls will the circuit remain closed for before the failure
+    /// rate is recalculated and the circuit may open
+    pub fn closed_len(mut self, closed_len: NonZeroUsize) -> Self {
+        self.builder = self.builder.closed_len(closed_len.get());
+        self
+    }
+
+    /// How many calls will the circuit remain HalfOpen for before the failure
+    /// rate is recalculated and the circuit may either open or close
+    pub fn half_open_len(mut self, half_open_len: NonZeroUsize) -> Self {
+        self.builder = self.builder.half_open_len(half_open_len.get());
+        self
+    }
+
+    /// The duration for which the circuit will remain Open, returning
+    /// with immediate Rejected errors, before transitioning to HalfOpen
+    pub fn open_wait(mut self, open_wait: Duration) -> Self {
+        self.builder = self.builder.open_wait(open_wait);
+        self
+    }
+}
+
+/// Executor is a thread safe Circuit Breaker, Timeout, and Retry helper.
+/// For a given future F,
+/// 1. First the circuit breaker is checked
+/// 2. If the circuit is open, the future is rejected with a Rejected error
+/// 3. If the circuit is closed, the future is executed
+/// 4. If the future does not complete within `timeout` `Error::Elapsed` is returned
+///
+/// `Executor` forces the caller to provide a timeout, and the circuit will open if too many
+/// calls exceed this timeout. This should help servers under heavy load to recover.
+///
+/// When the circuit is OPEN, the future is rejected with `Error::Rejected`.
+///
+/// After a wait time duration has elapsed, the CircuitBreaker state changes from OPEN to HALF_OPEN
+/// and permits `half_open_len` calls to see if the backend is still unavailable or has
+/// become available again.
+///
+/// If the failure rate or slow call rate is then equal or greater than the configured threshold,
+/// the state changes back to OPEN. If the failure rate and slow call rate is below the threshold,
+/// the state changes back to CLOSED.
+#[derive(Clone)]
+pub struct Executor {
+    recloser: AsyncRecloser,
+    timeout: Duration,
+}
+
+impl Executor {
+    pub fn new(config: ExecutorConfig) -> Self {
+        let timeout = config.timeout;
+        Executor {
+            recloser: AsyncRecloser::from(config.builder.build()),
+            timeout,
+        }
+    }
+
+    pub fn spawn<A, I, T>(&self, strategy: T, mut action: A) -> Execution<I, A>
+    where
+        I: Iterator<Item = Duration>,
+        A: Action,
+        T: IntoIterator<IntoIter = I, Item = Duration>,
+    {
+        Execution {
+            strategy: strategy.into_iter(),
+            state: ExecuteState::Running(
+                self.recloser
+                    .call(TryTimeout::new(self.timeout.clone(), action.run())),
+            ),
+            timeout: self.timeout.clone(),
+            recloser: &self.recloser,
+            action,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::Ordering,
+        Arc,
+    };
+
+    use super::*;
+
+    #[derive(thiserror::Error, Debug)]
+    enum MyCustomError {
+        #[error("OhNo!")]
+        OhNo(i32),
+    }
+
+    #[tokio::test]
+    async fn test_retries() -> Result<(), Box<dyn std::error::Error>> {
+        let executor = Executor::new(ExecutorConfig::new(Duration::from_secs(10)));
+
+        executor
+            .spawn([], || async move { Ok::<(), MyCustomError>(()) })
+            .await?;
+
+        let i = Arc::new(std::sync::atomic::AtomicI32::new(0));
+        executor
+            .spawn([Duration::from_millis(0), Duration::from_millis(0)], || {
+                let i = i.clone();
+                async move {
+                    let i = i.fetch_add(1, Ordering::Acquire);
+                    if i == 2 {
+                        Ok(())
+                    } else {
+                        Err(MyCustomError::OhNo(i))
+                    }
+                }
+            })
+            .await?;
+
+        let i = Arc::new(std::sync::atomic::AtomicI32::new(0));
+        let result = executor
+            .spawn([Duration::from_millis(0)], || {
+                let i = i.clone();
+                async move {
+                    let i = i.fetch_add(1, Ordering::Acquire);
+                    if i == 2 {
+                        Ok(())
+                    } else {
+                        Err(MyCustomError::OhNo(i))
+                    }
+                }
+            })
+            .await;
+        assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_circuit_open() -> Result<(), Box<dyn std::error::Error>> {
+        let circuit_breaker = ExecutorConfig::new(Duration::from_secs(3))
+            .threshold(0.5)
+            .closed_len(NonZeroUsize::new(2).unwrap())
+            .open_wait(Duration::from_secs(1));
+        let executor = Executor::new(circuit_breaker);
+
+        let first_try = executor
+            .spawn([Duration::from_millis(0)], || async move {
+                Err::<(), _>(MyCustomError::OhNo(0))
+            })
+            .await;
+        // Circuit is closed, so we get the normal error
+        assert!(matches!(
+            first_try,
+            Err(Error::Inner(MyCustomError::OhNo(0)))
+        ));
+
+        let second_try = executor
+            .spawn([Duration::from_millis(0); 1], || async move {
+                Err::<(), _>(MyCustomError::OhNo(1))
+            })
+            .await;
+        // Circuit has opened, immediate rejection
+        assert!(matches!(second_try, Err(Error::Rejected)));
+
+        // Sleep until we can start calculating a new failure rate
+        tokio::time::sleep(Duration::from_millis(1_500)).await;
+
+        let third_try = executor
+            .spawn([Duration::from_millis(0)], || async move {
+                Ok::<(), MyCustomError>(())
+            })
+            .await;
+        // Circuit is closed
+        assert!(matches!(third_try, Ok(())));
+        Ok(())
+    }
+}

--- a/src/rust/plugin-registry/src/error.rs
+++ b/src/rust/plugin-registry/src/error.rs
@@ -70,6 +70,9 @@ impl From<PluginRegistryServiceError> for Status {
             Error::SqlxError(sqlx::Error::Configuration(_)) => {
                 Status::internal("Invalid SQL configuration")
             }
+            Error::SqlxError(rnf_error @ sqlx::Error::RowNotFound) => {
+                Status::not_found(rnf_error.to_string())
+            }
             Error::SqlxError(_) => Status::internal("Failed to operate on postgres"),
             Error::S3PutObjectError(_) => Status::internal("Failed to put s3 object"),
             Error::S3GetObjectError(_) => Status::internal("Failed to get s3 object"),

--- a/src/rust/plugin-registry/tests/test_create_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_create_plugin.rs
@@ -5,9 +5,8 @@ use clap::Parser;
 use grapl_utils::future_ext::GraplFutureExt;
 use rust_proto::{
     client_factory::{
-        build_grpc_client_with_options,
+        build_grpc_client,
         services::PluginRegistryClientConfig,
-        BuildGrpcClientOptions,
     },
     graplinc::grapl::api::plugin_registry::v1beta1::{
         GetPluginRequest,
@@ -25,14 +24,7 @@ async fn test_create_plugin() -> Result<(), Box<dyn std::error::Error>> {
         env=?std::env::args(),
     );
     let client_config = PluginRegistryClientConfig::parse();
-    let mut client = build_grpc_client_with_options(
-        client_config,
-        BuildGrpcClientOptions {
-            perform_healthcheck: true,
-            ..Default::default()
-        },
-    )
-    .await?;
+    let mut client = build_grpc_client(client_config).await?;
 
     let tenant_id = uuid::Uuid::new_v4();
 

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -7,9 +7,8 @@ use clap::Parser;
 use grapl_utils::future_ext::GraplFutureExt;
 use rust_proto::{
     client_factory::{
-        build_grpc_client_with_options,
+        build_grpc_client,
         services::PluginRegistryClientConfig,
-        BuildGrpcClientOptions,
     },
     graplinc::grapl::api::plugin_registry::v1beta1::{
         DeployPluginRequest,
@@ -36,14 +35,7 @@ fn get_sysmon_generator() -> Result<Bytes, std::io::Error> {
 #[test_log::test(tokio::test)]
 async fn test_deploy_example_generator() -> Result<(), Box<dyn std::error::Error>> {
     let client_config = PluginRegistryClientConfig::parse();
-    let mut client = build_grpc_client_with_options(
-        client_config,
-        BuildGrpcClientOptions {
-            perform_healthcheck: true,
-            ..Default::default()
-        },
-    )
-    .await?;
+    let mut client = build_grpc_client(client_config).await?;
 
     let tenant_id = uuid::Uuid::new_v4();
     let event_source_id = uuid::Uuid::new_v4();
@@ -82,14 +74,7 @@ async fn test_deploy_example_generator() -> Result<(), Box<dyn std::error::Error
 #[test_log::test(tokio::test)]
 async fn test_deploy_sysmon_generator() -> Result<(), Box<dyn std::error::Error>> {
     let client_config = PluginRegistryClientConfig::parse();
-    let mut client = build_grpc_client_with_options(
-        client_config,
-        BuildGrpcClientOptions {
-            perform_healthcheck: true,
-            ..Default::default()
-        },
-    )
-    .await?;
+    let mut client = build_grpc_client(client_config).await?;
 
     let tenant_id = uuid::Uuid::new_v4();
     let event_source_id = uuid::Uuid::new_v4();
@@ -167,14 +152,7 @@ async fn assert_health(
 /// hasn't been created yet
 async fn test_deploy_plugin_but_plugin_id_doesnt_exist() -> Result<(), Box<dyn std::error::Error>> {
     let client_config = PluginRegistryClientConfig::parse();
-    let mut client = build_grpc_client_with_options(
-        client_config,
-        BuildGrpcClientOptions {
-            perform_healthcheck: true,
-            ..Default::default()
-        },
-    )
-    .await?;
+    let mut client = build_grpc_client(client_config).await?;
 
     let randomly_selected_plugin_id = uuid::Uuid::new_v4();
 

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -19,7 +19,8 @@ use rust_proto::{
         PluginRegistryServiceClient,
         PluginRegistryServiceClientError,
         PluginType,
-    }, protocol::status::{Code},
+    },
+    protocol::status::Code,
 };
 
 pub const SMALL_TEST_BINARY: &'static [u8] = include_bytes!("./small_test_binary.sh");
@@ -165,9 +166,8 @@ async fn test_deploy_plugin_but_plugin_id_doesnt_exist() -> Result<(), Box<dyn s
 
     match response {
         Err(PluginRegistryServiceClientError::ErrorStatus(s)) => {
-            // TODO: We should consider a dedicated "PluginIDDoesntExist" exception
             assert_eq!(s.code(), Code::NotFound);
-            assert_contains(s.message(), "Failed to operate on postgres");
+            assert_contains(s.message(), &sqlx::Error::RowNotFound.to_string());
         }
         _ => panic!("Expected an error"),
     };

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -19,7 +19,7 @@ use rust_proto::{
         PluginRegistryServiceClient,
         PluginRegistryServiceClientError,
         PluginType,
-    },
+    }, protocol::status::{Code},
 };
 
 pub const SMALL_TEST_BINARY: &'static [u8] = include_bytes!("./small_test_binary.sh");
@@ -166,6 +166,7 @@ async fn test_deploy_plugin_but_plugin_id_doesnt_exist() -> Result<(), Box<dyn s
     match response {
         Err(PluginRegistryServiceClientError::ErrorStatus(s)) => {
             // TODO: We should consider a dedicated "PluginIDDoesntExist" exception
+            assert_eq!(s.code(), Code::NotFound);
             assert_contains(s.message(), "Failed to operate on postgres");
         }
         _ => panic!("Expected an error"),

--- a/src/rust/rust-proto/Cargo.toml
+++ b/src/rust/rust-proto/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "3.0", default_features = false, features = [
   "env",
   "derive"
 ], optional = true }
+client-executor = { path = "../client-executor" }
 futures = "0.3"
 grapl-utils = { path = "../grapl-utils" }
 prost = "0.10"

--- a/src/rust/rust-proto/src/client_macros.rs
+++ b/src/rust/rust-proto/src/client_macros.rs
@@ -1,0 +1,38 @@
+/// This macro implements boilerplate code to:
+/// - translate between the native types and tonic/prost types
+///   in the transport layer
+/// - Automatically hook these client RPCs up to the Executor, which provides
+///   retries (among other good behaviors).
+///
+/// It makes some expectations of the structure of `self` - like that it
+/// has a `self.executor` and `self.proto_client`.
+#[macro_export]
+macro_rules! execute_client_rpc {
+    (
+        $self: ident,
+        $native_request: ident,
+        $rpc_name: ident,
+        $proto_request_type: ty,
+        $native_response_type: ty,
+    ) => {{
+        {
+            let proto_request = <$proto_request_type>::try_from($native_request)?;
+
+            let proto_response = $self
+                .executor
+                .spawn(
+                    client_executor::strategy::FibonacciBackoff::from_millis(10)
+                        .map(jitter)
+                        .take(20),
+                    || {
+                        let mut proto_client = $self.proto_client.clone();
+                        let proto_request = proto_request.clone();
+                        async move { proto_client.$rpc_name(proto_request).await }
+                    },
+                )
+                .await?;
+            let native_response = <$native_response_type>::try_from(proto_response.into_inner())?;
+            Ok(native_response)
+        }
+    }};
+}

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -44,7 +44,7 @@ pub enum PluginRegistryServiceClientError {
 }
 
 // A compatibility layer for using
-// TryFrom<Error = SerDeError> 
+// TryFrom<Error = SerDeError>
 // in place of From.
 impl From<Infallible> for PluginRegistryServiceClientError {
     fn from(_: Infallible) -> Self {

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -43,9 +43,9 @@ pub enum PluginRegistryServiceClientError {
     Elapsed,
 }
 
-// This likely should be removed in favor of making all SerDe conversions
-// TryFrom<Error = SerDeError> instead of From.
-// Currently it's kind of scattershot.
+// A compatibility layer for using
+// TryFrom<Error = SerDeError> 
+// in place of From.
 impl From<Infallible> for PluginRegistryServiceClientError {
     fn from(_: Infallible) -> Self {
         unreachable!()

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -75,6 +75,7 @@ impl Connectable for PluginRegistryServiceClient {
 
     #[tracing::instrument(err)]
     async fn connect(endpoint: Endpoint) -> Result<Self, ConnectError> {
+        // TODO: We may want to macro-ize this like we did with the RPCs.
         let executor = Executor::new(ExecutorConfig::new(Duration::from_secs(30)));
         let proto_client = executor
             .spawn(

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -1,6 +1,14 @@
-use std::fmt::Debug;
+use std::{
+    fmt::Debug,
+    time::Duration,
+};
 
 use bytes::Bytes;
+use client_executor::{
+    strategy::jitter,
+    Executor,
+    ExecutorConfig,
+};
 use futures::{
     Stream,
     StreamExt,
@@ -27,11 +35,26 @@ pub enum PluginRegistryServiceClientError {
     ErrorStatus(#[from] Status),
     #[error("PluginRegistryDeserializationError {0}")]
     PluginRegistryDeserializationError(#[from] SerDeError),
+    #[error("CircuitOpen")]
+    CircuitOpen,
+    #[error("Timeout")]
+    Elapsed,
+}
+
+impl From<client_executor::Error<tonic::Status>> for PluginRegistryServiceClientError {
+    fn from(e: client_executor::Error<tonic::Status>) -> Self {
+        match e {
+            client_executor::Error::Inner(e) => Self::ErrorStatus(e.into()),
+            client_executor::Error::Rejected => Self::CircuitOpen,
+            client_executor::Error::Elapsed => Self::Elapsed,
+        }
+    }
 }
 
 #[derive(Clone)]
 pub struct PluginRegistryServiceClient {
     proto_client: PluginRegistryServiceClientProto<tonic::transport::Channel>,
+    executor: Executor,
 }
 
 #[async_trait::async_trait]
@@ -41,8 +64,26 @@ impl Connectable for PluginRegistryServiceClient {
 
     #[tracing::instrument(err)]
     async fn connect(endpoint: Endpoint) -> Result<Self, ConnectError> {
+        let executor = Executor::new(ExecutorConfig::new(Duration::from_secs(30)));
+        let proto_client = executor
+            .spawn(
+                client_executor::strategy::FibonacciBackoff::from_millis(10)
+                    .map(jitter)
+                    .take(20),
+                || {
+                    let endpoint = endpoint.clone();
+                    async move {
+                        PluginRegistryServiceClientProto::connect(endpoint)
+                            .await
+                            .map_err(ConnectError::from)
+                    }
+                },
+            )
+            .await?;
+
         Ok(PluginRegistryServiceClient {
-            proto_client: PluginRegistryServiceClientProto::connect(endpoint).await?,
+            proto_client,
+            executor,
         })
     }
 }
@@ -93,14 +134,24 @@ impl PluginRegistryServiceClient {
         &mut self,
         request: native::GetPluginRequest,
     ) -> Result<native::GetPluginResponse, PluginRegistryServiceClientError> {
-        let response = match self
-            .proto_client
-            .get_plugin(proto::GetPluginRequest::from(request))
-            .await
-        {
-            Ok(r) => r,
-            Err(e) => return Err(Status::from(e).into()),
-        };
+        let response = self
+            .executor
+            .spawn(
+                client_executor::strategy::FibonacciBackoff::from_millis(10)
+                    .map(jitter)
+                    .take(20),
+                || {
+                    let mut proto_client = self.proto_client.clone();
+                    let request = request.clone();
+                    async move {
+                        proto_client
+                            .get_plugin(proto::GetPluginRequest::from(request))
+                            .await
+                    }
+                },
+            )
+            .await?;
+
         let response = native::GetPluginResponse::try_from(response.into_inner())?;
         Ok(response)
     }
@@ -111,10 +162,22 @@ impl PluginRegistryServiceClient {
         request: native::DeployPluginRequest,
     ) -> Result<native::DeployPluginResponse, PluginRegistryServiceClientError> {
         let response = self
-            .proto_client
-            .deploy_plugin(proto::DeployPluginRequest::from(request))
-            .await
-            .map_err(Status::from)?;
+            .executor
+            .spawn(
+                client_executor::strategy::FibonacciBackoff::from_millis(10)
+                    .map(jitter)
+                    .take(20),
+                || {
+                    let mut proto_client = self.proto_client.clone();
+                    let request = request.clone();
+                    async move {
+                        proto_client
+                            .deploy_plugin(proto::DeployPluginRequest::from(request))
+                            .await
+                    }
+                },
+            )
+            .await?;
         let response = native::DeployPluginResponse::try_from(response.into_inner())?;
         Ok(response)
     }
@@ -136,10 +199,22 @@ impl PluginRegistryServiceClient {
         request: native::GetPluginHealthRequest,
     ) -> Result<native::GetPluginHealthResponse, PluginRegistryServiceClientError> {
         let response = self
-            .proto_client
-            .get_plugin_health(proto::GetPluginHealthRequest::from(request))
-            .await
-            .map_err(Status::from)?;
+            .executor
+            .spawn(
+                client_executor::strategy::FibonacciBackoff::from_millis(10)
+                    .map(jitter)
+                    .take(20),
+                || {
+                    let mut proto_client = self.proto_client.clone();
+                    let request = request.clone();
+                    async move {
+                        proto_client
+                            .get_plugin_health(proto::GetPluginHealthRequest::from(request))
+                            .await
+                    }
+                },
+            )
+            .await?;
         let response = native::GetPluginHealthResponse::try_from(response.into_inner())?;
         Ok(response)
     }
@@ -151,13 +226,24 @@ impl PluginRegistryServiceClient {
         request: native::GetGeneratorsForEventSourceRequest,
     ) -> Result<native::GetGeneratorsForEventSourceResponse, PluginRegistryServiceClientError> {
         let response = self
-            .proto_client
-            .get_generators_for_event_source(proto::GetGeneratorsForEventSourceRequest::from(
-                request,
-            ))
-            .await
-            .map_err(Status::from)?;
-
+            .executor
+            .spawn(
+                client_executor::strategy::FibonacciBackoff::from_millis(10)
+                    .map(jitter)
+                    .take(20),
+                || {
+                    let mut proto_client = self.proto_client.clone();
+                    let request = request.clone();
+                    async move {
+                        proto_client
+                            .get_generators_for_event_source(
+                                proto::GetGeneratorsForEventSourceRequest::from(request),
+                            )
+                            .await
+                    }
+                },
+            )
+            .await?;
         let response = native::GetGeneratorsForEventSourceResponse::from(response.into_inner());
 
         Ok(response)

--- a/src/rust/rust-proto/src/lib.rs
+++ b/src/rust/rust-proto/src/lib.rs
@@ -12,6 +12,7 @@ use thiserror::Error;
 
 #[cfg(feature = "client-factory")]
 pub mod client_factory;
+mod client_macros;
 pub mod protocol;
 
 pub(crate) mod server_internals;

--- a/src/rust/rust-proto/src/protocol/service_client.rs
+++ b/src/rust/rust-proto/src/protocol/service_client.rs
@@ -23,6 +23,25 @@ pub enum ConnectError {
     #[error("Healthcheck failed for {0}: {1}")]
     HealthcheckFailed(String, HealthcheckError),
 
-    #[error("Timeout elapsed {0}")]
-    TimeoutElapsed(#[from] Elapsed),
+    #[error("Timeout elapsed")]
+    TimeoutElapsed,
+
+    #[error("CircuitBreaker Open")]
+    CircuitBreakerOpen,
+}
+
+impl From<Elapsed> for ConnectError {
+    fn from(_e: Elapsed) -> Self {
+        Self::TimeoutElapsed
+    }
+}
+
+impl From<client_executor::Error<ConnectError>> for ConnectError {
+    fn from(e: client_executor::Error<ConnectError>) -> Self {
+        match e {
+            client_executor::Error::Inner(e) => e,
+            client_executor::Error::Rejected => {Self::CircuitBreakerOpen}
+            client_executor::Error::Elapsed => Self::TimeoutElapsed,
+        }
+    }
 }

--- a/src/rust/rust-proto/src/protocol/service_client.rs
+++ b/src/rust/rust-proto/src/protocol/service_client.rs
@@ -40,7 +40,7 @@ impl From<client_executor::Error<ConnectError>> for ConnectError {
     fn from(e: client_executor::Error<ConnectError>) -> Self {
         match e {
             client_executor::Error::Inner(e) => e,
-            client_executor::Error::Rejected => {Self::CircuitBreakerOpen}
+            client_executor::Error::Rejected => Self::CircuitBreakerOpen,
             client_executor::Error::Elapsed => Self::TimeoutElapsed,
         }
     }


### PR DESCRIPTION
Resurrecting Colin's pr here.
https://github.com/grapl-security/grapl/pull/1849

I cannot speak to literally anything in `client-executor` myself, but I can speak about the rust-proto macro change - a lot of it is not really a good fit for interfaces and is a much better fit for a repeatable macro. 

I haven't tackled the streaming RPC yet, but that's an edge case!