### PR TITLE
set CPU to 50 shares

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -271,6 +271,10 @@ job "grapl-core" {
           readonly = false
         }
       }
+
+      resources {
+        cpu = 50
+      }
     }
 
     service {
@@ -348,6 +352,11 @@ job "grapl-core" {
           }
         }
       }
+
+      resources {
+        cpu = 50
+      }
+
       service {
         name = "dgraph-zero-${zero.value.id}-grpc-private"
         port = "${zero.value.grpc_private_port}"
@@ -463,7 +472,8 @@ job "grapl-core" {
         }
 
         resources {
-          memory = 512
+          memory_max = 512
+          cpu        = 50
         }
 
       }
@@ -614,6 +624,10 @@ job "grapl-core" {
         RUST_BACKTRACE = local.rust_backtrace
         RUST_LOG       = var.rust_log
       }
+
+      resources {
+        cpu = 50
+      }
     }
 
     service {
@@ -678,6 +692,10 @@ job "grapl-core" {
         KAFKA_CONSUMER_GROUP_NAME = var.kafka_consumer_groups["graph-merger"]
         KAFKA_CONSUMER_TOPIC      = "identified-graphs"
         KAFKA_PRODUCER_TOPIC      = "merged-graphs"
+      }
+
+      resources {
+        cpu = 50
       }
     }
 
@@ -748,6 +766,10 @@ job "grapl-core" {
         GRAPL_DYNAMIC_SESSION_TABLE = var.session_table_name
       }
 
+      resources {
+        cpu = 50
+      }
+
       service {
         name = "node-identifier"
       }
@@ -795,6 +817,10 @@ job "grapl-core" {
         IS_LOCAL                      = "True"
         JWT_SECRET_ID                 = "JWT_SECRET_ID"
         PORT                          = "${NOMAD_PORT_graphql-endpoint-port}"
+      }
+
+      resources {
+        cpu = 50
       }
     }
 
@@ -857,6 +883,10 @@ job "grapl-core" {
         RUST_LOG       = var.rust_log
       }
 
+      resources {
+        cpu = 50
+      }
+
       service {
         name = "generator-dispatcher-retry"
       }
@@ -913,7 +943,8 @@ job "grapl-core" {
       resources {
         # Can OOM with default limit of 300 MB and a number of connections at the same
         # time, which seems low, but is reliably produced with the its integration tests.
-        memory = 1024
+        memory_max = 1024
+        cpu        = 50
       }
     }
 
@@ -987,6 +1018,10 @@ job "grapl-core" {
 
         ORGANIZATION_MANAGEMENT_HEALTHCHECK_POLLING_INTERVAL_MS = var.organization_management_healthcheck_polling_interval_ms
       }
+
+      resources {
+        cpu = 50
+      }
     }
 
     service {
@@ -1042,6 +1077,10 @@ job "grapl-core" {
         KAFKA_SASL_USERNAME                              = var.kafka_credentials["pipeline-ingress"].sasl_username
         KAFKA_SASL_PASSWORD                              = var.kafka_credentials["pipeline-ingress"].sasl_password
         KAFKA_PRODUCER_TOPIC                             = "raw-logs"
+      }
+
+      resources {
+        cpu = 50
       }
     }
 
@@ -1119,7 +1158,8 @@ job "grapl-core" {
 
       resources {
         # Probably too much. Let's figure out buffered writes to s3
-        memory = 512
+        memory_max = 512
+        cpu        = 50
       }
     }
 
@@ -1192,6 +1232,10 @@ job "grapl-core" {
         RUST_BACKTRACE = local.rust_backtrace
         RUST_LOG       = var.rust_log
       }
+
+      resources {
+        cpu = 50
+      }
     }
 
     service {
@@ -1255,6 +1299,10 @@ job "grapl-core" {
         # common Rust env vars
         RUST_BACKTRACE = local.rust_backtrace
         RUST_LOG       = var.rust_log
+      }
+
+      resources {
+        cpu = 50
       }
     }
 

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -31,9 +31,9 @@ locals {
       port = 5432,
     },
     {
-      name   = "plugin-work-queue-db",
-      port   = 5433,
-      memory = 1024,
+      name       = "plugin-work-queue-db",
+      port       = 5433,
+      memory_max = 1024,
     },
     {
       name = "organization-management-db",
@@ -129,6 +129,10 @@ job "grapl-local-infra" {
         AWS_SECRET_ACCESS_KEY = "test"
       }
 
+      resources {
+        cpu = 50
+      }
+
       service {
         name = "localstack"
         check {
@@ -167,6 +171,10 @@ job "grapl-local-infra" {
       config {
         image = "dgraph/ratel:latest"
         ports = ["ratel"]
+      }
+
+      resources {
+        cpu = 50
       }
 
       service {
@@ -220,7 +228,8 @@ job "grapl-local-infra" {
         }
 
         resources {
-          memory = 1256
+          memory_max = 1256
+          cpu        = 50
         }
 
         env {
@@ -296,6 +305,10 @@ job "grapl-local-infra" {
         ZOOKEEPER_CLIENT_PORT = var.zookeeper_port
         ZOOKEEPER_TICK_TIME   = 2000
         KAFKA_OPTS            = "-Dzookeeper.4lw.commands.whitelist=ruok,dump"
+      }
+
+      resources {
+        cpu = 50
       }
 
       service {
@@ -389,7 +402,8 @@ job "grapl-local-infra" {
           }
 
           resources {
-            memory = lookup(db_desc.value, "memory", 512) // (map, key, default) fyi
+            memory_max = lookup(db_desc.value, "memory_max", 512) // (map, key, default) fyi
+            cpu        = 50
           }
         }
       }
@@ -500,7 +514,10 @@ job "grapl-local-infra" {
             }
           }
         }
+      }
 
+      resources {
+        cpu = 50
       }
 
       service {
@@ -521,9 +538,7 @@ job "grapl-local-infra" {
             limit           = 3
             ignore_warnings = true
           }
-
         }
-
       }
     }
   }

--- a/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
@@ -80,9 +80,9 @@ job "grapl-plugin" {
     service {
       name = "plugin-execution-sidecar-${var.plugin_id}"
       tags = [
-        "serve_type:plugin-execution-sidecar",
-        "tenant_id:${var.tenant_id}",
-        "plugin_id:${var.plugin_id}"
+        "plugin-execution-sidecar",
+        "tenant-${var.tenant_id}",
+        "plugin-${var.plugin_id}"
       ]
 
       connect {


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?

NA

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

This PR reduces the placement requirements for (almost) every nomad task to 50 CPU shares. This ensures we don't run into placement constraint violations when running everything locally. Additionally, I changed all current usages of `memory` in the `resources` stanzas to `memory_max` because the latter is what was actually intended.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?

Automated integration tests.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
