### PR TITLE
Remove partitioning from plugin work queue

### DIFF
--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -33,7 +33,6 @@ locals {
     {
       name       = "plugin-work-queue-db",
       port       = 5433,
-      memory_max = 1024,
     },
     {
       name = "organization-management-db",

--- a/nomad/local/grapl-local-infra.nomad
+++ b/nomad/local/grapl-local-infra.nomad
@@ -31,8 +31,8 @@ locals {
       port = 5432,
     },
     {
-      name       = "plugin-work-queue-db",
-      port       = 5433,
+      name = "plugin-work-queue-db",
+      port = 5433,
     },
     {
       name = "organization-management-db",

--- a/src/rust/plugin-work-queue/migrations/1640037910_plugin_work_queue_migration.sql
+++ b/src/rust/plugin-work-queue/migrations/1640037910_plugin_work_queue_migration.sql
@@ -71,8 +71,3 @@ CREATE INDEX IF NOT EXISTS creation_time_ix ON plugin_work_queue.generator_plugi
 
 CREATE INDEX IF NOT EXISTS execution_key_ix ON plugin_work_queue.analyzer_plugin_executions (execution_key);
 CREATE INDEX IF NOT EXISTS creation_time_ix ON plugin_work_queue.analyzer_plugin_executions (creation_time);
-
-CREATE SCHEMA IF NOT EXISTS partman;
-CREATE EXTENSION IF NOT EXISTS pg_partman WITH SCHEMA partman;
-CREATE EXTENSION IF NOT EXISTS pg_cron;
-SELECT cron.schedule('@hourly', $$CALL partman.run_maintenance_proc()$$);

--- a/src/rust/plugin-work-queue/migrations/1640037910_plugin_work_queue_migration.sql
+++ b/src/rust/plugin-work-queue/migrations/1640037910_plugin_work_queue_migration.sql
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS plugin_work_queue.generator_plugin_executions
     CHECK (length(pipeline_message) < plugin_work_queue.megabytes(256)),
     CHECK (last_updated >= creation_time)
 )
-    PARTITION BY RANGE (creation_time);
+;
 
 CREATE TABLE IF NOT EXISTS plugin_work_queue.analyzer_plugin_executions
 (
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS plugin_work_queue.analyzer_plugin_executions
     CHECK (length(pipeline_message) < plugin_work_queue.megabytes(256)),
     CHECK (last_updated >= creation_time)
 )
-    PARTITION BY RANGE (creation_time);
+;
 
 CREATE INDEX IF NOT EXISTS execution_key_ix ON plugin_work_queue.generator_plugin_executions (execution_key);
 CREATE INDEX IF NOT EXISTS creation_time_ix ON plugin_work_queue.generator_plugin_executions (creation_time);
@@ -74,33 +74,5 @@ CREATE INDEX IF NOT EXISTS creation_time_ix ON plugin_work_queue.analyzer_plugin
 
 CREATE SCHEMA IF NOT EXISTS partman;
 CREATE EXTENSION IF NOT EXISTS pg_partman WITH SCHEMA partman;
-
-
--- We partition our queue based on time with a daily partition
-SELECT partman.create_parent(p_parent_table => 'plugin_work_queue.generator_plugin_executions',
-                             p_control => 'creation_time',
-                             p_type => 'native',
-                             p_interval=> 'hourly',
-                             p_premake => 24
-           );
-
-SELECT partman.create_parent(p_parent_table => 'plugin_work_queue.analyzer_plugin_executions',
-                             p_control => 'creation_time',
-                             p_type => 'native',
-                             p_interval=> 'hourly',
-                             p_premake => 24
-           );
-
 CREATE EXTENSION IF NOT EXISTS pg_cron;
-
--- We schedule partition maintenance to run hourly, retaining partitions for one month
-UPDATE partman.part_config
-SET infinite_time_partitions = true,
-    retention                = '1 month',
-    retention_keep_table= false
-WHERE (
-                  parent_table = 'plugin_work_queue.generator_plugin_executions' OR
-                  parent_table = 'plugin_work_queue.analyzer_plugin_executions'
-          );
-
 SELECT cron.schedule('@hourly', $$CALL partman.run_maintenance_proc()$$);


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
We were seeing some serious issues with the plugin work queue running locally (it'd OOM), and we can't quite figure out why. Based on the `explain` there appeared to be a serious number of partitions utilized by the `get_generator_messages` (and analyzer) query in psql_queue.rs. 

This is an experiment: to see if we get better behavior by removing the partitioning.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
CI

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
