### PR TITLE
Remove `sysmon-log-bucket` references in integration tests

### DIFF
--- a/pulumi/python_integration_tests/__main__.py
+++ b/pulumi/python_integration_tests/__main__.py
@@ -106,7 +106,6 @@ class GraplStack:
         self.redis_endpoint = require_str("redis-endpoint")
         self.schema_properties_table_name = require_str("schema-properties-table")
         self.schema_table_name = require_str("schema-table")
-        self.sysmon_log_bucket = require_str("sysmon-log-bucket")
         self.test_user_name = require_str("test-user-name")
 
         self.plugin_work_queue_db = cast(

--- a/pulumi/rust_integration_tests/__main__.py
+++ b/pulumi/rust_integration_tests/__main__.py
@@ -103,7 +103,6 @@ class GraplStack:
         self.redis_endpoint = require_str("redis-endpoint")
         self.schema_properties_table_name = require_str("schema-properties-table")
         self.schema_table_name = require_str("schema-table")
-        self.sysmon_log_bucket = require_str("sysmon-log-bucket")
         self.test_user_name = require_str("test-user-name")
 
         self.plugin_work_queue_db = cast(


### PR DESCRIPTION
The bucket was removed, but the references remained.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
