### PR TITLE
Internal 1013: add Analyzer Executor Sidecar

### DIFF
--- a/src/rust/plugin-execution-sidecar/analyzer-execution-sidecar.rs
+++ b/src/rust/plugin-execution-sidecar/analyzer-execution-sidecar.rs
@@ -1,4 +1,28 @@
+use clap::Parser;
+use grapl_tracing::setup_tracing;
+use plugin_execution_sidecar::{
+    config::PluginExecutorConfig,
+    plugin_executor::PluginExecutor,
+    work::AnalyzerWorkProcessor,
+};
+
+const SERVICE_NAME: &'static str = "analyzer-execution-sidecar";
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    todo!();
+    let _guard = setup_tracing(SERVICE_NAME)?;
+    let plugin_executor_config = PluginExecutorConfig::parse();
+
+    tracing::info!("logging configured successfully");
+
+    // Give the plugin a little time to become available.
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    let analyzer_work_processor = AnalyzerWorkProcessor::new(&plugin_executor_config).await?;
+    let mut plugin_executor =
+        PluginExecutor::new(plugin_executor_config, analyzer_work_processor).await?;
+
+    tracing::info!("starting analyzer executor");
+
+    plugin_executor.main_loop().await
 }

--- a/src/rust/plugin-execution-sidecar/src/work.rs
+++ b/src/rust/plugin-execution-sidecar/src/work.rs
@@ -4,5 +4,8 @@ pub use plugin_work_processor::{
     Workload,
 };
 
+mod analyzer_work_processor;
+pub use analyzer_work_processor::AnalyzerWorkProcessor;
+
 mod generator_work_processor;
 pub use generator_work_processor::GeneratorWorkProcessor;

--- a/src/rust/plugin-execution-sidecar/src/work/analyzer_work_processor.rs
+++ b/src/rust/plugin-execution-sidecar/src/work/analyzer_work_processor.rs
@@ -9,7 +9,7 @@ use rust_proto::{
             messages::{
                 ExecutionResult,
                 RunAnalyzerRequest,
-                Update,
+                Updates,
             },
         },
         plugin_work_queue::v1beta1::{
@@ -152,7 +152,7 @@ impl PluginWorkProcessor for AnalyzerWorkProcessor {
     ) -> Result<Self::ProducedMessage, PluginWorkProcessorError> {
         let run_analyzer_response = self
             .analyzer_service_client
-            .run_analyzer(RunAnalyzerRequest::new(Update::deserialize(job.data())?))
+            .run_analyzer(RunAnalyzerRequest::new(Updates::deserialize(job.data())?))
             .await?;
 
         Ok(run_analyzer_response.execution_result)

--- a/src/rust/plugin-execution-sidecar/src/work/analyzer_work_processor.rs
+++ b/src/rust/plugin-execution-sidecar/src/work/analyzer_work_processor.rs
@@ -1,0 +1,160 @@
+use rust_proto::{
+    client_factory::{
+        build_grpc_client,
+        services::AnalyzerClientConfig,
+    },
+    graplinc::grapl::api::{
+        plugin_sdk::analyzers::v1beta1::{
+            client::AnalyzerServiceClient,
+            messages::{
+                ExecutionResult,
+                RunAnalyzerRequest,
+                Update,
+            },
+        },
+        plugin_work_queue::v1beta1::{
+            AcknowledgeAnalyzerRequest,
+            ExecutionJob,
+            GetExecuteAnalyzerRequest,
+            GetExecuteAnalyzerResponse,
+            PluginWorkQueueServiceClient,
+        },
+    },
+    SerDe,
+};
+use uuid::Uuid;
+
+use super::{
+    plugin_work_processor::{
+        PluginWorkProcessorError,
+        RequestId,
+        Workload,
+    },
+    PluginWorkProcessor,
+};
+use crate::config::PluginExecutorConfig;
+
+impl Workload for GetExecuteAnalyzerResponse {
+    fn request_id(&self) -> i64 {
+        self.request_id()
+    }
+
+    fn maybe_job(self) -> Option<ExecutionJob> {
+        self.execution_job()
+    }
+}
+
+pub struct AnalyzerWorkProcessor {
+    analyzer_service_client: AnalyzerServiceClient,
+}
+
+impl AnalyzerWorkProcessor {
+    pub async fn new(config: &PluginExecutorConfig) -> Result<Self, Box<dyn std::error::Error>> {
+        let plugin_id = config.plugin_id;
+        let upstream_addr_env_var = format!("NOMAD_UPSTREAM_ADDR_plugin-{plugin_id}");
+        let upstream_addr = std::env::var(&upstream_addr_env_var).expect(&upstream_addr_env_var);
+        let address = format!("http://{upstream_addr}");
+
+        tracing::info!(message = "connecting to analyzer plugin", address = address);
+
+        let client_config = AnalyzerClientConfig {
+            analyzer_client_address: address.parse().expect("analyzer client address"),
+        };
+
+        let analyzer_service_client = build_grpc_client(client_config).await?;
+
+        Ok(AnalyzerWorkProcessor {
+            analyzer_service_client,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl PluginWorkProcessor for AnalyzerWorkProcessor {
+    type Work = GetExecuteAnalyzerResponse;
+    type ProducedMessage = ExecutionResult;
+
+    async fn get_work(
+        &self,
+        config: &PluginExecutorConfig,
+        pwq_client: &mut PluginWorkQueueServiceClient,
+    ) -> Result<Self::Work, PluginWorkProcessorError> {
+        let plugin_id = config.plugin_id;
+        let response = pwq_client
+            .get_execute_analyzer(GetExecuteAnalyzerRequest::new(plugin_id))
+            .await?;
+        let request_id = response.request_id();
+        let response_retval = response.clone();
+
+        if let Some(execution_job) = response.execution_job() {
+            let tenant_id = execution_job.tenant_id();
+            let trace_id = execution_job.trace_id();
+            let event_source_id = execution_job.event_source_id();
+
+            tracing::debug!(
+                message = "retrieved execution job",
+                tenant_id =% tenant_id,
+                trace_id =% trace_id,
+                event_source_id =% event_source_id,
+                plugin_id =% plugin_id,
+                request_id =? request_id,
+            );
+        } else {
+            tracing::debug!(
+                message = "found no execution jobs",
+                plugin_id =% plugin_id,
+            )
+        }
+
+        Ok(response_retval)
+    }
+
+    async fn ack_work(
+        &self,
+        config: &PluginExecutorConfig,
+        pwq_client: &mut PluginWorkQueueServiceClient,
+        process_result: Result<Self::ProducedMessage, PluginWorkProcessorError>,
+        request_id: RequestId,
+        tenant_id: Uuid,
+        trace_id: Uuid,
+        event_source_id: Uuid,
+    ) -> Result<(), PluginWorkProcessorError> {
+        let plugin_id = config.plugin_id;
+
+        tracing::debug!(
+            message = "acknowledging analyzer work",
+            tenant_id =% tenant_id,
+            trace_id =% trace_id,
+            event_source_id =% event_source_id,
+            plugin_id =% plugin_id,
+            request_id =? request_id,
+        );
+
+        let execution_hit = process_result.ok();
+        let ack_request = AcknowledgeAnalyzerRequest::new(
+            request_id,
+            execution_hit.is_some(),
+            plugin_id,
+            tenant_id,
+            trace_id,
+            event_source_id,
+        );
+
+        pwq_client.acknowledge_analyzer(ack_request).await?;
+
+        Ok(())
+    }
+
+    async fn process_job(
+        &mut self,
+        _config: &PluginExecutorConfig,
+        job: ExecutionJob,
+    ) -> Result<Self::ProducedMessage, PluginWorkProcessorError> {
+        let run_analyzer_response = self
+            .analyzer_service_client
+            .run_analyzer(RunAnalyzerRequest::new(Update::deserialize(job.data())?))
+            .await?;
+
+        Ok(run_analyzer_response.execution_result)
+    }
+}

--- a/src/rust/plugin-execution-sidecar/src/work/plugin_work_processor.rs
+++ b/src/rust/plugin-execution-sidecar/src/work/plugin_work_processor.rs
@@ -5,6 +5,7 @@ use rust_proto::{
     },
     protocol::error::GrpcClientError,
     SerDe,
+    SerDeError,
 };
 use uuid::Uuid;
 
@@ -14,12 +15,17 @@ pub type RequestId = i64;
 
 #[derive(thiserror::Error, Debug)]
 pub enum PluginWorkProcessorError {
-    #[error("GrpcClientError {0}")]
+    #[error("Grpc call failed {0}")]
     GrpcClientError(#[from] GrpcClientError),
+
     #[error("Processing job failed, marking failed: {0}")]
     ProcessingJobFailed(String),
+
     #[error("Processing job failed, PWQ will retry: {0}")]
     ProcessingJobFailedRetriable(String),
+
+    #[error("Error serializing/deserializing protocol buffer: {0}")]
+    SerDeError(#[from] SerDeError),
 }
 
 impl PluginWorkProcessorError {
@@ -28,6 +34,7 @@ impl PluginWorkProcessorError {
             PluginWorkProcessorError::GrpcClientError(_) => true,
             PluginWorkProcessorError::ProcessingJobFailedRetriable(_) => true,
             PluginWorkProcessorError::ProcessingJobFailed(_) => false,
+            PluginWorkProcessorError::SerDeError(_) => false,
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->
Resurrects PR https://github.com/grapl-security/grapl/pull/1980

### Which issue does this PR correspond to?

https://app.zenhub.com/workspaces/grapl-6036cbd36bacff000ef314f2/issues/grapl-security/issue-tracker/1013
https://github.com/grapl-security/issue-tracker/issues/1013

## What changes does this PR make to Grapl? Why?
This PR adds an analyzer execution sidecar (more or less like the generator execution sidecar)

## How were these changes tested?
This isn't super well exercised, however I (as in wimax, not jesse) do exercise it in my grapl-analyzerlib PR: https://github.com/grapl-security/grapl/pull/1969/files