### PR TITLE
Rename `confluent-cloud-py` to `confluent-cloud`

### DIFF
--- a/pulumi/infra/kafka.py
+++ b/pulumi/infra/kafka.py
@@ -151,10 +151,7 @@ class Kafka(pulumi.ComponentResource):
                     )
         else:
             confluent_stack_output = StackReference(
-                # TODO: Once we remove the old TypeScript project,
-                # we'll rename `confluent-cloud-py` back to
-                # `confluent-cloud`.
-                "grapl/confluent-cloud-py/production"
+                "grapl/confluent-cloud/production"
             ).require_output("confluent")
             self.confluent_environment = Confluent.from_json(
                 cast(pulumi.Output[Mapping[str, Any]], confluent_stack_output)


### PR DESCRIPTION
We're ready to delete the old project and rename the new one.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
