### PR TITLE
Potentially defend against postgres OOMkiller

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,7 @@ BUILD @christophermaier
 /pants @christophermaier
 /pants.ci.toml @christophermaier
 /pants.toml @christophermaier
+/postgres/ @colin-grapl @wimax-grapl
 /pulumi/ @christophermaier
 /pyproject.toml @christophermaier
 /README.md @christophermaier

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -7,5 +7,5 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=postgreg-apt 
     postgresql-13-cron=1.3.0-2 && \
     rm -rf /var/lib/apt/lists/*
 
-RUN echo "shared_preload_libraries = 'pg_cron'" >> /usr/share/postgresql/13/postgresql.conf.sample && \
-    echo "cron.database_name = 'postgres'" >> /usr/share/postgresql/13/postgresql.conf.sample
+COPY postgres.conf /tmp/postgres.conf
+RUN cat /tmp/postgres.conf >> /usr/share/postgresql/13/postgresql.conf.sample

--- a/postgres/postgres.conf
+++ b/postgres/postgres.conf
@@ -1,0 +1,23 @@
+cron.database_name = 'postgres'
+shared_preload_libraries = 'pg_cron'
+
+
+##### <Memory>
+# Nomad by default supplies 300MB RAM.
+# (There's probably some Docker overhead but that's besides the point)
+
+# Suggestions come from
+# https://www.enterprisedb.com/postgres-tutorials/how-tune-postgresql-memory
+# These are only applicable to local-grapl.
+
+# shared_buffers: 15 to 25% of $TOTALRAM.
+shared_buffers = 45MB
+# max_connections: 100 is the default. no need to change
+max_connections = 100 
+# work_mem: $TOTAL_RAM * 0.25 / max_connections
+work_mem = 7MB
+# maintenance_work_mem: $TOTAL_RAM * 0.05
+maintenance_work_mem = 15MB
+# effective_cache_size: $TOTAL_RAM * 0.5
+effective_cache_size = 150MB
+##### </Memory>


### PR DESCRIPTION
We've been getting Postgres signal 9s that may be internal OOMKillers. What if we tune it so we don't get OOM?

I found a guide - https://www.enterprisedb.com/postgres-tutorials/how-tune-postgresql-memory - and basically followed their suggestions.
