### PR TITLE
Graph Query proxy integrated into plugin architecture

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,6 +66,7 @@ BUILD @christophermaier
 /src/rust/generators/ @inickles-grapl
 /src/rust/graph-merger/ @grapl-security/wg-data-infra
 /src/rust/graph-mutation/ @colin-grapl
+/src/rust/graph-query-proxy/ @colin-grapl
 /src/rust/graph-query-service/ @colin-grapl
 /src/rust/graph-schema-manager @colin-grapl @wimax-grapl
 /src/rust/grapl-config/ @inickles-grapl @wimax-grapl

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -169,6 +169,7 @@ group "rust-services" {
     "graph-merger",
     "graph-mutation",
     "graph-query",
+    "graph-query-proxy",
     "graph-schema-manager",
     "grapl-web-ui",
     "kafka-retry",
@@ -332,6 +333,14 @@ target "graph-query" {
   target   = "graph-query-deploy"
   tags = [
     upstream_aware_tag("graph-query")
+  ]
+}
+
+target "graph-query-proxy" {
+  inherits = ["_rust-base"]
+  target   = "graph-query-proxy-deploy"
+  tags = [
+    upstream_aware_tag("graph-query-proxy")
   ]
 }
 

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -825,6 +825,7 @@ job "grapl-core" {
         PLUGIN_EXECUTION_OBSERVABILITY_ENV_VARS         = var.observability_env_vars
         PLUGIN_EXECUTION_GENERATOR_SIDECAR_IMAGE        = var.container_images["generator-execution-sidecar"]
         PLUGIN_EXECUTION_ANALYZER_SIDECAR_IMAGE         = var.container_images["analyzer-execution-sidecar"]
+        PLUGIN_EXECUTION_GRAPH_QUERY_PROXY_IMAGE        = var.container_images["graph-query-proxy"]
 
         # common Rust env vars
         RUST_BACKTRACE = local.rust_backtrace

--- a/pulumi/grapl/__main__.py
+++ b/pulumi/grapl/__main__.py
@@ -78,6 +78,7 @@ def _container_images(artifacts: ArtifactGetter) -> Mapping[str, DockerImageId]:
         "graph-merger": builder.build_with_tag("graph-merger"),
         "graph-mutation": builder.build_with_tag("graph-mutation"),
         "graph-query": builder.build_with_tag("graph-query"),
+        "graph-query-proxy": builder.build_with_tag("graph-query-proxy"),
         "graph-schema-manager": builder.build_with_tag("graph-schema-manager"),
         "hax-docker-plugin-runtime": DockerImageId("debian:bullseye-slim"),
         "kafka-retry": builder.build_with_tag("kafka-retry"),

--- a/src/python/grapl-plugin-sdk/grapl_plugin_sdk/analyzer/service_impl.py
+++ b/src/python/grapl-plugin-sdk/grapl_plugin_sdk/analyzer/service_impl.py
@@ -26,7 +26,7 @@ from python_proto.grapl.common.v1beta1 import messages as grapl_common_messages
 
 
 def _get_tenant_id() -> PythonProtoUuid:
-    env_var: str = os.environ["TENANT_ID"]  # specified in hax_docker_plugin.nomad
+    env_var: str = os.environ["TENANT_ID"]  # specified in hax_docker_analyzer.nomad
     py_native_uuid = UUID(env_var)
     return PythonProtoUuid.from_uuid(py_native_uuid)
 

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -858,14 +858,11 @@ version = "3.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2bd7a1eb07da9ac757c923f69373deb7bc2ba5efc951b873bcb5e693992dca"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
  "once_cell",
- "strsim",
- "termcolor",
  "textwrap 0.15.0",
 ]
 
@@ -1893,10 +1890,8 @@ dependencies = [
  "futures",
  "grapl-tracing",
  "rust-proto",
- "serde",
  "thiserror",
  "tokio",
- "tonic 0.6.2",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -4762,12 +4757,6 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -858,11 +858,14 @@ version = "3.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2bd7a1eb07da9ac757c923f69373deb7bc2ba5efc951b873bcb5e693992dca"
 dependencies = [
+ "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
  "once_cell",
+ "strsim",
+ "termcolor",
  "textwrap 0.15.0",
 ]
 
@@ -1875,6 +1878,25 @@ dependencies = [
  "tokio",
  "tonic 0.6.2",
  "tonic-build 0.6.2",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "graph-query-proxy"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "clap 3.2.13",
+ "futures",
+ "grapl-tracing",
+ "rust-proto",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tonic 0.6.2",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -4740,6 +4762,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "./graph-merger",
   "./graph-mutation",
   "./graph-query-service", # TODO rename dir
+  "./graph-query-proxy",
   "./graph-schema-manager",
   "./grapl-config",
   "./grapl-graphql-codegen",

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -322,6 +322,12 @@ FROM rust-dist AS graph-mutation-deploy
 COPY --from=build /outputs/graph-mutation /
 ENTRYPOINT ["/graph-mutation"]
 
+##### graph-query-proxy
+FROM rust-dist as graph-query-proxy-deploy
+
+COPY --from=build /outputs/graph-query-proxy /
+ENTRYPOINT ["/graph-query-proxy"]
+
 ##### plugin-work-queue
 FROM rust-dist AS plugin-work-queue-deploy
 

--- a/src/rust/graph-query-proxy/Cargo.toml
+++ b/src/rust/graph-query-proxy/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "graph-query-proxy"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+async-trait = "0.1.56"
+bytes = "1.1"
+clap = { version = "3.2.13", features = ["std", "env", "derive"] }
+futures = "0.3.21"
+grapl-tracing = { path = "../grapl-tracing" }
+tokio = { version = "1.17.0", features = ["full"] }
+tracing = "0.1.32"
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+    "env-filter",
+    "fmt"
+] }
+rust-proto = { path = "../rust-proto" }
+serde = { version = "1.0.136", features = ["derive"] }
+tonic = "0.6.1"
+thiserror = "1.0.31"
+uuid = "1.1.2"
+
+[features]
+integration_tests = []

--- a/src/rust/graph-query-proxy/Cargo.toml
+++ b/src/rust/graph-query-proxy/Cargo.toml
@@ -6,21 +6,19 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 async-trait = "0.1.56"
-bytes = "1.1"
-clap = { version = "3.2.13", features = ["std", "env", "derive"] }
+bytes = { workspace = true }
+clap = { workspace = true }
 futures = "0.3.21"
 grapl-tracing = { path = "../grapl-tracing" }
-tokio = { version = "1.17.0", features = ["full"] }
-tracing = "0.1.32"
+tokio = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", default-features = false, features = [
   "env-filter",
   "fmt"
 ] }
 rust-proto = { path = "../rust-proto" }
-serde = { version = "1.0.136", features = ["derive"] }
-tonic = "0.6.1"
-thiserror = "1.0.31"
-uuid = "1.1.2"
+thiserror = { workspace = true }
+uuid = { workspace = true }
 
 [features]
 integration_tests = []

--- a/src/rust/graph-query-proxy/Cargo.toml
+++ b/src/rust/graph-query-proxy/Cargo.toml
@@ -13,8 +13,8 @@ grapl-tracing = { path = "../grapl-tracing" }
 tokio = { version = "1.17.0", features = ["full"] }
 tracing = "0.1.32"
 tracing-subscriber = { version = "0.3", default-features = false, features = [
-    "env-filter",
-    "fmt"
+  "env-filter",
+  "fmt"
 ] }
 rust-proto = { path = "../rust-proto" }
 serde = { version = "1.0.136", features = ["derive"] }

--- a/src/rust/graph-query-proxy/src/config.rs
+++ b/src/rust/graph-query-proxy/src/config.rs
@@ -1,0 +1,15 @@
+use std::net::SocketAddr;
+
+use rust_proto::{client_factory::services::GraphQueryClientConfig};
+
+#[derive(clap::Parser, Debug, Clone)]
+pub struct GraphQueryProxyConfig {
+    /// The tenant id to proxy for
+    #[clap(long, env)]
+    pub tenant_id: uuid::Uuid,
+    #[clap(long, env)]
+    /// The address to bind the graph query service to
+    pub graph_query_proxy_bind_address: SocketAddr,
+    #[clap(flatten)]
+    pub graph_query_service_client_config: GraphQueryClientConfig,
+}

--- a/src/rust/graph-query-proxy/src/config.rs
+++ b/src/rust/graph-query-proxy/src/config.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use rust_proto::{client_factory::services::GraphQueryClientConfig};
+use rust_proto::client_factory::services::GraphQueryClientConfig;
 
 #[derive(clap::Parser, Debug, Clone)]
 pub struct GraphQueryProxyConfig {

--- a/src/rust/graph-query-proxy/src/main.rs
+++ b/src/rust/graph-query-proxy/src/main.rs
@@ -7,7 +7,7 @@ use rust_proto::{
     },
     protocol::{
         healthcheck::HealthcheckStatus,
-        service_client::Connectable,
+        service_client::ConnectWithConfig,
     },
 };
 use tokio::net::TcpListener;
@@ -29,7 +29,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let graph_query_service = GraphQueryProxy::new(
         config.tenant_id,
-        GraphQueryClient::connect(graph_query_service_client_config).await?,
+        GraphQueryClient::connect_with_config(config.graph_query_service_client_config.clone())
+            .await?,
     );
 
     exec_service(config, graph_query_service).await

--- a/src/rust/graph-query-proxy/src/main.rs
+++ b/src/rust/graph-query-proxy/src/main.rs
@@ -1,0 +1,61 @@
+use clap::Parser;
+use grapl_tracing::setup_tracing;
+use rust_proto::{
+    graplinc::grapl::api::graph_query_service::v1beta1::{
+        client::GraphQueryClient,
+        server::GraphQueryServiceServer,
+    },
+    protocol::{
+        healthcheck::HealthcheckStatus,
+        service_client::Connectable,
+    },
+};
+use tokio::net::TcpListener;
+
+use crate::{
+    config::GraphQueryProxyConfig,
+    server::GraphQueryProxy,
+};
+
+mod config;
+mod server;
+
+const SERVICE_NAME: &'static str = "graph-query-proxy";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = setup_tracing(SERVICE_NAME)?;
+    let config = config::GraphQueryProxyConfig::parse();
+
+    let graph_query_service = GraphQueryProxy::new(
+        config.tenant_id,
+        GraphQueryClient::connect(graph_query_service_client_config).await?,
+    );
+
+    exec_service(config, graph_query_service).await
+}
+
+#[tracing::instrument(skip(config, api_server))]
+pub async fn exec_service(
+    config: GraphQueryProxyConfig,
+    api_server: GraphQueryProxy,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let addr = config.graph_query_proxy_bind_address;
+    let healthcheck_polling_interval_ms = 5000;
+
+    tracing::info!(
+        message = "Binding service",
+        socket_address = %addr,
+    );
+
+    let (server, _shutdown_tx) = GraphQueryServiceServer::new(
+        api_server,
+        TcpListener::bind(addr.clone()).await?,
+        || async { Ok(HealthcheckStatus::Serving) }, // FIXME: this is garbage
+        std::time::Duration::from_millis(healthcheck_polling_interval_ms),
+    );
+
+    tracing::info!(message = "starting gRPC server",);
+
+    Ok(server.serve().await?)
+}

--- a/src/rust/graph-query-proxy/src/server.rs
+++ b/src/rust/graph-query-proxy/src/server.rs
@@ -1,0 +1,70 @@
+use rust_proto::{
+    graplinc::grapl::api::graph_query_service::v1beta1::{
+        client::{
+            GraphQueryClient,
+            GraphQueryClientError,
+        },
+        messages::{
+            QueryGraphFromUidRequest,
+            QueryGraphFromUidResponse,
+            QueryGraphWithUidRequest,
+            QueryGraphWithUidResponse,
+        },
+        server::GraphQueryApi,
+    },
+    protocol::status::Status,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum GraphQueryProxyError {
+    #[error("GraphQueryClientError {0}")]
+    GraphQueryClientError(#[from] GraphQueryClientError),
+}
+
+impl From<GraphQueryProxyError> for Status {
+    fn from(gqs_err: GraphQueryProxyError) -> Self {
+        match gqs_err {
+            GraphQueryProxyError::GraphQueryClientError(e) => Status::unknown(e.to_string()),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct GraphQueryProxy {
+    tenant_id: uuid::Uuid,
+    graph_query_client: GraphQueryClient,
+}
+
+impl GraphQueryProxy {
+    pub fn new(tenant_id: uuid::Uuid, graph_query_client: GraphQueryClient) -> Self {
+        Self {
+            tenant_id,
+            graph_query_client,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl GraphQueryApi for GraphQueryProxy {
+    type Error = GraphQueryProxyError;
+
+    #[tracing::instrument(skip(self), err)]
+    async fn query_graph_with_uid(
+        &self,
+        mut request: QueryGraphWithUidRequest,
+    ) -> Result<QueryGraphWithUidResponse, GraphQueryProxyError> {
+        request.tenant_id = self.tenant_id;
+        let mut graph_query_client = self.graph_query_client.clone();
+        Ok(graph_query_client.query_graph_with_uid(request).await?)
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    async fn query_graph_from_uid(
+        &self,
+        mut request: QueryGraphFromUidRequest,
+    ) -> Result<QueryGraphFromUidResponse, GraphQueryProxyError> {
+        request.tenant_id = self.tenant_id;
+        let mut graph_query_client = self.graph_query_client.clone();
+        Ok(graph_query_client.query_graph_from_uid(request).await?)
+    }
+}

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -66,7 +66,7 @@ pub fn get_job(
     let graph_query_proxy_image = match plugin_type {
         PluginType::Generator => None,
         PluginType::Analyzer => Some(passthru.graph_query_proxy_image),
-    }
+    };
     match plugin_runtime {
         PluginRuntime::HaxDocker => {
             let job_file_hcl = static_files::HAX_DOCKER_PLUGIN_JOB;

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -63,11 +63,14 @@ pub fn get_job(
         PluginType::Generator => passthru.generator_sidecar_image,
         PluginType::Analyzer => passthru.analyzer_sidecar_image,
     };
-    let graph_query_proxy_image = passthru.graph_query_proxy_image;
+    let hax_docker_nomad_job = match plugin_type {
+        PluginType::Generator => static_files::HAX_DOCKER_GENERATOR_JOB,
+        PluginType::Analyzer => static_files::HAX_DOCKER_ANALYZER_JOB,
+    };
     match plugin_runtime {
         PluginRuntime::HaxDocker => {
             let job_file_hcl = static_files::HAX_DOCKER_PLUGIN_JOB;
-            let job_file_vars: NomadVars = HashMap::from([
+            let mut job_file_vars: NomadVars = HashMap::from([
                 ("aws_account_id", service_config.bucket_aws_account_id),
                 ("plugin_artifact_url", plugin_artifact_url),
                 (
@@ -85,6 +88,9 @@ pub fn get_job(
                 ("observability_env_vars", passthru.observability_env_vars),
                 ("graph_query_proxy_image", graph_query_proxy_image),
             ]);
+            if plugin_type == PluginType::Analyzer {
+                job_file_vars.insert("graph_query_proxy_image", passthru.graph_query_proxy_image);
+            }
             cli.parse_hcl2(job_file_hcl, job_file_vars)
         }
         PluginRuntime::Firecracker => {

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -63,14 +63,11 @@ pub fn get_job(
         PluginType::Generator => passthru.generator_sidecar_image,
         PluginType::Analyzer => passthru.analyzer_sidecar_image,
     };
-    let graph_query_proxy_image = match plugin_type {
-        PluginType::Generator => None,
-        PluginType::Analyzer => Some(passthru.graph_query_proxy_image),
-    };
+    let graph_query_proxy_image = passthru.graph_query_proxy_image;
     match plugin_runtime {
         PluginRuntime::HaxDocker => {
             let job_file_hcl = static_files::HAX_DOCKER_PLUGIN_JOB;
-            let mut job_file_vars: NomadVars = HashMap::from([
+            let job_file_vars: NomadVars = HashMap::from([
                 ("aws_account_id", service_config.bucket_aws_account_id),
                 ("plugin_artifact_url", plugin_artifact_url),
                 (
@@ -86,10 +83,8 @@ pub fn get_job(
                 // Passthrough vars
                 ("rust_log", passthru.rust_log),
                 ("observability_env_vars", passthru.observability_env_vars),
+                ("graph_query_proxy_image", graph_query_proxy_image),
             ]);
-            if let Some(graph_query_proxy_image) = graph_query_proxy_image {
-                job_file_vars.insert("graph_query_proxy_image", graph_query_proxy_image);
-            }
             cli.parse_hcl2(job_file_hcl, job_file_vars)
         }
         PluginRuntime::Firecracker => {

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -63,13 +63,12 @@ pub fn get_job(
         PluginType::Generator => passthru.generator_sidecar_image,
         PluginType::Analyzer => passthru.analyzer_sidecar_image,
     };
-    let hax_docker_nomad_job = match plugin_type {
-        PluginType::Generator => static_files::HAX_DOCKER_GENERATOR_JOB,
-        PluginType::Analyzer => static_files::HAX_DOCKER_ANALYZER_JOB,
-    };
     match plugin_runtime {
         PluginRuntime::HaxDocker => {
-            let job_file_hcl = static_files::HAX_DOCKER_PLUGIN_JOB;
+            let hax_docker_nomad_job = match plugin_type {
+                PluginType::Generator => static_files::HAX_DOCKER_GENERATOR_JOB,
+                PluginType::Analyzer => static_files::HAX_DOCKER_ANALYZER_JOB,
+            };
             let mut job_file_vars: NomadVars = HashMap::from([
                 ("aws_account_id", service_config.bucket_aws_account_id),
                 ("plugin_artifact_url", plugin_artifact_url),
@@ -86,12 +85,11 @@ pub fn get_job(
                 // Passthrough vars
                 ("rust_log", passthru.rust_log),
                 ("observability_env_vars", passthru.observability_env_vars),
-                ("graph_query_proxy_image", graph_query_proxy_image),
             ]);
             if plugin_type == PluginType::Analyzer {
                 job_file_vars.insert("graph_query_proxy_image", passthru.graph_query_proxy_image);
             }
-            cli.parse_hcl2(job_file_hcl, job_file_vars)
+            cli.parse_hcl2(hax_docker_nomad_job, job_file_vars)
         }
         PluginRuntime::Firecracker => {
             // This is currently dead code until we revive our Firecracker

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -127,6 +127,8 @@ pub struct PluginExecutionPassthroughVars {
     pub generator_sidecar_image: String,
     #[clap(long, env = "PLUGIN_EXECUTION_ANALYZER_SIDECAR_IMAGE")]
     pub analyzer_sidecar_image: String,
+    #[clap(long, env = "PLUGIN_EXECUTION_GRAPH_QUERY_PROXY_IMAGE")]
+    pub graph_query_proxy_image: String,
 
     // Pass through a couple env vars also used for the plugin-registry service
     // Since they're used in both ways - locally for this service, and the

--- a/src/rust/plugin-registry/src/static_files/README.md
+++ b/src/rust/plugin-registry/src/static_files/README.md
@@ -1,0 +1,5 @@
+Please try to keep these two files mostly-in-sync as much as it makes sense to
+do so. Right now the differences are:
+
+- Analyzer takes a `graph_query_proxy_image` variable
+- Analyzer spins up a `graph-query-proxy` job

--- a/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
@@ -53,7 +53,7 @@ In prod, this is currently disabled.
 EOF
 }
 
-job "grapl-plugin" {
+job "grapl-plugin-analyzer" {
   datacenters = ["dc1"]
   namespace   = "plugin-${var.plugin_id}"
   type        = "service"
@@ -74,19 +74,19 @@ job "grapl-plugin" {
     value     = true
   }
 
-  group "plugin-execution-sidecar" {
+  group "analyzer-execution-sidecar" {
     count = var.plugin_count
 
     network {
       mode = "bridge"
-      port "plugin-execution-sidecar" {}
+      port "analyzer-execution-sidecar" {}
       port "graph-query-proxy" {}
     }
 
     service {
-      name = "plugin-execution-sidecar-${var.plugin_id}"
+      name = "analyzer-execution-sidecar-${var.plugin_id}"
       tags = [
-        "plugin-execution-sidecar",
+        "analyzer-execution-sidecar",
         "tenant-${var.tenant_id}",
         "plugin-${var.plugin_id}"
       ]
@@ -117,8 +117,8 @@ job "grapl-plugin" {
     }
 
     # The execution task pulls messages from the plugin-work-queue and
-    # sends them to the plugin
-    task "plugin-execution-sidecar" {
+    # sends them to the analyzer
+    task "analyzer-execution-sidecar" {
       driver = "docker"
 
       config {

--- a/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
@@ -53,7 +53,7 @@ In prod, this is currently disabled.
 EOF
 }
 
-job "grapl-plugin-analyzer" {
+job "grapl-plugin" {
   datacenters = ["dc1"]
   namespace   = "plugin-${var.plugin_id}"
   type        = "service"

--- a/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
@@ -63,7 +63,10 @@ job "grapl-plugin" {
     attempts = 0
   }
 
-  # We'll want to make sure we have the opposite constraint on other services
+  # This makes sure that analyzers only run on a certain subset of Nomad agents
+  # that have "meta.is_grapl_plugin_host" set to true.
+  # (We'll want to eventually ensure we have the opposite constraint on 
+  # non-plugin jobs.)
   # This is set in the Nomad agent's `client` stanza:
   # https://www.nomadproject.io/docs/configuration/client#meta
   constraint {

--- a/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
@@ -84,7 +84,7 @@ job "grapl-plugin" {
     }
 
     service {
-      name = "analyzer-execution-sidecar-${var.plugin_id}"
+      name = "analyzer-exec-sidecar-${var.plugin_id}"
       tags = [
         "analyzer-execution-sidecar",
         "tenant-${var.tenant_id}",

--- a/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
@@ -114,6 +114,13 @@ job "grapl-plugin-analyzer" {
           }
         }
       }
+
+      check {
+        type     = "grpc"
+        port     = "graph-query-proxy"
+        interval = "10s"
+        timeout  = "3s"
+      }
     }
 
     # The execution task pulls messages from the plugin-work-queue and

--- a/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
@@ -76,10 +76,6 @@ job "grapl-plugin" {
 
     network {
       mode = "bridge"
-      // TODO i think? possibly cargo culted?
-      // dns {
-      //   servers = local.dns_servers
-      // }
       port "plugin-execution-sidecar" {}
       port "graph-query-proxy" {}
     }
@@ -185,10 +181,6 @@ job "grapl-plugin" {
   group "plugin" {
     network {
       mode = "bridge"
-      // TODO
-      // dns {
-      //   servers = local.dns_servers
-      // }
       port "plugin" {}
     }
 
@@ -264,7 +256,6 @@ EOF
         # Consumed by GeneratorServiceConfig
         PLUGIN_BIND_ADDRESS = "0.0.0.0:${NOMAD_PORT_plugin}"
 
-        # Should we make these eventually customizable?
         RUST_LOG       = var.rust_log
         RUST_BACKTRACE = 1
       }

--- a/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
@@ -148,7 +148,6 @@ job "grapl-plugin" {
     # A level of indirection in front of the Graph Query Service that prevents
     # the plugin from querying other tenants' data.
 
-    # TODO: We should not launch this for generators. Perhaps two sep Nomad files?
     task "graph-query-proxy-sidecar" {
       driver = "docker"
 
@@ -169,6 +168,11 @@ job "grapl-plugin" {
 
         RUST_LOG       = var.rust_log
         RUST_BACKTRACE = 1
+      }
+
+      resources {
+        cpu    = 25  // MHz
+        memory = 128 // MB
       }
     }
 

--- a/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
@@ -47,7 +47,7 @@ In prod, this is currently disabled.
 EOF
 }
 
-job "grapl-plugin-generator" {
+job "grapl-plugin" {
   datacenters = ["dc1"]
   namespace   = "plugin-${var.plugin_id}"
   type        = "service"

--- a/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
@@ -99,12 +99,6 @@ job "grapl-plugin" {
               # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
               local_bind_port = 1001
             }
-
-            upstreams {
-              destination_name = "graph-query"
-              # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
-              local_bind_port = 1002
-            }
           }
         }
       }

--- a/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
@@ -77,7 +77,7 @@ job "grapl-plugin" {
     }
 
     service {
-      name = "generator-execution-sidecar-${var.plugin_id}"
+      name = "generator-exec-sidecar-${var.plugin_id}"
       tags = [
         "generator-execution-sidecar",
         "tenant-${var.tenant_id}",

--- a/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
@@ -57,7 +57,10 @@ job "grapl-plugin" {
     attempts = 0
   }
 
-  # We'll want to make sure we have the opposite constraint on other services
+  # This makes sure that generators only run on a certain subset of Nomad agents
+  # that have "meta.is_grapl_plugin_host" set to true.
+  # (We'll want to eventually ensure we have the opposite constraint on 
+  # non-plugin jobs.)
   # This is set in the Nomad agent's `client` stanza:
   # https://www.nomadproject.io/docs/configuration/client#meta
   constraint {

--- a/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
@@ -70,10 +70,6 @@ job "grapl-plugin" {
 
     network {
       mode = "bridge"
-      // TODO i think? possibly cargo culted?
-      // dns {
-      //   servers = local.dns_servers
-      // }
       port "plugin-execution-sidecar" {}
     }
 
@@ -141,10 +137,6 @@ job "grapl-plugin" {
   group "plugin" {
     network {
       mode = "bridge"
-      // TODO
-      // dns {
-      //   servers = local.dns_servers
-      // }
       port "plugin" {}
     }
 
@@ -220,7 +212,6 @@ EOF
         # Consumed by GeneratorServiceConfig
         PLUGIN_BIND_ADDRESS = "0.0.0.0:${NOMAD_PORT_plugin}"
 
-        # Should we make these eventually customizable?
         RUST_LOG       = var.rust_log
         RUST_BACKTRACE = 1
       }

--- a/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
@@ -1,0 +1,246 @@
+variable "plugin_id" {
+  type        = string
+  description = "The ID for this plugin."
+}
+
+variable "tenant_id" {
+  type        = string
+  description = "The tenant's ID. Used in the plugin-execution-sidecar."
+}
+
+variable "plugin_artifact_url" {
+  type        = string
+  description = "The url that specifies which binary to run as the plugin."
+}
+
+variable "plugin_count" {
+  type        = number
+  default     = 1
+  description = "The number of instances of the plugin to run."
+}
+
+variable "aws_account_id" {
+  type        = string
+  description = "The account ID of the aws account that holds onto the plugin binaries."
+}
+
+variable "plugin_runtime_image" {
+  type        = string
+  description = "The container that will load and run the plugin"
+}
+
+variable "plugin_execution_sidecar_image" {
+  type        = string
+  description = "The container that will load and run the Generator Executor or Analyzer Executor"
+}
+
+variable "rust_log" {
+  type        = string
+  description = "Controls the logging behavior of Rust-based services."
+}
+
+variable "observability_env_vars" {
+  type        = string
+  description = <<EOF
+With local-grapl, we have to inject env vars for Opentelemetry.
+In prod, this is currently disabled.
+EOF
+}
+
+job "grapl-plugin" {
+  datacenters = ["dc1"]
+  namespace   = "plugin-${var.plugin_id}"
+  type        = "service"
+
+  reschedule {
+    # Make this a one-shot job
+    attempts = 0
+  }
+
+  # We'll want to make sure we have the opposite constraint on other services
+  # This is set in the Nomad agent's `client` stanza:
+  # https://www.nomadproject.io/docs/configuration/client#meta
+  constraint {
+    attribute = "${meta.is_grapl_plugin_host}"
+    value     = true
+  }
+
+  group "plugin-execution-sidecar" {
+    count = var.plugin_count
+
+    network {
+      mode = "bridge"
+      // TODO i think? possibly cargo culted?
+      // dns {
+      //   servers = local.dns_servers
+      // }
+      port "plugin-execution-sidecar" {}
+    }
+
+    service {
+      name = "plugin-execution-sidecar-${var.plugin_id}"
+      tags = [
+        "plugin-execution-sidecar",
+        "tenant-${var.tenant_id}",
+        "plugin-${var.plugin_id}"
+      ]
+
+      connect {
+        sidecar_service {
+          proxy {
+            upstreams {
+              destination_name = "plugin-work-queue"
+              # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
+              local_bind_port = 1000
+            }
+
+            upstreams {
+              destination_name = "plugin-${var.plugin_id}"
+              # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
+              local_bind_port = 1001
+            }
+
+            upstreams {
+              destination_name = "graph-query"
+              # port unique but arbitrary - https://github.com/hashicorp/nomad/issues/7135
+              local_bind_port = 1002
+            }
+          }
+        }
+      }
+    }
+
+    # The execution task pulls messages from the plugin-work-queue and
+    # sends them to the plugin
+    task "plugin-execution-sidecar" {
+      driver = "docker"
+
+      config {
+        image = var.plugin_execution_sidecar_image
+      }
+
+      template {
+        data        = var.observability_env_vars
+        destination = "observability.env"
+        env         = true
+      }
+
+      env {
+        PLUGIN_EXECUTOR_PLUGIN_ID = var.plugin_id
+
+        // FYI: the upstream plugin's address is discovered at runtime, not
+        // env{}, because the upstream's name is based on ${PLUGIN_ID}.
+
+        PLUGIN_WORK_QUEUE_CLIENT_ADDRESS = "http://${NOMAD_UPSTREAM_ADDR_plugin-work-queue}"
+
+        RUST_LOG       = var.rust_log
+        RUST_BACKTRACE = 1
+      }
+    }
+
+    restart {
+      attempts = 1
+      delay    = "5s"
+    }
+  }
+
+  group "plugin" {
+    network {
+      mode = "bridge"
+      // TODO
+      // dns {
+      //   servers = local.dns_servers
+      // }
+      port "plugin" {}
+    }
+
+    count = var.plugin_count
+
+    service {
+      name = "plugin-${var.plugin_id}"
+      port = "plugin"
+      tags = [
+        "plugin",
+        "tenant-${var.tenant_id}",
+        "plugin-${var.plugin_id}"
+      ]
+
+      connect {
+        sidecar_service {
+        }
+      }
+
+      check {
+        type     = "grpc"
+        port     = "plugin"
+        interval = "10s"
+        timeout  = "3s"
+      }
+    }
+
+    # a Docker task holding:
+    # - the plugin binary itself (mounted)
+    task "plugin" {
+      driver = "docker"
+
+      config {
+        ports = ["plugin"]
+
+        image      = var.plugin_runtime_image
+        entrypoint = ["/bin/bash", "-o", "errexit", "-o", "nounset", "-c"]
+        command = trimspace(<<EOF
+        chmod +x "${PLUGIN_BIN}"
+        "${PLUGIN_BIN}"
+EOF
+        )
+
+        mount {
+          type   = "bind"
+          target = "/mnt/nomad_task_dir"
+          source = "local/"
+          # sigh - we need to `chmod +x` the binary, hence, mount is rw
+          readonly = false
+        }
+      }
+
+      artifact {
+        source      = var.plugin_artifact_url
+        destination = "local/plugin.bin"
+        mode        = "file"
+        headers {
+          x-amz-expected-bucket-owner = var.aws_account_id
+          x-amz-meta-client-id        = "nomad-deployer"
+        }
+      }
+
+      template {
+        data        = var.observability_env_vars
+        destination = "observability.env"
+        env         = true
+      }
+
+      env {
+        TENANT_ID  = "${var.tenant_id}"
+        PLUGIN_ID  = "${var.plugin_id}"
+        PLUGIN_BIN = "/mnt/nomad_task_dir/plugin.bin"
+        # Consumed by GeneratorServiceConfig
+        PLUGIN_BIND_ADDRESS = "0.0.0.0:${NOMAD_PORT_plugin}"
+
+        # Should we make these eventually customizable?
+        RUST_LOG       = var.rust_log
+        RUST_BACKTRACE = 1
+      }
+
+      // Each plugin should ideally have a very small footprint.
+      resources {
+        cpu    = 25  // MHz
+        memory = 128 // MB
+      }
+    }
+
+    restart {
+      attempts = 1
+      delay    = "5s"
+    }
+  }
+}

--- a/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
@@ -47,7 +47,7 @@ In prod, this is currently disabled.
 EOF
 }
 
-job "grapl-plugin" {
+job "grapl-plugin-generator" {
   datacenters = ["dc1"]
   namespace   = "plugin-${var.plugin_id}"
   type        = "service"
@@ -68,18 +68,18 @@ job "grapl-plugin" {
     value     = true
   }
 
-  group "plugin-execution-sidecar" {
+  group "generator-execution-sidecar" {
     count = var.plugin_count
 
     network {
       mode = "bridge"
-      port "plugin-execution-sidecar" {}
+      port "generator-execution-sidecar" {}
     }
 
     service {
-      name = "plugin-execution-sidecar-${var.plugin_id}"
+      name = "generator-execution-sidecar-${var.plugin_id}"
       tags = [
-        "plugin-execution-sidecar",
+        "generator-execution-sidecar",
         "tenant-${var.tenant_id}",
         "plugin-${var.plugin_id}"
       ]
@@ -104,8 +104,8 @@ job "grapl-plugin" {
     }
 
     # The execution task pulls messages from the plugin-work-queue and
-    # sends them to the plugin
-    task "plugin-execution-sidecar" {
+    # sends them to the generator
+    task "generator-execution-sidecar" {
       driver = "docker"
 
       config {

--- a/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_plugin.nomad
@@ -150,7 +150,7 @@ job "grapl-plugin" {
     # hence the "dynamic" trickery.
     dynamic "task" {
       # Disable graph-query if graph_query_proxy_image is not specified (for generators)
-      for_each = (graph_query_proxy_image == null) ? ["arbitrary 1-length array"] : []
+      for_each = (graph_query_proxy_image == null) ? [/*empty*/] : ["arbitrary 1-length array"]
       iterator = i
 
       labels = ["graph-query-proxy-sidecar"]

--- a/src/rust/plugin-registry/src/static_files/mod.rs
+++ b/src/rust/plugin-registry/src/static_files/mod.rs
@@ -1,2 +1,3 @@
 pub const PLUGIN_JOB: &'static str = include_str!("plugin.nomad");
-pub const HAX_DOCKER_PLUGIN_JOB: &'static str = include_str!("hax_docker_plugin.nomad");
+pub const HAX_DOCKER_GENERATOR_JOB: &'static str = include_str!("hax_docker_generator.nomad");
+pub const HAX_DOCKER_ANALYZER_JOB: &'static str = include_str!("hax_docker_analyzer.nomad");

--- a/src/rust/rust-proto/src/client_factory/services/graph_query.rs
+++ b/src/rust/rust-proto/src/client_factory/services/graph_query.rs
@@ -3,7 +3,7 @@ use crate::client_factory::grpc_client_config::{
     GrpcClientConfig,
 };
 
-#[derive(clap::Parser, Debug)]
+#[derive(clap::Parser, Debug, Clone)]
 pub struct GraphQueryClientConfig {
     #[clap(long, env)]
     pub graph_query_client_address: String,


### PR DESCRIPTION
### Which issue does this PR correspond to?
Takes https://github.com/grapl-security/grapl/pull/1970 and rebases it, then integrates it into our Docker/Nomad stuff.
https://app.zenhub.com/workspaces/grapl-6036cbd36bacff000ef314f2/issues/grapl-security/issue-tracker/1016

### What changes does this PR make to Grapl? Why?
This introduces a new service, the `graph-query-proxy`. This service will act as a sidecar for every plugin, acting as an intermediary between the plugin and the actual `graph-query-service`.

The service is spun up by plugin-registry infra, but doesn't get consumed by analyzers yet.

Note that there is no client currently. The client will likely exist first in Python.

### How were these changes tested?
We have an existing test that deploys analyzers and checks for their health, which should catch if this service went down.