### PR TITLE
Make use of the Toolchain remote cache when gathering artifacts

### DIFF
--- a/.buildkite/pipeline.provision.yml
+++ b/.buildkite/pipeline.provision.yml
@@ -38,6 +38,8 @@ steps:
       - grapl-security/vault-env#v0.2.0:
           secrets:
             - PULUMI_ACCESS_TOKEN
+            # dump_artifacts.sh uses Pants; let's benefit from the cache
+            - grapl/TOOLCHAIN_AUTH_TOKEN
       - improbable-eng/metahook#v0.4.1:
           post-command: |
             .buildkite/scripts/grapl_testing_stack/dump_artifacts.sh

--- a/.buildkite/pipeline.testing.yml
+++ b/.buildkite/pipeline.testing.yml
@@ -15,6 +15,8 @@ steps:
       - grapl-security/vault-env#v0.2.0:
           secrets:
             - PULUMI_ACCESS_TOKEN
+            # dump_artifacts.sh uses Pants; let's benefit from the cache
+            - grapl/TOOLCHAIN_AUTH_TOKEN
       - improbable-eng/metahook#v0.4.1:
           post-command: |
             .buildkite/scripts/grapl_testing_stack/dump_artifacts.sh

--- a/.buildkite/scripts/grapl_testing_stack/dump_artifacts.sh
+++ b/.buildkite/scripts/grapl_testing_stack/dump_artifacts.sh
@@ -8,13 +8,8 @@
 ##########
 set -euo pipefail
 
-REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
-readonly REPOSITORY_ROOT
+NOMAD_ADDRESS=$(pulumi stack output address --stack="grapl/nomad/testing")
+export NOMAD_ADDRESS
 
-readonly STACK="grapl/nomad/testing"
-_NOMAD_ADDRESS=$(pulumi stack output address --stack="${STACK}")
-readonly _NOMAD_ADDRESS
-
-cd "${REPOSITORY_ROOT}"
 # dump-artifacts is a Grapl custom alias defined in pants.toml
-NOMAD_ADDRESS="${_NOMAD_ADDRESS}" ./pants dump-artifacts --no-dump-agent-logs
+./pants dump-artifacts --no-dump-agent-logs


### PR DESCRIPTION
The `dump-artifacts` command we use invokes Pants, so we can likely
cut down the time that this action takes by using the cache.

(The wrapper script was also simplified.)