### PR TITLE
Set cpu=50 for proxy tasks in plugins. They are currently 250.

### DIFF
--- a/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
@@ -84,6 +84,12 @@ job "grapl-plugin" {
       ]
 
       connect {
+        sidecar_task {
+          resources {
+            cpu = 50
+          }
+        }
+
         sidecar_service {
           proxy {
             upstreams {
@@ -112,6 +118,12 @@ job "grapl-plugin" {
       ]
 
       connect {
+        sidecar_task {
+          resources {
+            cpu = 50
+          }
+        }
+
         sidecar_service {
           proxy {
             upstreams {
@@ -202,6 +214,12 @@ job "grapl-plugin" {
       ]
 
       connect {
+        sidecar_task {
+          resources {
+            cpu = 50
+          }
+        }
+
         sidecar_service {
           proxy {
             upstreams {

--- a/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
@@ -77,6 +77,12 @@ job "grapl-plugin" {
       ]
 
       connect {
+        sidecar_task {
+          resources {
+            cpu = 50
+          }
+        }
+
         sidecar_service {
           proxy {
             upstreams {
@@ -141,6 +147,12 @@ job "grapl-plugin" {
       ]
 
       connect {
+        sidecar_task {
+          resources {
+            cpu = 50
+          }
+        }
+
         sidecar_service {
         }
       }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
none
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
running rust-integration-tests on laptop results in it complaining about too little CPU. Turns out we were giving the proxy tasks the default amount of 250 shares of cpu. I've dialed it down to 50. 

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
unfortunately my laptop is out of space so working on testing it...

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
