### PR TITLE
Scylla optimize provision

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -4301,11 +4301,12 @@ dependencies = [
 
 [[package]]
 name = "scylla"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed40c02a5c835d894044bbd6f454ef54b6937ec8af23efe3cdeaa57005bb00d"
+checksum = "345a33a39eb25c82e48f7e82cb7378ec724e72a48579bb9c83e1c511d5b44fb6"
 dependencies = [
  "arc-swap",
+ "async-trait",
  "bigdecimal",
  "byteorder",
  "bytes",
@@ -4332,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e0ac8202660385589dba16123cc5916cf4eb3078e2dac0ab6af6903d7f5467"
+checksum = "f01015d74993239c1ad6fa89e4c0baed8af37efaaaf1fb9a5abecc119a7e31c6"
 dependencies = [
  "bigdecimal",
  "byteorder",

--- a/src/rust/graph-mutation/Cargo.toml
+++ b/src/rust/graph-mutation/Cargo.toml
@@ -15,7 +15,7 @@ hash_hasher = "2.0.3"
 lazy_static = "1.4.0"
 moka = { version = "0.9", features = ["future"] }
 rust-proto = { path = "../rust-proto" }
-scylla = "0.5"
+scylla = "0.6"
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/src/rust/graph-mutation/src/graph_mutation.rs
+++ b/src/rust/graph-mutation/src/graph_mutation.rs
@@ -374,11 +374,11 @@ impl GraphMutationManager {
         self.write_dropper
             .check_node_type(tenant_id, uid, || {
                 async move {
-                    let query = Query::new(format!(
+                    let query = Query::new(
                         "INSERT INTO tenant_graph_ks.node_type \
                         (tenant_id, uid, node_type) \
-                        VALUES (?, ?, ?)"
-                    ));
+                        VALUES (?, ?, ?)",
+                    );
 
                     self.scylla_client
                         .execute(query, &(tenant_id, uid.as_i64(), node_type.value))
@@ -449,16 +449,15 @@ impl GraphMutationManager {
                 r_edge_name,
                 |f_edge_name, r_edge_name| {
                     async move {
-                        let f_statement = format!(
-                            "INSERT INTO tenant_graph_ks.edges (\
+                        let f_statement = "INSERT INTO tenant_graph_ks.edges (\
                                 tenant_id, \
                                 source_uid, \
                                 destination_uid, \
                                 f_edge_name, \
                                 r_edge_name\
                             ) \
-                            VALUES (?, ?, ?, ?, ?)",
-                        );
+                            VALUES (?, ?, ?, ?, ?)"
+                            .to_string();
                         let r_statement = f_statement.clone();
 
                         let mut batch: scylla::batch::Batch = Default::default();

--- a/src/rust/graph-mutation/src/graph_mutation.rs
+++ b/src/rust/graph-mutation/src/graph_mutation.rs
@@ -137,7 +137,10 @@ impl GraphMutationManager {
                     query.set_timestamp(Some(property_value));
 
                     self.scylla_client
-                        .execute(query, &(tenant_id, uid.as_i64(), property_name.value, property_value))
+                        .execute(
+                            query,
+                            &(tenant_id, uid.as_i64(), property_name.value, property_value),
+                        )
                         .await?;
                     Ok(())
                 },
@@ -172,7 +175,10 @@ impl GraphMutationManager {
                         query.set_timestamp(Some(-property_value));
 
                         self.scylla_client
-                            .execute(query, &(tenant_id, uid.as_i64(), property_name.value, property_value))
+                            .execute(
+                                query,
+                                &(tenant_id, uid.as_i64(), property_name.value, property_value),
+                            )
                             .timeout(std::time::Duration::from_secs(3))
                             .await
                             .map_err(|_| GraphMutationManagerError::ScyllaInsertTimeout {
@@ -209,7 +215,10 @@ impl GraphMutationManager {
                     ));
 
                     self.scylla_client
-                        .execute(query, &(tenant_id, uid.as_i64(), property_name.value, property_value))
+                        .execute(
+                            query,
+                            &(tenant_id, uid.as_i64(), property_name.value, property_value),
+                        )
                         .timeout(std::time::Duration::from_secs(3))
                         .await
                         .map_err(|_| GraphMutationManagerError::ScyllaInsertTimeout {
@@ -250,7 +259,10 @@ impl GraphMutationManager {
                         query.set_timestamp(Some(property_value));
 
                         self.scylla_client
-                            .execute(query, &(tenant_id, uid.as_i64(), property_name.value, property_value))
+                            .execute(
+                                query,
+                                &(tenant_id, uid.as_i64(), property_name.value, property_value),
+                            )
                             .timeout(std::time::Duration::from_secs(3))
                             .await
                             .map_err(|_| GraphMutationManagerError::ScyllaInsertTimeout {
@@ -292,7 +304,15 @@ impl GraphMutationManager {
                         query.set_timestamp(Some(-property_value));
 
                         self.scylla_client
-                            .execute(query, &(&tenant_id, uid.as_i64(), property_name.value, property_value))
+                            .execute(
+                                query,
+                                &(
+                                    &tenant_id,
+                                    uid.as_i64(),
+                                    property_name.value,
+                                    property_value,
+                                ),
+                            )
                             .timeout(std::time::Duration::from_secs(3))
                             .await
                             .map_err(|_| GraphMutationManagerError::ScyllaInsertTimeout {
@@ -327,7 +347,10 @@ impl GraphMutationManager {
                     ));
 
                     self.scylla_client
-                        .execute(query, &(tenant_id, uid.as_i64(), property_name.value, property_value))
+                        .execute(
+                            query,
+                            &(tenant_id, uid.as_i64(), property_name.value, property_value),
+                        )
                         .timeout(std::time::Duration::from_secs(3))
                         .await
                         .map_err(|_| GraphMutationManagerError::ScyllaInsertTimeout {
@@ -391,7 +414,10 @@ impl GraphMutationManager {
                     ));
 
                     self.scylla_client
-                        .execute(query, &(tenant_id, uid.as_i64(), property_name.value, property_value))
+                        .execute(
+                            query,
+                            &(tenant_id, uid.as_i64(), property_name.value, property_value),
+                        )
                         .timeout(std::time::Duration::from_secs(3))
                         .await
                         .map_err(|_| GraphMutationManagerError::ScyllaInsertTimeout {

--- a/src/rust/graph-query/Cargo.toml
+++ b/src/rust/graph-query/Cargo.toml
@@ -18,7 +18,7 @@ prost = "0.9.0"
 rand = "0.8.5"
 rust-proto = { path = "../rust-proto" }
 rustc-hash = "1.1.0"
-scylla = "0.5"
+scylla = "0.6"
 secrecy = "0.8.0"
 serde = { version = "1.0.136", features = ["derive"] }
 test-log = { version = "0.2.8", features = ["trace"] }

--- a/src/rust/graph-query/src/property_query.rs
+++ b/src/rust/graph-query/src/property_query.rs
@@ -69,7 +69,7 @@ impl PropertyQueryExecutor {
         uid: Uid,
         property_name: &PropertyName,
     ) -> Result<Option<StringField>, PropertyQueryError> {
-        let mut query = scylla::query::Query::from(
+        let mut query = scylla::query::Query::from(format!(
             r"
             SELECT value
             FROM tenant_graph_ks.{IMM_STRING_TABLE_NAME}
@@ -80,7 +80,7 @@ impl PropertyQueryExecutor {
             LIMIT 1
             ALLOW FILTERING;
             ",
-        );
+        ));
 
         query.set_is_idempotent(true);
 

--- a/src/rust/graph-query/src/property_query.rs
+++ b/src/rust/graph-query/src/property_query.rs
@@ -17,6 +17,8 @@ use scylla::{
     CachingSession,
 };
 
+use crate::table_names::IMM_STRING_TABLE_NAME;
+
 #[derive(Debug, thiserror::Error)]
 pub enum PropertyQueryError {
     #[error("QueryError: {0}")]

--- a/src/rust/graph-query/src/property_query.rs
+++ b/src/rust/graph-query/src/property_query.rs
@@ -17,9 +17,7 @@ use scylla::{
     CachingSession,
 };
 
-use crate::table_names::{
-    IMM_STRING_TABLE_NAME,
-};
+use crate::table_names::IMM_STRING_TABLE_NAME;
 
 #[derive(Debug, thiserror::Error)]
 pub enum PropertyQueryError {
@@ -111,7 +109,6 @@ impl PropertyQueryExecutor {
         uid: Uid,
         edge_name: &EdgeName,
     ) -> Result<Option<Vec<EdgeRow>>, PropertyQueryError> {
-
         let mut query = scylla::query::Query::from(format!(
             r"
             SELECT r_edge_name, destination_uid

--- a/src/rust/graph-query/src/property_query.rs
+++ b/src/rust/graph-query/src/property_query.rs
@@ -17,8 +17,6 @@ use scylla::{
     CachingSession,
 };
 
-use crate::table_names::IMM_STRING_TABLE_NAME;
-
 #[derive(Debug, thiserror::Error)]
 pub enum PropertyQueryError {
     #[error("QueryError: {0}")]
@@ -71,7 +69,7 @@ impl PropertyQueryExecutor {
         uid: Uid,
         property_name: &PropertyName,
     ) -> Result<Option<StringField>, PropertyQueryError> {
-        let mut query = scylla::query::Query::from(format!(
+        let mut query = scylla::query::Query::from(
             r"
             SELECT value
             FROM tenant_graph_ks.{IMM_STRING_TABLE_NAME}
@@ -81,8 +79,8 @@ impl PropertyQueryExecutor {
                 populated_field = ?
             LIMIT 1
             ALLOW FILTERING;
-            "
-        ));
+            ",
+        );
 
         query.set_is_idempotent(true);
 
@@ -109,7 +107,7 @@ impl PropertyQueryExecutor {
         uid: Uid,
         edge_name: &EdgeName,
     ) -> Result<Option<Vec<EdgeRow>>, PropertyQueryError> {
-        let mut query = scylla::query::Query::from(format!(
+        let mut query = scylla::query::Query::from(
             r"
             SELECT r_edge_name, destination_uid
             FROM tenant_graph_ks.edges
@@ -118,8 +116,8 @@ impl PropertyQueryExecutor {
                 source_uid = ? AND
                 f_edge_name = ?
             ALLOW FILTERING;
-            "
-        ));
+            ",
+        );
 
         println!("query: \n{}\n", &query.contents);
 

--- a/src/rust/scylla-provisioner/Cargo.toml
+++ b/src/rust/scylla-provisioner/Cargo.toml
@@ -9,7 +9,7 @@ async-trait = "0.1.56"
 clap = { workspace = true }
 grapl-tracing = { path = "../grapl-tracing" }
 rust-proto = { path = "../rust-proto" }
-scylla = "0.5"
+scylla = "0.6"
 secrecy = "0.8.0"
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/src/rust/scylla-provisioner/src/server.rs
+++ b/src/rust/scylla-provisioner/src/server.rs
@@ -77,7 +77,7 @@ impl ScyllaProvisionerApi for ScyllaProvisioner {
         let session = self.scylla_client.as_ref();
 
         session.query(
-            r"CREATE KEYSPACE IF NOT EXISTS tenant_graph_ks WITH REPLICATION = {{'class' : 'SimpleStrategy', 'replication_factor' : 1}};",
+            r"CREATE KEYSPACE IF NOT EXISTS tenant_graph_ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1};",
             &[],
         ).await?;
 

--- a/src/rust/scylla-provisioner/src/server.rs
+++ b/src/rust/scylla-provisioner/src/server.rs
@@ -77,9 +77,7 @@ impl ScyllaProvisionerApi for ScyllaProvisioner {
         let session = self.scylla_client.as_ref();
 
         session.query(
-            format!(
-                r"CREATE KEYSPACE IF NOT EXISTS tenant_graph_ks WITH REPLICATION = {{'class' : 'SimpleStrategy', 'replication_factor' : 1}};"
-            ),
+            r"CREATE KEYSPACE IF NOT EXISTS tenant_graph_ks WITH REPLICATION = {{'class' : 'SimpleStrategy', 'replication_factor' : 1}};",
             &[],
         ).await?;
 
@@ -111,27 +109,23 @@ impl ScyllaProvisionerApi for ScyllaProvisioner {
 
         session
             .query(
-                format!(
-                    r"CREATE TABLE IF NOT EXISTS tenant_graph_ks.node_type (
+                "CREATE TABLE IF NOT EXISTS tenant_graph_ks.node_type (
                         uid bigint,
                         node_type text,
                         PRIMARY KEY (uid, node_type)
-                    )"
-                ),
+                    )",
                 &(),
             )
             .await?;
         session
             .query(
-                format!(
-                    r"CREATE TABLE IF NOT EXISTS tenant_graph_ks.edges (
+                r"CREATE TABLE IF NOT EXISTS tenant_graph_ks.edges (
                         source_uid bigint,
                         destination_uid bigint,
                         f_edge_name text,
                         r_edge_name text,
                         PRIMARY KEY (source_uid, f_edge_name, destination_uid)
-                    )"
-                ),
+                    )",
                 &(),
             )
             .await?;

--- a/src/rust/scylla-provisioner/src/server.rs
+++ b/src/rust/scylla-provisioner/src/server.rs
@@ -1,8 +1,10 @@
 use std::{
-    sync::Arc,
+    sync::{
+        atomic::AtomicBool,
+        Arc,
+    },
     time::Duration,
 };
-use std::sync::atomic::AtomicBool;
 
 use async_trait::async_trait;
 use rust_proto::{
@@ -65,7 +67,10 @@ impl ScyllaProvisionerApi for ScyllaProvisioner {
         &self,
         request: native::ProvisionGraphForTenantRequest,
     ) -> Result<native::ProvisionGraphForTenantResponse, Self::Error> {
-        if self.already_provisioned.load(std::sync::atomic::Ordering::SeqCst) {
+        if self
+            .already_provisioned
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
             return Ok(native::ProvisionGraphForTenantResponse {});
         }
         let native::ProvisionGraphForTenantRequest { tenant_id: _ } = request;
@@ -132,7 +137,8 @@ impl ScyllaProvisionerApi for ScyllaProvisioner {
             .await?;
 
         session.await_schema_agreement().await?;
-        self.already_provisioned.store(true, std::sync::atomic::Ordering::SeqCst);
+        self.already_provisioned
+            .store(true, std::sync::atomic::Ordering::SeqCst);
 
         Ok(native::ProvisionGraphForTenantResponse {})
     }

--- a/src/rust/scylla-provisioner/src/server.rs
+++ b/src/rust/scylla-provisioner/src/server.rs
@@ -96,10 +96,11 @@ impl ScyllaProvisionerApi for ScyllaProvisioner {
                 .query(
                     format!(
                         r"CREATE TABLE IF NOT EXISTS tenant_graph_ks.{table_name} (
+                            tenant_id uuid,
                             uid bigint,
                             populated_field text,
                             value {value_type},
-                            PRIMARY KEY (uid, populated_field)
+                            PRIMARY KEY (tenant_id, uid, populated_field)
                         )"
                     ),
                     &(),
@@ -110,9 +111,10 @@ impl ScyllaProvisionerApi for ScyllaProvisioner {
         session
             .query(
                 "CREATE TABLE IF NOT EXISTS tenant_graph_ks.node_type (
+                        tenant_id uuid,
                         uid bigint,
                         node_type text,
-                        PRIMARY KEY (uid, node_type)
+                        PRIMARY KEY (tenant_id, uid, node_type)
                     )",
                 &(),
             )
@@ -120,11 +122,12 @@ impl ScyllaProvisionerApi for ScyllaProvisioner {
         session
             .query(
                 r"CREATE TABLE IF NOT EXISTS tenant_graph_ks.edges (
+                        tenant_id uuid,
                         source_uid bigint,
                         destination_uid bigint,
                         f_edge_name text,
                         r_edge_name text,
-                        PRIMARY KEY (source_uid, f_edge_name, destination_uid)
+                        PRIMARY KEY (tenant_id, source_uid, f_edge_name, destination_uid)
                     )",
                 &(),
             )

--- a/src/rust/scylla-provisioner/src/table_names.rs
+++ b/src/rust/scylla-provisioner/src/table_names.rs
@@ -7,9 +7,3 @@ pub const MAX_U_64_TABLE_NAME: &str = "max_u64";
 pub const MIN_U_64_TABLE_NAME: &str = "min_u64";
 pub const IMM_U_64_TABLE_NAME: &str = "imm_u64";
 pub const IMM_STRING_TABLE_NAME: &str = "imm_string";
-
-pub fn tenant_keyspace_name(tenant_id: uuid::Uuid) -> String {
-    // scylla keyspace names must be alphanumeric + underscores, and max out at 48.
-    // fun fact: the result of this is exactly 48
-    format!("tenant_keyspace_{}", tenant_id.simple())
-}


### PR DESCRIPTION
### Which issue does this PR correspond to?
https://app.zenhub.com/workspaces/grapl-6036cbd36bacff000ef314f2/issues/grapl-security/issue-tracker/1031

### What changes does this PR make to Grapl? Why?
Provisioning keyspaces and tables in parallel is slow and error prone. This changes things so that we provision things once and instead our tenancy isolation is done via partition keys, not keyspaces.

This PR also updates Scylla to 0.6, which includes a number of bug fixes, including changes around the reliability of ALTER commands.

Note that the tenant-id no longer needs to be communicated to the service but this PR does not remove it. There will be follow up issues to track this work.

Further, we attempt to only provision once by storing a boolean value and short circuiting if a provision is already successful. Provisioning should already be idempotent so this shouldn't be a problem, but it should help speed up tests.

### How were these changes tested?
Existing tests.