### PR TITLE
Don't try to gather "lost" Nomad allocations

### DIFF
--- a/etc/ci_scripts/dump_artifacts/nomad_artifacts.py
+++ b/etc/ci_scripts/dump_artifacts/nomad_artifacts.py
@@ -169,6 +169,7 @@ def _get_allocations(
         job_name: [
             NomadAllocation(a, parent=parent, opts=opts)
             for a in nomad_client.job.get_allocations(job_name)
+            if a["ClientStatus"] != "lost"
         ]
         for job_name in job_names
     }


### PR DESCRIPTION
Our pipelines started suddenly failing when our "dump artifacts" code started dying when fetching Nomad logs. Apparently some allocations for the `rust-integration-tests` job were "lost", and you can't fetch logs for things that are lost.

I've tried to prune these jobs from Nomad, but haven't found the right incantation yet. In the meantime, we can just not try to fetch those logs.

This is not the "real" solution, but should at least allow our pipeline to continue while we sort out what's going on.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>