### PR TITLE
Slice out the rust-proto part of Graph Query Service PR

### DIFF
--- a/src/proto/graplinc/grapl/api/graph_query_service/v1beta1/graph_query_service.proto
+++ b/src/proto/graplinc/grapl/api/graph_query_service/v1beta1/graph_query_service.proto
@@ -1,0 +1,369 @@
+syntax = "proto3";
+
+package graplinc.grapl.api.graph_query_service.v1beta1;
+
+import "graplinc/common/v1beta1/types.proto";
+import "graplinc/grapl/api/graph/v1beta1/types.proto";
+import "graplinc/grapl/common/v1beta1/types.proto";
+
+// IntegerProperty wraps one of the underlying integer property
+// types
+message IntegerProperty {
+  // The inner property
+  oneof property {
+    // An integer that only grows
+    graph.v1beta1.IncrementOnlyIntProp increment_only = 1;
+    // An integer that only shrinks
+    graph.v1beta1.DecrementOnlyIntProp decrement_only = 2;
+    // An integer that never changes after its first write
+    graph.v1beta1.ImmutableIntProp immutable = 3;
+  }
+}
+
+// A filter for querying an integer
+message IntFilter {
+  // The operation to filter with
+  enum Operation {
+    // An unknown operation
+    OPERATION_UNSPECIFIED = 0;
+    // If the property is set at all
+    OPERATION_HAS = 1;
+    // If the property is equal to `value`
+    OPERATION_EQUAL = 2;
+    // If the property is less than `value`
+    OPERATION_LESS_THAN = 3;
+    // If the property is less than or equal to `value`
+    OPERATION_LESS_THAN_OR_EQUAL = 4;
+    // If the property is greater than `value`
+    OPERATION_GREATER_THAN = 5;
+    // If the property is greater than or equal to `value`
+    OPERATION_GREATER_THAN_OR_EQUAL = 6;
+  }
+  // The filter operation to apply
+  Operation operation = 1;
+  // The value to compare against. Unset if operation is `Has`
+  int64 value = 2;
+  // Negation of the operation
+  // defaults to `false`
+  bool negated = 3;
+}
+
+// AndIntFilters represents a group of filters that must all
+// be satisfied in order to match
+message AndIntFilters {
+  // The internal filters
+  repeated IntFilter int_filters = 1;
+}
+
+// `OrIntFilters` represents groups of 'And'ed constraints, of which
+// any group can match.
+message OrIntFilters {
+  // The groups of And filters
+  repeated AndIntFilters and_int_filters = 1;
+}
+
+// `StringFilter` represents a filter against a string property
+message StringFilter {
+  // The operation to apply as a filter
+  enum Operation {
+    // The operation is unspecified
+    OPERATION_UNSPECIFIED = 0;
+    // If the property is set at all
+    OPERATION_HAS = 1;
+    // If the property is equal to `value`
+    OPERATION_EQUAL = 2;
+    // If the property contains `value`
+    OPERATION_CONTAINS = 3;
+    // If the property matches the regex `value`
+    OPERATION_REGEX = 4;
+  }
+  // The operation to apply as a filter
+  Operation operation = 1;
+  // The value to compare against, or an empty string if `Has`
+  string value = 2;
+  // Whether to negate the filter or not
+  // defaults to `false`
+  bool negated = 3;
+}
+
+// A group of StringFilter that must all match to satisfy a query
+message AndStringFilters {
+  // The underlying filters
+  repeated StringFilter string_filters = 1;
+}
+
+// A group of AndStringFilters for which only one group must match
+// in order to satisfy a query
+message OrStringFilters {
+  // The underlying filters
+  repeated AndStringFilters and_string_filters = 1;
+}
+
+// UidFilter represents a filter operation on a `Uid`
+message UidFilter {
+  // The operation to apply
+  enum Operation {
+    // If the operation is unknown or unset
+    OPERATION_UNSPECIFIED = 0;
+    // If the uid property is equal to `value`
+    OPERATION_EQUAL = 1;
+  }
+  // The operation to apply as a filter
+  Operation operation = 1;
+  // The value to compare against
+  graplinc.grapl.common.v1beta1.Uid value = 2;
+}
+
+// The filters to apply, of which if any match the query is satisfied
+message UidFilters {
+  // The underlying uid filters
+  repeated UidFilter uid_filters = 1;
+}
+
+// QueryId is a unique identifier for a node query
+message QueryId {
+  // A non-zero value, guaranteed to be unique within a single query
+  uint64 value = 1;
+}
+
+// A NodePropertyQuery is a group of filters for a node
+// where all filters must match in order for the overall query
+// to be satisfied
+message NodePropertyQuery {
+  // The type of the node
+  graplinc.grapl.common.v1beta1.NodeType node_type = 1;
+  // The unique identifier of this query within an overall GraphQuery
+  QueryId query_id = 2;
+  // A mapping of string property names to OrStringFilters
+  // Note that the key is `string` but when serializing and deserializing
+  // the keys must be treated as PropertyName
+  map<string, OrStringFilters> string_filters = 3;
+  // A mapping of integer property names to OrIntFilters
+  // Note that the key is `string` but when serializing and deserializing
+  // the keys must be treated as PropertyName
+  map<string, OrIntFilters> int_filters = 4;
+  // todo: Add unsigned 64bit property types
+  // The UidFilters
+  UidFilters uid_filters = 5;
+}
+
+// An entry in a map, consisting of composite keys and a value
+// Used in the `EdgeQueryMap`
+message EdgeQueryEntry {
+  // The QueryId for the source of this edge
+  // Part of the key
+  QueryId query_id = 1;
+  // The name of the edge
+  // Part of the key
+  graplinc.grapl.common.v1beta1.EdgeName edge_name = 2;
+  // The QueryIds for destination node queries
+  repeated QueryId neighbor_query_ids = 3;
+}
+
+// A Map of (QueryId, EdgeName) to List[QueryId]
+message EdgeQueryMap {
+  // The underlying map entries, stored as a list
+  repeated EdgeQueryEntry entries = 1;
+}
+
+// An entry in an EdgeNameMap, holding the associated forward
+// and reverse edge names
+message EdgeNameEntry {
+  // The forward edge name
+  // Key
+  graplinc.grapl.common.v1beta1.EdgeName forward_edge_name = 1;
+  // The reverse edge name
+  // Value
+  graplinc.grapl.common.v1beta1.EdgeName reverse_edge_name = 2;
+}
+
+// A Map of EdgeName to associated EdgeName
+message EdgeNameMap {
+  // The underlying map entries, encoded as a list
+  repeated EdgeNameEntry entries = 1;
+}
+
+// An entry in the NodePropertyQueryMap, associating
+// a QueryId with a NodePropertyQuery
+message NodePropertyQueryEntry {
+  // The unique identifier for this NodePropertyQuery
+  // The Key
+  QueryId query_id = 1;
+  // The NodePropertyQuery itself
+  // The value
+  NodePropertyQuery node_property_query = 2;
+}
+
+// `NodePropertyQueryMap` associates `QueryIds` with `NodePropertyQuery`s
+message NodePropertyQueryMap {
+  // The underlying map entries encoded as a list
+  repeated NodePropertyQueryEntry entries = 1;
+}
+
+// A query for a *connected* graph.
+// The server does not define any behavior if the graph query is disjoint,
+// clients should be careful to construct graphs such that they are always
+// connected
+message GraphQuery {
+  // The query id of the "root node". The root node
+  // is used to determine where to start the execution
+  // of the graph as well as to allow the client to associate
+  // this query id with a specific node that gets returned
+  QueryId root_query_id = 1;
+  // Queries for nodes within this graph
+  NodePropertyQueryMap node_property_queries = 2;
+  // Filters on edges between nodes
+  EdgeQueryMap edge_filters = 3;
+  // A mapping of every associated edge name involved in this query
+  EdgeNameMap edge_map = 4;
+}
+
+// StringProperty wraps a property name and its associated string value
+message StringProperty {
+  // The name of this property
+  graplinc.grapl.common.v1beta1.PropertyName property_name = 1;
+  // The value
+  string property_value = 2;
+}
+
+// A map of string property names to string property values
+message StringProperties {
+  // The underlying property entries
+  repeated StringProperty properties = 1;
+}
+
+// IntProperty wraps a property name and its associated integer value
+message IntProperty {
+  // The name of this property
+  graplinc.grapl.common.v1beta1.PropertyName property_name = 1;
+  // The value
+  int64 property_value = 2;
+}
+
+// A map of integer property names to integer values
+message IntProperties {
+  // The underlying property entries
+  repeated IntProperty properties = 1;
+}
+
+// Represents the properties of a node in the graph
+message NodePropertiesView {
+  // The uid of the node
+  graplinc.grapl.common.v1beta1.Uid uid = 1;
+  // The name of the node's type
+  graplinc.grapl.common.v1beta1.NodeType node_type = 2;
+  // The string properties of the node
+  StringProperties string_properties = 3;
+  // Todo: add other property types - int
+}
+
+// An entry in the NodePropertiesViewMap
+message NodePropertiesViewEntry {
+  // The uid of the node
+  // Key
+  graplinc.grapl.common.v1beta1.Uid uid = 1;
+  // The node properties
+  // Value
+  NodePropertiesView node_view = 2;
+}
+
+// A Map of NodePropertyViewEntrys
+message NodePropertiesViewMap {
+  // The underlying entries
+  repeated NodePropertiesViewEntry entries = 1;
+}
+
+// An entry in the EdgeViewMap associating a Uid, EdgeName with
+// its neighbors
+message EdgeViewEntry {
+  // The Uid of the source node
+  // Key
+  graplinc.grapl.common.v1beta1.Uid uid = 1;
+  // The name of the outgoing edge
+  // Key
+  graplinc.grapl.common.v1beta1.EdgeName edge_name = 2;
+  // The neighbors targeted by this edge
+  // Value
+  repeated graplinc.grapl.common.v1beta1.Uid neighbors = 3;
+}
+
+// A Map of (Uid, EdgeName) -> List[Uid]
+message EdgeViewMap {
+  // The underlying entries
+  repeated EdgeViewEntry entries = 1;
+}
+
+// A view of the graph
+message GraphView {
+  // The nodes in the graph
+  NodePropertiesViewMap nodes = 1;
+  // The edges in the graph
+  EdgeViewMap edges = 2;
+}
+
+// A Request to find a graph matching `GraphQuery` where
+// a node in that graph has the uid `node_uid`
+message QueryGraphWithUidRequest {
+  // The tenant id that the graph is associated with
+  graplinc.common.v1beta1.Uuid tenant_id = 1;
+  // The node to parameterize against
+  graplinc.grapl.common.v1beta1.Uid node_uid = 2;
+  // The query to match
+  GraphQuery graph_query = 3;
+}
+
+message MatchedGraphWithUid {
+  // A view of the graph that matched our query
+  GraphView matched_graph = 1;
+  // The uid of the node that corresponds to the "root" query
+  // This is *not* necessarily the `node_uid` from the request
+  graplinc.grapl.common.v1beta1.Uid root_uid = 2;
+}
+
+// Represents a 'miss' for a QueryGraphWithUidRequest
+message NoMatchWithUid {
+  // empty
+}
+
+message MaybeMatchWithUid {
+  // The inner representation
+  oneof inner {
+    MatchedGraphWithUid matched = 1;
+    NoMatchWithUid missed = 2;
+  }
+}
+
+// The Response associated with a QueryGraphWithUidRequest
+// containing a matched graph and the associated uid
+message QueryGraphWithUidResponse {
+  MaybeMatchWithUid maybe_match = 1;
+}
+
+// The QueryGraphFromUidRequest represents a graph query
+// where the `node_uid` and the `graph_query.root_query_id`
+// represent the same node. Used for pivoting from `node_uid`
+// to any connected graphs.
+message QueryGraphFromUidRequest {
+  // The tenant id that the graph is associated with
+  graplinc.common.v1beta1.Uuid tenant_id = 1;
+  // The node to parameterize against
+  graplinc.grapl.common.v1beta1.Uid node_uid = 2;
+  // The query to match
+  GraphQuery graph_query = 3;
+}
+
+// The QueryGraphFromUidResponse contains the graph that matched
+// a QueryGraphFromUidResponse
+message QueryGraphFromUidResponse {
+  // A view of the MergedGraph that matched our query
+  // or None if query did not match
+  GraphView matched_graph = 1;
+}
+
+// GraphQueryService manages read operations against the graph
+service GraphQueryService {
+  // Used to find a node within a graph that matches a query
+  rpc QueryGraphWithUid(QueryGraphWithUidRequest) returns (QueryGraphWithUidResponse);
+  // Performs a query on the node that corresponds to the provided uid as the root
+  rpc QueryGraphFromUid(QueryGraphFromUidRequest) returns (QueryGraphFromUidResponse);
+}

--- a/src/proto/graplinc/grapl/api/graph_query_service/v1beta1/graph_query_service.proto
+++ b/src/proto/graplinc/grapl/api/graph_query_service/v1beta1/graph_query_service.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package graplinc.grapl.api.graph_query_service.v1beta1;
 
 import "graplinc/common/v1beta1/types.proto";
-import "graplinc/grapl/api/graph/v1beta1/types.proto";
 import "graplinc/grapl/common/v1beta1/types.proto";
 
 // A filter for querying an integer

--- a/src/proto/graplinc/grapl/api/graph_query_service/v1beta1/graph_query_service.proto
+++ b/src/proto/graplinc/grapl/api/graph_query_service/v1beta1/graph_query_service.proto
@@ -6,20 +6,6 @@ import "graplinc/common/v1beta1/types.proto";
 import "graplinc/grapl/api/graph/v1beta1/types.proto";
 import "graplinc/grapl/common/v1beta1/types.proto";
 
-// IntegerProperty wraps one of the underlying integer property
-// types
-message IntegerProperty {
-  // The inner property
-  oneof property {
-    // An integer that only grows
-    graph.v1beta1.IncrementOnlyIntProp increment_only = 1;
-    // An integer that only shrinks
-    graph.v1beta1.DecrementOnlyIntProp decrement_only = 2;
-    // An integer that never changes after its first write
-    graph.v1beta1.ImmutableIntProp immutable = 3;
-  }
-}
-
 // A filter for querying an integer
 message IntFilter {
   // The operation to filter with
@@ -230,20 +216,6 @@ message StringProperty {
 message StringProperties {
   // The underlying property entries
   repeated StringProperty properties = 1;
-}
-
-// IntProperty wraps a property name and its associated integer value
-message IntProperty {
-  // The name of this property
-  graplinc.grapl.common.v1beta1.PropertyName property_name = 1;
-  // The value
-  int64 property_value = 2;
-}
-
-// A map of integer property names to integer values
-message IntProperties {
-  // The underlying property entries
-  repeated IntProperty properties = 1;
 }
 
 // Represents the properties of a node in the graph

--- a/src/proto/graplinc/grapl/api/graph_query_service/v1beta1/graph_query_service.proto
+++ b/src/proto/graplinc/grapl/api/graph_query_service/v1beta1/graph_query_service.proto
@@ -283,6 +283,7 @@ message QueryGraphWithUidRequest {
   GraphQuery graph_query = 3;
 }
 
+// Represents a 'hit' for a QueryGraphWithUidRequest
 message MatchedGraphWithUid {
   // A view of the graph that matched our query
   GraphView matched_graph = 1;
@@ -296,6 +297,8 @@ message NoMatchWithUid {
   // empty
 }
 
+// If we get a match for the root Uid in QueryGraphWithUidRequest,
+// contains a MatchedGraphWithUid. Otherwise, contains a NoMatchWithUid
 message MaybeMatchWithUid {
   // The inner representation
   oneof inner {
@@ -307,6 +310,8 @@ message MaybeMatchWithUid {
 // The Response associated with a QueryGraphWithUidRequest
 // containing a matched graph and the associated uid
 message QueryGraphWithUidResponse {
+  // If we get a match for the root Uid in QueryGraphWithUidRequest,
+  // contains a MatchedGraphWithUid. Otherwise, contains a NoMatchWithUid
   MaybeMatchWithUid maybe_match = 1;
 }
 

--- a/src/proto/graplinc/grapl/common/v1beta1/types.proto
+++ b/src/proto/graplinc/grapl/common/v1beta1/types.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package graplinc.grapl.common.v1beta1;
+
+// A wrapper type for property names
+message PropertyName {
+  // The property name must:
+  // - Be non-empty
+  // - Snake case, `^[a-z]+(_[a-z]+)*$`
+  // - Less than 32 characters
+  string value = 1;
+}
+
+// A wrapper type for edge names
+message EdgeName {
+  // The edge name must:
+  // - Be non-empty
+  // - Snake case, `^[a-z]+(_[a-z]+)*$`
+  // - Less than 32 characters
+  string value = 1;
+}
+
+// A wrapper type for node type names
+message NodeType {
+  // The node type must:
+  // - Be non-empty
+  // - PascalCase, `^([A-Z][a-z]+)+$`
+  // - Less than 32 characters
+  string value = 1;
+}
+
+// A wrapper type for a node's uid
+message Uid {
+  // Can never be 0
+  uint64 value = 1;
+}

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -4049,6 +4049,8 @@ dependencies = [
  "prost-build 0.10.4",
  "quickcheck",
  "quickcheck_macros",
+ "rand 0.8.5",
+ "rustc-hash",
  "test-context",
  "thiserror",
  "tokio",
@@ -4066,6 +4068,12 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"

--- a/src/rust/rust-proto/Cargo.toml
+++ b/src/rust/rust-proto/Cargo.toml
@@ -18,6 +18,8 @@ client-executor = { path = "../client-executor" }
 futures = "0.3"
 grapl-utils = { path = "../grapl-utils" }
 prost = "0.10"
+rand = "0.8.5"
+rustc-hash = "1.1.0"
 thiserror = "1.0"
 tokio = { version = "1.17", features = ["rt", "time"] }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph/v1beta1.rs
@@ -223,7 +223,7 @@ impl From<Session> for IdStrategy {
 // IncrementOnlyUintProp
 //
 
-#[derive(Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Clone)]
+#[derive(Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Hash)]
 pub struct IncrementOnlyUintProp {
     pub prop: u64,
 }
@@ -287,7 +287,7 @@ impl_from_for_unit!(
 // ImmutableUintProp
 //
 
-#[derive(Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Clone)]
+#[derive(Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Hash)]
 pub struct ImmutableUintProp {
     pub prop: u64,
 }
@@ -350,7 +350,7 @@ impl_from_for_unit!(
 // DecrementOnlyUintProp
 //
 
-#[derive(Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Clone)]
+#[derive(Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Hash)]
 pub struct DecrementOnlyUintProp {
     pub prop: u64,
 }
@@ -413,7 +413,7 @@ impl_from_for_unit!(
 // IncrementOnlyIntProp
 //
 
-#[derive(Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Clone)]
+#[derive(Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Hash)]
 pub struct IncrementOnlyIntProp {
     pub prop: i64,
 }
@@ -477,7 +477,7 @@ impl_from_for_unit!(
 // DecrementOnlyIntProp
 //
 
-#[derive(Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Clone)]
+#[derive(Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Hash)]
 pub struct DecrementOnlyIntProp {
     pub prop: i64,
 }
@@ -540,7 +540,7 @@ impl_from_for_unit!(
 // ImmutableIntProp
 //
 
-#[derive(Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Clone)]
+#[derive(Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Hash)]
 pub struct ImmutableIntProp {
     pub prop: i64,
 }
@@ -603,7 +603,7 @@ impl_from_for_unit!(
 // ImmutableStrProp
 //
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct ImmutableStrProp {
     pub prop: String,
 }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/client.rs
@@ -1,0 +1,71 @@
+use crate::{
+    graplinc::grapl::api::graph_query_service::v1beta1::messages::{
+        QueryGraphFromUidRequest,
+        QueryGraphFromUidResponse,
+        QueryGraphWithUidRequest,
+        QueryGraphWithUidResponse,
+    },
+    protobufs::graplinc::grapl::api::graph_query_service::v1beta1::{
+        graph_query_service_client::GraphQueryServiceClient,
+        QueryGraphFromUidRequest as QueryGraphFromUidRequestProto,
+        QueryGraphWithUidRequest as QueryGraphWithUidRequestProto,
+    },
+    protocol::status::Status,
+    SerDeError,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum GraphQueryClientError {
+    #[error("Failed to deserialize response {0}")]
+    SerDeError(#[from] SerDeError),
+    #[error("Status {0}")]
+    Status(#[from] Status),
+    #[error("ConnectError")]
+    ConnectError(tonic::transport::Error),
+}
+
+#[derive(Clone)]
+pub struct GraphQueryClient {
+    inner: GraphQueryServiceClient<tonic::transport::Channel>,
+}
+
+impl GraphQueryClient {
+    pub async fn connect<T>(endpoint: T) -> Result<Self, GraphQueryClientError>
+    where
+        T: TryInto<tonic::transport::Endpoint>,
+        T::Error: std::error::Error + Send + Sync + 'static,
+    {
+        Ok(GraphQueryClient {
+            inner: GraphQueryServiceClient::connect(endpoint)
+                .await
+                .map_err(GraphQueryClientError::ConnectError)?,
+        })
+    }
+
+    pub async fn query_graph_with_uid(
+        &mut self,
+        request: QueryGraphWithUidRequest,
+    ) -> Result<QueryGraphWithUidResponse, GraphQueryClientError> {
+        let request: QueryGraphWithUidRequestProto = request.into();
+        Ok(self
+            .inner
+            .query_graph_with_uid(request)
+            .await
+            .map_err(Status::from)?
+            .into_inner()
+            .try_into()?)
+    }
+    pub async fn query_graph_from_uid(
+        &mut self,
+        request: QueryGraphFromUidRequest,
+    ) -> Result<QueryGraphFromUidResponse, GraphQueryClientError> {
+        let request: QueryGraphFromUidRequestProto = request.into();
+        Ok(self
+            .inner
+            .query_graph_from_uid(request)
+            .await
+            .map_err(Status::from)?
+            .into_inner()
+            .try_into()?)
+    }
+}

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/messages.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/messages.rs
@@ -550,7 +550,7 @@ impl TryFrom<proto::NodePropertyQuery> for NodePropertyQuery {
                 Ok((
                     PropertyName::try_from(k).map_err(|e| SerDeError::InvalidField {
                         field_name: "string_filters",
-                        assertion: e.to_owned(),
+                        assertion: e.to_string(),
                     })?,
                     v.try_into()?,
                 ))
@@ -564,7 +564,7 @@ impl TryFrom<proto::NodePropertyQuery> for NodePropertyQuery {
                 Ok((
                     PropertyName::try_from(k).map_err(|e| SerDeError::InvalidField {
                         field_name: "int_filters",
-                        assertion: e.to_owned(),
+                        assertion: e.to_string(),
                     })?,
                     v.try_into()?,
                 ))

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/messages.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/messages.rs
@@ -19,46 +19,7 @@ use crate::{
             Uid,
         },
     },
-    protobufs::graplinc::grapl::api::graph_query_service::v1beta1::{
-        int_filter::Operation as IntOperationProto,
-        integer_property as integer_property_proto,
-        maybe_match_with_uid as maybe_match_with_uid_proto,
-        string_filter::Operation as StringOperationProto,
-        uid_filter::Operation as UidOperationProto,
-        AndIntFilters as AndIntFiltersProto,
-        AndStringFilters as AndStringFiltersProto,
-        EdgeNameEntry as EdgeNameEntryProto,
-        EdgeNameMap as EdgeNameMapProto,
-        EdgeQueryEntry as EdgeQueryEntryProto,
-        EdgeQueryMap as EdgeQueryMapProto,
-        EdgeViewEntry as EdgeViewEntryProto,
-        EdgeViewMap as EdgeViewMapProto,
-        GraphQuery as GraphQueryProto,
-        GraphView as GraphViewProto,
-        IntFilter as IntFilterProto,
-        IntegerProperty as IntegerPropertyProto,
-        MatchedGraphWithUid as MatchedGraphWithUidProto,
-        MaybeMatchWithUid as MaybeMatchWithUidProto,
-        NoMatchWithUid as NoMatchWithUidProto,
-        NodePropertiesView as NodePropertiesViewProto,
-        NodePropertiesViewEntry as NodePropertiesViewEntryProto,
-        NodePropertiesViewMap as NodePropertiesViewMapProto,
-        NodePropertyQuery as NodePropertyQueryProto,
-        NodePropertyQueryEntry as NodePropertyQueryEntryProto,
-        NodePropertyQueryMap as NodePropertyQueryMapProto,
-        OrIntFilters as OrIntFiltersProto,
-        OrStringFilters as OrStringFiltersProto,
-        QueryGraphFromUidRequest as QueryGraphFromUidRequestProto,
-        QueryGraphFromUidResponse as QueryGraphFromUidResponseProto,
-        QueryGraphWithUidRequest as QueryGraphWithUidRequestProto,
-        QueryGraphWithUidResponse as QueryGraphWithUidResponseProto,
-        QueryId as QueryIdProto,
-        StringFilter as StringFilterProto,
-        StringProperties as StringPropertiesProto,
-        StringProperty as StringPropertyProto,
-        UidFilter as UidFilterProto,
-        UidFilters as UidFiltersProto,
-    },
+    protobufs::graplinc::grapl::api::graph_query_service::v1beta1 as proto,
     SerDeError,
 };
 
@@ -75,14 +36,14 @@ impl Default for QueryId {
     }
 }
 
-impl TryFrom<QueryIdProto> for QueryId {
+impl TryFrom<proto::QueryId> for QueryId {
     type Error = SerDeError;
-    fn try_from(value: QueryIdProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::QueryId) -> Result<Self, Self::Error> {
         Ok(Self { value: value.value })
     }
 }
 
-impl From<QueryId> for QueryIdProto {
+impl From<QueryId> for proto::QueryId {
     fn from(value: QueryId) -> Self {
         Self { value: value.value }
     }
@@ -95,17 +56,17 @@ pub enum IntegerProperty {
     Immutable(ImmutableIntProp),
 }
 
-impl TryFrom<IntegerPropertyProto> for IntegerProperty {
+impl TryFrom<proto::IntProperty> for IntegerProperty {
     type Error = SerDeError;
-    fn try_from(value_proto: IntegerPropertyProto) -> Result<Self, Self::Error> {
+    fn try_from(value_proto: proto::IntProperty) -> Result<Self, Self::Error> {
         match value_proto.property {
-            Some(integer_property_proto::Property::IncrementOnly(p)) => {
+            Some(proto::integer_property::Property::IncrementOnly(p)) => {
                 Ok(IntegerProperty::IncrementOnly(p.try_into()?))
             }
-            Some(integer_property_proto::Property::DecrementOnly(p)) => {
+            Some(proto::integer_property::Property::DecrementOnly(p)) => {
                 Ok(IntegerProperty::DecrementOnly(p.try_into()?))
             }
-            Some(integer_property_proto::Property::Immutable(p)) => {
+            Some(proto::integer_property::Property::Immutable(p)) => {
                 Ok(IntegerProperty::Immutable(p.try_into()?))
             }
             None => Err(SerDeError::UnknownVariant("IntegerProperty")),
@@ -113,17 +74,17 @@ impl TryFrom<IntegerPropertyProto> for IntegerProperty {
     }
 }
 
-impl From<IntegerProperty> for IntegerPropertyProto {
+impl From<IntegerProperty> for proto::IntegerProperty {
     fn from(value: IntegerProperty) -> Self {
         match value {
-            IntegerProperty::IncrementOnly(p) => IntegerPropertyProto {
-                property: Some(integer_property_proto::Property::IncrementOnly(p.into())),
+            IntegerProperty::IncrementOnly(p) => proto::IntegerProperty {
+                property: Some(proto::integer_property::Property::IncrementOnly(p.into())),
             },
-            IntegerProperty::DecrementOnly(p) => IntegerPropertyProto {
-                property: Some(integer_property_proto::Property::DecrementOnly(p.into())),
+            IntegerProperty::DecrementOnly(p) => proto::IntegerProperty {
+                property: Some(proto::integer_property::Property::DecrementOnly(p.into())),
             },
-            IntegerProperty::Immutable(p) => IntegerPropertyProto {
-                property: Some(integer_property_proto::Property::Immutable(p.into())),
+            IntegerProperty::Immutable(p) => proto::IntegerProperty {
+                property: Some(proto::integer_property::Property::Immutable(p.into())),
             },
         }
     }
@@ -139,30 +100,30 @@ pub enum IntOperation {
     GreaterThanOrEqual,
 }
 
-impl TryFrom<IntOperationProto> for IntOperation {
+impl TryFrom<proto::int_filter::Operation> for IntOperation {
     type Error = SerDeError;
-    fn try_from(value_proto: IntOperationProto) -> Result<Self, Self::Error> {
+    fn try_from(value_proto: proto::int_filter::Operation) -> Result<Self, Self::Error> {
         match value_proto {
-            IntOperationProto::Unspecified => Err(SerDeError::UnknownVariant("IntOperation")),
-            IntOperationProto::Has => Ok(Self::Has),
-            IntOperationProto::Equal => Ok(Self::Equal),
-            IntOperationProto::LessThan => Ok(Self::LessThan),
-            IntOperationProto::LessThanOrEqual => Ok(Self::LessThanOrEqual),
-            IntOperationProto::GreaterThan => Ok(Self::GreaterThan),
-            IntOperationProto::GreaterThanOrEqual => Ok(Self::GreaterThanOrEqual),
+            proto::int_filter::Operation::Unspecified => Err(SerDeError::UnknownVariant("IntOperation")),
+            proto::int_filter::Operation::Has => Ok(Self::Has),
+            proto::int_filter::Operation::Equal => Ok(Self::Equal),
+            proto::int_filter::Operation::LessThan => Ok(Self::LessThan),
+            proto::int_filter::Operation::LessThanOrEqual => Ok(Self::LessThanOrEqual),
+            proto::int_filter::Operation::GreaterThan => Ok(Self::GreaterThan),
+            proto::int_filter::Operation::GreaterThanOrEqual => Ok(Self::GreaterThanOrEqual),
         }
     }
 }
 
-impl From<IntOperation> for IntOperationProto {
+impl From<IntOperation> for proto::int_filter::Operation {
     fn from(value: IntOperation) -> Self {
         match value {
-            IntOperation::Has => IntOperationProto::Has,
-            IntOperation::Equal => IntOperationProto::Equal,
-            IntOperation::LessThan => IntOperationProto::LessThan,
-            IntOperation::LessThanOrEqual => IntOperationProto::LessThanOrEqual,
-            IntOperation::GreaterThan => IntOperationProto::GreaterThan,
-            IntOperation::GreaterThanOrEqual => IntOperationProto::GreaterThanOrEqual,
+            IntOperation::Has => proto::int_filter::Operation::Has,
+            IntOperation::Equal => proto::int_filter::Operation::Equal,
+            IntOperation::LessThan => proto::int_filter::Operation::LessThan,
+            IntOperation::LessThanOrEqual => proto::int_filter::Operation::LessThanOrEqual,
+            IntOperation::GreaterThan => proto::int_filter::Operation::GreaterThan,
+            IntOperation::GreaterThanOrEqual => proto::int_filter::Operation::GreaterThanOrEqual,
         }
     }
 }
@@ -174,10 +135,10 @@ pub struct IntFilter {
     pub negated: bool,
 }
 
-impl TryFrom<IntFilterProto> for IntFilter {
+impl TryFrom<proto::IntFilter> for IntFilter {
     type Error = SerDeError;
 
-    fn try_from(value_proto: IntFilterProto) -> Result<Self, Self::Error> {
+    fn try_from(value_proto: proto::IntFilter) -> Result<Self, Self::Error> {
         let operation = value_proto.operation().try_into()?;
         let value = value_proto.value;
         let negated = value_proto.negated;
@@ -189,9 +150,9 @@ impl TryFrom<IntFilterProto> for IntFilter {
     }
 }
 
-impl From<IntFilter> for IntFilterProto {
-    fn from(value: IntFilter) -> IntFilterProto {
-        IntFilterProto {
+impl From<IntFilter> for proto::IntFilter {
+    fn from(value: IntFilter) -> proto::IntFilter {
+        proto::IntFilter {
             operation: value.operation as i32,
             value: value.value,
             negated: value.negated,
@@ -204,9 +165,9 @@ pub struct AndIntFilters {
     pub int_filters: Vec<IntFilter>,
 }
 
-impl TryFrom<AndIntFiltersProto> for AndIntFilters {
+impl TryFrom<proto::AndIntFilters> for AndIntFilters {
     type Error = SerDeError;
-    fn try_from(value: AndIntFiltersProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::AndIntFilters) -> Result<Self, Self::Error> {
         let int_filters = value
             .int_filters
             .into_iter()
@@ -216,13 +177,13 @@ impl TryFrom<AndIntFiltersProto> for AndIntFilters {
     }
 }
 
-impl From<AndIntFilters> for AndIntFiltersProto {
+impl From<AndIntFilters> for proto::AndIntFilters {
     fn from(value: AndIntFilters) -> Self {
         Self {
             int_filters: value
                 .int_filters
                 .into_iter()
-                .map(IntFilterProto::from)
+                .map(proto::IntFilter::from)
                 .collect(),
         }
     }
@@ -233,9 +194,9 @@ pub struct OrIntFilters {
     pub and_int_filters: Vec<AndIntFilters>,
 }
 
-impl TryFrom<OrIntFiltersProto> for OrIntFilters {
+impl TryFrom<proto::OrIntFilters> for OrIntFilters {
     type Error = SerDeError;
-    fn try_from(value: OrIntFiltersProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::OrIntFilters) -> Result<Self, Self::Error> {
         let and_int_filters = value
             .and_int_filters
             .into_iter()
@@ -245,12 +206,12 @@ impl TryFrom<OrIntFiltersProto> for OrIntFilters {
     }
 }
 
-impl From<OrIntFilters> for OrIntFiltersProto {
+impl From<OrIntFilters> for proto::OrIntFilters {
     fn from(value: OrIntFilters) -> Self {
         let and_int_filters = value
             .and_int_filters
             .into_iter()
-            .map(AndIntFiltersProto::from)
+            .map(proto::AndIntFilters::from)
             .collect();
         Self { and_int_filters }
     }
@@ -348,20 +309,20 @@ pub enum StringOperation {
     Regex,
 }
 
-impl TryFrom<StringOperationProto> for StringOperation {
+impl TryFrom<proto::string_filter::Operation> for StringOperation {
     type Error = SerDeError;
-    fn try_from(value_proto: StringOperationProto) -> Result<Self, Self::Error> {
+    fn try_from(value_proto: proto::string_filter::Operation) -> Result<Self, Self::Error> {
         match value_proto {
-            StringOperationProto::Unspecified => Err(SerDeError::UnknownVariant("StringOperation")),
-            StringOperationProto::Has => Ok(Self::Has),
-            StringOperationProto::Equal => Ok(Self::Equal),
-            StringOperationProto::Contains => Ok(Self::Contains),
-            StringOperationProto::Regex => Ok(Self::Regex),
+            proto::string_filter::Operation::Unspecified => Err(SerDeError::UnknownVariant("StringOperation")),
+            proto::string_filter::Operation::Has => Ok(Self::Has),
+            proto::string_filter::Operation::Equal => Ok(Self::Equal),
+            proto::string_filter::Operation::Contains => Ok(Self::Contains),
+            proto::string_filter::Operation::Regex => Ok(Self::Regex),
         }
     }
 }
 
-impl From<StringOperation> for StringOperationProto {
+impl From<StringOperation> for proto::string_filter::Operation {
     fn from(value: StringOperation) -> Self {
         match value {
             StringOperation::Has => Self::Has,
@@ -379,10 +340,10 @@ pub struct StringFilter {
     pub negated: bool,
 }
 
-impl TryFrom<StringFilterProto> for StringFilter {
+impl TryFrom<proto::StringFilter> for StringFilter {
     type Error = SerDeError;
 
-    fn try_from(value_proto: StringFilterProto) -> Result<Self, Self::Error> {
+    fn try_from(value_proto: proto::StringFilter) -> Result<Self, Self::Error> {
         let operation = value_proto.operation().try_into()?;
         let value = value_proto.value;
         let negated = value_proto.negated;
@@ -394,9 +355,9 @@ impl TryFrom<StringFilterProto> for StringFilter {
     }
 }
 
-impl From<StringFilter> for StringFilterProto {
-    fn from(value: StringFilter) -> StringFilterProto {
-        StringFilterProto {
+impl From<StringFilter> for proto::StringFilter {
+    fn from(value: StringFilter) -> proto::StringFilter {
+        proto::StringFilter {
             operation: value.operation as i32,
             value: value.value,
             negated: value.negated,
@@ -409,9 +370,9 @@ pub struct AndStringFilters {
     pub string_filters: Vec<StringFilter>,
 }
 
-impl TryFrom<AndStringFiltersProto> for AndStringFilters {
+impl TryFrom<proto::AndStringFilters> for AndStringFilters {
     type Error = SerDeError;
-    fn try_from(value: AndStringFiltersProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::AndStringFilters) -> Result<Self, Self::Error> {
         let string_filters = value
             .string_filters
             .into_iter()
@@ -421,13 +382,13 @@ impl TryFrom<AndStringFiltersProto> for AndStringFilters {
     }
 }
 
-impl From<AndStringFilters> for AndStringFiltersProto {
+impl From<AndStringFilters> for proto::AndStringFilters {
     fn from(value: AndStringFilters) -> Self {
         Self {
             string_filters: value
                 .string_filters
                 .into_iter()
-                .map(StringFilterProto::from)
+                .map(proto::StringFilter::from)
                 .collect(),
         }
     }
@@ -473,9 +434,9 @@ impl From<OrStringFilters> for Vec<Vec<StringCmp>> {
     }
 }
 
-impl TryFrom<OrStringFiltersProto> for OrStringFilters {
+impl TryFrom<proto::OrStringFilters> for OrStringFilters {
     type Error = SerDeError;
-    fn try_from(value: OrStringFiltersProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::OrStringFilters) -> Result<Self, Self::Error> {
         let and_string_filters = value
             .and_string_filters
             .into_iter()
@@ -485,12 +446,12 @@ impl TryFrom<OrStringFiltersProto> for OrStringFilters {
     }
 }
 
-impl From<OrStringFilters> for OrStringFiltersProto {
+impl From<OrStringFilters> for proto::OrStringFilters {
     fn from(value: OrStringFilters) -> Self {
         let and_string_filters = value
             .and_string_filters
             .into_iter()
-            .map(AndStringFiltersProto::from)
+            .map(proto::AndStringFilters::from)
             .collect();
         Self { and_string_filters }
     }
@@ -501,17 +462,17 @@ pub enum UidOperation {
     Equal,
 }
 
-impl TryFrom<UidOperationProto> for UidOperation {
+impl TryFrom<proto::uid_filter::Operation> for UidOperation {
     type Error = SerDeError;
-    fn try_from(value_proto: UidOperationProto) -> Result<Self, Self::Error> {
+    fn try_from(value_proto: proto::uid_filter::Operation) -> Result<Self, Self::Error> {
         match value_proto {
-            UidOperationProto::Unspecified => Err(SerDeError::UnknownVariant("UidOperation")),
-            UidOperationProto::Equal => Ok(Self::Equal),
+            proto::uid_filter::Operation::Unspecified => Err(SerDeError::UnknownVariant("UidOperation")),
+            proto::uid_filter::Operation::Equal => Ok(Self::Equal),
         }
     }
 }
 
-impl From<UidOperation> for UidOperationProto {
+impl From<UidOperation> for proto::uid_filter::Operation {
     fn from(value: UidOperation) -> Self {
         match value {
             UidOperation::Equal => Self::Equal,
@@ -525,10 +486,10 @@ pub struct UidFilter {
     pub value: Uid,
 }
 
-impl TryFrom<UidFilterProto> for UidFilter {
+impl TryFrom<proto::UidFilter> for UidFilter {
     type Error = SerDeError;
 
-    fn try_from(value_proto: UidFilterProto) -> Result<Self, Self::Error> {
+    fn try_from(value_proto: proto::UidFilter) -> Result<Self, Self::Error> {
         let operation = value_proto.operation().try_into()?;
         let value = value_proto
             .value
@@ -538,9 +499,9 @@ impl TryFrom<UidFilterProto> for UidFilter {
     }
 }
 
-impl From<UidFilter> for UidFilterProto {
-    fn from(value: UidFilter) -> UidFilterProto {
-        UidFilterProto {
+impl From<UidFilter> for proto::UidFilter {
+    fn from(value: UidFilter) -> proto::UidFilter {
+        proto::UidFilter {
             operation: value.operation as i32,
             value: Some(value.value.into()),
         }
@@ -552,9 +513,9 @@ pub struct UidFilters {
     pub uid_filters: Vec<UidFilter>,
 }
 
-impl TryFrom<UidFiltersProto> for UidFilters {
+impl TryFrom<proto::UidFilters> for UidFilters {
     type Error = SerDeError;
-    fn try_from(value: UidFiltersProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::UidFilters) -> Result<Self, Self::Error> {
         let uid_filters = value
             .uid_filters
             .into_iter()
@@ -564,13 +525,13 @@ impl TryFrom<UidFiltersProto> for UidFilters {
     }
 }
 
-impl From<UidFilters> for UidFiltersProto {
+impl From<UidFilters> for proto::UidFilters {
     fn from(value: UidFilters) -> Self {
         Self {
             uid_filters: value
                 .uid_filters
                 .into_iter()
-                .map(UidFilterProto::from)
+                .map(proto::UidFilter::from)
                 .collect(),
         }
     }
@@ -616,9 +577,9 @@ impl NodePropertyQuery {
     }
 }
 
-impl TryFrom<NodePropertyQueryProto> for NodePropertyQuery {
+impl TryFrom<proto::NodePropertyQuery> for NodePropertyQuery {
     type Error = SerDeError;
-    fn try_from(value: NodePropertyQueryProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::NodePropertyQuery) -> Result<Self, Self::Error> {
         let node_type = value
             .node_type
             .ok_or(SerDeError::MissingField("node_type"))?
@@ -671,7 +632,7 @@ impl TryFrom<NodePropertyQueryProto> for NodePropertyQuery {
     }
 }
 
-impl From<NodePropertyQuery> for NodePropertyQueryProto {
+impl From<NodePropertyQuery> for proto::NodePropertyQuery {
     fn from(value: NodePropertyQuery) -> Self {
         let query_id = Some(value.query_id.into());
         let node_type = Some(value.node_type.into());
@@ -733,9 +694,9 @@ impl GraphQuery {
     }
 }
 
-impl TryFrom<GraphQueryProto> for GraphQuery {
+impl TryFrom<proto::GraphQuery> for GraphQuery {
     type Error = SerDeError;
-    fn try_from(value: GraphQueryProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::GraphQuery) -> Result<Self, Self::Error> {
         let root_query_id: QueryId = value
             .root_query_id
             .ok_or_else(|| SerDeError::MissingField("root_query_id"))?
@@ -812,36 +773,36 @@ impl TryFrom<GraphQueryProto> for GraphQuery {
     }
 }
 
-impl From<GraphQuery> for GraphQueryProto {
+impl From<GraphQuery> for proto::GraphQuery {
     fn from(value: GraphQuery) -> Self {
         let root_query_id = Some(value.root_query_id.into());
-        let node_property_queries = Some(NodePropertyQueryMapProto {
+        let node_property_queries = Some(proto::NodePropertyQueryMap {
             entries: value
                 .node_property_queries
                 .into_iter()
-                .map(|(k, v)| NodePropertyQueryEntryProto {
+                .map(|(k, v)| proto::NodePropertyQueryEntry {
                     query_id: Some(k.into()),
                     node_property_query: Some(v.into()),
                 })
                 .collect(),
         });
-        let edge_filters = Some(EdgeQueryMapProto {
+        let edge_filters = Some(proto::EdgeQueryMap {
             entries: value
                 .edge_filters
                 .into_iter()
-                .map(|((k0, k1), v)| EdgeQueryEntryProto {
+                .map(|((k0, k1), v)| proto::EdgeQueryEntry {
                     query_id: Some(k0.into()),
                     edge_name: Some(k1.into()),
-                    neighbor_query_ids: v.into_iter().map(QueryIdProto::from).collect(),
+                    neighbor_query_ids: v.into_iter().map(proto::QueryId::from).collect(),
                 })
                 .collect(),
         });
 
-        let edge_map = Some(EdgeNameMapProto {
+        let edge_map = Some(proto::EdgeNameMap {
             entries: value
                 .edge_map
                 .into_iter()
-                .map(|(k, v)| EdgeNameEntryProto {
+                .map(|(k, v)| proto::EdgeNameEntry {
                     forward_edge_name: Some(k.into()),
                     reverse_edge_name: Some(v.into()),
                 })
@@ -887,9 +848,9 @@ impl NodePropertiesView {
     }
 }
 
-impl TryFrom<NodePropertiesViewProto> for NodePropertiesView {
+impl TryFrom<proto::NodePropertiesView> for NodePropertiesView {
     type Error = SerDeError;
-    fn try_from(value: NodePropertiesViewProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::NodePropertiesView) -> Result<Self, Self::Error> {
         let proto_string_properties = value
             .string_properties
             .ok_or_else(|| SerDeError::MissingField("string_properties"))?;
@@ -918,17 +879,17 @@ impl TryFrom<NodePropertiesViewProto> for NodePropertiesView {
     }
 }
 
-impl From<NodePropertiesView> for NodePropertiesViewProto {
+impl From<NodePropertiesView> for proto::NodePropertiesView {
     fn from(value: NodePropertiesView) -> Self {
-        let string_properties: Vec<StringPropertyProto> = value
+        let string_properties: Vec<proto::StringProperty> = value
             .string_properties
             .into_iter()
-            .map(|(k, v)| StringPropertyProto {
+            .map(|(k, v)| proto::StringProperty {
                 property_name: Some(k.into()),
                 property_value: v,
             })
             .collect();
-        let string_properties = Some(StringPropertiesProto {
+        let string_properties = Some(proto::StringProperties {
             properties: string_properties,
         });
 
@@ -946,9 +907,9 @@ pub struct NodePropertiesViewEntry {
     pub node_view: NodePropertiesView,
 }
 
-impl TryFrom<NodePropertiesViewEntryProto> for NodePropertiesViewEntry {
+impl TryFrom<proto::NodePropertiesViewEntry> for NodePropertiesViewEntry {
     type Error = SerDeError;
-    fn try_from(value: NodePropertiesViewEntryProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::NodePropertiesViewEntry) -> Result<Self, Self::Error> {
         Ok(Self {
             uid: value
                 .uid
@@ -962,9 +923,9 @@ impl TryFrom<NodePropertiesViewEntryProto> for NodePropertiesViewEntry {
     }
 }
 
-impl From<NodePropertiesViewEntry> for NodePropertiesViewEntryProto {
+impl From<NodePropertiesViewEntry> for proto::NodePropertiesViewEntry {
     fn from(value: NodePropertiesViewEntry) -> Self {
-        NodePropertiesViewEntryProto {
+        proto::NodePropertiesViewEntry {
             uid: Some(value.uid.into()),
             node_view: Some(value.node_view.into()),
         }
@@ -976,9 +937,9 @@ pub struct NodePropertiesViewMap {
     pub entries: FxHashMap<Uid, NodePropertiesView>,
 }
 
-impl TryFrom<NodePropertiesViewMapProto> for NodePropertiesViewMap {
+impl TryFrom<proto::NodePropertiesViewMap> for NodePropertiesViewMap {
     type Error = SerDeError;
-    fn try_from(value: NodePropertiesViewMapProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::NodePropertiesViewMap) -> Result<Self, Self::Error> {
         let mut entries = FxHashMap::default();
         entries.reserve(value.entries.len());
 
@@ -998,12 +959,12 @@ impl TryFrom<NodePropertiesViewMapProto> for NodePropertiesViewMap {
     }
 }
 
-impl From<NodePropertiesViewMap> for NodePropertiesViewMapProto {
+impl From<NodePropertiesViewMap> for proto::NodePropertiesViewMap {
     fn from(value: NodePropertiesViewMap) -> Self {
         let mut entries = Vec::with_capacity(value.entries.len());
 
         for (uid, node_view) in value.entries.into_iter() {
-            entries.push(NodePropertiesViewEntryProto {
+            entries.push(proto::NodePropertiesViewEntry {
                 uid: Some(uid.into()),
                 node_view: Some(node_view.into()),
             });
@@ -1020,9 +981,9 @@ pub struct EdgeViewEntry {
     pub neighbors: FxHashSet<Uid>,
 }
 
-impl TryFrom<EdgeViewEntryProto> for EdgeViewEntry {
+impl TryFrom<proto::EdgeViewEntry> for EdgeViewEntry {
     type Error = SerDeError;
-    fn try_from(value: EdgeViewEntryProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::EdgeViewEntry) -> Result<Self, Self::Error> {
         let mut neighbors = FxHashSet::default();
         neighbors.reserve(value.neighbors.len());
         for neighbor in value.neighbors.into_iter() {
@@ -1042,13 +1003,13 @@ impl TryFrom<EdgeViewEntryProto> for EdgeViewEntry {
     }
 }
 
-impl From<EdgeViewEntry> for EdgeViewEntryProto {
+impl From<EdgeViewEntry> for proto::EdgeViewEntry {
     fn from(value: EdgeViewEntry) -> Self {
         let mut neighbors = Vec::with_capacity(value.neighbors.len());
         for neighbor in value.neighbors.into_iter() {
             neighbors.push(neighbor.into());
         }
-        EdgeViewEntryProto {
+        proto::EdgeViewEntry {
             uid: Some(value.uid.into()),
             edge_name: Some(value.edge_name.into()),
             neighbors,
@@ -1061,9 +1022,9 @@ pub struct EdgeViewMap {
     pub entries: FxHashMap<(Uid, EdgeName), FxHashSet<Uid>>,
 }
 
-impl TryFrom<EdgeViewMapProto> for EdgeViewMap {
+impl TryFrom<proto::EdgeViewMap> for EdgeViewMap {
     type Error = SerDeError;
-    fn try_from(value: EdgeViewMapProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::EdgeViewMap) -> Result<Self, Self::Error> {
         let mut entries = FxHashMap::default();
         entries.reserve(value.entries.len());
 
@@ -1076,7 +1037,7 @@ impl TryFrom<EdgeViewMapProto> for EdgeViewMap {
     }
 }
 
-impl From<EdgeViewMap> for EdgeViewMapProto {
+impl From<EdgeViewMap> for proto::EdgeViewMap {
     fn from(value: EdgeViewMap) -> Self {
         let mut entries = Vec::with_capacity(value.entries.len());
 
@@ -1159,9 +1120,9 @@ impl GraphView {
     }
 }
 
-impl TryFrom<GraphViewProto> for GraphView {
+impl TryFrom<proto::GraphView> for GraphView {
     type Error = SerDeError;
-    fn try_from(value: GraphViewProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::GraphView) -> Result<Self, Self::Error> {
         let nodes: NodePropertiesViewMap = value
             .nodes
             .ok_or(SerDeError::MissingField("nodes"))?
@@ -1178,7 +1139,7 @@ impl TryFrom<GraphViewProto> for GraphView {
     }
 }
 
-impl From<GraphView> for GraphViewProto {
+impl From<GraphView> for proto::GraphView {
     fn from(value: GraphView) -> Self {
         let nodes = NodePropertiesViewMap {
             entries: value.nodes,
@@ -1202,10 +1163,10 @@ pub struct QueryGraphWithUidRequest {
     pub graph_query: GraphQuery,
 }
 
-impl TryFrom<QueryGraphWithUidRequestProto> for QueryGraphWithUidRequest {
+impl TryFrom<proto::QueryGraphWithUidRequest> for QueryGraphWithUidRequest {
     type Error = SerDeError;
 
-    fn try_from(value: QueryGraphWithUidRequestProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::QueryGraphWithUidRequest) -> Result<Self, Self::Error> {
         Ok(Self {
             tenant_id: value
                 .tenant_id
@@ -1223,7 +1184,7 @@ impl TryFrom<QueryGraphWithUidRequestProto> for QueryGraphWithUidRequest {
     }
 }
 
-impl From<QueryGraphWithUidRequest> for QueryGraphWithUidRequestProto {
+impl From<QueryGraphWithUidRequest> for proto::QueryGraphWithUidRequest {
     fn from(value: QueryGraphWithUidRequest) -> Self {
         Self {
             tenant_id: Some(value.tenant_id.into()),
@@ -1239,9 +1200,9 @@ pub struct MatchedGraphWithUid {
     pub root_uid: Uid,
 }
 
-impl TryFrom<MatchedGraphWithUidProto> for MatchedGraphWithUid {
+impl TryFrom<proto::MatchedGraphWithUid> for MatchedGraphWithUid {
     type Error = SerDeError;
-    fn try_from(value: MatchedGraphWithUidProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::MatchedGraphWithUid) -> Result<Self, Self::Error> {
         Ok(Self {
             matched_graph: value
                 .matched_graph
@@ -1256,7 +1217,7 @@ impl TryFrom<MatchedGraphWithUidProto> for MatchedGraphWithUid {
     }
 }
 
-impl From<MatchedGraphWithUid> for MatchedGraphWithUidProto {
+impl From<MatchedGraphWithUid> for proto::MatchedGraphWithUid {
     fn from(value: MatchedGraphWithUid) -> Self {
         Self {
             matched_graph: Some(value.matched_graph.into()),
@@ -1268,14 +1229,14 @@ impl From<MatchedGraphWithUid> for MatchedGraphWithUidProto {
 #[derive(Debug, Clone)]
 pub struct NoMatchWithUid {}
 
-impl From<NoMatchWithUidProto> for NoMatchWithUid {
-    fn from(value: NoMatchWithUidProto) -> Self {
-        let NoMatchWithUidProto {} = value;
+impl From<proto::NoMatchWithUid> for NoMatchWithUid {
+    fn from(value: proto::NoMatchWithUid) -> Self {
+        let proto::NoMatchWithUid {} = value;
         Self {}
     }
 }
 
-impl From<NoMatchWithUid> for NoMatchWithUidProto {
+impl From<NoMatchWithUid> for proto::NoMatchWithUid {
     fn from(value: NoMatchWithUid) -> Self {
         let NoMatchWithUid {} = value;
         Self {}
@@ -1288,14 +1249,14 @@ pub enum MaybeMatchWithUid {
     Missed(NoMatchWithUid),
 }
 
-impl TryFrom<MaybeMatchWithUidProto> for MaybeMatchWithUid {
+impl TryFrom<proto::MaybeMatchWithUid> for MaybeMatchWithUid {
     type Error = SerDeError;
-    fn try_from(value_proto: MaybeMatchWithUidProto) -> Result<Self, Self::Error> {
+    fn try_from(value_proto: proto::MaybeMatchWithUid) -> Result<Self, Self::Error> {
         match value_proto.inner {
-            Some(maybe_match_with_uid_proto::Inner::Matched(matched)) => {
+            Some(proto::maybe_match_with_uid::Inner::Matched(matched)) => {
                 Ok(MaybeMatchWithUid::Matched(matched.try_into()?))
             }
-            Some(maybe_match_with_uid_proto::Inner::Missed(missed)) => {
+            Some(proto::maybe_match_with_uid::Inner::Missed(missed)) => {
                 Ok(MaybeMatchWithUid::Missed(missed.into()))
             }
             None => Err(SerDeError::UnknownVariant("MaybeMatchWithUid")),
@@ -1303,14 +1264,14 @@ impl TryFrom<MaybeMatchWithUidProto> for MaybeMatchWithUid {
     }
 }
 
-impl From<MaybeMatchWithUid> for MaybeMatchWithUidProto {
+impl From<MaybeMatchWithUid> for proto::MaybeMatchWithUid {
     fn from(value: MaybeMatchWithUid) -> Self {
         match value {
-            MaybeMatchWithUid::Matched(matched) => MaybeMatchWithUidProto {
-                inner: Some(maybe_match_with_uid_proto::Inner::Matched(matched.into())),
+            MaybeMatchWithUid::Matched(matched) => proto::MaybeMatchWithUid {
+                inner: Some(proto::maybe_match_with_uid::Inner::Matched(matched.into())),
             },
-            MaybeMatchWithUid::Missed(p) => MaybeMatchWithUidProto {
-                inner: Some(maybe_match_with_uid_proto::Inner::Missed(p.into())),
+            MaybeMatchWithUid::Missed(p) => proto::MaybeMatchWithUid {
+                inner: Some(proto::maybe_match_with_uid::Inner::Missed(p.into())),
             },
         }
     }
@@ -1321,9 +1282,9 @@ pub struct QueryGraphWithUidResponse {
     pub maybe_match: MaybeMatchWithUid,
 }
 
-impl TryFrom<QueryGraphWithUidResponseProto> for QueryGraphWithUidResponse {
+impl TryFrom<proto::QueryGraphWithUidResponse> for QueryGraphWithUidResponse {
     type Error = SerDeError;
-    fn try_from(value: QueryGraphWithUidResponseProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::QueryGraphWithUidResponse) -> Result<Self, Self::Error> {
         Ok(Self {
             maybe_match: value
                 .maybe_match
@@ -1333,7 +1294,7 @@ impl TryFrom<QueryGraphWithUidResponseProto> for QueryGraphWithUidResponse {
     }
 }
 
-impl From<QueryGraphWithUidResponse> for QueryGraphWithUidResponseProto {
+impl From<QueryGraphWithUidResponse> for proto::QueryGraphWithUidResponse {
     fn from(value: QueryGraphWithUidResponse) -> Self {
         Self {
             maybe_match: Some(value.maybe_match.into()),
@@ -1348,10 +1309,10 @@ pub struct QueryGraphFromUidRequest {
     pub graph_query: GraphQuery,
 }
 
-impl TryFrom<QueryGraphFromUidRequestProto> for QueryGraphFromUidRequest {
+impl TryFrom<proto::QueryGraphFromUidRequest> for QueryGraphFromUidRequest {
     type Error = SerDeError;
 
-    fn try_from(value: QueryGraphFromUidRequestProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::QueryGraphFromUidRequest) -> Result<Self, Self::Error> {
         Ok(Self {
             tenant_id: value
                 .tenant_id
@@ -1369,7 +1330,7 @@ impl TryFrom<QueryGraphFromUidRequestProto> for QueryGraphFromUidRequest {
     }
 }
 
-impl From<QueryGraphFromUidRequest> for QueryGraphFromUidRequestProto {
+impl From<QueryGraphFromUidRequest> for proto::QueryGraphFromUidRequest {
     fn from(value: QueryGraphFromUidRequest) -> Self {
         Self {
             tenant_id: Some(value.tenant_id.into()),
@@ -1384,9 +1345,9 @@ pub struct QueryGraphFromUidResponse {
     pub matched_graph: GraphView,
 }
 
-impl TryFrom<QueryGraphFromUidResponseProto> for QueryGraphFromUidResponse {
+impl TryFrom<proto::QueryGraphFromUidResponse> for QueryGraphFromUidResponse {
     type Error = SerDeError;
-    fn try_from(value: QueryGraphFromUidResponseProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::QueryGraphFromUidResponse) -> Result<Self, Self::Error> {
         Ok(Self {
             matched_graph: value
                 .matched_graph
@@ -1396,7 +1357,7 @@ impl TryFrom<QueryGraphFromUidResponseProto> for QueryGraphFromUidResponse {
     }
 }
 
-impl From<QueryGraphFromUidResponse> for QueryGraphFromUidResponseProto {
+impl From<QueryGraphFromUidResponse> for proto::QueryGraphFromUidResponse {
     fn from(value: QueryGraphFromUidResponse) -> Self {
         Self {
             matched_graph: Some(value.matched_graph.into()),

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/messages.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/messages.rs
@@ -1,0 +1,1405 @@
+use std::collections::hash_map::Entry;
+
+use rustc_hash::{
+    FxHashMap,
+    FxHashSet,
+};
+
+use crate::{
+    graplinc::grapl::{
+        api::graph::v1beta1::{
+            DecrementOnlyIntProp,
+            ImmutableIntProp,
+            IncrementOnlyIntProp,
+        },
+        common::v1beta1::types::{
+            EdgeName,
+            NodeType,
+            PropertyName,
+            Uid,
+        },
+    },
+    protobufs::graplinc::grapl::api::graph_query_service::v1beta1::{
+        int_filter::Operation as IntOperationProto,
+        integer_property as integer_property_proto,
+        maybe_match_with_uid as maybe_match_with_uid_proto,
+        string_filter::Operation as StringOperationProto,
+        uid_filter::Operation as UidOperationProto,
+        AndIntFilters as AndIntFiltersProto,
+        AndStringFilters as AndStringFiltersProto,
+        EdgeNameEntry as EdgeNameEntryProto,
+        EdgeNameMap as EdgeNameMapProto,
+        EdgeQueryEntry as EdgeQueryEntryProto,
+        EdgeQueryMap as EdgeQueryMapProto,
+        EdgeViewEntry as EdgeViewEntryProto,
+        EdgeViewMap as EdgeViewMapProto,
+        GraphQuery as GraphQueryProto,
+        GraphView as GraphViewProto,
+        IntFilter as IntFilterProto,
+        IntegerProperty as IntegerPropertyProto,
+        MatchedGraphWithUid as MatchedGraphWithUidProto,
+        MaybeMatchWithUid as MaybeMatchWithUidProto,
+        NoMatchWithUid as NoMatchWithUidProto,
+        NodePropertiesView as NodePropertiesViewProto,
+        NodePropertiesViewEntry as NodePropertiesViewEntryProto,
+        NodePropertiesViewMap as NodePropertiesViewMapProto,
+        NodePropertyQuery as NodePropertyQueryProto,
+        NodePropertyQueryEntry as NodePropertyQueryEntryProto,
+        NodePropertyQueryMap as NodePropertyQueryMapProto,
+        OrIntFilters as OrIntFiltersProto,
+        OrStringFilters as OrStringFiltersProto,
+        QueryGraphFromUidRequest as QueryGraphFromUidRequestProto,
+        QueryGraphFromUidResponse as QueryGraphFromUidResponseProto,
+        QueryGraphWithUidRequest as QueryGraphWithUidRequestProto,
+        QueryGraphWithUidResponse as QueryGraphWithUidResponseProto,
+        QueryId as QueryIdProto,
+        StringFilter as StringFilterProto,
+        StringProperties as StringPropertiesProto,
+        StringProperty as StringPropertyProto,
+        UidFilter as UidFilterProto,
+        UidFilters as UidFiltersProto,
+    },
+    SerDeError,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct QueryId {
+    pub value: u64,
+}
+
+impl Default for QueryId {
+    fn default() -> Self {
+        Self {
+            value: rand::random::<u64>() | 1,
+        }
+    }
+}
+
+impl TryFrom<QueryIdProto> for QueryId {
+    type Error = SerDeError;
+    fn try_from(value: QueryIdProto) -> Result<Self, Self::Error> {
+        Ok(Self { value: value.value })
+    }
+}
+
+impl From<QueryId> for QueryIdProto {
+    fn from(value: QueryId) -> Self {
+        Self { value: value.value }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum IntegerProperty {
+    IncrementOnly(IncrementOnlyIntProp),
+    DecrementOnly(DecrementOnlyIntProp),
+    Immutable(ImmutableIntProp),
+}
+
+impl TryFrom<IntegerPropertyProto> for IntegerProperty {
+    type Error = SerDeError;
+    fn try_from(value_proto: IntegerPropertyProto) -> Result<Self, Self::Error> {
+        match value_proto.property {
+            Some(integer_property_proto::Property::IncrementOnly(p)) => {
+                Ok(IntegerProperty::IncrementOnly(p.try_into()?))
+            }
+            Some(integer_property_proto::Property::DecrementOnly(p)) => {
+                Ok(IntegerProperty::DecrementOnly(p.try_into()?))
+            }
+            Some(integer_property_proto::Property::Immutable(p)) => {
+                Ok(IntegerProperty::Immutable(p.try_into()?))
+            }
+            None => Err(SerDeError::UnknownVariant("IntegerProperty")),
+        }
+    }
+}
+
+impl From<IntegerProperty> for IntegerPropertyProto {
+    fn from(value: IntegerProperty) -> Self {
+        match value {
+            IntegerProperty::IncrementOnly(p) => IntegerPropertyProto {
+                property: Some(integer_property_proto::Property::IncrementOnly(p.into())),
+            },
+            IntegerProperty::DecrementOnly(p) => IntegerPropertyProto {
+                property: Some(integer_property_proto::Property::DecrementOnly(p.into())),
+            },
+            IntegerProperty::Immutable(p) => IntegerPropertyProto {
+                property: Some(integer_property_proto::Property::Immutable(p.into())),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum IntOperation {
+    Has,
+    Equal,
+    LessThan,
+    LessThanOrEqual,
+    GreaterThan,
+    GreaterThanOrEqual,
+}
+
+impl TryFrom<IntOperationProto> for IntOperation {
+    type Error = SerDeError;
+    fn try_from(value_proto: IntOperationProto) -> Result<Self, Self::Error> {
+        match value_proto {
+            IntOperationProto::Unspecified => Err(SerDeError::UnknownVariant("IntOperation")),
+            IntOperationProto::Has => Ok(Self::Has),
+            IntOperationProto::Equal => Ok(Self::Equal),
+            IntOperationProto::LessThan => Ok(Self::LessThan),
+            IntOperationProto::LessThanOrEqual => Ok(Self::LessThanOrEqual),
+            IntOperationProto::GreaterThan => Ok(Self::GreaterThan),
+            IntOperationProto::GreaterThanOrEqual => Ok(Self::GreaterThanOrEqual),
+        }
+    }
+}
+
+impl From<IntOperation> for IntOperationProto {
+    fn from(value: IntOperation) -> Self {
+        match value {
+            IntOperation::Has => IntOperationProto::Has,
+            IntOperation::Equal => IntOperationProto::Equal,
+            IntOperation::LessThan => IntOperationProto::LessThan,
+            IntOperation::LessThanOrEqual => IntOperationProto::LessThanOrEqual,
+            IntOperation::GreaterThan => IntOperationProto::GreaterThan,
+            IntOperation::GreaterThanOrEqual => IntOperationProto::GreaterThanOrEqual,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IntFilter {
+    pub operation: IntOperation,
+    pub value: i64,
+    pub negated: bool,
+}
+
+impl TryFrom<IntFilterProto> for IntFilter {
+    type Error = SerDeError;
+
+    fn try_from(value_proto: IntFilterProto) -> Result<Self, Self::Error> {
+        let operation = value_proto.operation().try_into()?;
+        let value = value_proto.value;
+        let negated = value_proto.negated;
+        Ok(Self {
+            operation,
+            value,
+            negated,
+        })
+    }
+}
+
+impl From<IntFilter> for IntFilterProto {
+    fn from(value: IntFilter) -> IntFilterProto {
+        IntFilterProto {
+            operation: value.operation as i32,
+            value: value.value,
+            negated: value.negated,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AndIntFilters {
+    pub int_filters: Vec<IntFilter>,
+}
+
+impl TryFrom<AndIntFiltersProto> for AndIntFilters {
+    type Error = SerDeError;
+    fn try_from(value: AndIntFiltersProto) -> Result<Self, Self::Error> {
+        let int_filters = value
+            .int_filters
+            .into_iter()
+            .map(IntFilter::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { int_filters })
+    }
+}
+
+impl From<AndIntFilters> for AndIntFiltersProto {
+    fn from(value: AndIntFilters) -> Self {
+        Self {
+            int_filters: value
+                .int_filters
+                .into_iter()
+                .map(IntFilterProto::from)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct OrIntFilters {
+    pub and_int_filters: Vec<AndIntFilters>,
+}
+
+impl TryFrom<OrIntFiltersProto> for OrIntFilters {
+    type Error = SerDeError;
+    fn try_from(value: OrIntFiltersProto) -> Result<Self, Self::Error> {
+        let and_int_filters = value
+            .and_int_filters
+            .into_iter()
+            .map(AndIntFilters::try_from)
+            .collect::<Result<_, SerDeError>>()?;
+        Ok(Self { and_int_filters })
+    }
+}
+
+impl From<OrIntFilters> for OrIntFiltersProto {
+    fn from(value: OrIntFilters) -> Self {
+        let and_int_filters = value
+            .and_int_filters
+            .into_iter()
+            .map(AndIntFiltersProto::from)
+            .collect();
+        Self { and_int_filters }
+    }
+}
+
+// Higher level helper
+#[derive(Clone, Debug)]
+pub enum StrCmp<'a> {
+    Eq(&'a str, bool),
+    Contains(&'a str, bool),
+    Has,
+}
+
+impl<'a> StrCmp<'a> {
+    pub fn eq(value: &'a str, negated: bool) -> Self {
+        StrCmp::Eq(value, negated)
+    }
+}
+
+impl<'a> From<&'a StringFilter> for StrCmp<'a> {
+    fn from(string_filter: &'a StringFilter) -> StrCmp<'a> {
+        match string_filter.operation {
+            StringOperation::Has => StrCmp::Has,
+            StringOperation::Equal => {
+                StrCmp::Eq(string_filter.value.as_str(), string_filter.negated)
+            }
+            StringOperation::Contains => {
+                StrCmp::Contains(string_filter.value.as_str(), string_filter.negated)
+            }
+            StringOperation::Regex => {
+                // todo: We don't currently support Regex, but we should
+                unimplemented!()
+            }
+        }
+    }
+}
+
+// Higher level helper
+#[derive(Clone, Debug)]
+pub enum StringCmp {
+    Eq(String, bool),
+    Contains(String, bool),
+    Has,
+}
+
+impl StringCmp {
+    pub fn eq(value: impl Into<String>, negated: bool) -> Self {
+        StringCmp::Eq(value.into(), negated)
+    }
+}
+
+impl From<StringFilter> for StringCmp {
+    fn from(string_filter: StringFilter) -> StringCmp {
+        match string_filter.operation {
+            StringOperation::Has => StringCmp::Has,
+            StringOperation::Equal => StringCmp::Eq(string_filter.value, string_filter.negated),
+            StringOperation::Contains => {
+                StringCmp::Contains(string_filter.value, string_filter.negated)
+            }
+            StringOperation::Regex => {
+                // todo: We don't currently support Regex, but we should
+                unimplemented!()
+            }
+        }
+    }
+}
+
+impl From<StringCmp> for StringFilter {
+    fn from(string_cmp: StringCmp) -> StringFilter {
+        match string_cmp {
+            StringCmp::Has => StringFilter {
+                operation: StringOperation::Has,
+                value: "".to_string(),
+                negated: false,
+            },
+            StringCmp::Eq(value, negated) => StringFilter {
+                operation: StringOperation::Equal,
+                value,
+                negated,
+            },
+            StringCmp::Contains(value, negated) => StringFilter {
+                operation: StringOperation::Contains,
+                value,
+                negated,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum StringOperation {
+    Has,
+    Equal,
+    Contains,
+    Regex,
+}
+
+impl TryFrom<StringOperationProto> for StringOperation {
+    type Error = SerDeError;
+    fn try_from(value_proto: StringOperationProto) -> Result<Self, Self::Error> {
+        match value_proto {
+            StringOperationProto::Unspecified => Err(SerDeError::UnknownVariant("StringOperation")),
+            StringOperationProto::Has => Ok(Self::Has),
+            StringOperationProto::Equal => Ok(Self::Equal),
+            StringOperationProto::Contains => Ok(Self::Contains),
+            StringOperationProto::Regex => Ok(Self::Regex),
+        }
+    }
+}
+
+impl From<StringOperation> for StringOperationProto {
+    fn from(value: StringOperation) -> Self {
+        match value {
+            StringOperation::Has => Self::Has,
+            StringOperation::Equal => Self::Equal,
+            StringOperation::Contains => Self::Contains,
+            StringOperation::Regex => Self::Regex,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StringFilter {
+    pub operation: StringOperation,
+    pub value: String,
+    pub negated: bool,
+}
+
+impl TryFrom<StringFilterProto> for StringFilter {
+    type Error = SerDeError;
+
+    fn try_from(value_proto: StringFilterProto) -> Result<Self, Self::Error> {
+        let operation = value_proto.operation().try_into()?;
+        let value = value_proto.value;
+        let negated = value_proto.negated;
+        Ok(Self {
+            operation,
+            value,
+            negated,
+        })
+    }
+}
+
+impl From<StringFilter> for StringFilterProto {
+    fn from(value: StringFilter) -> StringFilterProto {
+        StringFilterProto {
+            operation: value.operation as i32,
+            value: value.value,
+            negated: value.negated,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct AndStringFilters {
+    pub string_filters: Vec<StringFilter>,
+}
+
+impl TryFrom<AndStringFiltersProto> for AndStringFilters {
+    type Error = SerDeError;
+    fn try_from(value: AndStringFiltersProto) -> Result<Self, Self::Error> {
+        let string_filters = value
+            .string_filters
+            .into_iter()
+            .map(StringFilter::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { string_filters })
+    }
+}
+
+impl From<AndStringFilters> for AndStringFiltersProto {
+    fn from(value: AndStringFilters) -> Self {
+        Self {
+            string_filters: value
+                .string_filters
+                .into_iter()
+                .map(StringFilterProto::from)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct OrStringFilters {
+    pub and_string_filters: Vec<AndStringFilters>,
+}
+
+impl OrStringFilters {
+    pub fn new() -> Self {
+        Self {
+            and_string_filters: Vec::new(),
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            and_string_filters: Vec::with_capacity(capacity),
+        }
+    }
+
+    pub fn push(&mut self, filters: AndStringFilters) {
+        self.and_string_filters.push(filters);
+    }
+}
+
+impl From<OrStringFilters> for Vec<Vec<StringCmp>> {
+    fn from(or_string_filters: OrStringFilters) -> Vec<Vec<StringCmp>> {
+        // "or filters" are collections of "and" filters
+        let mut new_or_filters = Vec::with_capacity(or_string_filters.and_string_filters.len());
+        for and_filters in or_string_filters.and_string_filters {
+            let and_filters = and_filters.string_filters;
+            let mut new_and_filters = Vec::with_capacity(and_filters.len());
+            for string_cmp in and_filters {
+                new_and_filters.push(string_cmp.into());
+            }
+            new_or_filters.push(new_and_filters);
+        }
+
+        new_or_filters
+    }
+}
+
+impl TryFrom<OrStringFiltersProto> for OrStringFilters {
+    type Error = SerDeError;
+    fn try_from(value: OrStringFiltersProto) -> Result<Self, Self::Error> {
+        let and_string_filters = value
+            .and_string_filters
+            .into_iter()
+            .map(AndStringFilters::try_from)
+            .collect::<Result<_, SerDeError>>()?;
+        Ok(Self { and_string_filters })
+    }
+}
+
+impl From<OrStringFilters> for OrStringFiltersProto {
+    fn from(value: OrStringFilters) -> Self {
+        let and_string_filters = value
+            .and_string_filters
+            .into_iter()
+            .map(AndStringFiltersProto::from)
+            .collect();
+        Self { and_string_filters }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum UidOperation {
+    Equal,
+}
+
+impl TryFrom<UidOperationProto> for UidOperation {
+    type Error = SerDeError;
+    fn try_from(value_proto: UidOperationProto) -> Result<Self, Self::Error> {
+        match value_proto {
+            UidOperationProto::Unspecified => Err(SerDeError::UnknownVariant("UidOperation")),
+            UidOperationProto::Equal => Ok(Self::Equal),
+        }
+    }
+}
+
+impl From<UidOperation> for UidOperationProto {
+    fn from(value: UidOperation) -> Self {
+        match value {
+            UidOperation::Equal => Self::Equal,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UidFilter {
+    pub operation: UidOperation,
+    pub value: Uid,
+}
+
+impl TryFrom<UidFilterProto> for UidFilter {
+    type Error = SerDeError;
+
+    fn try_from(value_proto: UidFilterProto) -> Result<Self, Self::Error> {
+        let operation = value_proto.operation().try_into()?;
+        let value = value_proto
+            .value
+            .ok_or(SerDeError::MissingField("uid"))?
+            .try_into()?;
+        Ok(Self { operation, value })
+    }
+}
+
+impl From<UidFilter> for UidFilterProto {
+    fn from(value: UidFilter) -> UidFilterProto {
+        UidFilterProto {
+            operation: value.operation as i32,
+            value: Some(value.value.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UidFilters {
+    pub uid_filters: Vec<UidFilter>,
+}
+
+impl TryFrom<UidFiltersProto> for UidFilters {
+    type Error = SerDeError;
+    fn try_from(value: UidFiltersProto) -> Result<Self, Self::Error> {
+        let uid_filters = value
+            .uid_filters
+            .into_iter()
+            .map(UidFilter::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { uid_filters })
+    }
+}
+
+impl From<UidFilters> for UidFiltersProto {
+    fn from(value: UidFilters) -> Self {
+        Self {
+            uid_filters: value
+                .uid_filters
+                .into_iter()
+                .map(UidFilterProto::from)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NodePropertyQuery {
+    pub query_id: QueryId,
+    pub node_type: NodeType,
+    pub int_filters: FxHashMap<PropertyName, OrIntFilters>,
+    pub string_filters: FxHashMap<PropertyName, OrStringFilters>,
+    pub uid_filters: UidFilters,
+}
+
+impl NodePropertyQuery {
+    pub fn new(node_type: NodeType) -> Self {
+        Self {
+            node_type,
+            query_id: QueryId::default(),
+            int_filters: Default::default(),
+            string_filters: Default::default(),
+            uid_filters: Default::default(),
+        }
+    }
+
+    pub fn merge(&mut self, other: Self) {
+        debug_assert_eq!(self.query_id, other.query_id);
+        debug_assert_eq!(self.node_type, other.node_type);
+        self.string_filters.extend(other.string_filters);
+    }
+
+    pub fn with_string_filters(
+        &mut self,
+        property_name: PropertyName,
+        filters: impl Into<AndStringFilters>,
+    ) -> &mut Self {
+        let filters = filters.into();
+        self.string_filters
+            .entry(property_name)
+            .or_insert_with(|| OrStringFilters::with_capacity(1))
+            .push(filters);
+        self
+    }
+}
+
+impl TryFrom<NodePropertyQueryProto> for NodePropertyQuery {
+    type Error = SerDeError;
+    fn try_from(value: NodePropertyQueryProto) -> Result<Self, Self::Error> {
+        let node_type = value
+            .node_type
+            .ok_or(SerDeError::MissingField("node_type"))?
+            .try_into()?;
+
+        let string_filters = value
+            .string_filters
+            .into_iter()
+            .map(|(k, v)| {
+                Ok((
+                    PropertyName::try_from(k).map_err(|e| SerDeError::InvalidField {
+                        field_name: "string_filters",
+                        assertion: e.to_owned(),
+                    })?,
+                    v.try_into()?,
+                ))
+            })
+            .collect::<Result<_, SerDeError>>()?;
+
+        let int_filters = value
+            .int_filters
+            .into_iter()
+            .map(|(k, v)| {
+                Ok((
+                    PropertyName::try_from(k).map_err(|e| SerDeError::InvalidField {
+                        field_name: "int_filters",
+                        assertion: e.to_owned(),
+                    })?,
+                    v.try_into()?,
+                ))
+            })
+            .collect::<Result<_, SerDeError>>()?;
+
+        let uid_filters = value
+            .uid_filters
+            .ok_or(SerDeError::MissingField("uid_filters"))?
+            .try_into()?;
+
+        let query_id = value
+            .query_id
+            .ok_or(SerDeError::MissingField("query_id"))?
+            .try_into()?;
+        Ok(Self {
+            query_id,
+            node_type,
+            int_filters,
+            string_filters,
+            uid_filters,
+        })
+    }
+}
+
+impl From<NodePropertyQuery> for NodePropertyQueryProto {
+    fn from(value: NodePropertyQuery) -> Self {
+        let query_id = Some(value.query_id.into());
+        let node_type = Some(value.node_type.into());
+        let string_filters = value
+            .string_filters
+            .into_iter()
+            .map(|(k, v)| (k.value, v.into()))
+            .collect();
+
+        let int_filters = value
+            .int_filters
+            .into_iter()
+            .map(|(k, v)| (k.value, v.into()))
+            .collect();
+
+        let uid_filters = value.uid_filters.into();
+
+        Self {
+            query_id,
+            node_type,
+            int_filters,
+            string_filters,
+            uid_filters: Some(uid_filters),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GraphQuery {
+    pub root_query_id: QueryId,
+    pub node_property_queries: FxHashMap<QueryId, NodePropertyQuery>,
+    pub edge_filters: FxHashMap<(QueryId, EdgeName), FxHashSet<QueryId>>,
+    pub edge_map: FxHashMap<EdgeName, EdgeName>,
+}
+
+impl GraphQuery {
+    pub fn add_node(&mut self, query_id: QueryId, node_type: NodeType) {
+        self.node_property_queries.insert(
+            query_id,
+            NodePropertyQuery {
+                query_id,
+                node_type,
+                int_filters: Default::default(),
+                string_filters: Default::default(),
+                uid_filters: Default::default(),
+            },
+        );
+    }
+
+    pub fn merge_node(&mut self, node: NodePropertyQuery) {
+        match self.node_property_queries.entry(node.query_id) {
+            Entry::Occupied(n) => {
+                n.into_mut().merge(node);
+            }
+            Entry::Vacant(n) => {
+                n.insert(node);
+            }
+        }
+    }
+}
+
+impl TryFrom<GraphQueryProto> for GraphQuery {
+    type Error = SerDeError;
+    fn try_from(value: GraphQueryProto) -> Result<Self, Self::Error> {
+        let root_query_id: QueryId = value
+            .root_query_id
+            .ok_or_else(|| SerDeError::MissingField("root_query_id"))?
+            .try_into()?;
+
+        let node_property_queries_proto = value
+            .node_property_queries
+            .ok_or_else(|| SerDeError::MissingField("node_property_queries"))?;
+
+        let mut node_property_queries: FxHashMap<QueryId, NodePropertyQuery> = FxHashMap::default();
+        node_property_queries.reserve(node_property_queries_proto.entries.len());
+
+        for node_property_query in node_property_queries_proto.entries {
+            let query_id = node_property_query
+                .query_id
+                .ok_or_else(|| SerDeError::MissingField("query_id"))?
+                .try_into()?;
+            let node_property_query = node_property_query
+                .node_property_query
+                .ok_or_else(|| SerDeError::MissingField("node_property_query"))?
+                .try_into()?;
+            node_property_queries.insert(query_id, node_property_query);
+        }
+
+        let edge_filters_proto = value
+            .edge_filters
+            .ok_or_else(|| SerDeError::MissingField("edge_filters"))?;
+
+        let mut edge_filters: FxHashMap<(QueryId, EdgeName), FxHashSet<QueryId>> =
+            FxHashMap::default();
+        edge_filters.reserve(edge_filters_proto.entries.len());
+
+        for edge_filter in edge_filters_proto.entries {
+            let query_id = edge_filter
+                .query_id
+                .ok_or_else(|| SerDeError::MissingField("query_id"))?
+                .try_into()?;
+            let edge_name = edge_filter
+                .edge_name
+                .ok_or_else(|| SerDeError::MissingField("edge_name"))?
+                .try_into()?;
+            let neighbor_query_ids = edge_filter
+                .neighbor_query_ids
+                .into_iter()
+                .map(|query_id| query_id.try_into())
+                .collect::<Result<FxHashSet<_>, _>>()?;
+            edge_filters.insert((query_id, edge_name), neighbor_query_ids);
+        }
+
+        let edge_map_proto = value
+            .edge_map
+            .ok_or_else(|| SerDeError::MissingField("edge_map"))?;
+        let mut edge_map: FxHashMap<EdgeName, EdgeName> = FxHashMap::default();
+        edge_map.reserve(edge_map_proto.entries.len());
+
+        for edge_entry in edge_map_proto.entries {
+            let forward_edge_name = edge_entry
+                .forward_edge_name
+                .ok_or_else(|| SerDeError::MissingField("forward_edge_name"))?
+                .try_into()?;
+            let reverse_edge_name = edge_entry
+                .reverse_edge_name
+                .ok_or_else(|| SerDeError::MissingField("reverse_edge_name"))?
+                .try_into()?;
+            edge_map.insert(forward_edge_name, reverse_edge_name);
+        }
+
+        Ok(Self {
+            root_query_id,
+            node_property_queries,
+            edge_filters,
+            edge_map,
+        })
+    }
+}
+
+impl From<GraphQuery> for GraphQueryProto {
+    fn from(value: GraphQuery) -> Self {
+        let root_query_id = Some(value.root_query_id.into());
+        let node_property_queries = Some(NodePropertyQueryMapProto {
+            entries: value
+                .node_property_queries
+                .into_iter()
+                .map(|(k, v)| NodePropertyQueryEntryProto {
+                    query_id: Some(k.into()),
+                    node_property_query: Some(v.into()),
+                })
+                .collect(),
+        });
+        let edge_filters = Some(EdgeQueryMapProto {
+            entries: value
+                .edge_filters
+                .into_iter()
+                .map(|((k0, k1), v)| EdgeQueryEntryProto {
+                    query_id: Some(k0.into()),
+                    edge_name: Some(k1.into()),
+                    neighbor_query_ids: v.into_iter().map(QueryIdProto::from).collect(),
+                })
+                .collect(),
+        });
+
+        let edge_map = Some(EdgeNameMapProto {
+            entries: value
+                .edge_map
+                .into_iter()
+                .map(|(k, v)| EdgeNameEntryProto {
+                    forward_edge_name: Some(k.into()),
+                    reverse_edge_name: Some(v.into()),
+                })
+                .collect(),
+        });
+        Self {
+            root_query_id,
+            node_property_queries,
+            edge_filters,
+            edge_map,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NodePropertiesView {
+    pub uid: Uid,
+    pub node_type: NodeType,
+    pub string_properties: FxHashMap<PropertyName, String>,
+}
+
+impl NodePropertiesView {
+    pub fn new(
+        uid: Uid,
+        node_type: NodeType,
+        string_properties: FxHashMap<PropertyName, String>,
+    ) -> Self {
+        Self {
+            uid,
+            node_type,
+            string_properties,
+        }
+    }
+
+    pub fn merge(&mut self, other: Self) {
+        debug_assert_eq!(self.uid, other.uid);
+        debug_assert_eq!(self.node_type, other.node_type);
+        self.string_properties.extend(other.string_properties);
+    }
+
+    pub fn add_string_property(&mut self, property_name: PropertyName, value: String) {
+        self.string_properties.insert(property_name, value);
+    }
+}
+
+impl TryFrom<NodePropertiesViewProto> for NodePropertiesView {
+    type Error = SerDeError;
+    fn try_from(value: NodePropertiesViewProto) -> Result<Self, Self::Error> {
+        let proto_string_properties = value
+            .string_properties
+            .ok_or_else(|| SerDeError::MissingField("string_properties"))?;
+
+        let mut string_properties = FxHashMap::default();
+        string_properties.reserve(proto_string_properties.properties.len());
+
+        for string_property in proto_string_properties.properties {
+            let property_name = string_property
+                .property_name
+                .ok_or_else(|| SerDeError::MissingField("property_name"))?;
+            string_properties.insert(property_name.try_into()?, string_property.property_value);
+        }
+
+        Ok(Self {
+            uid: value
+                .uid
+                .ok_or(SerDeError::MissingField("uid"))?
+                .try_into()?,
+            node_type: value
+                .node_type
+                .ok_or(SerDeError::MissingField("node_type"))?
+                .try_into()?,
+            string_properties,
+        })
+    }
+}
+
+impl From<NodePropertiesView> for NodePropertiesViewProto {
+    fn from(value: NodePropertiesView) -> Self {
+        let string_properties: Vec<StringPropertyProto> = value
+            .string_properties
+            .into_iter()
+            .map(|(k, v)| StringPropertyProto {
+                property_name: Some(k.into()),
+                property_value: v,
+            })
+            .collect();
+        let string_properties = Some(StringPropertiesProto {
+            properties: string_properties,
+        });
+
+        Self {
+            uid: Some(value.uid.into()),
+            node_type: Some(value.node_type.into()),
+            string_properties,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NodePropertiesViewEntry {
+    pub uid: Uid,
+    pub node_view: NodePropertiesView,
+}
+
+impl TryFrom<NodePropertiesViewEntryProto> for NodePropertiesViewEntry {
+    type Error = SerDeError;
+    fn try_from(value: NodePropertiesViewEntryProto) -> Result<Self, Self::Error> {
+        Ok(Self {
+            uid: value
+                .uid
+                .ok_or(SerDeError::MissingField("uid"))?
+                .try_into()?,
+            node_view: value
+                .node_view
+                .ok_or(SerDeError::MissingField("node_view"))?
+                .try_into()?,
+        })
+    }
+}
+
+impl From<NodePropertiesViewEntry> for NodePropertiesViewEntryProto {
+    fn from(value: NodePropertiesViewEntry) -> Self {
+        NodePropertiesViewEntryProto {
+            uid: Some(value.uid.into()),
+            node_view: Some(value.node_view.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NodePropertiesViewMap {
+    pub entries: FxHashMap<Uid, NodePropertiesView>,
+}
+
+impl TryFrom<NodePropertiesViewMapProto> for NodePropertiesViewMap {
+    type Error = SerDeError;
+    fn try_from(value: NodePropertiesViewMapProto) -> Result<Self, Self::Error> {
+        let mut entries = FxHashMap::default();
+        entries.reserve(value.entries.len());
+
+        for entry in value.entries.into_iter() {
+            let uid = entry
+                .uid
+                .ok_or(SerDeError::MissingField("uid"))?
+                .try_into()?;
+            let node_view = entry
+                .node_view
+                .ok_or(SerDeError::MissingField("node_view"))?
+                .try_into()?;
+            entries.insert(uid, node_view);
+        }
+
+        Ok(Self { entries })
+    }
+}
+
+impl From<NodePropertiesViewMap> for NodePropertiesViewMapProto {
+    fn from(value: NodePropertiesViewMap) -> Self {
+        let mut entries = Vec::with_capacity(value.entries.len());
+
+        for (uid, node_view) in value.entries.into_iter() {
+            entries.push(NodePropertiesViewEntryProto {
+                uid: Some(uid.into()),
+                node_view: Some(node_view.into()),
+            });
+        }
+
+        Self { entries }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EdgeViewEntry {
+    pub uid: Uid,
+    pub edge_name: EdgeName,
+    pub neighbors: FxHashSet<Uid>,
+}
+
+impl TryFrom<EdgeViewEntryProto> for EdgeViewEntry {
+    type Error = SerDeError;
+    fn try_from(value: EdgeViewEntryProto) -> Result<Self, Self::Error> {
+        let mut neighbors = FxHashSet::default();
+        neighbors.reserve(value.neighbors.len());
+        for neighbor in value.neighbors.into_iter() {
+            neighbors.insert(neighbor.try_into()?);
+        }
+        Ok(Self {
+            uid: value
+                .uid
+                .ok_or(SerDeError::MissingField("uid"))?
+                .try_into()?,
+            edge_name: value
+                .edge_name
+                .ok_or(SerDeError::MissingField("edge_name"))?
+                .try_into()?,
+            neighbors,
+        })
+    }
+}
+
+impl From<EdgeViewEntry> for EdgeViewEntryProto {
+    fn from(value: EdgeViewEntry) -> Self {
+        let mut neighbors = Vec::with_capacity(value.neighbors.len());
+        for neighbor in value.neighbors.into_iter() {
+            neighbors.push(neighbor.into());
+        }
+        EdgeViewEntryProto {
+            uid: Some(value.uid.into()),
+            edge_name: Some(value.edge_name.into()),
+            neighbors,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EdgeViewMap {
+    pub entries: FxHashMap<(Uid, EdgeName), FxHashSet<Uid>>,
+}
+
+impl TryFrom<EdgeViewMapProto> for EdgeViewMap {
+    type Error = SerDeError;
+    fn try_from(value: EdgeViewMapProto) -> Result<Self, Self::Error> {
+        let mut entries = FxHashMap::default();
+        entries.reserve(value.entries.len());
+
+        for entry in value.entries.into_iter() {
+            let entry: EdgeViewEntry = entry.try_into()?;
+            entries.insert((entry.uid, entry.edge_name), entry.neighbors);
+        }
+
+        Ok(Self { entries })
+    }
+}
+
+impl From<EdgeViewMap> for EdgeViewMapProto {
+    fn from(value: EdgeViewMap) -> Self {
+        let mut entries = Vec::with_capacity(value.entries.len());
+
+        for ((uid, edge_name), neighbors) in value.entries.into_iter() {
+            entries.push(
+                EdgeViewEntry {
+                    uid,
+                    edge_name,
+                    neighbors,
+                }
+                .into(),
+            );
+        }
+
+        Self { entries }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct GraphView {
+    pub nodes: FxHashMap<Uid, NodePropertiesView>,
+    pub edges: FxHashMap<(Uid, EdgeName), FxHashSet<Uid>>,
+}
+
+impl GraphView {
+    pub fn new_node(&mut self, uid: Uid, node_type: NodeType) -> &mut NodePropertiesView {
+        self.nodes
+            .entry(uid)
+            .or_insert_with(|| NodePropertiesView::new(uid, node_type, Default::default()))
+    }
+
+    pub fn add_node(&mut self, node: NodePropertiesView) {
+        match self.nodes.entry(node.uid) {
+            Entry::Occupied(n) => {
+                n.into_mut().merge(node);
+            }
+            Entry::Vacant(n) => {
+                n.insert(node);
+            }
+        }
+    }
+
+    pub fn add_edge(&mut self, from: Uid, edge_name: EdgeName, to: Uid) {
+        self.edges
+            .entry((from, edge_name))
+            .or_insert_with(FxHashSet::default)
+            .insert(to);
+    }
+
+    pub fn add_edges(&mut self, src_uid: Uid, edge_name: EdgeName, dst_uids: FxHashSet<Uid>) {
+        self.edges
+            .entry((src_uid, edge_name))
+            .or_insert_with(FxHashSet::default)
+            .extend(dst_uids);
+    }
+
+    pub fn get_node(&self, uid: Uid) -> Option<&NodePropertiesView> {
+        self.nodes.get(&uid)
+    }
+
+    pub fn get_edges(&self, from: Uid) -> impl Iterator<Item = (&EdgeName, &FxHashSet<Uid>)> {
+        self.edges
+            .iter()
+            .filter(move |(key, _)| key.0 == from)
+            .map(|(key, value)| (&key.1, value))
+    }
+
+    pub fn merge(&mut self, other: Self) {
+        for (_, node) in other.nodes.into_iter() {
+            self.add_node(node);
+        }
+
+        for ((src_uid, edge_name), dst_uids) in other.edges.into_iter() {
+            self.add_edges(src_uid.clone(), edge_name.clone(), dst_uids.clone());
+        }
+    }
+
+    pub fn get_nodes(&self) -> &FxHashMap<Uid, NodePropertiesView> {
+        &self.nodes
+    }
+}
+
+impl TryFrom<GraphViewProto> for GraphView {
+    type Error = SerDeError;
+    fn try_from(value: GraphViewProto) -> Result<Self, Self::Error> {
+        let nodes: NodePropertiesViewMap = value
+            .nodes
+            .ok_or(SerDeError::MissingField("nodes"))?
+            .try_into()?;
+        let edges: EdgeViewMap = value
+            .edges
+            .ok_or(SerDeError::MissingField("edges"))?
+            .try_into()?;
+
+        Ok(Self {
+            nodes: nodes.entries,
+            edges: edges.entries,
+        })
+    }
+}
+
+impl From<GraphView> for GraphViewProto {
+    fn from(value: GraphView) -> Self {
+        let nodes = NodePropertiesViewMap {
+            entries: value.nodes,
+        }
+        .into();
+        let edges = EdgeViewMap {
+            entries: value.edges,
+        }
+        .into();
+        Self {
+            nodes: Some(nodes),
+            edges: Some(edges),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryGraphWithUidRequest {
+    pub tenant_id: uuid::Uuid,
+    pub node_uid: Uid,
+    pub graph_query: GraphQuery,
+}
+
+impl TryFrom<QueryGraphWithUidRequestProto> for QueryGraphWithUidRequest {
+    type Error = SerDeError;
+
+    fn try_from(value: QueryGraphWithUidRequestProto) -> Result<Self, Self::Error> {
+        Ok(Self {
+            tenant_id: value
+                .tenant_id
+                .ok_or(SerDeError::MissingField("tenant_id"))?
+                .into(),
+            node_uid: value
+                .node_uid
+                .ok_or(SerDeError::MissingField("node_uid"))?
+                .try_into()?,
+            graph_query: value
+                .graph_query
+                .ok_or(SerDeError::MissingField("node_query"))?
+                .try_into()?,
+        })
+    }
+}
+
+impl From<QueryGraphWithUidRequest> for QueryGraphWithUidRequestProto {
+    fn from(value: QueryGraphWithUidRequest) -> Self {
+        Self {
+            tenant_id: Some(value.tenant_id.into()),
+            node_uid: Some(value.node_uid.into()),
+            graph_query: Some(value.graph_query.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MatchedGraphWithUid {
+    pub matched_graph: GraphView,
+    pub root_uid: Uid,
+}
+
+impl TryFrom<MatchedGraphWithUidProto> for MatchedGraphWithUid {
+    type Error = SerDeError;
+    fn try_from(value: MatchedGraphWithUidProto) -> Result<Self, Self::Error> {
+        Ok(Self {
+            matched_graph: value
+                .matched_graph
+                .ok_or(SerDeError::MissingField("matched_graph"))?
+                .try_into()?,
+
+            root_uid: value
+                .root_uid
+                .ok_or(SerDeError::MissingField("root_uid"))?
+                .try_into()?,
+        })
+    }
+}
+
+impl From<MatchedGraphWithUid> for MatchedGraphWithUidProto {
+    fn from(value: MatchedGraphWithUid) -> Self {
+        Self {
+            matched_graph: Some(value.matched_graph.into()),
+            root_uid: Some(value.root_uid.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NoMatchWithUid {}
+
+impl From<NoMatchWithUidProto> for NoMatchWithUid {
+    fn from(value: NoMatchWithUidProto) -> Self {
+        let NoMatchWithUidProto {} = value;
+        Self {}
+    }
+}
+
+impl From<NoMatchWithUid> for NoMatchWithUidProto {
+    fn from(value: NoMatchWithUid) -> Self {
+        let NoMatchWithUid {} = value;
+        Self {}
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum MaybeMatchWithUid {
+    Matched(MatchedGraphWithUid),
+    Missed(NoMatchWithUid),
+}
+
+impl TryFrom<MaybeMatchWithUidProto> for MaybeMatchWithUid {
+    type Error = SerDeError;
+    fn try_from(value_proto: MaybeMatchWithUidProto) -> Result<Self, Self::Error> {
+        match value_proto.inner {
+            Some(maybe_match_with_uid_proto::Inner::Matched(matched)) => {
+                Ok(MaybeMatchWithUid::Matched(matched.try_into()?))
+            }
+            Some(maybe_match_with_uid_proto::Inner::Missed(missed)) => {
+                Ok(MaybeMatchWithUid::Missed(missed.into()))
+            }
+            None => Err(SerDeError::UnknownVariant("MaybeMatchWithUid")),
+        }
+    }
+}
+
+impl From<MaybeMatchWithUid> for MaybeMatchWithUidProto {
+    fn from(value: MaybeMatchWithUid) -> Self {
+        match value {
+            MaybeMatchWithUid::Matched(matched) => MaybeMatchWithUidProto {
+                inner: Some(maybe_match_with_uid_proto::Inner::Matched(matched.into())),
+            },
+            MaybeMatchWithUid::Missed(p) => MaybeMatchWithUidProto {
+                inner: Some(maybe_match_with_uid_proto::Inner::Missed(p.into())),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryGraphWithUidResponse {
+    pub maybe_match: MaybeMatchWithUid,
+}
+
+impl TryFrom<QueryGraphWithUidResponseProto> for QueryGraphWithUidResponse {
+    type Error = SerDeError;
+    fn try_from(value: QueryGraphWithUidResponseProto) -> Result<Self, Self::Error> {
+        Ok(Self {
+            maybe_match: value
+                .maybe_match
+                .ok_or(SerDeError::MissingField("maybe_match"))?
+                .try_into()?,
+        })
+    }
+}
+
+impl From<QueryGraphWithUidResponse> for QueryGraphWithUidResponseProto {
+    fn from(value: QueryGraphWithUidResponse) -> Self {
+        Self {
+            maybe_match: Some(value.maybe_match.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryGraphFromUidRequest {
+    pub tenant_id: uuid::Uuid,
+    pub node_uid: Uid,
+    pub graph_query: GraphQuery,
+}
+
+impl TryFrom<QueryGraphFromUidRequestProto> for QueryGraphFromUidRequest {
+    type Error = SerDeError;
+
+    fn try_from(value: QueryGraphFromUidRequestProto) -> Result<Self, Self::Error> {
+        Ok(Self {
+            tenant_id: value
+                .tenant_id
+                .ok_or(SerDeError::MissingField("tenant_id"))?
+                .into(),
+            node_uid: value
+                .node_uid
+                .ok_or(SerDeError::MissingField("node_uid"))?
+                .try_into()?,
+            graph_query: value
+                .graph_query
+                .ok_or(SerDeError::MissingField("graph_query"))?
+                .try_into()?,
+        })
+    }
+}
+
+impl From<QueryGraphFromUidRequest> for QueryGraphFromUidRequestProto {
+    fn from(value: QueryGraphFromUidRequest) -> Self {
+        Self {
+            tenant_id: Some(value.tenant_id.into()),
+            node_uid: Some(value.node_uid.into()),
+            graph_query: Some(value.graph_query.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryGraphFromUidResponse {
+    pub matched_graph: GraphView,
+}
+
+impl TryFrom<QueryGraphFromUidResponseProto> for QueryGraphFromUidResponse {
+    type Error = SerDeError;
+    fn try_from(value: QueryGraphFromUidResponseProto) -> Result<Self, Self::Error> {
+        Ok(Self {
+            matched_graph: value
+                .matched_graph
+                .ok_or(SerDeError::MissingField("matched_graph"))?
+                .try_into()?,
+        })
+    }
+}
+
+impl From<QueryGraphFromUidResponse> for QueryGraphFromUidResponseProto {
+    fn from(value: QueryGraphFromUidResponse) -> Self {
+        Self {
+            matched_graph: Some(value.matched_graph.into()),
+        }
+    }
+}

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/messages.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/messages.rs
@@ -775,7 +775,7 @@ impl From<GraphQuery> for proto::GraphQuery {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct StringProperties {
     pub prop_map: FxHashMap<PropertyName, String>,
 }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/messages.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/messages.rs
@@ -56,9 +56,9 @@ pub enum IntegerProperty {
     Immutable(ImmutableIntProp),
 }
 
-impl TryFrom<proto::IntProperty> for IntegerProperty {
+impl TryFrom<proto::IntegerProperty> for IntegerProperty {
     type Error = SerDeError;
-    fn try_from(value_proto: proto::IntProperty) -> Result<Self, Self::Error> {
+    fn try_from(value_proto: proto::IntegerProperty) -> Result<Self, Self::Error> {
         match value_proto.property {
             Some(proto::integer_property::Property::IncrementOnly(p)) => {
                 Ok(IntegerProperty::IncrementOnly(p.try_into()?))
@@ -104,7 +104,9 @@ impl TryFrom<proto::int_filter::Operation> for IntOperation {
     type Error = SerDeError;
     fn try_from(value_proto: proto::int_filter::Operation) -> Result<Self, Self::Error> {
         match value_proto {
-            proto::int_filter::Operation::Unspecified => Err(SerDeError::UnknownVariant("IntOperation")),
+            proto::int_filter::Operation::Unspecified => {
+                Err(SerDeError::UnknownVariant("IntOperation"))
+            }
             proto::int_filter::Operation::Has => Ok(Self::Has),
             proto::int_filter::Operation::Equal => Ok(Self::Equal),
             proto::int_filter::Operation::LessThan => Ok(Self::LessThan),
@@ -313,7 +315,9 @@ impl TryFrom<proto::string_filter::Operation> for StringOperation {
     type Error = SerDeError;
     fn try_from(value_proto: proto::string_filter::Operation) -> Result<Self, Self::Error> {
         match value_proto {
-            proto::string_filter::Operation::Unspecified => Err(SerDeError::UnknownVariant("StringOperation")),
+            proto::string_filter::Operation::Unspecified => {
+                Err(SerDeError::UnknownVariant("StringOperation"))
+            }
             proto::string_filter::Operation::Has => Ok(Self::Has),
             proto::string_filter::Operation::Equal => Ok(Self::Equal),
             proto::string_filter::Operation::Contains => Ok(Self::Contains),
@@ -466,7 +470,9 @@ impl TryFrom<proto::uid_filter::Operation> for UidOperation {
     type Error = SerDeError;
     fn try_from(value_proto: proto::uid_filter::Operation) -> Result<Self, Self::Error> {
         match value_proto {
-            proto::uid_filter::Operation::Unspecified => Err(SerDeError::UnknownVariant("UidOperation")),
+            proto::uid_filter::Operation::Unspecified => {
+                Err(SerDeError::UnknownVariant("UidOperation"))
+            }
             proto::uid_filter::Operation::Equal => Ok(Self::Equal),
         }
     }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/mod.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/mod.rs
@@ -1,0 +1,3 @@
+pub mod client;
+pub mod messages;
+pub mod server;

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/server.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/server.rs
@@ -1,0 +1,190 @@
+use std::net::SocketAddr;
+
+use futures::FutureExt;
+use tokio::{
+    net::TcpListener,
+    sync::oneshot::Receiver,
+};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::Server;
+
+use crate::{
+    graplinc::grapl::api::graph_query_service::v1beta1::messages::{
+        QueryGraphFromUidRequest,
+        QueryGraphFromUidResponse,
+        QueryGraphWithUidRequest,
+        QueryGraphWithUidResponse,
+    },
+    protobufs::graplinc::grapl::api::graph_query_service::v1beta1::{
+        graph_query_service_server::{
+            GraphQueryService as GraphQueryServiceProto,
+            GraphQueryServiceServer as GraphQueryServiceServerProto,
+        },
+        QueryGraphFromUidRequest as QueryGraphFromUidRequestProto,
+        QueryGraphFromUidResponse as QueryGraphFromUidResponseProto,
+        QueryGraphWithUidRequest as QueryGraphWithUidRequestProto,
+        QueryGraphWithUidResponse as QueryGraphWithUidResponseProto,
+    },
+    protocol::{
+        healthcheck::{
+            server::init_health_service,
+            HealthcheckStatus,
+        },
+        status::Status,
+    },
+    SerDeError,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum GraphQueryServiceServerError {
+    #[error("grpc transport error: {0}")]
+    GrpcTransportError(#[from] tonic::transport::Error),
+    #[error("Bind error: {0}")]
+    BindError(std::io::Error),
+}
+
+#[tonic::async_trait]
+pub trait GraphQueryApi {
+    type Error: Into<Status>;
+    async fn query_graph_with_uid(
+        &self,
+        request: QueryGraphWithUidRequest,
+    ) -> Result<QueryGraphWithUidResponse, Self::Error>;
+    async fn query_graph_from_uid(
+        &self,
+        request: QueryGraphFromUidRequest,
+    ) -> Result<QueryGraphFromUidResponse, Self::Error>;
+}
+
+#[tonic::async_trait]
+impl<T, E> GraphQueryServiceProto for T
+where
+    T: GraphQueryApi<Error = E> + Send + Sync + 'static,
+    E: Into<Status> + Send + Sync + 'static,
+{
+    async fn query_graph_with_uid(
+        &self,
+        request: tonic::Request<QueryGraphWithUidRequestProto>,
+    ) -> Result<tonic::Response<QueryGraphWithUidResponseProto>, tonic::Status> {
+        let request = request.into_inner();
+        let request = request
+            .try_into()
+            .map_err(|e: SerDeError| tonic::Status::invalid_argument(e.to_string()))?;
+        let response = GraphQueryApi::query_graph_with_uid(self, request)
+            .await
+            .map_err(|e| e.into())?;
+
+        Ok(tonic::Response::new(response.into()))
+    }
+
+    async fn query_graph_from_uid(
+        &self,
+        request: tonic::Request<QueryGraphFromUidRequestProto>,
+    ) -> Result<tonic::Response<QueryGraphFromUidResponseProto>, tonic::Status> {
+        let request = request.into_inner();
+        let request = request
+            .try_into()
+            .map_err(|e: SerDeError| tonic::Status::invalid_argument(e.to_string()))?;
+        let response = GraphQueryApi::query_graph_from_uid(self, request)
+            .await
+            .map_err(|e| e.into())?;
+        Ok(tonic::Response::new(response.into()))
+    }
+}
+
+/// A server construct that drives the GraphQueryApi implementation.
+pub struct GraphQueryServiceServer<T, E>
+where
+    T: GraphQueryApi<Error = E> + Send + Sync + 'static,
+    E: Into<Status> + Send + Sync + 'static,
+{
+    server: GraphQueryServiceServerProto<T>,
+    addr: SocketAddr,
+    shutdown_rx: Receiver<()>,
+}
+
+impl<T, E> GraphQueryServiceServer<T, E>
+where
+    T: GraphQueryApi<Error = E> + Send + Sync + 'static,
+    E: Into<Status> + Send + Sync + 'static,
+{
+    pub fn builder(
+        service: T,
+        addr: SocketAddr,
+        shutdown_rx: Receiver<()>,
+    ) -> GraphQueryServiceServerBuilder<T, E> {
+        GraphQueryServiceServerBuilder::new(service, addr, shutdown_rx)
+    }
+
+    pub async fn serve(self) -> Result<(), GraphQueryServiceServerError> {
+        let (healthcheck_handle, health_service) =
+            init_health_service::<GraphQueryServiceServerProto<T>, _, _>(
+                || async { Ok(HealthcheckStatus::Serving) },
+                std::time::Duration::from_millis(500),
+            )
+            .await;
+
+        let listener = TcpListener::bind(self.addr)
+            .await
+            .map_err(GraphQueryServiceServerError::BindError)?;
+
+        Server::builder()
+            .trace_fn(|request| {
+                tracing::trace_span!(
+                    "GraphQuery",
+                    headers = ?request.headers(),
+                    method = ?request.method(),
+                    uri = %request.uri(),
+                    extensions = ?request.extensions(),
+                )
+            })
+            .add_service(health_service)
+            .add_service(self.server)
+            .serve_with_incoming_shutdown(
+                TcpListenerStream::new(listener),
+                self.shutdown_rx.map(|_| ()),
+            )
+            .then(|result| async move {
+                healthcheck_handle.abort();
+                result
+            })
+            .await?;
+        Ok(())
+    }
+}
+
+pub struct GraphQueryServiceServerBuilder<T, E>
+where
+    T: GraphQueryApi<Error = E> + Send + Sync + 'static,
+    E: Into<Status> + Send + Sync + 'static,
+{
+    server: GraphQueryServiceServerProto<T>,
+    addr: SocketAddr,
+    shutdown_rx: Receiver<()>,
+}
+
+impl<T, E> GraphQueryServiceServerBuilder<T, E>
+where
+    T: GraphQueryApi<Error = E> + Send + Sync + 'static,
+    E: Into<Status> + Send + Sync + 'static,
+{
+    /// Create a new builder for a GraphQueryServiceServer,
+    /// taking the required arguments upfront.
+    pub fn new(service: T, addr: SocketAddr, shutdown_rx: Receiver<()>) -> Self {
+        Self {
+            server: GraphQueryServiceServerProto::new(service),
+            addr,
+            shutdown_rx,
+        }
+    }
+
+    /// Consumes the builder and returns a new `GraphQueryServiceServer`.
+    /// Note: Panics on invalid build state
+    pub fn build(self) -> GraphQueryServiceServer<T, E> {
+        GraphQueryServiceServer {
+            server: self.server,
+            addr: self.addr,
+            shutdown_rx: self.shutdown_rx,
+        }
+    }
+}

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/server.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_service/v1beta1/server.rs
@@ -14,7 +14,10 @@ use futures::{
 };
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
-use tonic::transport::Server;
+use tonic::transport::{
+    NamedService,
+    Server,
+};
 
 use crate::{
     execute_rpc,

--- a/src/rust/rust-proto/src/graplinc/grapl/common/v1beta1/types.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/common/v1beta1/types.rs
@@ -51,9 +51,10 @@ impl TryFrom<&'static str> for PropertyName {
 }
 
 impl TryFrom<String> for PropertyName {
-    type Error = &'static str;
+    type Error = SerDeError;
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        // todo: Validate this thing
+        // While this is currently infallible, we may add validation later,
+        // hence the TryFrom.
         Ok(PropertyName { value })
     }
 }
@@ -61,6 +62,8 @@ impl TryFrom<String> for PropertyName {
 impl TryFrom<PropertyNameProto> for PropertyName {
     type Error = SerDeError;
     fn try_from(proto: PropertyNameProto) -> Result<Self, Self::Error> {
+        // While this is currently infallible, we may add validation later,
+        // hence the TryFrom.
         Ok(Self { value: proto.value })
     }
 }
@@ -91,32 +94,29 @@ impl std::fmt::Display for EdgeName {
 }
 
 impl TryFrom<String> for EdgeName {
-    type Error = &'static str;
-    fn try_from(raw: String) -> Result<Self, Self::Error> {
-        if raw.is_empty() {
-            return Err("EdgeName can not be empty");
+    type Error = SerDeError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            return Err(SerDeError::MissingField("EdgeName"));
         }
-        if raw.len() > 32 {
-            return Err("EdgeName can not be more than 32 characters");
+        if value.len() > 32 {
+            return Err(SerDeError::InvalidField {
+                field_name: "EdgeName",
+                assertion: format!(
+                    "can not be more than 32 characters but was {len}",
+                    len = value.len()
+                ),
+            });
         }
 
-        Ok(Self { value: raw })
+        Ok(Self { value })
     }
 }
 
-impl TryFrom<&'static str> for EdgeName {
-    type Error = &'static str;
-    fn try_from(raw: &'static str) -> Result<Self, Self::Error> {
-        if raw.is_empty() {
-            return Err("EdgeName can not be empty");
-        }
-        if raw.len() > 32 {
-            return Err("EdgeName can not be more than 32 characters");
-        }
-
-        Ok(Self {
-            value: raw.to_owned(),
-        })
+impl TryFrom<&str> for EdgeName {
+    type Error = SerDeError;
+    fn try_from(raw: &str) -> Result<Self, Self::Error> {
+        EdgeName::try_from(raw.to_owned())
     }
 }
 

--- a/src/rust/rust-proto/src/graplinc/grapl/common/v1beta1/types.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/common/v1beta1/types.rs
@@ -1,0 +1,245 @@
+use crate::{
+    protobufs::graplinc::grapl::common::v1beta1::{
+        EdgeName as EdgeNameProto,
+        NodeType as NodeTypeProto,
+        PropertyName as PropertyNameProto,
+        Uid as UidProto,
+    },
+    serde_impl,
+    type_url,
+    SerDeError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PropertyName {
+    pub value: String,
+}
+
+impl std::fmt::Display for PropertyName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.value)
+    }
+}
+
+impl PropertyName {
+    pub fn new_unchecked(value: String) -> Self {
+        // todo: debug assertion
+        Self { value }
+    }
+}
+
+impl TryFrom<&'static str> for PropertyName {
+    type Error = SerDeError;
+    fn try_from(raw: &'static str) -> Result<Self, Self::Error> {
+        if raw.is_empty() {
+            return Err(SerDeError::InvalidField {
+                field_name: "PropertyName",
+                assertion: "can not be empty".to_owned(),
+            });
+        }
+        if raw.len() > 32 {
+            return Err(SerDeError::InvalidField {
+                field_name: "PropertyName",
+                assertion: "can not be more than 32 characters".to_owned(),
+            });
+        }
+
+        Ok(Self {
+            value: raw.to_owned(),
+        })
+    }
+}
+
+impl TryFrom<String> for PropertyName {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        // todo: Validate this thing
+        Ok(PropertyName { value })
+    }
+}
+
+impl TryFrom<PropertyNameProto> for PropertyName {
+    type Error = SerDeError;
+    fn try_from(proto: PropertyNameProto) -> Result<Self, Self::Error> {
+        Ok(Self { value: proto.value })
+    }
+}
+
+impl From<PropertyName> for PropertyNameProto {
+    fn from(value: PropertyName) -> Self {
+        Self { value: value.value }
+    }
+}
+
+impl serde_impl::ProtobufSerializable for PropertyName {
+    type ProtobufMessage = PropertyNameProto;
+}
+
+impl type_url::TypeUrl for PropertyName {
+    const TYPE_URL: &'static str = "graplsecurity.com/graplinc.grapl.common.v1beta1.PropertyName";
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EdgeName {
+    pub value: String,
+}
+
+impl std::fmt::Display for EdgeName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.value)
+    }
+}
+
+impl TryFrom<String> for EdgeName {
+    type Error = &'static str;
+    fn try_from(raw: String) -> Result<Self, Self::Error> {
+        if raw.is_empty() {
+            return Err("EdgeName can not be empty");
+        }
+        if raw.len() > 32 {
+            return Err("EdgeName can not be more than 32 characters");
+        }
+
+        Ok(Self { value: raw })
+    }
+}
+
+impl TryFrom<&'static str> for EdgeName {
+    type Error = &'static str;
+    fn try_from(raw: &'static str) -> Result<Self, Self::Error> {
+        if raw.is_empty() {
+            return Err("EdgeName can not be empty");
+        }
+        if raw.len() > 32 {
+            return Err("EdgeName can not be more than 32 characters");
+        }
+
+        Ok(Self {
+            value: raw.to_owned(),
+        })
+    }
+}
+
+impl TryFrom<EdgeNameProto> for EdgeName {
+    type Error = SerDeError;
+    fn try_from(proto: EdgeNameProto) -> Result<Self, Self::Error> {
+        Ok(Self { value: proto.value })
+    }
+}
+
+impl From<EdgeName> for EdgeNameProto {
+    fn from(value: EdgeName) -> Self {
+        Self { value: value.value }
+    }
+}
+
+impl serde_impl::ProtobufSerializable for EdgeName {
+    type ProtobufMessage = EdgeNameProto;
+}
+
+impl type_url::TypeUrl for EdgeName {
+    const TYPE_URL: &'static str = "graplsecurity.com/graplinc.grapl.common.v1beta1.EdgeName";
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NodeType {
+    pub value: String,
+}
+
+impl std::fmt::Display for NodeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.value)
+    }
+}
+
+impl TryFrom<&'static str> for NodeType {
+    type Error = SerDeError;
+    fn try_from(raw: &'static str) -> Result<Self, Self::Error> {
+        if raw.is_empty() {
+            return Err(SerDeError::InvalidField {
+                field_name: "EdgeName",
+                assertion: "can not be empty".to_owned(),
+            });
+        }
+        if raw.len() > 32 {
+            return Err(SerDeError::InvalidField {
+                field_name: "EdgeName",
+                assertion: "can not be more than 32 characters".to_owned(),
+            });
+        }
+
+        Ok(Self {
+            value: raw.to_owned(),
+        })
+    }
+}
+
+impl TryFrom<NodeTypeProto> for NodeType {
+    type Error = SerDeError;
+    fn try_from(proto: NodeTypeProto) -> Result<Self, Self::Error> {
+        Ok(Self { value: proto.value })
+    }
+}
+
+impl From<NodeType> for NodeTypeProto {
+    fn from(value: NodeType) -> Self {
+        Self { value: value.value }
+    }
+}
+
+impl serde_impl::ProtobufSerializable for NodeType {
+    type ProtobufMessage = NodeTypeProto;
+}
+
+impl type_url::TypeUrl for NodeType {
+    const TYPE_URL: &'static str = "graplsecurity.com/graplinc.grapl.common.v1beta1.NodeType";
+}
+
+#[derive(Debug, PartialOrd, Ord, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Uid {
+    value: u64,
+}
+
+impl Uid {
+    pub fn from_i64(value: i64) -> Option<Self> {
+        if value == 0 {
+            None
+        } else {
+            Self::from_u64(value as u64)
+        }
+    }
+    pub fn from_u64(value: u64) -> Option<Self> {
+        if value == 0 {
+            None
+        } else {
+            Some(Self { value })
+        }
+    }
+    pub fn as_i64(&self) -> i64 {
+        self.value as i64
+    }
+    pub fn as_u64(&self) -> u64 {
+        self.value
+    }
+}
+
+impl TryFrom<UidProto> for Uid {
+    type Error = SerDeError;
+    fn try_from(proto: UidProto) -> Result<Self, Self::Error> {
+        Ok(Self { value: proto.value })
+    }
+}
+
+impl From<Uid> for UidProto {
+    fn from(value: Uid) -> Self {
+        Self { value: value.value }
+    }
+}
+
+impl serde_impl::ProtobufSerializable for Uid {
+    type ProtobufMessage = UidProto;
+}
+
+impl type_url::TypeUrl for Uid {
+    const TYPE_URL: &'static str = "graplsecurity.com/graplinc.grapl.common.v1beta1.Uid";
+}

--- a/src/rust/rust-proto/src/lib.rs
+++ b/src/rust/rust-proto/src/lib.rs
@@ -29,6 +29,15 @@ pub(crate) mod protobufs {
         }
 
         pub(crate) mod grapl {
+            pub(crate) mod common {
+                pub(crate) mod v1beta1 {
+                    include!(concat!(
+                        env!("OUT_DIR"),
+                        "/graplinc.grapl.common.v1beta1.rs"
+                    ));
+                }
+            }
+
             pub(crate) mod api {
                 pub(crate) mod event_source {
                     pub(crate) mod v1beta1 {
@@ -44,6 +53,15 @@ pub(crate) mod protobufs {
                         include!(concat!(
                             env!("OUT_DIR"),
                             "/graplinc.grapl.api.graph.v1beta1.rs"
+                        ));
+                    }
+                }
+
+                pub(crate) mod graph_query_service {
+                    pub(crate) mod v1beta1 {
+                        include!(concat!(
+                            env!("OUT_DIR"),
+                            "/graplinc.grapl.api.graph_query_service.v1beta1.rs"
                         ));
                     }
                 }
@@ -143,12 +161,22 @@ pub mod graplinc {
     }
 
     pub mod grapl {
+        pub mod common {
+            pub mod v1beta1 {
+                pub mod types;
+            }
+        }
+
         pub mod api {
             pub mod event_source {
                 pub mod v1beta1;
             }
 
             pub mod graph {
+                pub mod v1beta1;
+            }
+
+            pub mod graph_query_service {
                 pub mod v1beta1;
             }
 


### PR DESCRIPTION
Just updates the messages in rust-proto to account for Graph Query Service. Colin asked I do this separately to unblock people.