### PR TITLE
Revert "Temporarily disable Pulumi refreshes in provision pipeline"

### DIFF
--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -14,7 +14,6 @@ steps:
           command: preview
           project_dir: pulumi/grapl
           stack: grapl/testing
-          refresh: false
     agents:
       queue: "pulumi-staging"
 
@@ -46,7 +45,6 @@ steps:
           command: update
           project_dir: pulumi/grapl
           stack: grapl/testing
-          refresh: false
     agents:
       queue: "pulumi-staging"
     artifact_paths:
@@ -64,7 +62,6 @@ steps:
           command: preview
           project_dir: pulumi/rust_integration_tests
           stack: grapl/testing
-          refresh: false
     agents:
       queue: "pulumi-staging"
 
@@ -80,7 +77,6 @@ steps:
           command: update
           project_dir: pulumi/rust_integration_tests
           stack: grapl/testing
-          refresh: false
     agents:
       queue: "pulumi-staging"
 


### PR DESCRIPTION
This reverts commit 41f70132d36823016d54e99fe0b957eaed9def31.

See #1897.
