### PR TITLE
Pull Kafka configuration from new Python project

### DIFF
--- a/pulumi/infra/kafka.py
+++ b/pulumi/infra/kafka.py
@@ -170,7 +170,10 @@ class Kafka(pulumi.ComponentResource):
                     )
         else:
             confluent_stack_output = StackReference(
-                "grapl/confluent-cloud/production"
+                # TODO: Once we remove the old TypeScript project,
+                # we'll rename `confluent-cloud-py` back to
+                # `confluent-cloud`.
+                "grapl/confluent-cloud-py/production"
             ).require_output("confluent")
             self.confluent_environment = Confluent.from_json(
                 cast(pulumi.Output[Mapping[str, Any]], confluent_stack_output)


### PR DESCRIPTION
We are transitioning to using the new official Confluent Cloud Pulumi provider, rather than our home-grown dynamic-resource-based TypeScript project.

This begins to pull configuration from the new project. Once we're successfully pulling the configuration from there, we'll rename the project to `confluent-cloud` (`confluent-cloud-py` is just to differentiate from the old project while both exist).

Signed-off-by: Christopher Maier <chris@graplsecurity.com>