### PR TITLE
Fix a minor shell bug in log.sh

### DIFF
--- a/src/sh/log.sh
+++ b/src/sh/log.sh
@@ -69,7 +69,7 @@ function error() {
 function fatal() {
     log "$(bright_red FATAL):" "${@}"
 
-    if [ -n "${EXIT_CODE}" ]; then
+    if [ -v EXIT_CODE ]; then
         exit "${EXIT_CODE}"
     else
         exit 1


### PR DESCRIPTION
If you have `-euo pipefail` set while calling this function, but do not specify EXIT_CODE, it fails.

`-v` checks if such a variable exists. 

Yes, the syntax is, in fact, correct! No quotes, no $