### PR TITLE
Remove (some) `pex_binary` Pants targets

### DIFF
--- a/build-support/BUILD
+++ b/build-support/BUILD
@@ -1,8 +1,3 @@
 python_sources()
 
 shell_sources(name="shell")
-
-pex_binary(
-    name="bk-run",
-    entry_point="bk-run.py",
-)

--- a/etc/ci_scripts/dump_artifacts/BUILD
+++ b/etc/ci_scripts/dump_artifacts/BUILD
@@ -1,8 +1,3 @@
 python_sources(
     name="dump_artifacts_lib",
 )
-
-pex_binary(
-    name="dump_artifacts",
-    entry_point="cli.py:main",
-)

--- a/etc/ci_scripts/dump_artifacts/BUILD
+++ b/etc/ci_scripts/dump_artifacts/BUILD
@@ -1,3 +1,1 @@
-python_sources(
-    name="dump_artifacts_lib",
-)
+python_sources()

--- a/pants.toml
+++ b/pants.toml
@@ -231,5 +231,5 @@ ignore_adding_targets = [
 ]
 
 [cli.alias]
-bk-run = "run build-support:bk-run --"
+bk-run = "run build-support/bk-run.py --"
 dump-artifacts = "run etc/ci_scripts/dump_artifacts:dump_artifacts --"

--- a/pants.toml
+++ b/pants.toml
@@ -232,4 +232,4 @@ ignore_adding_targets = [
 
 [cli.alias]
 bk-run = "run build-support/bk-run.py --"
-dump-artifacts = "run etc/ci_scripts/dump_artifacts:dump_artifacts --"
+dump-artifacts = "run etc/ci_scripts/dump_artifacts/cli.py --"


### PR DESCRIPTION
Pants can `run` Python sources directly now, without a `pex_binary` intermediate. This is preferred for internal tooling which doesn't need to be packaged and distributed.