### PR TITLE
Make sqlx a workspace dependency, and upgrade to 0.6.2

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1372,10 +1372,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "ed9155c8f4dc55c7470ae9da3f63c6785245093b3f6aeb0f5bf2e968efbba314"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "duct"
@@ -4492,6 +4495,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006769ba83e921b3085caa8334186b00cf92b4cb1a6cf4632fbccc8eff5c7549"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4635,9 +4649,9 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.1.8"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b7922be017ee70900be125523f38bdd644f4f06a1b16e8fa5a8ee8c34bffd4"
+checksum = "f87e292b4291f154971a43c3774364e2cbcaec599d3f5bf6fa9d122885dbc38a"
 dependencies = [
  "itertools",
  "nom",
@@ -4646,9 +4660,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f82cbe94f41641d6c410ded25bbf5097c240cefdf8e3b06d04198d0a96af6a4"
+checksum = "9249290c05928352f71c077cc44a464d880c63f26f7534728cca008e135c0428"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -4656,9 +4670,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b69bf218860335ddda60d6ce85ee39f6cf6e5630e300e19757d1de15886a093"
+checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
 dependencies = [
  "ahash",
  "atoi",
@@ -4670,6 +4684,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "dirs",
+ "dotenvy",
  "either",
  "event-listener",
  "futures-channel",
@@ -4694,7 +4709,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
- "sha-1",
+ "sha1",
  "sha2 0.10.2",
  "smallvec",
  "sqlformat",
@@ -4711,11 +4726,11 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40c63177cf23d356b159b60acd27c54af7423f1736988502e36bae9a712118f"
+checksum = "b850fa514dc11f2ee85be9d055c512aa866746adfacd1cb42d867d68e6a5b0d9"
 dependencies = [
- "dotenv",
+ "dotenvy",
  "either",
  "heck 0.4.0",
  "hex",
@@ -4733,9 +4748,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874e93a365a598dc3dadb197565952cb143ae4aa716f7bcc933a8d836f6bf89f"
+checksum = "24c5b2d25fa654cc5f841750b8e1cdedbe21189bf9a9382ee90bfa9dd3562396"
 dependencies = [
  "once_cell",
  "tokio",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -46,7 +46,7 @@ clap = { version = "3.0", default_features = false, features = [
   "derive"
 ] }
 eyre = "0.6"
-sqlx = { version = "0.6.2", features = [
+sqlx = { version = "0.6", features = [
   "chrono",
   "migrate",
   "offline",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -46,6 +46,15 @@ clap = { version = "3.0", default_features = false, features = [
   "derive"
 ] }
 eyre = "0.6"
+sqlx = { version = "0.6.2", features = [
+  "chrono",
+  "migrate",
+  "offline",
+  "postgres",
+  "runtime-tokio-rustls",
+  "time",
+  "uuid",
+] }
 test-context = "0.1"
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["macros", "rt-multi-thread"] }

--- a/src/rust/event-source/Cargo.toml
+++ b/src/rust/event-source/Cargo.toml
@@ -10,14 +10,7 @@ grapl-config = { path = "../grapl-config" }
 grapl-tracing = { path = "../grapl-tracing" }
 grapl-utils = { path = "../grapl-utils" }
 rust-proto = { path = "../rust-proto" }
-sqlx = { version = "0.6", features = [
-  "chrono",
-  "migrate",
-  "offline",
-  "postgres",
-  "runtime-tokio-rustls",
-  "uuid",
-] }
+sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/src/rust/graph-schema-manager/Cargo.toml
+++ b/src/rust/graph-schema-manager/Cargo.toml
@@ -11,14 +11,7 @@ grapl-config = { path = "../grapl-config" }
 grapl-graphql-codegen = { path = "../grapl-graphql-codegen" }
 grapl-tracing = { path = "../grapl-tracing" }
 rust-proto = { path = "../rust-proto" }
-sqlx = { version = "0.6", features = [
-  "runtime-tokio-rustls",
-  "postgres",
-  "time",
-  "offline",
-  "uuid",
-  "migrate",
-] }
+sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/src/rust/grapl-config/Cargo.toml
+++ b/src/rust/grapl-config/Cargo.toml
@@ -21,14 +21,7 @@ rusoto_s3 = { version = "0.47", default_features = false, features = [
   "rustls"
 ] }
 secrecy = "0.8"
-sqlx = { version = "0.6", features = [
-  "chrono",
-  "migrate",
-  "offline",
-  "postgres",
-  "runtime-tokio-rustls",
-  "uuid",
-] }
+sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/src/rust/organization-management/Cargo.toml
+++ b/src/rust/organization-management/Cargo.toml
@@ -18,13 +18,7 @@ grapl-config = { path = "../grapl-config" }
 grapl-tracing = { path = "../grapl-tracing" }
 grapl-utils = { path = "../grapl-utils" }
 rust-proto = { path = "../rust-proto", version = "*" }
-sqlx = { version = "0.6", features = [
-  "runtime-tokio-rustls",
-  "postgres",
-  "offline",
-  "uuid",
-  "migrate",
-] }
+sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/src/rust/plugin-registry/Cargo.toml
+++ b/src/rust/plugin-registry/Cargo.toml
@@ -28,14 +28,7 @@ rusoto_s3 = { version = "0.47", default_features = false, features = [
 ] }
 rust-proto = { path = "../rust-proto" }
 serde_json = "1.0"
-sqlx = { version = "0.6", features = [
-  "chrono",
-  "migrate",
-  "offline",
-  "postgres",
-  "runtime-tokio-rustls",
-  "uuid",
-] }
+sqlx = { workspace = true }
 tempfile = "3.3"
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/src/rust/plugin-work-queue/Cargo.toml
+++ b/src/rust/plugin-work-queue/Cargo.toml
@@ -22,14 +22,7 @@ grapl-tracing = { path = "../grapl-tracing" }
 grapl-utils = { path = "../grapl-utils" }
 kafka = { path = "../kafka" }
 rust-proto = { path = "../rust-proto" }
-sqlx = { version = "0.6", features = [
-  "chrono",
-  "migrate",
-  "postgres",
-  "runtime-tokio-rustls",
-  "uuid",
-  "offline",
-] }
+sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/src/rust/uid-allocator/Cargo.toml
+++ b/src/rust/uid-allocator/Cargo.toml
@@ -21,12 +21,7 @@ prost = "0.9.0"
 rand = "0.8.5"
 rust-proto = { path = "../rust-proto" }
 serde = { version = "1.0.136", features = ["derive"] }
-sqlx = { version = "0.6", features = [
-  "postgres",
-  "runtime-tokio-rustls",
-  "uuid",
-  "offline"
-] }
+sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->
Just centralize where we defined sqlx. Updated the cargo.lock for it