### PR TITLE
Add web routes for ingress service

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -627,7 +627,8 @@ job "grapl-core" {
         GRAPL_USER_AUTH_TABLE    = var.user_auth_table
         GRAPL_USER_SESSION_TABLE = var.user_session_table
 
-        PLUGIN_REGISTRY_CLIENT_ADDRESS = "http://${NOMAD_UPSTREAM_ADDR_plugin-registry}"
+        PLUGIN_REGISTRY_CLIENT_ADDRESS  = "http://${NOMAD_UPSTREAM_ADDR_plugin-registry}"
+        PIPELINE_INGRESS_CLIENT_ADDRESS = "http://${NOMAD_UPSTREAM_ADDR_pipeline-ingress}"
 
         GRAPL_WEB_UI_BIND_ADDRESS = "0.0.0.0:${NOMAD_PORT_web-ui-port}"
         GRAPL_GOOGLE_CLIENT_ID    = var.google_client_id
@@ -657,6 +658,10 @@ job "grapl-core" {
             upstreams {
               destination_name = "plugin-registry"
               local_bind_port  = 1001
+            }
+            upstreams {
+              destination_name = "pipeline-ingress"
+              local_bind_port  = 1002
             }
           }
         }

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1994,6 +1994,7 @@ dependencies = [
  "actix-web",
  "argon2",
  "awc",
+ "bytes",
  "chrono",
  "clap 3.2.13",
  "e2e-tests",

--- a/src/rust/grapl-web-ui/Cargo.toml
+++ b/src/rust/grapl-web-ui/Cargo.toml
@@ -25,6 +25,7 @@ argon2 = { version = "0.4", features = ["std"] }
 awc = { version = "3", default_features = false, features = [
   "compress-brotli"
 ] }
+bytes = { workspace = true }
 chrono = { version = "0.4" }
 clap = { workspace = true }
 futures = "0.3"

--- a/src/rust/grapl-web-ui/src/config.rs
+++ b/src/rust/grapl-web-ui/src/config.rs
@@ -3,8 +3,14 @@ use grapl_config::env_helpers::FromEnv;
 use rand::Rng;
 use rusoto_dynamodb::DynamoDbClient;
 use rust_proto::{
-    client_factory::services::PluginRegistryClientConfig,
-    graplinc::grapl::api::plugin_registry::v1beta1::PluginRegistryServiceClient,
+    client_factory::services::{
+        PipelineIngressClientConfig,
+        PluginRegistryClientConfig,
+    },
+    graplinc::grapl::api::{
+        pipeline_ingress::v1beta1::client::PipelineIngressClient,
+        plugin_registry::v1beta1::PluginRegistryServiceClient,
+    },
     protocol::service_client::ConnectWithConfig,
 };
 
@@ -31,6 +37,7 @@ pub struct Config {
     pub user_auth_table_name: String,
     pub user_session_table_name: String,
     pub plugin_registry_client: PluginRegistryServiceClient,
+    pub pipeline_ingress_client: PipelineIngressClient,
     pub google_client_id: String,
 }
 
@@ -44,6 +51,9 @@ impl Config {
             PluginRegistryServiceClient::connect_with_config(builder.plugin_registry_config)
                 .await?;
 
+        let pipeline_ingress_client =
+            PipelineIngressClient::connect_with_config(builder.pipeline_ingress_config).await?;
+
         let dynamodb_client = DynamoDbClient::from_env();
 
         // generate a random key for encrypting user state.
@@ -56,6 +66,7 @@ impl Config {
             user_auth_table_name: builder.user_auth_table_name,
             user_session_table_name: builder.user_session_table_name,
             plugin_registry_client,
+            pipeline_ingress_client,
             google_client_id: builder.google_client_id,
         };
 
@@ -74,6 +85,8 @@ pub struct ConfigBuilder {
     pub user_session_table_name: String,
     #[clap(flatten)]
     pub plugin_registry_config: PluginRegistryClientConfig,
+    #[clap(flatten)]
+    pub pipeline_ingress_config: PipelineIngressClientConfig,
     #[clap(env = "GRAPL_GOOGLE_CLIENT_ID")]
     pub google_client_id: String,
 }

--- a/src/rust/grapl-web-ui/src/lib.rs
+++ b/src/rust/grapl-web-ui/src/lib.rs
@@ -25,6 +25,7 @@ pub fn run(config: config::Config) -> Result<Server, std::io::Error> {
             jsonwebtoken_google::Parser::new(&config.google_client_id),
         ));
         let plugin_registry_client = Data::new(config.plugin_registry_client.clone());
+        let pipeline_ingress_client = Data::new(config.pipeline_ingress_client.clone());
 
         App::new()
             .wrap(actix_web::middleware::Logger::default())
@@ -47,6 +48,7 @@ pub fn run(config: config::Config) -> Result<Server, std::io::Error> {
             )))
             .app_data(web_client)
             .app_data(plugin_registry_client)
+            .app_data(pipeline_ingress_client)
             .app_data(web_authenticator)
             .configure(routes::config)
     })

--- a/src/rust/grapl-web-ui/src/routes/api.rs
+++ b/src/rust/grapl-web-ui/src/routes/api.rs
@@ -1,11 +1,13 @@
 mod auth;
 mod health;
+pub mod ingress;
 pub mod plugin;
 
 use actix_web::web;
 
 pub(super) fn config(cfg: &mut web::ServiceConfig) {
     cfg.service(web::scope("/auth").configure(auth::config));
+    cfg.service(web::scope("/ingress").configure(ingress::config));
     cfg.service(web::scope("/plugin").configure(plugin::config));
     cfg.route("/health", web::get().to(health::health));
 }

--- a/src/rust/grapl-web-ui/src/routes/api/ingress.rs
+++ b/src/rust/grapl-web-ui/src/routes/api/ingress.rs
@@ -1,0 +1,12 @@
+mod error;
+pub mod publish;
+
+use actix_web::web;
+pub use error::IngressError;
+
+pub(super) fn config(cfg: &mut web::ServiceConfig) {
+    cfg.route(
+        "/publish/{event_source_id}",
+        web::post().to(publish::publish),
+    );
+}

--- a/src/rust/grapl-web-ui/src/routes/api/ingress/error.rs
+++ b/src/rust/grapl-web-ui/src/routes/api/ingress/error.rs
@@ -1,0 +1,28 @@
+use rust_proto::protocol::error::GrpcClientError;
+
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum IngressError {
+    #[error(transparent)]
+    PluginRegistryClient(#[from] GrpcClientError),
+    #[error(transparent)]
+    Payload(#[from] actix_web::error::PayloadError),
+    #[error("gRPC client timeout: {0}")]
+    RcpTimeout(#[from] tokio::time::error::Elapsed),
+}
+
+impl actix_web::error::ResponseError for IngressError {
+    fn error_response(&self) -> actix_web::HttpResponse<actix_web::body::BoxBody> {
+        match *self {
+            IngressError::Payload(_) => actix_web::HttpResponse::BadRequest().finish(),
+            _ => actix_web::HttpResponse::InternalServerError().finish(),
+        }
+    }
+
+    fn status_code(&self) -> actix_web::http::StatusCode {
+        match *self {
+            IngressError::Payload(_) => actix_web::http::StatusCode::BAD_REQUEST,
+            _ => actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}

--- a/src/rust/grapl-web-ui/src/routes/api/ingress/publish.rs
+++ b/src/rust/grapl-web-ui/src/routes/api/ingress/publish.rs
@@ -1,0 +1,51 @@
+use actix_web::{
+    web,
+    HttpResponse,
+};
+use futures::StreamExt;
+use grapl_utils::future_ext::GraplFutureExt;
+use rust_proto::graplinc::grapl::api::pipeline_ingress::v1beta1::{
+    client::PipelineIngressClient,
+    PublishRawLogRequest,
+};
+
+use super::IngressError;
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct PublishLogResponse {
+    pub created_time: std::time::SystemTime,
+}
+
+#[tracing::instrument(skip(plugin_registry_client, body))]
+pub(super) async fn publish(
+    plugin_registry_client: web::Data<PipelineIngressClient>,
+    user: crate::authn::AuthenticatedUser,
+    path: web::Path<uuid::Uuid>,
+    mut body: web::Payload,
+) -> Result<impl actix_web::Responder, IngressError> {
+    let mut bytes = web::BytesMut::new();
+    while let Some(item) = body.next().await {
+        let item = item?;
+        bytes.extend_from_slice(&item);
+    }
+
+    let authenticated_tenant_id = user.get_organization_id().to_owned();
+    let event_source_id = path.into_inner();
+    let publish_log_request = PublishRawLogRequest::new(
+        event_source_id,
+        authenticated_tenant_id,
+        bytes::Bytes::from(bytes),
+    );
+
+    tracing::debug!(message = "publish log", ?publish_log_request);
+
+    let mut plugin_registry_client = plugin_registry_client.get_ref().clone();
+    let response = plugin_registry_client
+        .publish_raw_log(publish_log_request)
+        .timeout(std::time::Duration::from_secs(5))
+        .await??;
+
+    let created_time = response.created_time();
+
+    Ok(HttpResponse::Ok().json(PublishLogResponse { created_time }))
+}

--- a/src/rust/grapl-web-ui/tests/api/ingress.rs
+++ b/src/rust/grapl-web-ui/tests/api/ingress.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "integration_tests")]
+
+use eyre::ContextCompat;
+
+use crate::test_app::TestApp;
+
+#[actix_web::test]
+async fn publish_log() -> eyre::Result<()> {
+    let app = TestApp::init().await?;
+
+    app.login_with_test_user().await?;
+
+    let plugin_name = "Test Plugin";
+
+    let create_response = crate::plugin::create_plugin(&app, plugin_name).await?;
+
+    //TODO: this shouldn't be necessary, but we're seeing 500 errors without it.
+    // I'll file a task to look into it for now so we can unblock frontend work.
+    std::thread::sleep(std::time::Duration::from_secs(5));
+
+    let plugin_metadata =
+        crate::plugin::get_plugin_metadata(&app, &create_response.plugin_id).await?;
+
+    let event_source_id = plugin_metadata
+        .event_source_id
+        .wrap_err("new plugin is missing event_source_id")?;
+
+    let response = app
+        .post(format!("api/ingress/publish/{event_source_id}").as_str())
+        .body("junk data")
+        .send()
+        .await?;
+
+    eyre::ensure!(
+        response.status() == actix_web::http::StatusCode::OK,
+        "unexpected response: {:?}",
+        &response
+    );
+
+    Ok(())
+}

--- a/src/rust/grapl-web-ui/tests/api/main.rs
+++ b/src/rust/grapl-web-ui/tests/api/main.rs
@@ -2,5 +2,6 @@
 
 mod auth;
 mod config;
-mod plugin;
+mod ingress;
+pub mod plugin;
 mod test_app;

--- a/src/rust/grapl-web-ui/tests/api/plugin.rs
+++ b/src/rust/grapl-web-ui/tests/api/plugin.rs
@@ -102,7 +102,7 @@ async fn plugin_lifecycle() -> eyre::Result<()> {
     Ok(())
 }
 
-async fn create_plugin(app: &TestApp, plugin_name: &str) -> eyre::Result<CreateResponse> {
+pub async fn create_plugin(app: &TestApp, plugin_name: &str) -> eyre::Result<CreateResponse> {
     let create_metadata_body = serde_json::json!({
             "plugin_name": plugin_name,
             "plugin_type": "generator",
@@ -136,7 +136,7 @@ async fn create_plugin(app: &TestApp, plugin_name: &str) -> eyre::Result<CreateR
     Ok(response_body)
 }
 
-async fn get_plugin_metadata(
+pub async fn get_plugin_metadata(
     app: &TestApp,
     plugin_id: &uuid::Uuid,
 ) -> eyre::Result<GetPluginMetadataResponse> {

--- a/src/rust/grapl-web-ui/tests/api/test_app/test_user.rs
+++ b/src/rust/grapl-web-ui/tests/api/test_app/test_user.rs
@@ -70,3 +70,9 @@ impl TestUser {
         Ok(())
     }
 }
+
+impl Default for TestUser {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/rust/rust-proto/src/graplinc/grapl/api/pipeline_ingress/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/pipeline_ingress/v1beta1/client.rs
@@ -30,6 +30,7 @@ use crate::{
 
 pub type PipelineIngressClientError = GrpcClientError;
 
+#[derive(Clone)]
 pub struct PipelineIngressClient {
     executor: Executor,
     proto_client: PipelineIngressServiceClientProto<tonic::transport::Channel>,


### PR DESCRIPTION
### What changes does this PR make to Grapl? Why?

This creates a web API to expose the ingress service for publishing logs to Grapl.

This includes an integration test and enables the E2E tests to use a public API instead of hitting this Ingress Service directly.

### How were these changes tested?

CI