### PR TITLE
Fix main - PR race condition

### DIFF
--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -124,7 +124,7 @@ impl PluginRegistryServiceClient {
             list_plugins,
             proto::ListPluginsRequest,
             native::ListPluginsResponse,
-            ExecuteClientRpcOptions::default(),
+            RpcConfig::default(),
         )
     }
 


### PR DESCRIPTION
Recently renamed the Options struct to Config, but a PR was landed after my change that still used the old name