### PR TITLE
Upgrade from Mypy 0.910 to 0.960

### DIFF
--- a/3rdparty/python/mypy.lockfile
+++ b/3rdparty/python/mypy.lockfile
@@ -9,7 +9,7 @@
 //     "CPython==3.10.*"
 //   ],
 //   "generated_with_requirements": [
-//     "mypy==0.910"
+//     "mypy==0.960"
 //   ]
 // }
 // --- END PANTS LOCKFILE METADATA ---
@@ -27,26 +27,52 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d",
-              "url": "https://files.pythonhosted.org/packages/15/e9/6b19c33819c27db7d69b938f062ea416398af62ae93aeb0fe47cb35d8a44/mypy-0.910-py3-none-any.whl"
+              "hash": "bfd4f6536bd384c27c392a8b8f790fd0ed5c0cf2f63fc2fed7bce56751d53026",
+              "url": "https://files.pythonhosted.org/packages/7e/53/386d8b939c5654c7a2218c1625f991cc123c3d3f69d2c0e2aed16c475eb4/mypy-0.960-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150",
-              "url": "https://files.pythonhosted.org/packages/33/46/b5d01f8844c84772e950bfc6adcaaa94cd22fedeb7c01776fd6effb3c2f6/mypy-0.910.tar.gz"
+              "hash": "7a76dc4f91e92db119b1be293892df8379b08fd31795bb44e0ff84256d34c251",
+              "url": "https://files.pythonhosted.org/packages/0c/8f/9b3e12e9971389befe2bfca98eb99b5555a5f6f625f8482ded3a0e97715e/mypy-0.960-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d4fccf04c1acf750babd74252e0f2db6bd2ac3aa8fe960797d9f3ef41cf2bfd4",
+              "url": "https://files.pythonhosted.org/packages/22/22/49792504e249a774554cd473e69af411a62c7d0591651104538fbcdaec10/mypy-0.960.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ffdad80a92c100d1b0fe3d3cf1a4724136029a29afe8566404c0146747114382",
+              "url": "https://files.pythonhosted.org/packages/33/b8/bab515402dbb5874b3bc5c1586c9a70bccee73f5daa82c170c54a72b729e/mypy-0.960-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7d390248ec07fa344b9f365e6ed9d205bd0205e485c555bed37c4235c868e9d5",
+              "url": "https://files.pythonhosted.org/packages/7f/b8/aaa840a5f37e39bb3eccef982d48dccb8689074e7f6fd76d8dfffe3a8a66/mypy-0.960-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3a3e525cd76c2c4f90f1449fd034ba21fcca68050ff7c8397bb7dd25dd8b8248",
+              "url": "https://files.pythonhosted.org/packages/a7/1c/ac13b5d83aa025adc9d7e525b8eea180f3600ac40d47b6ad7746cf796a9a/mypy-0.960-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "925aa84369a07846b7f3b8556ccade1f371aa554f2bd4fb31cb97a24b73b036e",
+              "url": "https://files.pythonhosted.org/packages/f1/8f/1cf7aaad4957c3e329e160d993353b440da7499365d2f639cf973ab0f235/mypy-0.960-cp310-cp310-win_amd64.whl"
             }
           ],
           "project_name": "mypy",
           "requires_dists": [
-            "mypy-extensions<0.5.0,>=0.4.3",
+            "lxml; extra == \"reports\"",
+            "mypy-extensions>=0.4.3",
             "psutil>=4.0; extra == \"dmypy\"",
-            "toml",
-            "typed-ast<1.5.0,>=1.4.0; extra == \"python2\"",
-            "typed-ast<1.5.0,>=1.4.0; python_version < \"3.8\"",
-            "typing-extensions>=3.7.4"
+            "tomli>=1.1.0; python_version < \"3.11\"",
+            "typed-ast<2,>=1.4.0; extra == \"python2\"",
+            "typed-ast<2,>=1.4.0; python_version < \"3.8\"",
+            "typing-extensions>=3.10"
           ],
-          "requires_python": ">=3.5",
-          "version": "0.910"
+          "requires_python": ">=3.6",
+          "version": "0.960"
         },
         {
           "artifacts": [
@@ -72,19 +98,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-              "url": "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl"
+              "hash": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+              "url": "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f",
-              "url": "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz"
+              "hash": "de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f",
+              "url": "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz"
             }
           ],
-          "project_name": "toml",
+          "project_name": "tomli",
           "requires_dists": [],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,>=2.6",
-          "version": "0.10.2"
+          "requires_python": ">=3.7",
+          "version": "2.0.1"
         },
         {
           "artifacts": [
@@ -116,7 +142,7 @@
   "pex_version": "2.1.90",
   "prefer_older_binary": false,
   "requirements": [
-    "mypy==0.910"
+    "mypy==0.960"
   ],
   "requires_python": [
     "==3.10.*"

--- a/pants.toml
+++ b/pants.toml
@@ -141,6 +141,7 @@ extra_requirements = [
 args = [ "--suppress-no-test-exit-code" ]
 
 [mypy]
+version = "mypy==0.960"
 lockfile = "3rdparty/python/mypy.lockfile"
 config = "src/python/mypy.ini"
 # read this section of the mypy docs:
@@ -152,6 +153,7 @@ config = "src/python/mypy.ini"
 args = [ "--show-error-codes", "--namespace-packages" ] #, "--verbose" ]
 
 extra_type_stubs = [
+  "grpc-stubs",
   "mypy_boto3_cloudwatch==1.20.35.post1",
   "mypy_boto3_dynamodb==1.20.35.post1",
   "mypy_boto3_ec2==1.20.35.post1",

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -387,7 +387,7 @@ def main() -> None:
         assert upstream_stacks, "Upstream stacks previously initialized"
 
         vpc_id = upstream_stacks.networking.require_output("grapl-vpc")
-        subnet_ids = upstream_stacks.networking.require_output(
+        subnet_ids: pulumi.Input[list[str]] = upstream_stacks.networking.require_output(
             "grapl-private-subnet-ids"
         )
         nomad_agent_security_group_id = upstream_stacks.nomad_agents.require_output(

--- a/src/python/python-proto/python_proto/api/graph/v1beta1/messages.py
+++ b/src/python/python-proto/python_proto/api/graph/v1beta1/messages.py
@@ -14,7 +14,7 @@ class Session(SerDe[proto.Session]):
     create_time: int
     last_seen_time: int
     terminate_time: int
-    proto_cls = proto.Session
+    _proto_cls = proto.Session
 
     @classmethod
     def from_proto(cls, proto_session: proto.Session) -> Session:
@@ -41,7 +41,7 @@ class Session(SerDe[proto.Session]):
 class Static(SerDe[proto.Static]):
     primary_key_properties: Sequence[str]
     primary_key_requires_asset_id: bool
-    proto_cls = proto.Static
+    _proto_cls = proto.Static
 
     @classmethod
     def from_proto(cls, proto_static: proto.Static) -> Static:
@@ -61,7 +61,7 @@ class Static(SerDe[proto.Static]):
 @dataclasses.dataclass(frozen=True)
 class IdStrategy(SerDe[proto.IdStrategy]):
     strategy: Session | Static
-    proto_cls = proto.IdStrategy
+    _proto_cls = proto.IdStrategy
 
     @classmethod
     def from_proto(cls, proto_id_strategy: proto.IdStrategy) -> IdStrategy:
@@ -90,7 +90,7 @@ class IdStrategy(SerDe[proto.IdStrategy]):
 @dataclasses.dataclass(frozen=True)
 class IncrementOnlyUintProp(SerDe[proto.IncrementOnlyUintProp]):
     prop: int
-    proto_cls = proto.IncrementOnlyUintProp
+    _proto_cls = proto.IncrementOnlyUintProp
 
     @classmethod
     def from_proto(
@@ -108,7 +108,7 @@ class IncrementOnlyUintProp(SerDe[proto.IncrementOnlyUintProp]):
 @dataclasses.dataclass(frozen=True)
 class ImmutableUintProp(SerDe[proto.ImmutableUintProp]):
     prop: int
-    proto_cls = proto.ImmutableUintProp
+    _proto_cls = proto.ImmutableUintProp
 
     @classmethod
     def from_proto(
@@ -126,7 +126,7 @@ class ImmutableUintProp(SerDe[proto.ImmutableUintProp]):
 @dataclasses.dataclass(frozen=True)
 class DecrementOnlyUintProp(SerDe[proto.DecrementOnlyUintProp]):
     prop: int
-    proto_cls = proto.DecrementOnlyUintProp
+    _proto_cls = proto.DecrementOnlyUintProp
 
     @classmethod
     def from_proto(
@@ -144,7 +144,7 @@ class DecrementOnlyUintProp(SerDe[proto.DecrementOnlyUintProp]):
 @dataclasses.dataclass(frozen=True)
 class IncrementOnlyIntProp(SerDe[proto.IncrementOnlyIntProp]):
     prop: int
-    proto_cls = proto.IncrementOnlyIntProp
+    _proto_cls = proto.IncrementOnlyIntProp
 
     @classmethod
     def from_proto(
@@ -162,7 +162,7 @@ class IncrementOnlyIntProp(SerDe[proto.IncrementOnlyIntProp]):
 @dataclasses.dataclass(frozen=True)
 class DecrementOnlyIntProp(SerDe[proto.DecrementOnlyIntProp]):
     prop: int
-    proto_cls = proto.DecrementOnlyIntProp
+    _proto_cls = proto.DecrementOnlyIntProp
 
     @classmethod
     def from_proto(
@@ -180,7 +180,7 @@ class DecrementOnlyIntProp(SerDe[proto.DecrementOnlyIntProp]):
 @dataclasses.dataclass(frozen=True)
 class ImmutableIntProp(SerDe[proto.ImmutableIntProp]):
     prop: int
-    proto_cls = proto.ImmutableIntProp
+    _proto_cls = proto.ImmutableIntProp
 
     @classmethod
     def from_proto(
@@ -198,7 +198,7 @@ class ImmutableIntProp(SerDe[proto.ImmutableIntProp]):
 @dataclasses.dataclass(frozen=True)
 class ImmutableStrProp(SerDe[proto.ImmutableStrProp]):
     prop: str
-    proto_cls = proto.ImmutableStrProp
+    _proto_cls = proto.ImmutableStrProp
 
     @classmethod
     def from_proto(
@@ -224,7 +224,7 @@ class NodeProperty(SerDe[proto.NodeProperty]):
         | ImmutableIntProp
         | ImmutableStrProp
     )
-    proto_cls = proto.NodeProperty
+    _proto_cls = proto.NodeProperty
 
     @classmethod
     def from_proto(cls, proto_node_property: proto.NodeProperty) -> NodeProperty:
@@ -310,7 +310,7 @@ class NodeDescription(SerDe[proto.NodeDescription]):
     node_key: str
     node_type: str
     id_strategy: Sequence[IdStrategy]
-    proto_cls = proto.NodeDescription
+    _proto_cls = proto.NodeDescription
 
     @classmethod
     def from_proto(
@@ -344,7 +344,7 @@ class IdentifiedNode(SerDe[proto.IdentifiedNode]):
     properties: Mapping[str, NodeProperty]
     node_key: str
     node_type: str
-    proto_cls = proto.IdentifiedNode
+    _proto_cls = proto.IdentifiedNode
 
     @classmethod
     def from_proto(cls, proto_identified_node: proto.IdentifiedNode) -> IdentifiedNode:
@@ -372,7 +372,7 @@ class MergedNode(SerDe[proto.MergedNode]):
     uid: int
     node_key: str
     node_type: str
-    proto_cls = proto.MergedNode
+    _proto_cls = proto.MergedNode
 
     @classmethod
     def from_proto(cls, proto_merged_node: proto.MergedNode) -> MergedNode:
@@ -401,7 +401,7 @@ class Edge(SerDe[proto.Edge]):
     from_node_key: str
     to_node_key: str
     edge_name: str
-    proto_cls = proto.Edge
+    _proto_cls = proto.Edge
 
     @classmethod
     def from_proto(cls, proto_edge: proto.Edge) -> Edge:
@@ -422,7 +422,7 @@ class Edge(SerDe[proto.Edge]):
 @dataclasses.dataclass(frozen=True)
 class EdgeList(SerDe[proto.EdgeList]):
     edges: Sequence[Edge]
-    proto_cls = proto.EdgeList
+    _proto_cls = proto.EdgeList
 
     @classmethod
     def from_proto(cls, proto_edge_list: proto.EdgeList) -> EdgeList:
@@ -442,7 +442,7 @@ class MergedEdge(SerDe[proto.MergedEdge]):
     to_uid: str
     to_node_key: str
     edge_name: str
-    proto_cls = proto.MergedEdge
+    _proto_cls = proto.MergedEdge
 
     @classmethod
     def from_proto(cls, proto_merged_edge: proto.MergedEdge) -> MergedEdge:
@@ -470,7 +470,7 @@ class MergedEdgeList(SerDe[proto.MergedEdgeList]):
     # /src/python/grapl_analyzerlib/grapl_analyzerlib/view_from_proto.py
     # /src/python/grapl_analyzerlib/grapl_analyzerlib/subgraph_view.py
     edges: Sequence[MergedEdge]
-    proto_cls = proto.MergedEdgeList
+    _proto_cls = proto.MergedEdgeList
 
     @classmethod
     def from_proto(cls, proto_merged_edge_list: proto.MergedEdgeList) -> MergedEdgeList:
@@ -489,7 +489,7 @@ class MergedEdgeList(SerDe[proto.MergedEdgeList]):
 class GraphDescription(SerDe[proto.GraphDescription]):
     nodes: Mapping[str, NodeDescription]
     edges: Mapping[str, EdgeList]
-    proto_cls = proto.GraphDescription
+    _proto_cls = proto.GraphDescription
 
     @classmethod
     def from_proto(
@@ -519,7 +519,7 @@ class GraphDescription(SerDe[proto.GraphDescription]):
 class IdentifiedGraph(SerDe[proto.IdentifiedGraph]):
     nodes: Mapping[str, IdentifiedNode]
     edges: Mapping[str, EdgeList]
-    proto_cls = proto.IdentifiedGraph
+    _proto_cls = proto.IdentifiedGraph
 
     @classmethod
     def from_proto(
@@ -549,7 +549,7 @@ class IdentifiedGraph(SerDe[proto.IdentifiedGraph]):
 class MergedGraph(SerDe[proto.MergedGraph]):
     nodes: Mapping[str, MergedNode]
     edges: Mapping[str, MergedEdgeList]
-    proto_cls = proto.MergedGraph
+    _proto_cls = proto.MergedGraph
 
     @classmethod
     def from_proto(cls, proto_merged_graph: proto.MergedGraph) -> MergedGraph:
@@ -579,7 +579,7 @@ class Lens(SerDe[proto.Lens]):
     lens_name: str
     uid: int | None = None
     score: int | None = None
-    proto_cls = proto.Lens
+    _proto_cls = proto.Lens
 
     @classmethod
     def from_proto(cls, proto_lens: proto.Lens) -> Lens:
@@ -609,7 +609,7 @@ class ExecutionHit(SerDe[proto.ExecutionHit]):
     risk_score: int
     lenses: Sequence[Lens]
     risky_node_keys: Sequence[str]
-    proto_cls = proto.ExecutionHit
+    _proto_cls = proto.ExecutionHit
 
     @classmethod
     def from_proto(cls, proto_execution_hit: proto.ExecutionHit) -> ExecutionHit:

--- a/src/python/python-proto/python_proto/common.py
+++ b/src/python/python-proto/python_proto/common.py
@@ -17,7 +17,7 @@ EPOCH = datetime.datetime.fromisoformat("1970-01-01T00:00:00.000")
 class Uuid(SerDe[_Uuid]):
     lsb: int
     msb: int
-    proto_cls = _Uuid
+    _proto_cls = _Uuid
 
     @staticmethod
     def from_uuid(uuid_: uuid.UUID) -> Uuid:
@@ -47,7 +47,7 @@ class Uuid(SerDe[_Uuid]):
 class Duration(SerDe[_Duration]):
     seconds: int
     nanos: int
-    proto_cls = _Duration
+    _proto_cls = _Duration
 
     def __post_init__(self) -> None:
         if self.seconds < 0 or self.nanos < 0:
@@ -88,7 +88,7 @@ class Duration(SerDe[_Duration]):
 class Timestamp(SerDe[_Timestamp]):
     duration: Duration
     before_epoch: bool
-    proto_cls = _Timestamp
+    _proto_cls = _Timestamp
 
     @staticmethod
     def from_datetime(datetime_: datetime.datetime) -> Timestamp:

--- a/src/python/python-proto/python_proto/grapl/common/v1beta1/messages.py
+++ b/src/python/python-proto/python_proto/grapl/common/v1beta1/messages.py
@@ -10,14 +10,14 @@ from python_proto.serde import SerDe
 class Uid(SerDe[proto.Uid]):
     value: int
 
-    proto_cls = proto.Uid
+    _proto_cls = proto.Uid
 
     @classmethod
     def from_proto(cls, proto_value: proto.Uid) -> Uid:
         return cls(value=proto_value.value)
 
     def into_proto(self) -> proto.Uid:
-        proto_value = self.proto_cls()
+        proto_value = self.new_proto()
         proto_value.value = self.value
         return proto_value
 
@@ -26,14 +26,14 @@ class Uid(SerDe[proto.Uid]):
 class PropertyName(SerDe[proto.PropertyName]):
     value: str
 
-    proto_cls = proto.PropertyName
+    _proto_cls = proto.PropertyName
 
     @classmethod
     def from_proto(cls, proto_value: proto.PropertyName) -> PropertyName:
         return cls(value=proto_value.value)
 
     def into_proto(self) -> proto.PropertyName:
-        proto_value = self.proto_cls()
+        proto_value = self.new_proto()
         proto_value.value = self.value
         return proto_value
 
@@ -42,14 +42,14 @@ class PropertyName(SerDe[proto.PropertyName]):
 class EdgeName(SerDe[proto.EdgeName]):
     value: str
 
-    proto_cls = proto.EdgeName
+    _proto_cls = proto.EdgeName
 
     @classmethod
     def from_proto(cls, proto_value: proto.EdgeName) -> EdgeName:
         return cls(value=proto_value.value)
 
     def into_proto(self) -> proto.EdgeName:
-        proto_value = self.proto_cls()
+        proto_value = self.new_proto()
         proto_value.value = self.value
         return proto_value
 
@@ -58,13 +58,13 @@ class EdgeName(SerDe[proto.EdgeName]):
 class NodeType(SerDe[proto.NodeType]):
     value: str
 
-    proto_cls = proto.NodeType
+    _proto_cls = proto.NodeType
 
     @classmethod
     def from_proto(cls, proto_value: proto.NodeType) -> NodeType:
         return cls(value=proto_value.value)
 
     def into_proto(self) -> proto.NodeType:
-        proto_value = self.proto_cls()
+        proto_value = self.new_proto()
         proto_value.value = self.value
         return proto_value

--- a/src/python/python-proto/python_proto/metrics.py
+++ b/src/python/python-proto/python_proto/metrics.py
@@ -16,7 +16,7 @@ from python_proto.serde import SerDe
 class Label(SerDe[_Label]):
     key: str
     value: str
-    proto_cls = _Label
+    _proto_cls = _Label
 
     @classmethod
     def from_proto(cls, proto_label: _Label) -> Label:
@@ -34,7 +34,7 @@ class Counter(SerDe[_Counter]):
     name: str
     increment: int
     labels: Sequence[Label]
-    proto_cls = _Counter
+    _proto_cls = _Counter
 
     @classmethod
     def from_proto(cls, proto_counter: _Counter) -> Counter:
@@ -66,7 +66,7 @@ class Gauge(SerDe[_Gauge]):
     name: str
     value: float
     labels: Sequence[Label]
-    proto_cls = _Gauge
+    _proto_cls = _Gauge
 
     @classmethod
     def from_proto(cls, proto_gauge: _Gauge) -> Gauge:
@@ -92,7 +92,7 @@ class Histogram(SerDe):
     name: str
     value: float
     labels: Sequence[Label]
-    proto_cls = _Histogram
+    _proto_cls = _Histogram
 
     @classmethod
     def from_proto(cls, proto_histogram: _Histogram) -> Histogram:
@@ -114,7 +114,7 @@ class Histogram(SerDe):
 @dataclasses.dataclass(frozen=True)
 class MetricWrapper(SerDe):
     metric: Counter | Gauge | Histogram
-    proto_cls = _MetricWrapper
+    _proto_cls = _MetricWrapper
 
     @classmethod
     def from_proto(cls, proto_metric_wrapper: _MetricWrapper) -> MetricWrapper:

--- a/src/python/python-proto/python_proto/pipeline.py
+++ b/src/python/python-proto/python_proto/pipeline.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import uuid
-from typing import Generic, cast
+from typing import Generic
 
 from google.protobuf.any_pb2 import Any as _Any
 from graplinc.grapl.pipeline.v1beta1.types_pb2 import Envelope as _Envelope
@@ -22,15 +22,15 @@ class Envelope(SerDeWithInner[I, _Envelope], Generic[I]):
     last_updated_time: datetime.datetime
 
     inner_message: I
-    proto_cls = _Envelope
+    _proto_cls = _Envelope
 
     @classmethod
     def from_proto(
         cls: type[Envelope[I]], proto_envelope: _Envelope, inner_cls: type[I]
     ) -> Envelope[I]:
-        inner_message_proto = inner_cls.proto_cls()
+        inner_message_proto = inner_cls.new_proto()
         proto_envelope.inner_message.Unpack(inner_message_proto)
-        inner_message = cast(I, inner_cls.from_proto(inner_message_proto))  # fuck it
+        inner_message = inner_cls.from_proto(inner_message_proto)
         return cls(
             trace_id=Uuid.from_proto(proto_envelope.trace_id).into_uuid(),
             tenant_id=Uuid.from_proto(proto_envelope.tenant_id).into_uuid(),
@@ -71,7 +71,7 @@ class Envelope(SerDeWithInner[I, _Envelope], Generic[I]):
 @dataclasses.dataclass(frozen=True)
 class RawLog(SerDe[_RawLog]):
     log_event: bytes
-    proto_cls = _RawLog
+    _proto_cls = _RawLog
 
     @classmethod
     def from_proto(cls, proto_raw_log: _RawLog) -> RawLog:


### PR DESCRIPTION
I ahve some code from colin that uses pattern matching and walrus := syntax - requiring a mypy upgrade. I tested that the previous fails vs succeeds with https://mypy-play.net/?mypy=0.960&python=3.10

(also, adding some extra type stubs)