### PR TITLE
Move most RPCs tonic error types to Unknown, not Internal. Let each RPC specify which statuscode to retry on.

### DIFF
--- a/src/rust/event-source/src/error.rs
+++ b/src/rust/event-source/src/error.rs
@@ -10,6 +10,6 @@ pub enum EventSourceError {
 
 impl From<EventSourceError> for Status {
     fn from(e: EventSourceError) -> Self {
-        Status::internal(e.to_string())
+        Status::unknown(e.to_string())
     }
 }

--- a/src/rust/generators/sysmon-generator/src/error.rs
+++ b/src/rust/generators/sysmon-generator/src/error.rs
@@ -39,6 +39,6 @@ impl From<SysmonGeneratorError> for kafka::StreamProcessorError {
 
 impl From<SysmonGeneratorError> for Status {
     fn from(e: SysmonGeneratorError) -> Self {
-        Status::internal(e.to_string())
+        Status::unknown(e.to_string())
     }
 }

--- a/src/rust/organization-management/src/server.rs
+++ b/src/rust/organization-management/src/server.rs
@@ -59,7 +59,8 @@ impl From<argon2::password_hash::Error> for OrganizationManagementServiceError {
 impl From<OrganizationManagementServiceError> for Status {
     fn from(e: OrganizationManagementServiceError) -> Self {
         match e {
-            OrganizationManagementServiceError::Sql(e) => Status::internal(e.to_string()),
+            OrganizationManagementServiceError::ServeError(e) => Status::internal(e.to_string()),
+            OrganizationManagementServiceError::Sql(e) => Status::unknown(e.to_string()),
             _ => todo!(),
         }
     }

--- a/src/rust/pipeline-ingress/src/main.rs
+++ b/src/rust/pipeline-ingress/src/main.rs
@@ -49,7 +49,7 @@ enum IngressApiError {
 
 impl From<IngressApiError> for Status {
     fn from(e: IngressApiError) -> Self {
-        Status::internal(e.to_string())
+        Status::unknown(e.to_string())
     }
 }
 

--- a/src/rust/plugin-bootstrap/src/server.rs
+++ b/src/rust/plugin-bootstrap/src/server.rs
@@ -29,7 +29,7 @@ pub enum PluginBootstrapError {
 impl From<PluginBootstrapError> for Status {
     fn from(e: PluginBootstrapError) -> Self {
         match e {
-            PluginBootstrapError::IoError(e) => Status::internal(e.to_string()),
+            PluginBootstrapError::IoError(e) => Status::unknown(e.to_string()),
             PluginBootstrapError::ServeError(e) => Status::internal(e.to_string()),
         }
     }

--- a/src/rust/plugin-registry/src/error.rs
+++ b/src/rust/plugin-registry/src/error.rs
@@ -68,30 +68,30 @@ impl From<PluginRegistryServiceError> for Status {
         type Error = PluginRegistryServiceError;
         match err {
             Error::SqlxError(sqlx::Error::Configuration(_)) => {
-                Status::internal("Invalid SQL configuration")
+                Status::unknown("Invalid SQL configuration")
             }
             Error::SqlxError(rnf_error @ sqlx::Error::RowNotFound) => {
                 Status::not_found(rnf_error.to_string())
             }
-            Error::SqlxError(_) => Status::internal("Failed to operate on postgres"),
-            Error::S3PutObjectError(_) => Status::internal("Failed to put s3 object"),
-            Error::S3GetObjectError(_) => Status::internal("Failed to get s3 object"),
-            Error::EmptyObject => Status::internal("S3 Object was unexpectedly empty"),
-            Error::IoError(_) => Status::internal("IoError"),
+            Error::SqlxError(_) => Status::unknown("Failed to operate on postgres"),
+            Error::S3PutObjectError(_) => Status::unknown("Failed to put s3 object"),
+            Error::S3GetObjectError(_) => Status::unknown("Failed to get s3 object"),
+            Error::EmptyObject => Status::unknown("S3 Object was unexpectedly empty"),
+            Error::IoError(_) => Status::unknown("IoError"),
             Error::SerDeError(_) => Status::invalid_argument("Unable to deserialize message"),
             Error::DatabaseSerDeError(_) => {
                 Status::invalid_argument("Unable to deserialize message from database")
             }
-            Error::NomadClientError(_) => Status::internal("Failed RPC with Nomad"),
-            Error::NomadCliError(_) => Status::internal("Failed using Nomad CLI"),
+            Error::NomadClientError(_) => Status::unknown("Failed RPC with Nomad"),
+            Error::NomadCliError(_) => Status::unknown("Failed using Nomad CLI"),
             Error::NomadJobAllocationError => {
-                Status::internal("Unable to allocate Nomad job - it may be out of resources.")
+                Status::unknown("Unable to allocate Nomad job - it may be out of resources.")
             }
             Error::StreamInputError(e) => {
                 // Since it's regarding user input, we can de-anonymize this message
                 Status::invalid_argument(format!("Unexpected input to Stream RPC: {e}"))
             }
-            Error::DeploymentStateError(_) => Status::internal("Deployment state error."),
+            Error::DeploymentStateError(_) => Status::unknown("Deployment state error."),
             Error::NotFound => Status::not_found("not found"),
         }
     }

--- a/src/rust/plugin-sdk/generator-sdk/src/examples/example_generator.rs
+++ b/src/rust/plugin-sdk/generator-sdk/src/examples/example_generator.rs
@@ -39,7 +39,7 @@ pub enum ExampleGeneratorError {
 
 impl From<ExampleGeneratorError> for Status {
     fn from(e: ExampleGeneratorError) -> Self {
-        Status::internal(e.to_string())
+        Status::unknown(e.to_string())
     }
 }
 

--- a/src/rust/plugin-work-queue/src/server.rs
+++ b/src/rust/plugin-work-queue/src/server.rs
@@ -57,8 +57,8 @@ pub enum PluginWorkQueueInitError {
 impl From<PluginWorkQueueError> for Status {
     fn from(err: PluginWorkQueueError) -> Self {
         match err {
-            PluginWorkQueueError::PsqlQueueError(_) => Status::internal("Sql Error"),
-            PluginWorkQueueError::KafkaProducerError(_) => Status::internal("Kafka Produce error"),
+            PluginWorkQueueError::PsqlQueueError(_) => Status::unknown("Sql Error"),
+            PluginWorkQueueError::KafkaProducerError(_) => Status::unknown("Kafka Produce error"),
             PluginWorkQueueError::DeserializationError(_) => {
                 Status::invalid_argument("Invalid argument")
             }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/event_source/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/event_source/v1beta1/client.rs
@@ -6,6 +6,7 @@ use client_executor::{
 };
 
 use crate::{
+    client_macros::ExecuteClientRpcOptions,
     create_proto_client,
     execute_client_rpc,
     graplinc::grapl::api::event_source::v1beta1 as native,
@@ -62,6 +63,7 @@ impl EventSourceServiceClient {
             create_event_source,
             proto::CreateEventSourceRequest,
             native::CreateEventSourceResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 
@@ -75,6 +77,7 @@ impl EventSourceServiceClient {
             update_event_source,
             proto::UpdateEventSourceRequest,
             native::UpdateEventSourceResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 
@@ -88,6 +91,7 @@ impl EventSourceServiceClient {
             get_event_source,
             proto::GetEventSourceRequest,
             native::GetEventSourceResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/organization_management/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/organization_management/v1beta1.rs
@@ -200,6 +200,7 @@ pub mod client {
     };
 
     use crate::{
+        client_macros::ExecuteClientRpcOptions,
         create_proto_client,
         execute_client_rpc,
         graplinc::grapl::api::organization_management::v1beta1 as native,
@@ -255,6 +256,7 @@ pub mod client {
                 create_organization,
                 proto::CreateOrganizationRequest,
                 native::CreateOrganizationResponse,
+                ExecuteClientRpcOptions::default(),
             )
         }
 
@@ -268,6 +270,7 @@ pub mod client {
                 create_user,
                 proto::CreateUserRequest,
                 native::CreateUserResponse,
+                ExecuteClientRpcOptions::default(),
             )
         }
     }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/pipeline_ingress/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/pipeline_ingress/v1beta1/client.rs
@@ -6,6 +6,7 @@ use client_executor::{
 };
 
 use crate::{
+    client_macros::ExecuteClientRpcOptions,
     create_proto_client,
     execute_client_rpc,
     protocol::{
@@ -65,6 +66,7 @@ impl PipelineIngressClient {
             publish_raw_log,
             proto::PublishRawLogRequest,
             native::PublishRawLogResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -12,6 +12,7 @@ use futures::{
 use proto::plugin_registry_service_client::PluginRegistryServiceClient as PluginRegistryServiceClientProto;
 
 use crate::{
+    client_macros::ExecuteClientRpcOptions,
     create_proto_client,
     execute_client_rpc,
     graplinc::grapl::api::plugin_registry::v1beta1 as native,
@@ -104,6 +105,7 @@ impl PluginRegistryServiceClient {
             get_plugin,
             proto::GetPluginRequest,
             native::GetPluginResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 
@@ -118,6 +120,7 @@ impl PluginRegistryServiceClient {
             deploy_plugin,
             proto::DeployPluginRequest,
             native::DeployPluginResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 
@@ -132,6 +135,7 @@ impl PluginRegistryServiceClient {
             tear_down_plugin,
             proto::TearDownPluginRequest,
             native::TearDownPluginResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 
@@ -145,6 +149,7 @@ impl PluginRegistryServiceClient {
             get_plugin_health,
             proto::GetPluginHealthRequest,
             native::GetPluginHealthResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 
@@ -160,6 +165,7 @@ impl PluginRegistryServiceClient {
             get_generators_for_event_source,
             proto::GetGeneratorsForEventSourceRequest,
             native::GetGeneratorsForEventSourceResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 
@@ -174,6 +180,7 @@ impl PluginRegistryServiceClient {
             get_analyzers_for_tenant,
             proto::GetAnalyzersForTenantRequest,
             native::GetAnalyzersForTenantResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_server.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_server.rs
@@ -122,7 +122,7 @@ where
                     let req = req?.try_into()?;
                     tx.send(req)
                         .await
-                        .map_err(|e| Status::internal(e.to_string()))?;
+                        .map_err(|e| Status::unknown(e.to_string()))?;
                 }
                 Ok(())
             } as Result<(), Status>)

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/generators/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/generators/v1beta1/client.rs
@@ -8,6 +8,7 @@ use generator_service_client::GeneratorServiceClient as GeneratorServiceClientPr
 
 pub use crate::protobufs::graplinc::grapl::api::plugin_sdk::generators::v1beta1::generator_service_client;
 use crate::{
+    client_macros::ExecuteClientRpcOptions,
     create_proto_client,
     execute_client_rpc,
     graplinc::grapl::api::plugin_sdk::generators::v1beta1 as native,
@@ -58,6 +59,7 @@ impl GeneratorServiceClient {
             run_generator,
             proto::RunGeneratorRequest,
             native::RunGeneratorResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1_client.rs
@@ -7,6 +7,7 @@ use client_executor::{
 use proto::plugin_work_queue_service_client::PluginWorkQueueServiceClient as PluginWorkQueueServiceClientProto;
 
 use crate::{
+    client_macros::ExecuteClientRpcOptions,
     create_proto_client,
     execute_client_rpc,
     graplinc::grapl::api::plugin_work_queue::v1beta1 as native,
@@ -63,6 +64,7 @@ impl PluginWorkQueueServiceClient {
             push_execute_generator,
             proto::PushExecuteGeneratorRequest,
             native::PushExecuteGeneratorResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 
@@ -78,6 +80,7 @@ impl PluginWorkQueueServiceClient {
             push_execute_analyzer,
             proto::PushExecuteAnalyzerRequest,
             native::PushExecuteAnalyzerResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 
@@ -93,6 +96,7 @@ impl PluginWorkQueueServiceClient {
             get_execute_generator,
             proto::GetExecuteGeneratorRequest,
             native::GetExecuteGeneratorResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 
@@ -108,6 +112,7 @@ impl PluginWorkQueueServiceClient {
             get_execute_analyzer,
             proto::GetExecuteAnalyzerRequest,
             native::GetExecuteAnalyzerResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 
@@ -123,6 +128,7 @@ impl PluginWorkQueueServiceClient {
             acknowledge_generator,
             proto::AcknowledgeGeneratorRequest,
             native::AcknowledgeGeneratorResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 
@@ -138,6 +144,7 @@ impl PluginWorkQueueServiceClient {
             acknowledge_analyzer,
             proto::AcknowledgeAnalyzerRequest,
             native::AcknowledgeAnalyzerResponse,
+            ExecuteClientRpcOptions::default(),
         )
     }
 }

--- a/src/rust/rust-proto/tests/pipeline_ingress_grpc_tests.rs
+++ b/src/rust/rust-proto/tests/pipeline_ingress_grpc_tests.rs
@@ -75,7 +75,7 @@ enum MockPipelineIngressApiError {
 
 impl From<MockPipelineIngressApiError> for Status {
     fn from(e: MockPipelineIngressApiError) -> Self {
-        Status::internal(e.to_string())
+        Status::unknown(e.to_string())
     }
 }
 


### PR DESCRIPTION
As discussed around here: https://grapl-internal.slack.com/archives/C03JNJ57A9G/p1660317993208369

I arbitrarily decided to just do it based on Code; you're _RARELY_ looking at any other property of a Status. Like if you have to inspect the message, that seems bad