### PR TITLE
Internal 720 get analyzers for tenant

### DIFF
--- a/src/rust/e2e-tests/src/test_utils/context.rs
+++ b/src/rust/e2e-tests/src/test_utils/context.rs
@@ -142,21 +142,19 @@ impl E2eTestContext {
             let plugin = self
                 .plugin_registry_client
                 .create_plugin(
-                    PluginMetadata {
+                    PluginMetadata::new(
                         tenant_id,
-                        display_name: options.test_name.clone(),
-                        plugin_type: PluginType::Generator,
-                        event_source_id: Some(event_source.event_source_id),
-                    },
+                        options.test_name.clone(),
+                        PluginType::Generator,
+                        Some(event_source.event_source_id),
+                    ),
                     futures::stream::once(async move { options.generator_artifact }),
                 )
                 .await?;
 
             if options.should_deploy_generator {
                 self.plugin_registry_client
-                    .deploy_plugin(DeployPluginRequest {
-                        plugin_id: plugin.plugin_id,
-                    })
+                    .deploy_plugin(DeployPluginRequest::new(plugin.plugin_id()))
                     .await?;
             }
             plugin
@@ -164,7 +162,7 @@ impl E2eTestContext {
 
         Ok(SetupResult {
             tenant_id,
-            plugin_id: plugin.plugin_id,
+            plugin_id: plugin.plugin_id(),
             event_source_id: event_source.event_source_id,
         })
     }

--- a/src/rust/generator-dispatcher/src/generator_ids_cache.rs
+++ b/src/rust/generator-dispatcher/src/generator_ids_cache.rs
@@ -111,12 +111,12 @@ impl GeneratorIdsCache {
                     async move {
 
                         let generator_ids = match plugin_registry_client
-                            .get_generators_for_event_source(GetGeneratorsForEventSourceRequest {
-                                event_source_id
-                            })
+                            .get_generators_for_event_source(
+                                GetGeneratorsForEventSourceRequest::new(event_source_id)
+                            )
                             .await {
                                 Ok(response) => {
-                                    response.plugin_ids
+                                    response.plugin_ids().to_vec()
                                 },
                                 Err(PluginRegistryServiceClientError::ErrorStatus(Status {
                                     code: Code::NotFound,
@@ -156,15 +156,16 @@ impl GeneratorIdsCache {
                                         tokio::time::sleep(backoff).await;
 
                                         result = plugin_registry_client
-                                            .get_generators_for_event_source(GetGeneratorsForEventSourceRequest {
-                                                event_source_id
-                                            })
+                                            .get_generators_for_event_source(
+                                                GetGeneratorsForEventSourceRequest::new(event_source_id)
+                                            )
                                             .await;
                                     };
 
                                     result
                                         .expect("fatal error, unknown state")
-                                        .plugin_ids
+                                        .plugin_ids()
+                                        .to_vec()
                                 },
                             };
 

--- a/src/rust/kafka/Cargo.toml
+++ b/src/rust/kafka/Cargo.toml
@@ -24,11 +24,7 @@ rdkafka = { version = "0.28", features = [
   "zstd"
 ] }
 rust-proto = { path = "../rust-proto", version = "*" }
-tokio = { version = "1.17", features = [
-  "macros",
-  "rt",
-  "rt-multi-thread"
-]}
+tokio = { version = "1.17", features = ["macros", "rt", "rt-multi-thread"] }
 thiserror = "1.0"
 tracing = "0.1"
 uuid = { version = "1.0", features = ["v4"], optional = true }

--- a/src/rust/kafka/Cargo.toml
+++ b/src/rust/kafka/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { version = "1.17", features = [
   "macros",
   "rt",
   "rt-multi-thread"
-], optional = true }
+]}
 thiserror = "1.0"
 tracing = "0.1"
 uuid = { version = "1.0", features = ["v4"], optional = true }
@@ -36,4 +36,4 @@ secrecy = "0.8.0"
 
 [features]
 default = []
-test-utils = ["tokio", "uuid"]
+test-utils = ["uuid"]

--- a/src/rust/plugin-registry/sqlx-data.json
+++ b/src/rust/plugin-registry/sqlx-data.json
@@ -174,5 +174,26 @@
       }
     },
     "query": "\n            SELECT\n            plugin_id,\n            tenant_id,\n            display_name,\n            plugin_type,\n            artifact_s3_key,\n            event_source_id\n            FROM plugins\n            WHERE plugin_id = $1\n            "
+  },
+  "ee70c580b98542fdf5cc49230ba968c926009e5cbba9b85b93af277927e92cb9": {
+    "describe": {
+      "columns": [
+        {
+          "name": "plugin_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text"
+        ]
+      }
+    },
+    "query": "\n            SELECT\n            plugin_id\n            FROM plugins\n            WHERE tenant_id = $1 AND plugin_type = $2;\n            "
   }
 }

--- a/src/rust/plugin-registry/src/db/client.rs
+++ b/src/rust/plugin-registry/src/db/client.rs
@@ -39,6 +39,26 @@ pub struct DbCreatePluginArgs {
 
 impl PluginRegistryDbClient {
     #[tracing::instrument(skip(self), err)]
+    pub async fn get_analyzers_for_tenant(
+        &self,
+        tenant_id: &uuid::Uuid,
+    ) -> Result<Vec<PluginIdRow>, sqlx::Error> {
+        sqlx::query_as!(
+            PluginIdRow,
+            r"
+            SELECT
+            plugin_id
+            FROM plugins
+            WHERE tenant_id = $1 AND plugin_type = $2;
+            ",
+            tenant_id,
+            PluginType::Analyzer.type_name(),
+        )
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    #[tracing::instrument(skip(self), err)]
     pub async fn get_generators_for_event_source(
         &self,
         event_source_id: &uuid::Uuid,

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -149,12 +149,7 @@ impl PluginRegistryApi for PluginRegistry {
 
         let mut request = request;
 
-        let PluginMetadata {
-            tenant_id,
-            display_name,
-            plugin_type,
-            event_source_id,
-        } = match request.next().await {
+        let plugin_metadata = match request.next().await {
             Some(CreatePluginRequest::Metadata(m)) => m,
             _ => {
                 return Err(Self::Error::StreamInputError(
@@ -162,6 +157,9 @@ impl PluginRegistryApi for PluginRegistry {
                 ));
             }
         };
+        let tenant_id = plugin_metadata.tenant_id();
+        let plugin_type = plugin_metadata.plugin_type();
+        let display_name = plugin_metadata.display_name();
 
         let plugin_id = generate_plugin_id();
         let s3_key = generate_artifact_s3_key(plugin_type, &tenant_id, &plugin_id);
@@ -193,15 +191,15 @@ impl PluginRegistryApi for PluginRegistry {
                 &plugin_id,
                 DbCreatePluginArgs {
                     tenant_id,
-                    display_name,
+                    display_name: display_name.to_string(),
                     plugin_type,
-                    event_source_id,
+                    event_source_id: plugin_metadata.event_source_id(),
                 },
                 &s3_key,
             )
             .await?;
 
-        Ok(CreatePluginResponse { plugin_id })
+        Ok(CreatePluginResponse::new(plugin_id))
     }
 
     #[tracing::instrument(skip(self, request), err)]
@@ -216,19 +214,14 @@ impl PluginRegistryApi for PluginRegistry {
             display_name,
             tenant_id,
             event_source_id,
-        } = self.db_client.get_plugin(&request.plugin_id).await?;
+        } = self.db_client.get_plugin(&request.plugin_id()).await?;
 
         let plugin_type: PluginType = try_from(&plugin_type)?;
 
-        let response = GetPluginResponse {
+        let response = GetPluginResponse::new(
             plugin_id,
-            plugin_metadata: PluginMetadata {
-                tenant_id,
-                display_name,
-                plugin_type,
-                event_source_id,
-            },
-        };
+            PluginMetadata::new(tenant_id, display_name, plugin_type, event_source_id),
+        );
 
         Ok(response)
     }
@@ -238,7 +231,7 @@ impl PluginRegistryApi for PluginRegistry {
         &self,
         request: DeployPluginRequest,
     ) -> Result<DeployPluginResponse, Self::Error> {
-        let plugin_id = request.plugin_id;
+        let plugin_id = request.plugin_id();
         let plugin_row = self.db_client.get_plugin(&plugin_id).await?;
 
         // TODO: Given how many fields I'm forwarding here, it may just
@@ -272,7 +265,7 @@ impl PluginRegistryApi for PluginRegistry {
     ) -> Result<GetGeneratorsForEventSourceResponse, Self::Error> {
         let plugin_ids: Vec<Uuid> = self
             .db_client
-            .get_generators_for_event_source(&request.event_source_id)
+            .get_generators_for_event_source(&request.event_source_id())
             .await?
             .iter()
             .map(|row| row.plugin_id)
@@ -281,7 +274,7 @@ impl PluginRegistryApi for PluginRegistry {
         if plugin_ids.is_empty() {
             Err(PluginRegistryServiceError::NotFound)
         } else {
-            Ok(GetGeneratorsForEventSourceResponse { plugin_ids })
+            Ok(GetGeneratorsForEventSourceResponse::new(plugin_ids))
         }
     }
 
@@ -302,10 +295,10 @@ impl PluginRegistryApi for PluginRegistry {
         let health_status = get_plugin_health::get_plugin_health(
             &self.nomad_client,
             &self.db_client,
-            request.plugin_id,
+            request.plugin_id(),
         )
         .await?;
-        Ok(GetPluginHealthResponse { health_status })
+        Ok(GetPluginHealthResponse::new(health_status))
     }
 }
 

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -279,12 +279,24 @@ impl PluginRegistryApi for PluginRegistry {
     }
 
     #[allow(dead_code)]
-    #[tracing::instrument(skip(self, _request), err)]
+    #[tracing::instrument(skip(self, request), err)]
     async fn get_analyzers_for_tenant(
         &self,
-        _request: GetAnalyzersForTenantRequest,
+        request: GetAnalyzersForTenantRequest,
     ) -> Result<GetAnalyzersForTenantResponse, Self::Error> {
-        todo!()
+        let plugin_ids: Vec<Uuid> = self
+            .db_client
+            .get_analyzers_for_tenant(&request.tenant_id())
+            .await?
+            .iter()
+            .map(|row| row.plugin_id)
+            .collect();
+
+        if plugin_ids.is_empty() {
+            Err(PluginRegistryServiceError::NotFound)
+        } else {
+            Ok(GetAnalyzersForTenantResponse::new(plugin_ids))
+        }
     }
 
     #[tracing::instrument(skip(self, request), err)]

--- a/src/rust/plugin-registry/tests/test_create_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_create_plugin.rs
@@ -40,12 +40,12 @@ async fn test_create_plugin() -> Result<(), Box<dyn std::error::Error>> {
 
     let event_source_id = uuid::Uuid::new_v4();
 
-    let meta = PluginMetadata {
+    let meta = PluginMetadata::new(
         tenant_id,
-        display_name: display_name.clone(),
-        plugin_type: PluginType::Generator,
-        event_source_id: Some(event_source_id),
-    };
+        display_name.clone(),
+        PluginType::Generator,
+        Some(event_source_id),
+    );
 
     let single_chunk = Bytes::from("dummy vec for now");
 
@@ -57,23 +57,20 @@ async fn test_create_plugin() -> Result<(), Box<dyn std::error::Error>> {
         .timeout(std::time::Duration::from_secs(5))
         .await??;
 
-    let plugin_id = response.plugin_id;
+    let plugin_id = response.plugin_id();
 
     let get_response: GetPluginResponse = client
-        .get_plugin(GetPluginRequest {
-            plugin_id,
-            tenant_id,
-        })
+        .get_plugin(GetPluginRequest::new(plugin_id, tenant_id))
         .timeout(std::time::Duration::from_secs(5))
         .await??;
-    assert_eq!(get_response.plugin_id, plugin_id);
+    assert_eq!(get_response.plugin_id(), plugin_id);
     assert_eq!(
-        get_response.plugin_metadata.plugin_type,
+        get_response.plugin_metadata().plugin_type(),
         PluginType::Generator
     );
-    assert_eq!(get_response.plugin_metadata.display_name, display_name);
+    assert_eq!(get_response.plugin_metadata().display_name(), &display_name);
     assert_eq!(
-        get_response.plugin_metadata.event_source_id,
+        get_response.plugin_metadata().event_source_id(),
         Some(event_source_id)
     );
 

--- a/src/rust/plugin-registry/tests/test_get_analyzers_for_tenant.rs
+++ b/src/rust/plugin-registry/tests/test_get_analyzers_for_tenant.rs
@@ -1,4 +1,4 @@
-//#![cfg(feature = "integration_tests")]
+#![cfg(feature = "integration_tests")]
 
 use bytes::Bytes;
 use clap::Parser;

--- a/src/rust/plugin-registry/tests/test_get_generators_for_event_source.rs
+++ b/src/rust/plugin-registry/tests/test_get_generators_for_event_source.rs
@@ -38,26 +38,26 @@ async fn test_get_generators_for_event_source() -> Result<(), Box<dyn std::error
     let analyzer_display_name = "my analyzer".to_string();
     let event_source_id = uuid::Uuid::new_v4();
 
-    let generator1_metadata = PluginMetadata {
+    let generator1_metadata = PluginMetadata::new(
         tenant_id,
-        display_name: generator1_display_name.clone(),
-        plugin_type: PluginType::Generator,
-        event_source_id: Some(event_source_id),
-    };
+        generator1_display_name.clone(),
+        PluginType::Generator,
+        Some(event_source_id),
+    );
 
-    let generator2_metadata = PluginMetadata {
+    let generator2_metadata = PluginMetadata::new(
         tenant_id,
-        display_name: generator2_display_name.clone(),
-        plugin_type: PluginType::Generator,
-        event_source_id: Some(event_source_id),
-    };
+        generator2_display_name.clone(),
+        PluginType::Generator,
+        Some(event_source_id),
+    );
 
-    let analyzer_metadata = PluginMetadata {
+    let analyzer_metadata = PluginMetadata::new(
         tenant_id,
-        display_name: analyzer_display_name.clone(),
-        plugin_type: PluginType::Analyzer,
-        event_source_id: None,
-    };
+        analyzer_display_name.clone(),
+        PluginType::Analyzer,
+        None,
+    );
 
     let chunk = Bytes::from("chonk");
 
@@ -69,7 +69,7 @@ async fn test_get_generators_for_event_source() -> Result<(), Box<dyn std::error
         )
         .timeout(std::time::Duration::from_secs(5))
         .await??;
-    let generator1_plugin_id = create_generator1_response.plugin_id;
+    let generator1_plugin_id = create_generator1_response.plugin_id();
 
     let create_generator2_chunk = chunk.clone();
     let create_generator2_response = client
@@ -79,7 +79,7 @@ async fn test_get_generators_for_event_source() -> Result<(), Box<dyn std::error
         )
         .timeout(std::time::Duration::from_secs(5))
         .await??;
-    let generator2_plugin_id = create_generator2_response.plugin_id;
+    let generator2_plugin_id = create_generator2_response.plugin_id();
 
     let create_analyzer_chunk = chunk.clone();
     let create_analyzer_response = client
@@ -89,22 +89,22 @@ async fn test_get_generators_for_event_source() -> Result<(), Box<dyn std::error
         )
         .timeout(std::time::Duration::from_secs(5))
         .await??;
-    let analyzer_plugin_id = create_analyzer_response.plugin_id;
+    let analyzer_plugin_id = create_analyzer_response.plugin_id();
 
     let generators_for_event_source_response = client
-        .get_generators_for_event_source(GetGeneratorsForEventSourceRequest { event_source_id })
+        .get_generators_for_event_source(GetGeneratorsForEventSourceRequest::new(event_source_id))
         .timeout(std::time::Duration::from_secs(5))
         .await??;
 
-    assert_eq!(generators_for_event_source_response.plugin_ids.len(), 2);
+    assert_eq!(generators_for_event_source_response.plugin_ids().len(), 2);
     assert!(generators_for_event_source_response
-        .plugin_ids
+        .plugin_ids()
         .contains(&generator1_plugin_id));
     assert!(generators_for_event_source_response
-        .plugin_ids
+        .plugin_ids()
         .contains(&generator2_plugin_id));
     assert!(!generators_for_event_source_response
-        .plugin_ids
+        .plugin_ids()
         .contains(&analyzer_plugin_id));
 
     Ok(())

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
@@ -14,7 +14,10 @@ pub use crate::graplinc::grapl::api::plugin_registry::{
     },
 };
 use crate::{
-    protobufs::graplinc::grapl::api::plugin_registry::v1beta1 as proto,
+    protobufs::graplinc::grapl::api::plugin_registry::{
+        v1beta1 as proto,
+        v1beta1::get_plugin_health_response::PluginHealthStatus as PluginHealthStatusProto,
+    },
     serde_impl::ProtobufSerializable,
     type_url,
     SerDeError,
@@ -79,14 +82,46 @@ impl From<PluginType> for proto::PluginType {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PluginMetadata {
     /// The platform tenant this plugin belongs to
-    pub tenant_id: uuid::Uuid,
+    tenant_id: uuid::Uuid,
     /// The string value to display to a user, non-empty
-    pub display_name: String,
+    display_name: String,
     /// The type of the plugin
-    pub plugin_type: PluginType,
+    plugin_type: PluginType,
     /// The event source id associated with this plugin. Present if
     /// PluginType::Generator, absent otherwise.
-    pub event_source_id: Option<uuid::Uuid>,
+    event_source_id: Option<uuid::Uuid>,
+}
+
+impl PluginMetadata {
+    pub fn new(
+        tenant_id: uuid::Uuid,
+        display_name: String,
+        plugin_type: PluginType,
+        event_source_id: Option<uuid::Uuid>,
+    ) -> Self {
+        Self {
+            tenant_id,
+            display_name,
+            plugin_type,
+            event_source_id,
+        }
+    }
+
+    pub fn tenant_id(&self) -> uuid::Uuid {
+        self.tenant_id
+    }
+
+    pub fn display_name(&self) -> &str {
+        &self.display_name
+    }
+
+    pub fn plugin_type(&self) -> PluginType {
+        self.plugin_type
+    }
+
+    pub fn event_source_id(&self) -> Option<uuid::Uuid> {
+        self.event_source_id
+    }
 }
 
 impl type_url::TypeUrl for PluginMetadata {
@@ -210,7 +245,17 @@ impl ProtobufSerializable for CreatePluginRequest {
 #[derive(Debug, Clone, PartialEq)]
 pub struct CreatePluginResponse {
     /// The identity of the plugin that was created
-    pub plugin_id: uuid::Uuid,
+    plugin_id: uuid::Uuid,
+}
+
+impl CreatePluginResponse {
+    pub fn new(plugin_id: uuid::Uuid) -> Self {
+        Self { plugin_id }
+    }
+
+    pub fn plugin_id(&self) -> uuid::Uuid {
+        self.plugin_id
+    }
 }
 
 impl type_url::TypeUrl for CreatePluginResponse {
@@ -249,7 +294,17 @@ impl ProtobufSerializable for CreatePluginResponse {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeployPluginRequest {
-    pub plugin_id: uuid::Uuid,
+    plugin_id: uuid::Uuid,
+}
+
+impl DeployPluginRequest {
+    pub fn new(plugin_id: uuid::Uuid) -> Self {
+        Self { plugin_id }
+    }
+
+    pub fn plugin_id(&self) -> uuid::Uuid {
+        self.plugin_id
+    }
 }
 
 impl type_url::TypeUrl for DeployPluginRequest {
@@ -319,7 +374,17 @@ impl ProtobufSerializable for DeployPluginResponse {
 #[derive(Debug, Clone, PartialEq)]
 pub struct GetAnalyzersForTenantRequest {
     /// The tenant id for the tenant whose analyzers we wish to fetch
-    pub tenant_id: uuid::Uuid,
+    tenant_id: uuid::Uuid,
+}
+
+impl GetAnalyzersForTenantRequest {
+    pub fn new(tenant_id: uuid::Uuid) -> Self {
+        Self { tenant_id }
+    }
+
+    pub fn tenant_id(&self) -> uuid::Uuid {
+        self.tenant_id
+    }
 }
 
 impl type_url::TypeUrl for GetAnalyzersForTenantRequest {
@@ -361,7 +426,17 @@ impl ProtobufSerializable for GetAnalyzersForTenantRequest {
 #[derive(Debug, Clone, PartialEq)]
 pub struct GetAnalyzersForTenantResponse {
     /// The plugin ids for the analyzers belonging to a tenant
-    pub plugin_ids: Vec<uuid::Uuid>,
+    plugin_ids: Vec<uuid::Uuid>,
+}
+
+impl GetAnalyzersForTenantResponse {
+    pub fn new(plugin_ids: Vec<uuid::Uuid>) -> Self {
+        Self { plugin_ids }
+    }
+
+    pub fn plugin_ids(&self) -> &[uuid::Uuid] {
+        &self.plugin_ids
+    }
 }
 
 impl type_url::TypeUrl for GetAnalyzersForTenantResponse {
@@ -403,7 +478,17 @@ impl ProtobufSerializable for GetAnalyzersForTenantResponse {
 #[derive(Debug, Clone, PartialEq)]
 pub struct GetGeneratorsForEventSourceRequest {
     /// The event source id
-    pub event_source_id: uuid::Uuid,
+    event_source_id: uuid::Uuid,
+}
+
+impl GetGeneratorsForEventSourceRequest {
+    pub fn new(event_source_id: uuid::Uuid) -> Self {
+        Self { event_source_id }
+    }
+
+    pub fn event_source_id(&self) -> uuid::Uuid {
+        self.event_source_id
+    }
 }
 
 impl type_url::TypeUrl for GetGeneratorsForEventSourceRequest {
@@ -444,7 +529,17 @@ impl ProtobufSerializable for GetGeneratorsForEventSourceRequest {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct GetGeneratorsForEventSourceResponse {
-    pub plugin_ids: Vec<uuid::Uuid>,
+    plugin_ids: Vec<uuid::Uuid>,
+}
+
+impl GetGeneratorsForEventSourceResponse {
+    pub fn new(plugin_ids: Vec<uuid::Uuid>) -> Self {
+        Self { plugin_ids }
+    }
+
+    pub fn plugin_ids(&self) -> &[uuid::Uuid] {
+        &self.plugin_ids
+    }
 }
 
 impl type_url::TypeUrl for GetGeneratorsForEventSourceResponse {
@@ -479,9 +574,26 @@ impl ProtobufSerializable for GetGeneratorsForEventSourceResponse {
 #[derive(Debug, Clone, PartialEq)]
 pub struct GetPluginRequest {
     /// The identity of the plugin
-    pub plugin_id: uuid::Uuid,
+    plugin_id: uuid::Uuid,
     /// The tenant for which the plugin belongs to
-    pub tenant_id: uuid::Uuid,
+    tenant_id: uuid::Uuid,
+}
+
+impl GetPluginRequest {
+    pub fn new(plugin_id: uuid::Uuid, tenant_id: uuid::Uuid) -> Self {
+        Self {
+            plugin_id,
+            tenant_id,
+        }
+    }
+
+    pub fn plugin_id(&self) -> uuid::Uuid {
+        self.plugin_id
+    }
+
+    pub fn tenant_id(&self) -> uuid::Uuid {
+        self.tenant_id
+    }
 }
 
 impl type_url::TypeUrl for GetPluginRequest {
@@ -531,8 +643,25 @@ impl ProtobufSerializable for GetPluginRequest {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct GetPluginResponse {
-    pub plugin_id: uuid::Uuid,
-    pub plugin_metadata: PluginMetadata,
+    plugin_id: uuid::Uuid,
+    plugin_metadata: PluginMetadata,
+}
+
+impl GetPluginResponse {
+    pub fn new(plugin_id: uuid::Uuid, plugin_metadata: PluginMetadata) -> Self {
+        Self {
+            plugin_id,
+            plugin_metadata,
+        }
+    }
+
+    pub fn plugin_id(&self) -> uuid::Uuid {
+        self.plugin_id
+    }
+
+    pub fn plugin_metadata(&self) -> &PluginMetadata {
+        &self.plugin_metadata
+    }
 }
 
 impl type_url::TypeUrl for GetPluginResponse {
@@ -582,7 +711,17 @@ impl ProtobufSerializable for GetPluginResponse {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct TearDownPluginRequest {
-    pub plugin_id: uuid::Uuid,
+    plugin_id: uuid::Uuid,
+}
+
+impl TearDownPluginRequest {
+    pub fn new(plugin_id: uuid::Uuid) -> Self {
+        Self { plugin_id }
+    }
+
+    pub fn plugin_id(&self) -> uuid::Uuid {
+        self.plugin_id
+    }
 }
 
 impl type_url::TypeUrl for TearDownPluginRequest {
@@ -651,7 +790,17 @@ impl ProtobufSerializable for TearDownPluginResponse {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct GetPluginHealthRequest {
-    pub plugin_id: uuid::Uuid,
+    plugin_id: uuid::Uuid,
+}
+
+impl GetPluginHealthRequest {
+    pub fn new(plugin_id: uuid::Uuid) -> Self {
+        Self { plugin_id }
+    }
+
+    pub fn plugin_id(&self) -> uuid::Uuid {
+        self.plugin_id
+    }
 }
 
 impl type_url::TypeUrl for GetPluginHealthRequest {
@@ -696,7 +845,6 @@ pub enum PluginHealthStatus {
     Dead,
 }
 
-use proto::get_plugin_health_response::PluginHealthStatus as PluginHealthStatusProto;
 impl TryFrom<PluginHealthStatusProto> for PluginHealthStatus {
     type Error = SerDeError;
 
@@ -730,7 +878,17 @@ impl From<PluginHealthStatus> for PluginHealthStatusProto {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct GetPluginHealthResponse {
-    pub health_status: PluginHealthStatus,
+    health_status: PluginHealthStatus,
+}
+
+impl GetPluginHealthResponse {
+    pub fn new(health_status: PluginHealthStatus) -> Self {
+        Self { health_status }
+    }
+
+    pub fn health_status(&self) -> PluginHealthStatus {
+        self.health_status
+    }
 }
 
 impl type_url::TypeUrl for GetPluginHealthResponse {

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -168,10 +168,14 @@ impl PluginRegistryServiceClient {
         &mut self,
         request: native::GetAnalyzersForTenantRequest,
     ) -> Result<native::GetAnalyzersForTenantResponse, PluginRegistryServiceClientError> {
-        self.proto_client
+        let response = self
+            .proto_client
             .get_analyzers_for_tenant(proto::GetAnalyzersForTenantRequest::from(request))
             .await
             .map_err(Status::from)?;
-        todo!()
+
+        let response = native::GetAnalyzersForTenantResponse::try_from(response.into_inner())?;
+
+        Ok(response)
     }
 }

--- a/src/rust/rust-proto/tests/test_utils/strategies.rs
+++ b/src/rust/rust-proto/tests/test_utils/strategies.rs
@@ -694,18 +694,18 @@ pub mod plugin_registry {
             event_source_id in uuids(),
         ) -> PluginMetadata {
             match plugin_type {
-                PluginType::Generator => PluginMetadata {
+                PluginType::Generator => PluginMetadata::new(
                     tenant_id,
                     display_name,
                     plugin_type,
-                    event_source_id: Some(event_source_id),
-                },
-                _ => PluginMetadata {
+                    Some(event_source_id),
+                ),
+                _ => PluginMetadata::new(
                     tenant_id,
                     display_name,
                     plugin_type,
-                    event_source_id: None,
-                }
+                    None,
+                )
             }
         }
     }
@@ -721,9 +721,7 @@ pub mod plugin_registry {
         pub fn create_plugin_responses()(
             plugin_id in uuids(),
         ) -> CreatePluginResponse {
-            CreatePluginResponse{
-                plugin_id,
-            }
+            CreatePluginResponse::new(plugin_id)
         }
     }
 
@@ -731,18 +729,14 @@ pub mod plugin_registry {
         pub fn get_analyzers_for_tenant_requests()(
             tenant_id in uuids(),
         ) -> GetAnalyzersForTenantRequest {
-            GetAnalyzersForTenantRequest{
-                tenant_id,
-            }
+            GetAnalyzersForTenantRequest::new(tenant_id)
         }
     }
     prop_compose! {
         pub fn get_analyzers_for_tenant_responses()(
             plugin_ids in vec_of_uuids()
         ) -> GetAnalyzersForTenantResponse {
-            GetAnalyzersForTenantResponse{
-                plugin_ids
-            }
+            GetAnalyzersForTenantResponse::new(plugin_ids)
         }
     }
 
@@ -750,9 +744,7 @@ pub mod plugin_registry {
         pub fn deploy_plugin_requests()(
             plugin_id in uuids()
         ) -> DeployPluginRequest {
-            DeployPluginRequest{
-                plugin_id
-            }
+            DeployPluginRequest::new(plugin_id)
         }
     }
 
@@ -764,9 +756,7 @@ pub mod plugin_registry {
         pub fn get_generators_for_event_source_requests()(
             event_source_id in uuids()
         ) -> GetGeneratorsForEventSourceRequest {
-            GetGeneratorsForEventSourceRequest{
-                event_source_id
-            }
+            GetGeneratorsForEventSourceRequest::new(event_source_id)
         }
     }
 
@@ -774,9 +764,7 @@ pub mod plugin_registry {
         pub fn get_generators_for_event_source_responses()(
             plugin_ids in vec_of_uuids()
         ) -> GetGeneratorsForEventSourceResponse {
-            GetGeneratorsForEventSourceResponse {
-                plugin_ids
-            }
+            GetGeneratorsForEventSourceResponse::new(plugin_ids)
         }
     }
 
@@ -785,10 +773,7 @@ pub mod plugin_registry {
             plugin_id in uuids(),
             tenant_id in uuids(),
         ) -> GetPluginRequest {
-            GetPluginRequest {
-                plugin_id,
-                tenant_id,
-            }
+            GetPluginRequest::new(plugin_id, tenant_id)
         }
     }
 
@@ -797,10 +782,7 @@ pub mod plugin_registry {
             plugin_id in uuids(),
             plugin_metadata in plugin_metadatas(),
         ) -> GetPluginResponse {
-            GetPluginResponse {
-                plugin_id,
-                plugin_metadata,
-            }
+            GetPluginResponse::new(plugin_id, plugin_metadata)
         }
     }
 
@@ -808,9 +790,7 @@ pub mod plugin_registry {
         pub fn tear_down_plugin_requests()(
             plugin_id in uuids()
         ) -> TearDownPluginRequest {
-            TearDownPluginRequest{
-                plugin_id
-            }
+            TearDownPluginRequest::new(plugin_id)
         }
     }
 
@@ -822,9 +802,7 @@ pub mod plugin_registry {
         pub fn get_plugin_health_requests()(
             plugin_id in uuids()
         ) -> GetPluginHealthRequest {
-            GetPluginHealthRequest{
-                plugin_id
-            }
+            GetPluginHealthRequest::new(plugin_id)
         }
     }
 
@@ -843,9 +821,7 @@ pub mod plugin_registry {
         pub fn get_plugin_health_responses()(
             health_status in plugin_health_statuses()
         ) -> GetPluginHealthResponse{
-            GetPluginHealthResponse{
-                health_status
-            }
+            GetPluginHealthResponse::new(health_status)
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?

https://app.zenhub.com/workspaces/grapl-6036cbd36bacff000ef314f2/issues/grapl-security/issue-tracker/720

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

This PR implements the `get_analyzers_for_tenant` RPC method in plugin-registry. I've also added an integration test to cover the "not found" branch of `get_generators_for_event_source`.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

Automated tests

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
