### PR TITLE
Revert "Remove ANSI codes in rust logs (#1874)"

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -39,7 +39,3 @@ inherits = "dev"
 # Results in a ~20x binary size reduction, for example
 # sysmon-generator: 279M -> 16M
 strip = "debuginfo"
-
-[term]
-# Disable ANSI color codes in test logs
-color = "never"


### PR DESCRIPTION
This doesn't work as intended, removing.