### PR TITLE
Use `jq` to extract the version of `protoc` that Pants uses

### DIFF
--- a/build-support/protoc_version.sh
+++ b/build-support/protoc_version.sh
@@ -5,28 +5,21 @@
 # this information (e.g., build arguments for container images to
 # ensure base images are in-sync with our Rust version)
 #
-# It can safely be invoked from anywhere in the repository, as it
-# resolves the .protoc-version file from the repository root.
+# It can safely be invoked from anywhere in the repository.
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel 2> /dev/null)"
 readonly repo_root
 
-# Ideally, we'd use something like https://github.com/kislyuk/yq to
-# introspect `pants.toml`, but given that the entry in pants.toml for
-# the protoc version is relatively unique and easy to grep for,
-# we'll just use that.
-
-# (Further diatribe:)
-# The problem with yq/tomlq? I'd like to install tomlq on the Buildkite agent
-# packer image, but the only way to install it is pip. Nothing else on
-# the buildkite packer uses pip right now. This seems like a serious rabbit
-# hole to go down to do something "right" when I could just grep.
-
-# grab [protoc] and the 1 line after that.
-protoc_section=$(grep -A 1 "\[protoc\]" "${repo_root}/pants.toml")
-
-# -n = quiet
-# -r = extended regex (enables \1)
-# /\1/ = only return what's in capture group 1 - the contents of the parens
-echo "${protoc_section}" | sed -nr 's/^version = "(.*)"$/\1/p'
+(
+    cd "${repo_root}"
+    # This magical bit of `jq` extracts the effective version of
+    # `protoc` from Pants, whether we're using the default version or
+    # have pinned a specific version in `pants.toml`.
+    ./pants help-all |
+        jq --raw-output \
+            '.scope_to_help_info.protoc.advanced |
+            .[] |
+            select(.config_key == "version") |
+            .value_history.ranked_values[-1].value'
+)

--- a/pants.toml
+++ b/pants.toml
@@ -209,12 +209,18 @@ lockfile = "3rdparty/python/pyupgrade.lockfile"
 # For keep-runtime-typing to work we also can't use py30-plus
 args = ["--py39-plus", "--keep-runtime-typing"]
 
-# The protoc section here is consumed both by Pants and also
-# the `build-support/protoc_version.sh` script.
-# It is the single source of truth for the version of protoc both our
-# Python and Rust libraries should be consuming.
-# Please don't refactor it away!
 [protoc]
+# While this is the current default value for Pants (as of Pants
+# 2.13.0), we're going to explicitly list it. We programmatically read
+# this value in `build-support/protoc_version.sh` in order to use the
+# same version in our Rust build process. That script can find out
+# what version Pants would use even if we didn't explicitly list it
+# here, but being explicit here makes it very easy to find out what
+# version we're using, without having to run any script.
+#
+# As such, there's nothing magical or special about this value, and
+# you should feel no compunctions about updating it if you need to, or
+# when Pants updates its defaults.
 version = "3.20.1"
 
 [tailor]


### PR DESCRIPTION
Rather than using `grep` on TOML to extract which version of `protoc` is being used (which works, but can be fragile), we will instead parse a gigantic JSON dump of Pants' state and extract the version using `jq`.

This is more robust because it takes into account the layering that Pants uses (i.e., CLI options override `pants.toml` configuration, which in turn overrides hardcoded defaults). This means we don't even have to pin a version in `pants.toml` and the script will still work!

For now, however, I *have* opted to keep the pin in `pants.toml`, purely for visibility and explicitness.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>