### PR TITLE
make the kafka::StreamProcessor API more flexible

### DIFF
--- a/src/rust/node-identifier/src/main.rs
+++ b/src/rust/node-identifier/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "1024"]
+
 use clap::Parser;
 use futures::{
     FutureExt,


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
NA
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
This PR makes the StreamProcessor API more flexible by updating the event handler's signature to emit a `Stream<Item = Result<Envelope<P>, StreamProcessorError>>`. This allows for cases where one input `Envelope<C>` results in multiple output `Envelope<P>`. 
<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Automated tests
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
