### PR TITLE
Dump a zip file of all artifacts

### DIFF
--- a/etc/ci_scripts/dump_artifacts/cli.py
+++ b/etc/ci_scripts/dump_artifacts/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import logging
 import os
+import shutil
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -99,6 +100,10 @@ def main() -> None:
     analysis_dir = artifacts_dir / "analysis"
     os.makedirs(analysis_dir, exist_ok=False)
     pipeline_message_flow.analyze_grapl_core(artifacts_dir, analysis_dir)
+
+    # Zip up everything
+    zip_filename = (artifacts_dir / "ALL_ARTIFACTS").resolve()
+    shutil.make_archive(base_name=zip_filename, format="zip", root_dir=artifacts_dir)
 
     LOGGER.info(f"--- Artifacts dumped to {artifacts_dir}")
 

--- a/etc/ci_scripts/dump_artifacts/cli.py
+++ b/etc/ci_scripts/dump_artifacts/cli.py
@@ -101,9 +101,11 @@ def main() -> None:
     os.makedirs(analysis_dir, exist_ok=False)
     pipeline_message_flow.analyze_grapl_core(artifacts_dir, analysis_dir)
 
-    # Zip up everything
-    zip_filename = str((artifacts_dir / "ALL_ARTIFACTS").resolve())
+    # Zip up everything. We can't zip up directly into artifacts_dir or you
+    # get a recursive zip - that is to say, eating up all the space on disk.
+    zip_filename = "/tmp/ALL_ARTIFACTS"
     shutil.make_archive(base_name=zip_filename, format="zip", root_dir=artifacts_dir)
+    shutil.move(src="/tmp/ALL_ARTIFACTS.zip", dst=artifacts_dir)
 
     LOGGER.info(f"--- Artifacts dumped to {artifacts_dir}")
 

--- a/etc/ci_scripts/dump_artifacts/cli.py
+++ b/etc/ci_scripts/dump_artifacts/cli.py
@@ -102,7 +102,7 @@ def main() -> None:
     pipeline_message_flow.analyze_grapl_core(artifacts_dir, analysis_dir)
 
     # Zip up everything
-    zip_filename = (artifacts_dir / "ALL_ARTIFACTS").resolve()
+    zip_filename = str((artifacts_dir / "ALL_ARTIFACTS").resolve())
     shutil.make_archive(base_name=zip_filename, format="zip", root_dir=artifacts_dir)
 
     LOGGER.info(f"--- Artifacts dumped to {artifacts_dir}")


### PR DESCRIPTION
Now, along with each file separately, each CI run will generate an ALL_ARTIFACTS.zip file