### PR TITLE
Rust integration tests: redirect stderr to stdout.

### DIFF
--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -260,7 +260,10 @@ COPY --from=build-test-integration /grapl/tests /tests
 # TODO: remove this when we can either a) rely on local service discovery to
 # finish setting up before we run our tests, or b) connect via the Nomad
 # ingress-service via HTTPS.
-ENTRYPOINT [ "sh", "-c", "sleep 10; find /tests -type f | parallel" ]
+#
+# Note: do not expand the following '-v' to '--verbose', the effect is
+# different and not desired.
+ENTRYPOINT [ "sh", "-c", "sleep 10; find /tests -type f | parallel -v '{}' '2>&1'" ]
 
 
 # images for running services


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

For the Rust integration tests, redirect std err to std out.

The Rust integration tests would previously capture stderr and stdout to two separate files. If multiple tests wrote to their stderr, it might not be immediately obvious what the error text corresponds to. The benefit of keeping these separate is less convenient than keeping them together, where the value of keeping them separate is unclear.

Additionally, this add a verbose flag to `parallel`, which prints the job command line to stdout for each job. This should help in debugging and help clarify the boundaries between jobs.

Ex"

```
/tests/schema_manager_integration_test-1e7cf03e1eca45e3 2>&1

running 1 test
test test_deploy_schema ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.68s

/tests/generator_dispatcher_integration_tests-208c0ba8ffc489a1 2>&1

running 1 test
{"timestamp":"2022-08-29T20:30:00.199206Z","level":"WARN","fields":{"message":"Skipping Jaeger tracer"},"target":"grapl_tracing::setup_tracing"}
...
```

### How were these changes tested?

I ran these changes locally while introducing two new unit tests that intentionally failed and write to stderr (via `eyre::ensure` macro).
