### PR TITLE
Extend gRPC timeout to 15s, preventing integration test timeouts on devbox

### DIFF
--- a/src/rust/rust-proto/src/client_factory/build_grpc_client.rs
+++ b/src/rust/rust-proto/src/client_factory/build_grpc_client.rs
@@ -50,7 +50,7 @@ async fn build_grpc_client_with_options<C: GrpcClientConfig, Client: Connectable
 
     // TODO: Add a `rust-proto` wrapper around tonic Endpoint
     let endpoint = Endpoint::from_shared(address)?
-        .timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(15))
         .concurrency_limit(300);
 
     if options.perform_healthcheck {


### PR DESCRIPTION
previously in integration tests when run on devbox:
```
Error: encountered protocol error status: Internal, message: "Timeout expired"

Caused by:
    status: Internal, message: "Timeout expired"

Location:
    /grapl/rust/e2e-tests/src/test_utils/context.rs:145:9
test test_analyzer_dispatcher_inserts_job_into_plugin_work_queue ... FAILED


----


Caused by:
    status: Internal, message: "Timeout expired"

Location:
    /grapl/rust/e2e-tests/src/test_utils/context.rs:145:9
test test_sysmon_log_e2e ... FAILED


-----


Caused by:
    status: Internal, message: "Timeout expired"

Location:
    /grapl/rust/e2e-tests/src/test_utils/context.rs:145:9
test test_sysmon_event_produces_merged_graph ... FAILED

-----

Caused by:
    status: Internal, message: "Timeout expired"

Location:
    /grapl/rust/e2e-tests/src/test_utils/context.rs:145:9
test test_dispatcher_inserts_job_into_plugin_work_queue ... FAILED
```

with this change: everything works on devbox.
i know a similar failrue happens on chromebook; i cannot confirm 15s is long enough for them.

the root cause is that the Scylla provisioner is too slow. 
https://github.com/grapl-security/issue-tracker/issues/1031

instead of rewriting that immediately, this is a quick short-term fix that should hopefully help everyone have a more stable integration-test experience locally. 