### PR TITLE
Resurrect graph-mutation's write-drop behavior.

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1838,6 +1838,7 @@ dependencies = [
  "blake2",
  "clap 3.2.13",
  "dashmap",
+ "eyre",
  "grapl-tracing",
  "grapl-utils",
  "hash_hasher",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -39,6 +39,7 @@ members = [
 ]
 
 [workspace.dependencies]
+blake2 = "0.10"
 bytes = "1.1"
 clap = { version = "3.0", default_features = false, features = [
   "std",

--- a/src/rust/graph-mutation/Cargo.toml
+++ b/src/rust/graph-mutation/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 async-trait = "0.1.53"
-blake2 = "0.10.4"
+blake2 = { workspace = true }
 clap = { workspace = true }
 dashmap = "5.2.0"
 grapl-tracing = { path = "../grapl-tracing" }

--- a/src/rust/graph-mutation/Cargo.toml
+++ b/src/rust/graph-mutation/Cargo.toml
@@ -21,3 +21,6 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 uid-allocator = { path = "../uid-allocator" }
 uuid = { workspace = true }
+
+[dev-dependencies]
+eyre = { workspace = true }

--- a/src/rust/graph-mutation/src/graph_mutation.rs
+++ b/src/rust/graph-mutation/src/graph_mutation.rs
@@ -147,6 +147,7 @@ impl GraphMutationManager {
                 },
             )
             .await
+            .map(|_| ())
     }
 
     #[tracing::instrument(skip(self), err)]
@@ -192,6 +193,7 @@ impl GraphMutationManager {
                 },
             )
             .await
+            .map(|_| ())
     }
 
     #[tracing::instrument(skip(self), err)]
@@ -229,6 +231,7 @@ impl GraphMutationManager {
                 .instrument(tracing::info_span!("upsert_max_u64"))
             })
             .await
+            .map(|_| ())
     }
 
     #[tracing::instrument(skip(self), err)]
@@ -272,6 +275,7 @@ impl GraphMutationManager {
                 },
             )
             .await
+            .map(|_| ())
     }
 
     #[tracing::instrument(skip(self), err)]
@@ -315,6 +319,7 @@ impl GraphMutationManager {
                 },
             )
             .await
+            .map(|_| ())
     }
 
     #[tracing::instrument(skip(self), err)]
@@ -351,6 +356,7 @@ impl GraphMutationManager {
                 .instrument(tracing::info_span!("upsert_imm_i64"))
             })
             .await
+            .map(|_| ())
     }
 
     #[tracing::instrument(skip(self), err)]
@@ -384,6 +390,7 @@ impl GraphMutationManager {
                 .instrument(tracing::info_span!("set_node_type"))
             })
             .await
+            .map(|_| ())
     }
 
     #[tracing::instrument(skip(self), err)]
@@ -420,6 +427,7 @@ impl GraphMutationManager {
                 .instrument(tracing::info_span!("upsert_imm_string"))
             })
             .await
+            .map(|_| ())
     }
 
     #[tracing::instrument(skip(self), err)]
@@ -494,6 +502,7 @@ impl GraphMutationManager {
                 },
             )
             .await
+            .map(|_| ())
     }
 }
 

--- a/src/rust/graph-mutation/src/write_dropper.rs
+++ b/src/rust/graph-mutation/src/write_dropper.rs
@@ -401,7 +401,7 @@ mod tests {
             let status = check().await?;
             eyre::ensure!(
                 status == WriteDropStatus::Dropped,
-                "immutable is immutable!"
+                "immutable"
             );
         }
 
@@ -478,7 +478,7 @@ mod tests {
             let status = check().await?;
             eyre::ensure!(
                 status == WriteDropStatus::Dropped,
-                "immutable is immutable!"
+                "immutable"
             );
         }
 
@@ -503,8 +503,19 @@ mod tests {
             let status = check().await?;
             eyre::ensure!(
                 status == WriteDropStatus::Dropped,
-                "immutable is immutable!"
+                "immutable"
             );
+        }
+
+        // ##### check_node_type #####
+        {
+            let write_dropper = Arc::clone(&write_dropper);
+            let uid = Uid::from_u64(123).unwrap();
+
+            let status = write_dropper.check_node_type(tenant_id, uid, callback).await?;
+            eyre::ensure!(status == WriteDropStatus::Stored, "initial always stores");
+            let status = write_dropper.check_node_type(tenant_id, uid, callback).await?;
+            eyre::ensure!(status == WriteDropStatus::Dropped, "immutable");
         }
 
         Ok(())

--- a/src/rust/graph-mutation/src/write_dropper.rs
+++ b/src/rust/graph-mutation/src/write_dropper.rs
@@ -332,7 +332,7 @@ mod tests {
     enum CallbackError {}
 
     #[tokio::test]
-    async fn test_every_class_of_cache() -> eyre::Result<()> {
+    async fn test_every_cache_drops_when_expected() -> eyre::Result<()> {
         let tenant_id = uuid::Uuid::new_v4();
         let node_type = NodeType {
             value: "arbitrary_node_type".to_string(),

--- a/src/rust/node-identifier/Cargo.toml
+++ b/src/rust/node-identifier/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 integration_tests = []
 
 [dependencies]
-blake2 = "0.10.4"
+blake2 = { workspace = true }
 bytes = { workspace = true }
 chrono = "0.4"
 clap = { workspace = true }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
Satisfies https://github.com/grapl-security/issue-tracker/issues/1028 except for changes in src/rust/graph-mutation/src/reverse_edge_resolver.rs which will be done separately.
The blake2b stuff was pulled out in https://github.com/grapl-security/grapl/pull/1993

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Write Dropper is an optimization that lets us save some DB writes. Here's the docs:
```
/// WriteDropper lets us save database IO by proactively "dropping" db writes
/// that wouldn't change eventual outcome.
/// EXAMPLE 1: Immutable String
///   An immutable string can't change, so if we receive two instructions to
///   write an immutable string, we only have to write one of them.
/// EXAMPLE 2: Max u64/i64 (aka IncrOnly)
///   If you have a property that can only increment, and we've previously
///   written 5 to the DB, there's no reason to write a 4 if we encounter it.
#[derive(Clone, Debug)]
```
Currently we just skip all that caching behavior entirely, because the previous DashMap implementation was a big ol' footgun.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
bruh look at all these beautiful tests I added 

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
