### PR TITLE
Kafka producers compress messages with `zstd`

### DIFF
--- a/pulumi/infra/kafka.py
+++ b/pulumi/infra/kafka.py
@@ -144,7 +144,7 @@ class Kafka(pulumi.ComponentResource):
                         partitions=2,
                         replication_factor=3,
                         config={
-                            "compression.type": "zstd",
+                            "compression.type": "producer",
                             "min.insync.replicas": 2,
                         },
                         opts=pulumi.ResourceOptions(provider=provider),

--- a/src/rust/kafka/src/lib.rs
+++ b/src/rust/kafka/src/lib.rs
@@ -119,6 +119,7 @@ fn producer(
     sasl_password: secrecy::SecretString,
 ) -> Result<FutureProducer, ConfigurationError> {
     configure(bootstrap_servers, sasl_username, sasl_password)
+        .set("compression.type", "zstd")
         .set("acks", "all")
         .create()
         .map_err(|e| ConfigurationError::ProducerCreateFailed(e))


### PR DESCRIPTION
Due to an apparent bug in the Confluent Cloud Terraform provider, it's not possible to create _topics_ with a `compression.type` setting of anything other than `producer`. This essentially means that a topic will honor whatever scheme a received message is compressed with, and won't re-compress it according to its own compression scheme.

As a result, we'll want to ensure that our messages are `zstd`-compressed when they enter our pipeline; if all our topics are configured with `compression.type` set to `producer`, then the `zstd` compression will be preserved throughout the pipeline.

In retrospect, it's actually better this way; now, we're explicitly controlling the compression at the head of the pipeline.

(An upcoming refresh of our Confluent Cloud infrastructure will ensure our topics are all set up with the `provider` compression setting, but even without that change, *this* change should be effectively transparent, as far as Grapl is concerned.)

Signed-off-by: Christopher Maier <chris@graplsecurity.com>