### PR TITLE
use "client-executor" for Generator client

### DIFF
--- a/src/rust/generator-dispatcher/src/generator_ids_cache.rs
+++ b/src/rust/generator-dispatcher/src/generator_ids_cache.rs
@@ -18,9 +18,9 @@ use rust_proto::{
     graplinc::grapl::api::plugin_registry::v1beta1::{
         GetGeneratorsForEventSourceRequest,
         GetGeneratorsForEventSourceResponse,
-        PluginRegistryServiceClientError,
     },
     protocol::{
+        error::GrpcClientError,
         service_client::ConnectError,
         status::{
             Code,
@@ -118,7 +118,7 @@ impl GeneratorIdsCache {
                                 Ok(response) => {
                                     response.plugin_ids().to_vec()
                                 },
-                                Err(PluginRegistryServiceClientError::ErrorStatus(Status {
+                                Err(GrpcClientError::ErrorStatus(Status {
                                     code: Code::NotFound,
                                     ..
                                 })) => {
@@ -135,7 +135,7 @@ impl GeneratorIdsCache {
                                     // exponential backoff with jitter, capped
                                     // at 5s.
 
-                                    let mut result: Result<GetGeneratorsForEventSourceResponse, PluginRegistryServiceClientError> = Err(e);
+                                    let mut result: Result<GetGeneratorsForEventSourceResponse, GrpcClientError> = Err(e);
                                     let mut n = 0;
                                     while let Err(ref e) = result {
                                         n += 1;

--- a/src/rust/plugin-execution-sidecar/src/work/plugin_work_processor.rs
+++ b/src/rust/plugin-execution-sidecar/src/work/plugin_work_processor.rs
@@ -1,12 +1,10 @@
 use rust_proto::{
-    graplinc::grapl::api::{
-        plugin_sdk::generators::v1beta1::client::GeneratorServiceClientError,
-        plugin_work_queue::v1beta1::{
-            ExecutionJob,
-            PluginWorkQueueServiceClient,
-            PluginWorkQueueServiceClientError,
-        },
+    graplinc::grapl::api::plugin_work_queue::v1beta1::{
+        ExecutionJob,
+        PluginWorkQueueServiceClient,
+        PluginWorkQueueServiceClientError,
     },
+    protocol::error::GrpcClientError,
     SerDe,
 };
 use uuid::Uuid;
@@ -19,8 +17,8 @@ pub type RequestId = i64;
 pub enum PluginWorkProcessorError {
     #[error("PluginWorkQueueServiceClientError {0}")]
     PluginWorkQueueServiceClientError(#[from] PluginWorkQueueServiceClientError),
-    #[error("GeneratorServiceClientError {0}")]
-    GeneratorServiceClientError(#[from] GeneratorServiceClientError),
+    #[error("GrpcClientError {0}")]
+    GrpcClientError(#[from] GrpcClientError),
     // Likely want one for Analyzer as well once that SDK exists
     #[error("ProcessJob {0}")]
     ProcessJob(String),

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -17,10 +17,12 @@ use rust_proto::{
         PluginHealthStatus,
         PluginMetadata,
         PluginRegistryServiceClient,
-        PluginRegistryServiceClientError,
         PluginType,
     },
-    protocol::status::Code,
+    protocol::{
+        error::GrpcClientError,
+        status::Code,
+    },
 };
 
 pub const SMALL_TEST_BINARY: &'static [u8] = include_bytes!("./small_test_binary.sh");
@@ -165,7 +167,7 @@ async fn test_deploy_plugin_but_plugin_id_doesnt_exist() -> Result<(), Box<dyn s
         .await?;
 
     match response {
-        Err(PluginRegistryServiceClientError::ErrorStatus(s)) => {
+        Err(GrpcClientError::ErrorStatus(s)) => {
             assert_eq!(s.code(), Code::NotFound);
             assert_contains(s.message(), &sqlx::Error::RowNotFound.to_string());
         }

--- a/src/rust/plugin-registry/tests/test_get_analyzers_for_tenant.rs
+++ b/src/rust/plugin-registry/tests/test_get_analyzers_for_tenant.rs
@@ -12,10 +12,12 @@ use rust_proto::{
     graplinc::grapl::api::plugin_registry::v1beta1::{
         GetAnalyzersForTenantRequest,
         PluginMetadata,
-        PluginRegistryServiceClientError,
         PluginType,
     },
-    protocol::status::Code,
+    protocol::{
+        error::GrpcClientError,
+        status::Code,
+    },
 };
 
 #[test_log::test(tokio::test)]
@@ -137,7 +139,7 @@ async fn test_get_analyzers_for_tenant_not_found() -> Result<(), Box<dyn std::er
         .await?
     {
         match e {
-            PluginRegistryServiceClientError::ErrorStatus(s) => {
+            GrpcClientError::ErrorStatus(s) => {
                 if let Code::NotFound = s.code() {
                     Ok(()) // 👍 great success 👍
                 } else {

--- a/src/rust/plugin-registry/tests/test_get_generators_for_event_source.rs
+++ b/src/rust/plugin-registry/tests/test_get_generators_for_event_source.rs
@@ -12,10 +12,12 @@ use rust_proto::{
     graplinc::grapl::api::plugin_registry::v1beta1::{
         GetGeneratorsForEventSourceRequest,
         PluginMetadata,
-        PluginRegistryServiceClientError,
         PluginType,
     },
-    protocol::status::Code,
+    protocol::{
+        error::GrpcClientError,
+        status::Code,
+    },
 };
 
 #[test_log::test(tokio::test)]
@@ -137,7 +139,7 @@ async fn test_get_generators_for_event_source_not_found() -> Result<(), Box<dyn 
         .await?
     {
         match e {
-            PluginRegistryServiceClientError::ErrorStatus(s) => {
+            GrpcClientError::ErrorStatus(s) => {
                 if let Code::NotFound = s.code() {
                     Ok(()) // 👍 great success 👍
                 } else {

--- a/src/rust/plugin-sdk/generator-sdk/src/test_utils/test_ctx.rs
+++ b/src/rust/plugin-sdk/generator-sdk/src/test_utils/test_ctx.rs
@@ -1,8 +1,7 @@
 use rust_proto::{
     client_factory::{
-        build_grpc_client_with_options,
+        build_grpc_client,
         services::GeneratorClientConfig,
-        BuildGrpcClientOptions,
     },
     graplinc::{
         common::v1beta1::Duration,
@@ -90,15 +89,7 @@ impl GeneratorTestContextInternals {
         let client_config = GeneratorClientConfig {
             generator_client_address: endpoint,
         };
-        let client = build_grpc_client_with_options(
-            client_config,
-            BuildGrpcClientOptions {
-                perform_healthcheck: true,
-                healthcheck_polling_interval: Duration::from_millis(10),
-            },
-        )
-        .await
-        .unwrap();
+        let client = build_grpc_client(client_config).await.unwrap();
 
         GeneratorTestContextInternals {
             client,

--- a/src/rust/rust-proto/src/client_macros.rs
+++ b/src/rust/rust-proto/src/client_macros.rs
@@ -48,12 +48,12 @@ macro_rules! execute_client_rpc {
     }};
 }
 
-/// This macro implements boilerplace code to connect to
+/// This macro implements boilerplate code to connect to
 /// a gRPC service (and do retries if needed).
 /// Unfortunately, each $proto_client_type doesn't share traits, so a
 /// macro is the quickest solution.
 #[macro_export]
-macro_rules! get_proto_client {
+macro_rules! create_proto_client {
     (
         $executor: ident,
         $proto_client_type: ty,

--- a/src/rust/rust-proto/src/client_macros.rs
+++ b/src/rust/rust-proto/src/client_macros.rs
@@ -31,7 +31,9 @@ macro_rules! execute_client_rpc {
             let proto_response = $self
                 .executor
                 .spawn_conditional(
-                    backoff.map(jitter).take(num_retries),
+                    backoff
+                        .map(client_executor::strategy::jitter)
+                        .take(num_retries),
                     || {
                         let mut proto_client = $self.proto_client.clone();
                         let proto_request = proto_request.clone();
@@ -42,6 +44,41 @@ macro_rules! execute_client_rpc {
                 .await?;
             let native_response = <$native_response_type>::try_from(proto_response.into_inner())?;
             Ok(native_response)
+        }
+    }};
+}
+
+/// This macro implements boilerplace code to connect to
+/// a gRPC service (and do retries if needed).
+/// Unfortunately, each $proto_client_type doesn't share traits, so a
+/// macro is the quickest solution.
+#[macro_export]
+macro_rules! get_proto_client {
+    (
+        $executor: ident,
+        $proto_client_type: ty,
+        $endpoint: ident,
+    ) => {{
+        {
+            let backoff = client_executor::strategy::FibonacciBackoff::from_millis(10);
+            let num_retries = 20;
+
+            let proto_client = $executor
+                .spawn(
+                    backoff
+                        .map(client_executor::strategy::jitter)
+                        .take(num_retries),
+                    || {
+                        let endpoint = $endpoint.clone();
+                        async move {
+                            <$proto_client_type>::connect(endpoint)
+                                .await
+                                .map_err(ConnectError::from)
+                        }
+                    },
+                )
+                .await?;
+            proto_client
         }
     }};
 }

--- a/src/rust/rust-proto/src/client_macros.rs
+++ b/src/rust/rust-proto/src/client_macros.rs
@@ -16,11 +16,9 @@ macro_rules! execute_client_rpc {
         $native_response_type: ty,
     ) => {{
         {
-            // Taking fib sequence 10 times:
-            // 1 + 1 + 2 + 3 + 5 + 8 + 13 + 21 + 34 + 55 = 143
-            // We're arbitrarily selecting 5000ms as a maximum delay, so we'll
-            // choose 5000/143 as our starter, that's 35
-            let backoff = client_executor::strategy::FibonacciBackoff::from_millis(35);
+            let backoff = client_executor::strategy::FibonacciBackoff::from_millis(100)
+                .max_delay(Duration::from_millis(5000))
+                .map(client_executor::strategy::jitter);
             let num_retries = 10;
 
             let proto_request = <$proto_request_type>::try_from($native_request)?;
@@ -35,9 +33,7 @@ macro_rules! execute_client_rpc {
             let proto_response = $self
                 .executor
                 .spawn_conditional(
-                    backoff
-                        .map(client_executor::strategy::jitter)
-                        .take(num_retries),
+                    backoff.take(num_retries),
                     || {
                         let mut proto_client = $self.proto_client.clone();
                         let proto_request = proto_request.clone();
@@ -64,27 +60,20 @@ macro_rules! create_proto_client {
         $endpoint: ident,
     ) => {{
         {
-            // Taking fib sequence 10 times:
-            // 1 + 1 + 2 + 3 + 5 + 8 + 13 + 21 + 34 + 55 = 143
-            // We're arbitrarily selecting 5000ms as a maximum delay, so we'll
-            // choose 5000/143 as our starter, that's 35
-            let backoff = client_executor::strategy::FibonacciBackoff::from_millis(35);
+            let backoff = client_executor::strategy::FibonacciBackoff::from_millis(100)
+                .max_delay(Duration::from_millis(5000))
+                .map(client_executor::strategy::jitter);
             let num_retries = 10;
 
             let proto_client = $executor
-                .spawn(
-                    backoff
-                        .map(client_executor::strategy::jitter)
-                        .take(num_retries),
-                    || {
-                        let endpoint = $endpoint.clone();
-                        async move {
-                            <$proto_client_type>::connect(endpoint)
-                                .await
-                                .map_err(ConnectError::from)
-                        }
-                    },
-                )
+                .spawn(backoff.take(num_retries), || {
+                    let endpoint = $endpoint.clone();
+                    async move {
+                        <$proto_client_type>::connect(endpoint)
+                            .await
+                            .map_err(ConnectError::from)
+                    }
+                })
                 .await?;
             proto_client
         }

--- a/src/rust/rust-proto/src/client_macros.rs
+++ b/src/rust/rust-proto/src/client_macros.rs
@@ -16,7 +16,11 @@ macro_rules! execute_client_rpc {
         $native_response_type: ty,
     ) => {{
         {
-            let backoff = client_executor::strategy::FibonacciBackoff::from_millis(100);
+            // Taking fib sequence 10 times:
+            // 1 + 1 + 2 + 3 + 5 + 8 + 13 + 21 + 34 + 55 = 143
+            // We're arbitrarily selecting 5000ms as a maximum delay, so we'll
+            // choose 5000/143 as our starter, that's 35
+            let backoff = client_executor::strategy::FibonacciBackoff::from_millis(35);
             let num_retries = 10;
 
             let proto_request = <$proto_request_type>::try_from($native_request)?;
@@ -60,8 +64,12 @@ macro_rules! create_proto_client {
         $endpoint: ident,
     ) => {{
         {
-            let backoff = client_executor::strategy::FibonacciBackoff::from_millis(10);
-            let num_retries = 20;
+            // Taking fib sequence 10 times:
+            // 1 + 1 + 2 + 3 + 5 + 8 + 13 + 21 + 34 + 55 = 143
+            // We're arbitrarily selecting 5000ms as a maximum delay, so we'll
+            // choose 5000/143 as our starter, that's 35
+            let backoff = client_executor::strategy::FibonacciBackoff::from_millis(35);
+            let num_retries = 10;
 
             let proto_client = $executor
                 .spawn(

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
@@ -4,10 +4,7 @@ use bytes::Bytes;
 use proto::create_plugin_request;
 
 pub use crate::graplinc::grapl::api::plugin_registry::{
-    v1beta1_client::{
-        PluginRegistryServiceClient,
-        PluginRegistryServiceClientError,
-    },
+    v1beta1_client::PluginRegistryServiceClient,
     v1beta1_server::{
         PluginRegistryApi,
         PluginRegistryServer,

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -12,8 +12,8 @@ use futures::{
 use proto::plugin_registry_service_client::PluginRegistryServiceClient as PluginRegistryServiceClientProto;
 
 use crate::{
+    create_proto_client,
     execute_client_rpc,
-    get_proto_client,
     graplinc::grapl::api::plugin_registry::v1beta1 as native,
     protobufs::graplinc::grapl::api::plugin_registry::v1beta1 as proto,
     protocol::{
@@ -41,7 +41,7 @@ impl Connectable for PluginRegistryServiceClient {
     #[tracing::instrument(err)]
     async fn connect(endpoint: Endpoint) -> Result<Self, ConnectError> {
         let executor = Executor::new(ExecutorConfig::new(Duration::from_secs(30)));
-        let proto_client = get_proto_client!(
+        let proto_client = create_proto_client!(
             executor,
             PluginRegistryServiceClientProto<tonic::transport::Channel>,
             endpoint,

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -1,8 +1,4 @@
-use std::{
-    convert::Infallible,
-    fmt::Debug,
-    time::Duration,
-};
+use std::time::Duration;
 
 use bytes::Bytes;
 use client_executor::{
@@ -22,47 +18,14 @@ use crate::{
     protobufs::graplinc::grapl::api::plugin_registry::v1beta1 as proto,
     protocol::{
         endpoint::Endpoint,
+        error::GrpcClientError,
         service_client::{
             ConnectError,
             Connectable,
         },
         status::Status,
     },
-    SerDeError,
 };
-
-// TODO It looks like *ClientError is basically duplicated everywhere, we could
-// simplify and have GrpcClientError or something
-#[derive(Debug, thiserror::Error)]
-pub enum PluginRegistryServiceClientError {
-    #[error("ErrorStatus {0}")]
-    ErrorStatus(#[from] Status),
-    #[error("PluginRegistryDeserializationError {0}")]
-    PluginRegistryDeserializationError(#[from] SerDeError),
-    #[error("CircuitOpen")]
-    CircuitOpen,
-    #[error("Timeout")]
-    Elapsed,
-}
-
-// A compatibility layer for using
-// TryFrom<Error = SerDeError>
-// in place of From.
-impl From<Infallible> for PluginRegistryServiceClientError {
-    fn from(_: Infallible) -> Self {
-        unreachable!()
-    }
-}
-
-impl From<client_executor::Error<tonic::Status>> for PluginRegistryServiceClientError {
-    fn from(e: client_executor::Error<tonic::Status>) -> Self {
-        match e {
-            client_executor::Error::Inner(e) => Self::ErrorStatus(e.into()),
-            client_executor::Error::Rejected => Self::CircuitOpen,
-            client_executor::Error::Elapsed => Self::Elapsed,
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct PluginRegistryServiceClient {
@@ -98,7 +61,7 @@ impl PluginRegistryServiceClient {
     pub async fn create_plugin_raw<S>(
         &mut self,
         request: S,
-    ) -> Result<native::CreatePluginResponse, PluginRegistryServiceClientError>
+    ) -> Result<native::CreatePluginResponse, GrpcClientError>
     where
         S: Stream<Item = native::CreatePluginRequest> + Send + 'static,
     {
@@ -117,7 +80,7 @@ impl PluginRegistryServiceClient {
         &mut self,
         metadata: native::PluginMetadata,
         plugin_artifact: S,
-    ) -> Result<native::CreatePluginResponse, PluginRegistryServiceClientError>
+    ) -> Result<native::CreatePluginResponse, GrpcClientError>
     where
         S: Stream<Item = Bytes> + Send + 'static,
     {
@@ -134,7 +97,7 @@ impl PluginRegistryServiceClient {
     pub async fn get_plugin(
         &mut self,
         request: native::GetPluginRequest,
-    ) -> Result<native::GetPluginResponse, PluginRegistryServiceClientError> {
+    ) -> Result<native::GetPluginResponse, GrpcClientError> {
         execute_client_rpc!(
             self,
             request,
@@ -148,7 +111,7 @@ impl PluginRegistryServiceClient {
     pub async fn deploy_plugin(
         &mut self,
         request: native::DeployPluginRequest,
-    ) -> Result<native::DeployPluginResponse, PluginRegistryServiceClientError> {
+    ) -> Result<native::DeployPluginResponse, GrpcClientError> {
         execute_client_rpc!(
             self,
             request,
@@ -162,7 +125,7 @@ impl PluginRegistryServiceClient {
     pub async fn tear_down_plugin(
         &mut self,
         request: native::TearDownPluginRequest,
-    ) -> Result<native::TearDownPluginResponse, PluginRegistryServiceClientError> {
+    ) -> Result<native::TearDownPluginResponse, GrpcClientError> {
         execute_client_rpc!(
             self,
             request,
@@ -175,7 +138,7 @@ impl PluginRegistryServiceClient {
     pub async fn get_plugin_health(
         &mut self,
         request: native::GetPluginHealthRequest,
-    ) -> Result<native::GetPluginHealthResponse, PluginRegistryServiceClientError> {
+    ) -> Result<native::GetPluginHealthResponse, GrpcClientError> {
         execute_client_rpc!(
             self,
             request,
@@ -190,7 +153,7 @@ impl PluginRegistryServiceClient {
     pub async fn get_generators_for_event_source(
         &mut self,
         request: native::GetGeneratorsForEventSourceRequest,
-    ) -> Result<native::GetGeneratorsForEventSourceResponse, PluginRegistryServiceClientError> {
+    ) -> Result<native::GetGeneratorsForEventSourceResponse, GrpcClientError> {
         execute_client_rpc!(
             self,
             request,
@@ -204,7 +167,7 @@ impl PluginRegistryServiceClient {
     pub async fn get_analyzers_for_tenant(
         &mut self,
         request: native::GetAnalyzersForTenantRequest,
-    ) -> Result<native::GetAnalyzersForTenantResponse, PluginRegistryServiceClientError> {
+    ) -> Result<native::GetAnalyzersForTenantResponse, GrpcClientError> {
         execute_client_rpc!(
             self,
             request,

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/generators/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/generators/v1beta1/client.rs
@@ -1,8 +1,4 @@
-use std::{
-    convert::Infallible,
-    fmt::Debug,
-    time::Duration,
-};
+use std::time::Duration;
 
 use client_executor::{
     Executor,
@@ -18,47 +14,13 @@ use crate::{
     protobufs::graplinc::grapl::api::plugin_sdk::generators::v1beta1 as proto,
     protocol::{
         endpoint::Endpoint,
+        error::GrpcClientError,
         service_client::{
             ConnectError,
             Connectable,
         },
-        status::Status,
     },
-    SerDeError,
 };
-
-// TODO It looks like *ClientError is basically duplicated everywhere, we could
-// simplify and have GrpcClientError or something
-#[derive(Debug, thiserror::Error)]
-pub enum GeneratorServiceClientError {
-    #[error("ErrorStatus")]
-    ErrorStatus(#[from] Status),
-    #[error("PluginRegistryDeserializationError")]
-    GeneratorDeserializationError(#[from] SerDeError),
-    #[error("CircuitOpen")]
-    CircuitOpen,
-    #[error("Timeout")]
-    Elapsed,
-}
-
-// A compatibility layer for using
-// TryFrom<Error = SerDeError>
-// in place of From.
-impl From<Infallible> for GeneratorServiceClientError {
-    fn from(_: Infallible) -> Self {
-        unreachable!()
-    }
-}
-
-impl From<client_executor::Error<tonic::Status>> for GeneratorServiceClientError {
-    fn from(e: client_executor::Error<tonic::Status>) -> Self {
-        match e {
-            client_executor::Error::Inner(e) => Self::ErrorStatus(e.into()),
-            client_executor::Error::Rejected => Self::CircuitOpen,
-            client_executor::Error::Elapsed => Self::Elapsed,
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct GeneratorServiceClient {
@@ -89,7 +51,7 @@ impl GeneratorServiceClient {
     pub async fn run_generator(
         &mut self,
         request: native::RunGeneratorRequest,
-    ) -> Result<native::RunGeneratorResponse, GeneratorServiceClientError> {
+    ) -> Result<native::RunGeneratorResponse, GrpcClientError> {
         execute_client_rpc!(
             self,
             request,

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/generators/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/generators/v1beta1/client.rs
@@ -8,8 +8,8 @@ use generator_service_client::GeneratorServiceClient as GeneratorServiceClientPr
 
 pub use crate::protobufs::graplinc::grapl::api::plugin_sdk::generators::v1beta1::generator_service_client;
 use crate::{
+    create_proto_client,
     execute_client_rpc,
-    get_proto_client,
     graplinc::grapl::api::plugin_sdk::generators::v1beta1 as native,
     protobufs::graplinc::grapl::api::plugin_sdk::generators::v1beta1 as proto,
     protocol::{
@@ -35,7 +35,7 @@ impl Connectable for GeneratorServiceClient {
     #[tracing::instrument(err)]
     async fn connect(endpoint: Endpoint) -> Result<Self, ConnectError> {
         let executor = Executor::new(ExecutorConfig::new(Duration::from_secs(30)));
-        let proto_client = get_proto_client!(
+        let proto_client = create_proto_client!(
             executor,
             GeneratorServiceClientProto<tonic::transport::Channel>,
             endpoint,

--- a/src/rust/rust-proto/src/protocol/error.rs
+++ b/src/rust/rust-proto/src/protocol/error.rs
@@ -1,3 +1,5 @@
+use std::convert::Infallible;
+
 use thiserror::Error;
 
 #[non_exhaustive]
@@ -5,4 +7,35 @@ use thiserror::Error;
 pub enum ServeError {
     #[error("encountered tonic error {0}")]
     TransportError(#[from] tonic::transport::Error),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GrpcClientError {
+    #[error("ErrorStatus")]
+    ErrorStatus(#[from] crate::protocol::status::Status),
+    #[error("SerDeError")]
+    SerDeError(#[from] crate::SerDeError),
+    #[error("CircuitOpen")]
+    CircuitOpen,
+    #[error("Timeout")]
+    Elapsed,
+}
+
+// A compatibility layer for using
+// TryFrom<Error = SerDeError>
+// in place of From.
+impl From<Infallible> for GrpcClientError {
+    fn from(_: Infallible) -> Self {
+        unreachable!()
+    }
+}
+
+impl From<client_executor::Error<tonic::Status>> for GrpcClientError {
+    fn from(e: client_executor::Error<tonic::Status>) -> Self {
+        match e {
+            client_executor::Error::Inner(e) => Self::ErrorStatus(e.into()),
+            client_executor::Error::Rejected => Self::CircuitOpen,
+            client_executor::Error::Elapsed => Self::Elapsed,
+        }
+    }
 }


### PR DESCRIPTION
https://github.com/grapl-security/grapl/pull/1872 introduced the client-executor crate, and introduced using it for plugin-registry. Now I'm porting generator to it.

I made a macro that deduplicates some boilerplate for the "get a proto client" stuff.

in the course of adding this to generator I realized the error types were exactly the same, so, I standardized. 