### PR TITLE
Remove OTEL from plugins

### DIFF
--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -848,7 +848,6 @@ job "grapl-core" {
         PLUGIN_REGISTRY_HAX_DOCKER_PLUGIN_RUNTIME_IMAGE = var.container_images["hax-docker-plugin-runtime"]
         PLUGIN_REGISTRY_BUCKET_AWS_ACCOUNT_ID           = var.plugin_registry_bucket_aws_account_id
         PLUGIN_REGISTRY_BUCKET_NAME                     = var.plugin_registry_bucket_name
-        PLUGIN_EXECUTION_OBSERVABILITY_ENV_VARS         = var.observability_env_vars
         PLUGIN_EXECUTION_GENERATOR_SIDECAR_IMAGE        = var.container_images["generator-execution-sidecar"]
         PLUGIN_EXECUTION_ANALYZER_SIDECAR_IMAGE         = var.container_images["analyzer-execution-sidecar"]
         PLUGIN_EXECUTION_GRAPH_QUERY_PROXY_IMAGE        = var.container_images["graph-query-proxy"]

--- a/src/rust/plugin-registry/src/server/deploy_plugin.rs
+++ b/src/rust/plugin-registry/src/server/deploy_plugin.rs
@@ -84,7 +84,6 @@ pub fn get_job(
                 ("tenant_id", plugin.tenant_id.to_string()),
                 // Passthrough vars
                 ("rust_log", passthru.rust_log),
-                ("observability_env_vars", passthru.observability_env_vars),
             ]);
             if plugin_type == PluginType::Analyzer {
                 job_file_vars.insert("graph_query_proxy_image", passthru.graph_query_proxy_image);

--- a/src/rust/plugin-registry/src/server/service.rs
+++ b/src/rust/plugin-registry/src/server/service.rs
@@ -121,8 +121,6 @@ pub struct PluginRegistryServiceConfig {
 
 #[derive(clap::Parser, Clone, Debug, Default)]
 pub struct PluginExecutionPassthroughVars {
-    #[clap(long, env = "PLUGIN_EXECUTION_OBSERVABILITY_ENV_VARS")]
-    pub observability_env_vars: String,
     #[clap(long, env = "PLUGIN_EXECUTION_GENERATOR_SIDECAR_IMAGE")]
     pub generator_sidecar_image: String,
     #[clap(long, env = "PLUGIN_EXECUTION_ANALYZER_SIDECAR_IMAGE")]

--- a/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
@@ -45,14 +45,6 @@ variable "rust_log" {
   description = "Controls the logging behavior of Rust-based services."
 }
 
-variable "observability_env_vars" {
-  type        = string
-  description = <<EOF
-With local-grapl, we have to inject env vars for Opentelemetry.
-In prod, this is currently disabled.
-EOF
-}
-
 job "grapl-plugin" {
   datacenters = ["dc1"]
   namespace   = "plugin-${var.plugin_id}"
@@ -148,12 +140,6 @@ job "grapl-plugin" {
         image = var.plugin_execution_sidecar_image
       }
 
-      template {
-        data        = var.observability_env_vars
-        destination = "observability.env"
-        env         = true
-      }
-
       env {
         PLUGIN_EXECUTOR_PLUGIN_ID = var.plugin_id
 
@@ -175,12 +161,6 @@ job "grapl-plugin" {
 
       config {
         image = var.graph_query_proxy_image
-      }
-
-      template {
-        data        = var.observability_env_vars
-        destination = "observability.env"
-        env         = true
       }
 
       env {
@@ -273,12 +253,6 @@ EOF
           x-amz-expected-bucket-owner = var.aws_account_id
           x-amz-meta-client-id        = "nomad-deployer"
         }
-      }
-
-      template {
-        data        = var.observability_env_vars
-        destination = "observability.env"
-        env         = true
       }
 
       env {

--- a/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
@@ -39,14 +39,6 @@ variable "rust_log" {
   description = "Controls the logging behavior of Rust-based services."
 }
 
-variable "observability_env_vars" {
-  type        = string
-  description = <<EOF
-With local-grapl, we have to inject env vars for Opentelemetry.
-In prod, this is currently disabled.
-EOF
-}
-
 job "grapl-plugin" {
   datacenters = ["dc1"]
   namespace   = "plugin-${var.plugin_id}"
@@ -110,12 +102,6 @@ job "grapl-plugin" {
 
       config {
         image = var.plugin_execution_sidecar_image
-      }
-
-      template {
-        data        = var.observability_env_vars
-        destination = "observability.env"
-        env         = true
       }
 
       env {
@@ -200,12 +186,6 @@ EOF
           x-amz-expected-bucket-owner = var.aws_account_id
           x-amz-meta-client-id        = "nomad-deployer"
         }
-      }
-
-      template {
-        data        = var.observability_env_vars
-        destination = "observability.env"
-        env         = true
       }
 
       env {


### PR DESCRIPTION
After this discussion in Slack:
https://gist.github.com/wimax-grapl/7f2565e1f6d988a19dde3fc617f515bb
https://grapl-internal.slack.com/archives/C03JNJ57A9G/p1666020843029249

We decided to remove all metrics from the plugin runtime and, instead, to do metrics from their upstream (plugin-work-queue). 