### PR TITLE
Don't compile as much stuff

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2045,12 +2045,12 @@ dependencies = [
 name = "grapl-tracing"
 version = "0.0.1"
 dependencies = [
- "opentelemetry 0.17.0",
- "opentelemetry-jaeger 0.16.0",
+ "opentelemetry",
+ "opentelemetry-jaeger",
  "thiserror",
  "tracing",
  "tracing-appender",
- "tracing-opentelemetry 0.17.4",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -2424,12 +2424,6 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "integer-encoding"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
 
 [[package]]
 name = "integer-encoding"
@@ -3041,25 +3035,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures",
- "js-sys",
- "lazy_static",
- "percent-encoding",
- "pin-project",
- "rand 0.8.5",
- "thiserror",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
@@ -3081,19 +3056,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50ceb0b0e8b75cb3e388a2571a807c8228dabc5d6670f317b6eb21301095373"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "opentelemetry 0.16.0",
-]
-
-[[package]]
-name = "opentelemetry-http"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "449048140ee61e28f57abe6e9975eedc1f3a29855c7407bd6c12b18578863379"
@@ -3101,24 +3063,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry 0.17.0",
-]
-
-[[package]]
-name = "opentelemetry-jaeger"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db22f492873ea037bc267b35a0e8e4fb846340058cb7c864efe3d0bf23684593"
-dependencies = [
- "async-trait",
- "http",
- "lazy_static",
- "opentelemetry 0.16.0",
- "opentelemetry-http 0.5.0",
- "opentelemetry-semantic-conventions 0.8.0",
- "thiserror",
- "thrift 0.13.0",
- "tokio",
+ "opentelemetry",
 ]
 
 [[package]]
@@ -3130,21 +3075,12 @@ dependencies = [
  "async-trait",
  "http",
  "lazy_static",
- "opentelemetry 0.17.0",
- "opentelemetry-http 0.6.0",
- "opentelemetry-semantic-conventions 0.9.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-semantic-conventions",
  "thiserror",
- "thrift 0.15.0",
+ "thrift",
  "tokio",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffeac823339e8b0f27b961f4385057bf9f97f2863bc745bd015fd6091f2270e9"
-dependencies = [
- "opentelemetry 0.16.0",
 ]
 
 [[package]]
@@ -3153,7 +3089,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
 dependencies = [
- "opentelemetry 0.17.0",
+ "opentelemetry",
 ]
 
 [[package]]
@@ -5077,25 +5013,12 @@ dependencies = [
 
 [[package]]
 name = "thrift"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
-dependencies = [
- "byteorder",
- "integer-encoding 1.1.7",
- "log",
- "ordered-float",
- "threadpool",
-]
-
-[[package]]
-name = "thrift"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b82ca8f46f95b3ce96081fe3dd89160fdea970c254bb72925255d1b62aae692e"
 dependencies = [
  "byteorder",
- "integer-encoding 3.0.4",
+ "integer-encoding",
  "log",
  "ordered-float",
  "threadpool",
@@ -5513,25 +5436,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffbf13a0f8b054a4e59df3a173b818e9c6177c02789871f2073977fd0062076"
-dependencies = [
- "opentelemetry 0.16.0",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
 version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
 dependencies = [
  "once_cell",
- "opentelemetry 0.17.0",
+ "opentelemetry",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -5666,8 +5576,8 @@ dependencies = [
  "grapl-config",
  "grapl-tracing",
  "itertools 0.10.3",
- "opentelemetry 0.16.0",
- "opentelemetry-jaeger 0.15.0",
+ "opentelemetry",
+ "opentelemetry-jaeger",
  "prost 0.9.0",
  "rand 0.8.5",
  "rust-proto",
@@ -5677,7 +5587,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-appender",
- "tracing-opentelemetry 0.16.0",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
 ]

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -3027,15 +3027,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "111.22.0+1.1.1q"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3044,7 +3035,6 @@ dependencies = [
  "autocfg 1.1.0",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -6151,4 +6141,5 @@ checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -22,13 +22,13 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-base-apt
         curl=7.74.0-1.3+deb11u3 \
         jq=1.6-2.1 \
         unzip=6.0-26+deb11u1 \
-    && apt-get install --yes --no-install-recommends \
         build-essential=12.9 \
         cmake=3.18.4-2+deb11u1 \
         libssl-dev=1.1.1n-0+deb11u3 \
         perl=5.32.1-4+deb11u2 \
         pkg-config=0.29.2-1 \
-        tcl=8.6.11+1
+        tcl=8.6.11+1 \
+        libzstd-dev=1.4.8+dfsg-2.1
 
 # Grab a Nomad binary, which we use for parsing HCL2-with-variables into JSON:
 # - in plugin-registry integration tests

--- a/src/rust/build-env.Dockerfile
+++ b/src/rust/build-env.Dockerfile
@@ -20,7 +20,8 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=rust-build-en
         pkg-config=0.29.2-1 \
         tcl=8.6.11+1 \
         curl=7.74.0-1.3+deb11u3 \
-        unzip=6.0-26+deb11u1
+        unzip=6.0-26+deb11u1 \
+        libzstd-dev=1.4.8+dfsg-2.1
 EOF
 
 # Grab a Nomad binary, which we use for parsing HCL2-with-variables into JSON:

--- a/src/rust/kafka/Cargo.toml
+++ b/src/rust/kafka/Cargo.toml
@@ -18,10 +18,10 @@ clap = { version = "3.0", default_features = false, features = [
 futures = "0.3"
 rdkafka = { version = "0.28", features = [
   "cmake-build",
-  "ssl-vendored",
+  "ssl",
   "gssapi-vendored",
   "tokio",
-  "zstd"
+  "zstd-pkg-config"
 ] }
 rust-proto = { path = "../rust-proto", version = "*" }
 secrecy = "0.8.0"

--- a/src/rust/uid-allocator/Cargo.toml
+++ b/src/rust/uid-allocator/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 tokio = { version = "1.17.0", features = ["full"] }
 uuid = { version = "1.0.0", features = ["v4"] }
 tracing-appender = "0.2"
-tracing-opentelemetry = "0.16"
+tracing-opentelemetry = "0.17"
 tracing = "0.1.32"
 tracing-subscriber = { version = "0.3", default-features = false, features = [
   "env-filter",
@@ -36,8 +36,8 @@ thiserror = "1.0.30"
 dashmap = "5.2.0"
 async-trait = "0.1.53"
 grapl-config = { path = "../grapl-config" }
-opentelemetry = { version = "0.16", features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.15", features = [
+opentelemetry = { version = "0.17", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.16", features = [
   "collector_client",
   "rt-tokio"
 ] }


### PR DESCRIPTION
### Which issue does this PR correspond to?
None

### What changes does this PR make to Grapl? Why?
1. Statically links to zstd in the `kafka` crate
2. Statically links to openssl in the `kafka` crate
3. Syncs the opentelemetry versions in `uid-allocator` to be the same as elsewhere

### How were these changes tested?
No additional testing