### PR TITLE
Use different images for analyzer and generator sidecars. (analyzer exec sidecar not done yet!)

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -1195,10 +1195,11 @@ job "grapl-core" {
         PLUGIN_REGISTRY_KERNEL_ARTIFACT_URL             = var.plugin_registry_kernel_artifact_url
         PLUGIN_REGISTRY_ROOTFS_ARTIFACT_URL             = var.plugin_registry_rootfs_artifact_url
         PLUGIN_REGISTRY_HAX_DOCKER_PLUGIN_RUNTIME_IMAGE = var.container_images["hax-docker-plugin-runtime"]
-        PLUGIN_EXECUTION_IMAGE                          = var.container_images["generator-execution-sidecar"] # TODO: add support for analyzer too
         PLUGIN_REGISTRY_BUCKET_AWS_ACCOUNT_ID           = var.plugin_registry_bucket_aws_account_id
         PLUGIN_REGISTRY_BUCKET_NAME                     = var.plugin_registry_bucket_name
         PLUGIN_EXECUTION_OBSERVABILITY_ENV_VARS         = var.observability_env_vars
+        PLUGIN_EXECUTION_GENERATOR_SIDECAR_IMAGE        = var.container_images["generator-execution-sidecar"]
+        PLUGIN_EXECUTION_ANALYZER_SIDECAR_IMAGE         = var.container_images["analyzer-execution-sidecar"]
 
         # common Rust env vars
         RUST_BACKTRACE = local.rust_backtrace

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -65,7 +65,7 @@ def _container_images(artifacts: ArtifactGetter) -> Mapping[str, DockerImageId]:
     )
 
     return {
-        "analzyer-execution-sidecar": builder.build_with_tag(
+        "analyzer-execution-sidecar": builder.build_with_tag(
             "TODO implement analzyer executor"
         ),
         "dgraph": DockerImageId("dgraph/dgraph:v21.03.1"),

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -65,6 +65,9 @@ def _container_images(artifacts: ArtifactGetter) -> Mapping[str, DockerImageId]:
     )
 
     return {
+        "analzyer-execution-sidecar": builder.build_with_tag(
+            "TODO implement analzyer executor"
+        ),
         "dgraph": DockerImageId("dgraph/dgraph:v21.03.1"),
         "engagement-creator": builder.build_with_tag("engagement-creator"),
         "event-source": builder.build_with_tag("event-source"),

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -178,7 +178,6 @@ mod tests {
             hax_docker_plugin_runtime_image: Default::default(),
             kernel_artifact_url: Default::default(),
             plugin_bootstrap_container_image: Default::default(),
-            plugin_execution_image: Default::default(),
             bucket_aws_account_id: Default::default(),
             bucket_name: Default::default(),
             rootfs_artifact_url: Default::default(),

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -56,6 +56,11 @@ pub fn get_job(
         get_s3_url(bucket, key)
     };
     let passthru = service_config.passthrough_vars;
+    let plugin_execution_sidecar_image = match plugin_type {
+        PluginType::Generator => passthru.generator_sidecar_image,
+        PluginType::Analyzer => passthru.analyzer_sidecar_image,
+    }
+    .to_string();
     match plugin_runtime {
         PluginRuntime::HaxDocker => {
             let job_file_hcl = static_files::HAX_DOCKER_PLUGIN_JOB;
@@ -67,8 +72,8 @@ pub fn get_job(
                     service_config.hax_docker_plugin_runtime_image,
                 ),
                 (
-                    "plugin_execution_image",
-                    service_config.plugin_execution_image,
+                    "plugin_execution_sidecar_image",
+                    plugin_execution_sidecar_image,
                 ),
                 ("plugin_id", plugin.plugin_id.to_string()),
                 ("tenant_id", plugin.tenant_id.to_string()),

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -62,8 +62,7 @@ pub fn get_job(
     let plugin_execution_sidecar_image = match plugin_type {
         PluginType::Generator => passthru.generator_sidecar_image,
         PluginType::Analyzer => passthru.analyzer_sidecar_image,
-    }
-    .to_string();
+    };
     match plugin_runtime {
         PluginRuntime::HaxDocker => {
             let job_file_hcl = static_files::HAX_DOCKER_PLUGIN_JOB;

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use nomad_client_gen::models;
+use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::PluginType;
 
 use super::{
     plugin_nomad_job,
@@ -56,6 +57,7 @@ pub fn get_job(
         get_s3_url(bucket, key)
     };
     let passthru = service_config.passthrough_vars;
+    let plugin_type = PluginType::try_from(plugin.plugin_type.as_str()).expect("Unknown plugin-type in DB is bad news");
     let plugin_execution_sidecar_image = match plugin_type {
         PluginType::Generator => passthru.generator_sidecar_image,
         PluginType::Analyzer => passthru.analyzer_sidecar_image,
@@ -96,8 +98,8 @@ pub fn get_job(
                     service_config.plugin_bootstrap_container_image,
                 ),
                 (
-                    "plugin_execution_image",
-                    service_config.plugin_execution_image,
+                    "plugin_execution_sidecar_image",
+                    plugin_execution_sidecar_image,
                 ),
                 ("plugin_id", plugin.plugin_id.to_string()),
                 ("rootfs_artifact_url", service_config.rootfs_artifact_url),

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -57,7 +57,8 @@ pub fn get_job(
         get_s3_url(bucket, key)
     };
     let passthru = service_config.passthrough_vars;
-    let plugin_type = PluginType::try_from(plugin.plugin_type.as_str()).expect("Unknown plugin-type in DB is bad news");
+    let plugin_type = PluginType::try_from(plugin.plugin_type.as_str())
+        .expect("Unknown plugin-type in DB is bad news");
     let plugin_execution_sidecar_image = match plugin_type {
         PluginType::Generator => passthru.generator_sidecar_image,
         PluginType::Analyzer => passthru.analyzer_sidecar_image,

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -98,8 +98,6 @@ pub struct PluginRegistryServiceConfig {
     pub plugin_registry_bind_address: SocketAddr,
     #[clap(long, env)]
     pub plugin_bootstrap_container_image: String,
-    #[clap(long, env)]
-    pub plugin_execution_image: String,
     #[clap(long, env = "PLUGIN_REGISTRY_KERNEL_ARTIFACT_URL")]
     pub kernel_artifact_url: String,
     #[clap(long, env = "PLUGIN_REGISTRY_ROOTFS_ARTIFACT_URL")]
@@ -120,6 +118,11 @@ pub struct PluginRegistryServiceConfig {
 pub struct PluginExecutionPassthroughVars {
     #[clap(long, env = "PLUGIN_EXECUTION_OBSERVABILITY_ENV_VARS")]
     pub observability_env_vars: String,
+    #[clap(long, env = "PLUGIN_EXECUTION_GENERATOR_SIDECAR_IMAGE")]
+    pub generator_sidecar_image: String,
+    #[clap(long, env = "PLUGIN_EXECUTION_ANALYZER_SIDECAR_IMAGE")]
+    pub analyzer_sidecar_image: String,
+
     // Pass through a couple env vars also used for the plugin-registry service
     // Since they're used in both ways - locally for this service, and the
     // spawned plugins - I decided against prefixing PLUGIN_EXECUTION_.

--- a/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
@@ -29,7 +29,7 @@ variable "plugin_runtime_image" {
   description = "The container that will load and run the plugin"
 }
 
-variable "plugin_execution_image" {
+variable "plugin_execution_sidecar_image" {
   type        = string
   description = "The container that will load and run the Generator Executor or Analyzer Executor"
 }
@@ -112,7 +112,7 @@ job "grapl-plugin" {
       driver = "docker"
 
       config {
-        image = var.plugin_execution_image
+        image = var.plugin_execution_sidecar_image
       }
 
       template {

--- a/src/rust/plugin-registry/src/static_files/plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/plugin.nomad
@@ -39,7 +39,7 @@ variable "plugin_bootstrap_container_image" {
   description = "The tenant-plugin-bootstrap-sidecar task's DockerImageId."
 }
 
-variable "plugin_execution_image" {
+variable "plugin_execution_sidecar_image" {
   type        = string
   description = "The tenant-plugin-execution-sidecar task's DockerImageId."
 }
@@ -92,9 +92,8 @@ job "grapl-plugin" {
       }
 
       config {
-        image = var.plugin_execution_image
-        ports = [
-        "plugin_sidecar_grpc_receiver"]
+        image = var.plugin_execution_sidecar_image
+        ports = ["plugin_sidecar_grpc_receiver"]
       }
 
       env {


### PR DESCRIPTION
Previously the generator image was hardcoded; now we'll switch it around based on if the plugin type is Analyzer or Generator.