### PR TITLE
Give plugin-work-queue db 1024 memory

### DIFF
--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -27,12 +27,12 @@ locals {
   # `pulumi/grapl/__main__.py`; sorry for the duplication :(
   database_descriptors = [
     {
-      name   = "plugin-registry-db",
-      port   = 5432,
+      name = "plugin-registry-db",
+      port = 5432,
     },
     {
-      name = "plugin-work-queue-db",
-      port = 5433,
+      name   = "plugin-work-queue-db",
+      port   = 5433,
       memory = 1024,
     },
     {

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -29,11 +29,11 @@ locals {
     {
       name   = "plugin-registry-db",
       port   = 5432,
-      memory = 1024,
     },
     {
       name = "plugin-work-queue-db",
       port = 5433,
+      memory = 1024,
     },
     {
       name = "organization-management-db",


### PR DESCRIPTION
I removed the 1024 from PWQ's db by accident last time:
https://github.com/grapl-security/grapl/pull/1930

it should have 1024, not plugin-registry.