### PR TITLE
[backburner] Teardown plugins after tests if the test otherwise succeeded. Also eyre-ify some stuff

### DIFF
--- a/src/rust/e2e-tests/src/test_utils/context.rs
+++ b/src/rust/e2e-tests/src/test_utils/context.rs
@@ -29,8 +29,10 @@ use rust_proto::{
             PluginMetadata,
             PluginRegistryServiceClient,
             PluginType,
+            TearDownPluginRequest,
         },
     },
+    protocol::error::GrpcClientError,
 };
 use test_context::AsyncTestContext;
 use uuid::Uuid;
@@ -101,6 +103,16 @@ impl E2eTestContext {
             should_deploy_generator: true,
         })
         .await
+    }
+
+    /// This is the "be kind, please rewind" of the plugin world - we ask that
+    /// users manually call teardown on their plugin so we can claw back some
+    /// Nomad cpu/memory.
+    pub async fn teardown_plugin(&mut self, plugin_id: Uuid) -> Result<(), GrpcClientError> {
+        self.plugin_registry_client
+            .tear_down_plugin(TearDownPluginRequest::new(plugin_id))
+            .await
+            .map(|_| ())
     }
 
     pub async fn setup_generator(

--- a/src/rust/graph-merger/tests/integration_test.rs
+++ b/src/rust/graph-merger/tests/integration_test.rs
@@ -46,7 +46,7 @@ async fn test_sysmon_event_produces_merged_graph(ctx: &mut E2eTestContext) -> ey
     let test_name = "test_sysmon_event_produces_merged_graph";
     let SetupResult {
         tenant_id,
-        plugin_id: _,
+        plugin_id,
         event_source_id,
     } = ctx.setup_sysmon_generator(test_name).await?;
 
@@ -165,6 +165,8 @@ async fn test_sysmon_event_produces_merged_graph(ctx: &mut E2eTestContext) -> ey
         .iter()
         .flat_map(|edge_list| edge_list.edges.iter())
         .any(|edge| edge.to_node_key == child_process.get_node_key()));
+
+    ctx.teardown_plugin(plugin_id).await?;
 
     Ok(())
 }

--- a/src/rust/node-identifier/tests/integration_test.rs
+++ b/src/rust/node-identifier/tests/integration_test.rs
@@ -46,7 +46,7 @@ async fn test_sysmon_event_produces_identified_graph(ctx: &mut E2eTestContext) -
     let test_name = "test_sysmon_event_produces_identified_graph";
     let SetupResult {
         tenant_id,
-        plugin_id: _,
+        plugin_id,
         event_source_id,
     } = ctx.setup_sysmon_generator(test_name).await?;
 
@@ -159,6 +159,8 @@ async fn test_sysmon_event_produces_identified_graph(ctx: &mut E2eTestContext) -
         .expect("missing edge from parent to child");
 
     assert_eq!(parent_to_child_edge.edge_name, "children");
+
+    ctx.teardown_plugin(plugin_id).await?;
 
     Ok(())
 }

--- a/src/rust/plugin-registry/tests/test_deploy_plugin.rs
+++ b/src/rust/plugin-registry/tests/test_deploy_plugin.rs
@@ -266,16 +266,11 @@ async fn test_teardown_plugin() -> eyre::Result<()> {
         .plugin_deployment();
 
     eyre::ensure!(plugin_deployment.plugin_id() == plugin_id, "plugins equal");
-    eyre::ensure!(plugin_deployment.deployed(), "plugin deployed");
+    eyre::ensure!(!plugin_deployment.deployed(), "plugin not deployed");
     eyre::ensure!(
         plugin_deployment.status() == PluginDeploymentStatus::Success,
         "deployment successful"
     );
-
-    // Last, clean up the plugin to get back some Nomad resources.
-    client
-        .tear_down_plugin(TearDownPluginRequest::new(plugin_id))
-        .await?;
 
     Ok(())
 }


### PR DESCRIPTION
One tradeoff worth mentioning here is that we won't have logs for "successful" plugins based on how nomad_artifacts.py currently works! Just failed plugins. Seems fine for now.