### PR TITLE
Make our Rust logs a bit more readable by quieting noisy stuff

### DIFF
--- a/pulumi/infra/log_levels.py
+++ b/pulumi/infra/log_levels.py
@@ -8,7 +8,11 @@ RUST_LOG_LEVELS = ",".join(
         "rusoto_core=WARN",
         "rustls=WARN",
         # noisy, only for debugging
-        "client_executor=trace",
+        "client_executor=TRACE",
+        # By default, sqlx outputs an INFO for every query executed.
+        # It's very noisy!
+        # https://github.com/launchbadge/sqlx/issues/942
+        "sqlx::query=WARN",
     ]
 )
 PY_LOG_LEVEL = "DEBUG"

--- a/src/rust/kafka/src/test_utils/topic_scanner.rs
+++ b/src/rust/kafka/src/test_utils/topic_scanner.rs
@@ -162,7 +162,7 @@ where
                     let ret_span = span.clone();
                     let _guard = span.enter();
 
-                    tracing::debug!(message = "consumed kafka message");
+                    tracing::trace!(message = "consumed kafka message");
 
                     if envelope.tenant_id() == priming_message_tenant_id {
                         tracing::info!("received priming message");
@@ -203,7 +203,7 @@ where
                             .expect("failed to acquire filter predicate lock")(
                             envelope.clone()
                         ) {
-                            tracing::debug!("filter predicate matched");
+                            tracing::trace!("filter predicate matched");
                             Some((ret_span, envelope))
                         } else {
                             None


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
Relates to https://github.com/launchbadge/sqlx/issues/942#issuecomment-1221641020
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Shush sqlx::query INFO logs
Downgrade noisy KafkaTopicScanner logs to TRACE

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
CI
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
