### PR TITLE
Fix PWQ by not ack'ing retriable errors

### DIFF
--- a/src/rust/plugin-execution-sidecar/src/plugin_executor.rs
+++ b/src/rust/plugin-execution-sidecar/src/plugin_executor.rs
@@ -97,7 +97,8 @@ where
                     // available again in 10 seconds.
                     Err(e) if e.is_retriable() => false,
                     // Otherwise, it's a perma-fail error or a success, so inform PWQ
-                    _ => true,
+                    Err(_) => true,
+                    Ok(_) => true,
                 };
 
                 if should_ack {

--- a/src/rust/plugin-execution-sidecar/src/work/plugin_work_processor.rs
+++ b/src/rust/plugin-execution-sidecar/src/work/plugin_work_processor.rs
@@ -16,9 +16,20 @@ pub type RequestId = i64;
 pub enum PluginWorkProcessorError {
     #[error("GrpcClientError {0}")]
     GrpcClientError(#[from] GrpcClientError),
-    // Likely want one for Analyzer as well once that SDK exists
-    #[error("ProcessJob {0}")]
-    ProcessJob(String),
+    #[error("Processing job failed, marking failed: {0}")]
+    ProcessingJobFailed(String),
+    #[error("Processing job failed, PWQ will retry: {0}")]
+    ProcessingJobFailedRetriable(String),
+}
+
+impl PluginWorkProcessorError {
+    pub fn is_retriable(&self) -> bool {
+        match self {
+            PluginWorkProcessorError::GrpcClientError(_) => true,
+            PluginWorkProcessorError::ProcessingJobFailedRetriable(_) => true,
+            PluginWorkProcessorError::ProcessingJobFailed(_) => false,
+        }
+    }
 }
 
 // Abstract out between Get[Generator/Analyzer]ExecutionResponse,

--- a/src/rust/plugin-work-queue/tests/pwq_integration_test.rs
+++ b/src/rust/plugin-work-queue/tests/pwq_integration_test.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "integration_tests")]
 
+use std::time::Duration;
+
 use clap::Parser;
 use rust_proto::{
     client_factory::{
@@ -7,6 +9,7 @@ use rust_proto::{
         services::PluginWorkQueueClientConfig,
     },
     graplinc::grapl::api::plugin_work_queue::v1beta1::{
+        AcknowledgeGeneratorRequest,
         ExecutionJob,
         GetExecuteGeneratorRequest,
         PushExecuteGeneratorRequest,
@@ -82,21 +85,74 @@ async fn test_push_and_get_execute_generator() -> eyre::Result<()> {
     );
 
     // Fetch for plugin_id 2 again, we should get Job 3
-    let retrieve_job_for_plugin_id_2 = pwq_client
+    let retrieve_job_3_for_plugin_id_2 = pwq_client
         .get_execute_generator(GetExecuteGeneratorRequest::new(plugin_id_2))
         .await?;
 
     assert_eq!(
-        retrieve_job_for_plugin_id_2.execution_job(),
+        retrieve_job_3_for_plugin_id_2.execution_job(),
         Some(job_3.execution_job())
     );
 
     // Fetch one more time, we should be out of work
-    let retrieve_job_for_plugin_id_2 = pwq_client
+    let retrieve_job_None_for_plugin_id_2 = pwq_client
         .get_execute_generator(GetExecuteGeneratorRequest::new(plugin_id_2))
         .await?;
 
-    assert_eq!(retrieve_job_for_plugin_id_2.execution_job(), None);
+    assert_eq!(retrieve_job_None_for_plugin_id_2.execution_job(), None);
 
     Ok(())
+}
+
+#[tokio::test]
+async fn test_message_available_after_failure() -> eyre::Result<()> {
+    let mut pwq_client = build_grpc_client(PluginWorkQueueClientConfig::parse()).await?;
+
+    // Send a job to Plugin Work Queue
+    let tenant_id = uuid::Uuid::new_v4();
+    let trace_id = uuid::Uuid::new_v4();
+    let event_source_id = uuid::Uuid::new_v4();
+    let plugin_id = uuid::Uuid::new_v4();
+
+    let job = PushExecuteGeneratorRequest::new(
+        ExecutionJob::new("the only job".into(), tenant_id, trace_id, event_source_id),
+        plugin_id,
+    );
+
+    pwq_client.push_execute_generator(request.clone()).await?;
+
+    async fn retrieve_job() -> eyre::Result<GetExecuteGeneratorRequest> {
+        pwq_client
+            .get_execute_generator(GetExecuteGeneratorRequest::new(plugin_id_1))
+            .await?
+    }
+
+    // Get the job
+    let retrieved_job = retrieve_job().await?;
+    eyre::ensure!(
+        retrieve_job.execution_job() == Some(job.execution_job()),
+        "Expected job equality: {:?}, {:?}",
+        retrieve_job,
+        job
+    );
+
+    // If we get the job again, it should be None this time.
+    let retrieved_job = retrieve_job().await?;
+    eyre::ensure!(
+        retrieve_job.execution_job() == None,
+        "Expected job equality: {:?}, {:?}",
+        retrieve_job,
+        None
+    );
+
+    // If we haven't acknowledged it for 10 seconds, it becomes visible again
+    tokio::time::sleep(Duration::from_millis(10_500)).await?;
+
+    let retrieved_job = retrieve_job().await?;
+    eyre::ensure!(
+        retrieve_job.execution_job() == Some(job.execution_job()),
+        "Expected job equality: {:?}, {:?}",
+        retrieve_job,
+        job
+    );
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/1007

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
I misunderstood how we're using PWQ. 
Acknowledging a generator message as failed (with an empty graph) means this message is permanently dead and never recoverable.
Never acknowledging means the message will become visible again in 10 seconds.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I added an integration test to PWQ to test the visibility stuff. I haven't really changed how we test the PWQ->Execution Sidecar->PWQ border; that _is_ testable but that's not done as part of this PR. I'm happy to go down that rabbithole if people want!

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
