### PR TITLE
Plugin health should be checked from Consul health, not Nomad job status

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,6 +59,7 @@ BUILD @christophermaier
 /src/rust/async-cache/ @jgrillo-grapl
 /src/rust/analyzer-dispatcher/ @jgrillo-grapl
 /src/rust/client-executor/ @colin-grapl
+/src/rust/consul-client/ @wimax-grapl
 /src/rust/consul-connect/ @colin-grapl @wimax-grapl
 /src/rust/derive-dynamic-node/ @colin-grapl
 /src/rust/e2e-tests/ @wimax-grapl

--- a/nomad/grapl-core.nomad
+++ b/nomad/grapl-core.nomad
@@ -922,6 +922,7 @@ job "grapl-core" {
 
       env {
         AWS_REGION                                      = var.aws_region
+        CONSUL_SERVICE_ADDRESS                          = "${attr.unique.network.ip-address}:8500"
         NOMAD_SERVICE_ADDRESS                           = "${attr.unique.network.ip-address}:4646"
         PLUGIN_REGISTRY_BIND_ADDRESS                    = "0.0.0.0:${NOMAD_PORT_plugin-registry-port}"
         PLUGIN_REGISTRY_DB_ADDRESS                      = "${var.plugin_registry_db.hostname}:${var.plugin_registry_db.port}"

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -989,6 +989,7 @@ version = "0.0.1"
 dependencies = [
  "clap 3.2.23",
  "reqwest",
+ "rust-proto",
  "serde",
  "thiserror",
  "tracing",

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -984,6 +984,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
 
 [[package]]
+name = "consul-client"
+version = "0.0.1"
+dependencies = [
+ "clap 3.2.23",
+ "reqwest",
+ "serde",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "consul-connect"
 version = "1.0.0"
 dependencies = [
@@ -3532,6 +3543,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "clap 3.2.23",
+ "consul-client",
  "e2e-tests",
  "eyre",
  "figment",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -4,7 +4,7 @@ members = [
   "./async-cache",
   "./client-executor",
   "./consul-client",
-  "./consul-connect",  # TODO delete
+  "./consul-connect", # TODO delete
   "./derive-dynamic-node",
   "./e2e-tests",
   "./endpoint-plugin",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -3,7 +3,8 @@ members = [
   "./analyzer-dispatcher",
   "./async-cache",
   "./client-executor",
-  "./consul-connect",
+  "./consul-client",
+  "./consul-connect",  # TODO delete
   "./derive-dynamic-node",
   "./e2e-tests",
   "./endpoint-plugin",

--- a/src/rust/consul-client/Cargo.toml
+++ b/src/rust/consul-client/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Max Wittek <wimax@graplsecurity.com>"]
 edition = "2021"
 
 [dependencies]
-reqwest = { version = "0.11", default-features = false, features = [
-    "json"
-] }
+clap = { workspace = true }
+reqwest = { version = "0.11", default-features = false, features = ["json"] }
 serde = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }

--- a/src/rust/consul-client/Cargo.toml
+++ b/src/rust/consul-client/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 clap = { workspace = true }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
+rust-proto = { path = "../rust-proto" }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/src/rust/consul-client/Cargo.toml
+++ b/src/rust/consul-client/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "consul-client"
+version = "0.0.1"
+authors = ["Max Wittek <wimax@graplsecurity.com>"]
+edition = "2021"
+
+[dependencies]
+reqwest = { version = "0.11", default-features = false, features = [
+    "json"
+] }
+serde = { workspace = true }
+thiserror = { workspace = true }

--- a/src/rust/consul-client/src/lib.rs
+++ b/src/rust/consul-client/src/lib.rs
@@ -17,7 +17,6 @@ pub struct ConsulClientConfig {
     consul_service_address: SocketAddr,
 }
 
-/// A thin wrapper around the nomad_client_gen with usability improvements.
 pub struct ConsulClient {
     address: String,
 }

--- a/src/rust/consul-client/src/lib.rs
+++ b/src/rust/consul-client/src/lib.rs
@@ -1,0 +1,30 @@
+//
+
+#[derive(thiserror::Error, Debug)]
+pub enum ConsulClientError {
+    #[error("consul check health error: '{0}'")]
+    CheckHealthError(reqwest::Error),
+    #[error("reqwest serde error: '{0}'")]
+    ReqwestSerdeError(reqwest::Error),
+}
+
+#[derive(Debug)]
+pub struct CheckHealthResponse(Vec<CheckHealthResponseElem>);
+
+#[derive(serde::Deserialize, Debug)]
+pub struct CheckHealthResponseElem {}
+
+pub async fn check_health(
+    service_name: impl Into<String>,
+) -> Result<CheckHealthResponse, ConsulClientError> {
+    let service_name = service_name.into();
+    let url = format!("http://consul.service.consul:8500/v1/health/checks/{service_name}");
+    let response = reqwest::get(url)
+        .await
+        .map_err(ConsulClientError::CheckHealthError)?;
+    let responses = response
+        .json::<Vec<CheckHealthResponseElem>>()
+        .await
+        .map_err(ConsulClientError::ReqwestSerdeError)?;
+    Ok(CheckHealthResponse(responses))
+}

--- a/src/rust/consul-client/src/models.rs
+++ b/src/rust/consul-client/src/models.rs
@@ -1,0 +1,28 @@
+#[derive(Debug)]
+pub struct CheckHealthResponse(pub Vec<CheckHealthResponseElem>);
+
+impl CheckHealthResponse {
+    pub fn all_passing(&self) -> bool {
+        if self.0.len() == 0 {
+            tracing::info!("no service found");
+            // no such service found
+            return false;
+        }
+
+        if self.0.iter().all(|elem| elem.status == "passing") {
+            tracing::info!("all pass");
+            return true;
+        }
+
+        tracing::info!("other");
+        return false;
+    }
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct CheckHealthResponseElem {
+    #[serde(alias = "Status")]
+    pub status: String,
+    #[serde(alias = "ServiceName")]
+    pub service_name: String,
+}

--- a/src/rust/consul-client/src/models.rs
+++ b/src/rust/consul-client/src/models.rs
@@ -2,20 +2,20 @@
 pub struct CheckHealthResponse(pub Vec<CheckHealthResponseElem>);
 
 impl CheckHealthResponse {
+    /// Return whether all service healthchecks in a CheckHealthResponse
+    /// have state "passing"
     pub fn all_passing(&self) -> bool {
-        if self.0.len() == 0 {
-            tracing::info!("no service found");
-            // no such service found
+        if self.0.is_empty() {
+            // no such service found - it may still be booting up
             return false;
         }
 
         if self.0.iter().all(|elem| elem.status == "passing") {
-            tracing::info!("all pass");
             return true;
         }
 
-        tracing::info!("other");
-        return false;
+        // at least one such service is critical
+        false
     }
 }
 

--- a/src/rust/derive-dynamic-node/Cargo.toml
+++ b/src/rust/derive-dynamic-node/Cargo.toml
@@ -18,7 +18,7 @@ syn = "1.0"
 [dev-dependencies]
 log = "0.4"
 rust-proto = { path = "../rust-proto", version = "*" }
-serde = "1.0"
+serde = { workspace = true }
 serde_derive = "1.0"
 serde_json = "1.0"
 uuid = { workspace = true }

--- a/src/rust/e2e-tests/src/test_utils.rs
+++ b/src/rust/e2e-tests/src/test_utils.rs
@@ -1,3 +1,4 @@
 pub mod context;
 pub mod find_node;
+pub mod plugin_health;
 pub mod predicates;

--- a/src/rust/e2e-tests/src/test_utils/plugin_health.rs
+++ b/src/rust/e2e-tests/src/test_utils/plugin_health.rs
@@ -6,9 +6,9 @@ use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::{
     PluginRegistryClient,
 };
 
-/// After a deploy, plugins seem to take quite some time to deploy.
-/// This function lets us assert that a plugin eventually reaches
-/// a certain state within <some duration>.
+/// After a deploy, plugins seem to take quite some time to become healthy.
+/// This function lets us assert that a plugin eventually reaches a certain
+/// state within <some duration>.
 pub async fn assert_eventual_health(
     client: &PluginRegistryClient,
     plugin_id: uuid::Uuid,

--- a/src/rust/e2e-tests/src/test_utils/plugin_health.rs
+++ b/src/rust/e2e-tests/src/test_utils/plugin_health.rs
@@ -1,0 +1,41 @@
+use std::time::Duration;
+
+use rust_proto::graplinc::grapl::api::plugin_registry::v1beta1::{
+    GetPluginHealthRequest,
+    PluginHealthStatus,
+    PluginRegistryClient,
+};
+
+/// After a deploy, plugins seem to take quite some time to deploy.
+/// This function lets us assert that a plugin eventually reaches
+/// a certain state within <some duration>.
+pub async fn assert_eventual_health(
+    client: &PluginRegistryClient,
+    plugin_id: uuid::Uuid,
+    expected: PluginHealthStatus,
+    timeout: Duration,
+) -> eyre::Result<()> {
+    let mut client = client.clone();
+    let start_time = std::time::SystemTime::now();
+    let sleep_between_tries = Duration::from_secs(3);
+
+    loop {
+        let elapsed = start_time.elapsed()?;
+        if elapsed > timeout {
+            eyre::bail!("Plugin {plugin_id} never reached {expected:?} within {timeout:?}");
+        }
+
+        let actual_health_status = client
+            .get_plugin_health(GetPluginHealthRequest::new(plugin_id))
+            .await?
+            .health_status();
+        if expected == actual_health_status {
+            tracing::debug!(
+                "Plugin {plugin_id} reached expected status {expected:?} after {elapsed:?}"
+            );
+            return Ok(());
+        } else {
+            tokio::time::sleep(sleep_between_tries).await;
+        }
+    }
+}

--- a/src/rust/graph-query/Cargo.toml
+++ b/src/rust/graph-query/Cargo.toml
@@ -19,7 +19,7 @@ rust-proto = { path = "../rust-proto" }
 rustc-hash = "1.1.0"
 scylla = "0.6"
 secrecy = "0.8.0"
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/src/rust/grapl-web-ui/Cargo.toml
+++ b/src/rust/grapl-web-ui/Cargo.toml
@@ -44,7 +44,7 @@ rusoto_dynamodb = { version = "0.47", default_features = false, features = [
 ] }
 rust-proto = { path = "../rust-proto" }
 secrecy = { version = "0.8", features = ["serde"] }
-serde = "1"
+serde = { workspace = true }
 serde_dynamodb = "0.9"
 serde_json = "1"
 thiserror = { workspace = true }

--- a/src/rust/grapl-web-ui/src/routes/api/plugin/create.rs
+++ b/src/rust/grapl-web-ui/src/routes/api/plugin/create.rs
@@ -144,7 +144,7 @@ async fn get_plugin_artifact(payload: &mut Multipart) -> Result<web::Bytes, Plug
 
         // Get form body
         let mut body = web::BytesMut::new();
-        if let Some(chunk) = field.next().await {
+        while let Some(chunk) = field.next().await {
             let chunk = chunk?;
             body.extend_from_slice(&chunk);
         }

--- a/src/rust/grapl-web-ui/tests/api/test_app.rs
+++ b/src/rust/grapl-web-ui/tests/api/test_app.rs
@@ -66,7 +66,7 @@ impl TestApp {
 
             if status_code >= 500 && status_code <= 599 {
                 // We recevied a 500 error, wait a moment before trying the request again
-                println!("Error: {:?}", response);
+                println!("5xx Error: {:?}", response);
 
                 let one_sec = std::time::Duration::from_secs(1);
                 std::thread::sleep(one_sec);

--- a/src/rust/node-identifier/Cargo.toml
+++ b/src/rust/node-identifier/Cargo.toml
@@ -38,7 +38,7 @@ rusoto_dynamodb = { version = "0.47", default_features = false, features = [
   "rustls"
 ] }
 rust-proto = { path = "../rust-proto", version = "*" }
-serde = "1.0"
+serde = { workspace = true }
 serde_dynamodb = { version = "0.9", default_features = false, features = [
   "rustls"
 ] }

--- a/src/rust/plugin-registry/Cargo.toml
+++ b/src/rust/plugin-registry/Cargo.toml
@@ -13,6 +13,7 @@ name = "plugin_registry"
 [dependencies]
 async-trait = "0.1"
 bytes = { workspace = true }
+consul-client = { path = "../consul-client" }
 clap = { workspace = true }
 figment = { workspace = true }
 futures = "0.3"

--- a/src/rust/plugin-registry/src/error.rs
+++ b/src/rust/plugin-registry/src/error.rs
@@ -54,7 +54,7 @@ pub enum PluginRegistryServiceError {
     #[error("DeploymentStateError {0}")]
     DeploymentStateError(String),
     #[error(transparent)]
-    HealthCheckError(#[from] consul_client::CheckHealthError),
+    PluginHealthCheckError(#[from] consul_client::ConsulClientError),
     // TODO: These errs are meant to be human-readable and are not directly
     // sent over the wire, so add {0}s to them!
     #[error("not found")]
@@ -86,6 +86,7 @@ impl From<PluginRegistryServiceError> for Status {
             }
             e @ (Error::NomadClientError(_)
             | Error::NomadCliError(_)
+            | Error::PluginHealthCheckError(_)
             | Error::NomadJobAllocationError(_)) => Status::unknown(e.to_string()),
             Error::StreamInputError(e) => {
                 // Since it's regarding user input, we can de-anonymize this message

--- a/src/rust/plugin-registry/src/error.rs
+++ b/src/rust/plugin-registry/src/error.rs
@@ -53,6 +53,8 @@ pub enum PluginRegistryServiceError {
     StreamInputError(&'static str),
     #[error("DeploymentStateError {0}")]
     DeploymentStateError(String),
+    #[error(transparent)]
+    HealthCheckError(#[from] consul_client::CheckHealthError),
     // TODO: These errs are meant to be human-readable and are not directly
     // sent over the wire, so add {0}s to them!
     #[error("not found")]

--- a/src/rust/plugin-registry/src/server/get_plugin_health.rs
+++ b/src/rust/plugin-registry/src/server/get_plugin_health.rs
@@ -38,6 +38,11 @@ async fn query_nomad_for_health(
 ) -> Result<PluginHealthStatus, PluginRegistryServiceError> {
     let job_name = plugin_nomad_job::job_name().to_owned();
     let namespace_name = plugin_nomad_job::namespace_name(&plugin_id);
+    let service_name = format!("plugin-{plugin_id}");
+    let service_health = consul_client::check_health(service_name).await?;
+    tracing::info!("health result", service_health = ?service_health);
+    Ok(PluginHealthStatus::Dead);
+    /*
     let job = nomad_client.get_job(job_name, Some(namespace_name)).await?;
     match job.status {
         Some(status) => match status.as_str() {
@@ -51,5 +56,6 @@ async fn query_nomad_for_health(
         _ => Err(PluginRegistryServiceError::DeploymentStateError(
             "No State for this job? Is this even possible?".to_owned(),
         )),
-    }
+    } 
+    */
 }

--- a/src/rust/plugin-registry/src/server/get_plugin_health.rs
+++ b/src/rust/plugin-registry/src/server/get_plugin_health.rs
@@ -70,8 +70,5 @@ async fn query_consul_for_service_health(
     let consul_client = ConsulClient::new(ConsulClientConfig::parse());
     let service_health = consul_client.check_health(service_name).await?;
     tracing::info!(message = "health result", service_health =? service_health);
-    match service_health.all_passing() {
-        true => Ok(PluginHealthStatus::Running),
-        false => Ok(PluginHealthStatus::Pending),
-    }
+    Ok(service_health.into())
 }

--- a/src/rust/plugin-registry/src/server/get_plugin_health.rs
+++ b/src/rust/plugin-registry/src/server/get_plugin_health.rs
@@ -47,8 +47,8 @@ async fn query_nomad_for_health(
     match job.status {
         Some(status) => match status.as_str() {
             "pending" => Ok(PluginHealthStatus::Pending),
-            // Okay, so now we know the job is running; let's ask Consul
-            // if the plugin service is healthy.
+            // Okay, so now we know the job is running in Nomad; next let's
+            // query Consul if the plugin service is healthy.
             "running" => query_consul_for_service_health(plugin_id).await,
             "dead" => Ok(PluginHealthStatus::Dead),
             other => Err(PluginRegistryServiceError::DeploymentStateError(format!(
@@ -61,6 +61,8 @@ async fn query_nomad_for_health(
     }
 }
 
+/// Given a plugin-id, query Consul to see if the service
+/// `plugin-${plugin_id}` is healthy.
 async fn query_consul_for_service_health(
     plugin_id: uuid::Uuid,
 ) -> Result<PluginHealthStatus, PluginRegistryServiceError> {

--- a/src/rust/plugin-sdk/generator-sdk/Cargo.toml
+++ b/src/rust/plugin-sdk/generator-sdk/Cargo.toml
@@ -15,7 +15,7 @@ clap = { workspace = true }
 figment = { workspace = true }
 grapl-tracing = { path = "../../grapl-tracing" }
 rust-proto = { path = "../../rust-proto" }
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 #[dev-dependencies]
 # Only for test_utils
 test-context = { version = "0.1", optional = true }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1.rs
@@ -1192,6 +1192,7 @@ pub enum PluginHealthStatus {
     Pending,
     Running,
     Dead,
+    // We may want a discrimination between "running-healthy" and "running-unhealthy"
 }
 
 impl TryFrom<proto::PluginHealthStatus> for PluginHealthStatus {

--- a/src/rust/sysmon-parser/Cargo.toml
+++ b/src/rust/sysmon-parser/Cargo.toml
@@ -18,7 +18,7 @@ serde = ["dep:serde", "uuid/serde", "chrono/serde"]
 chrono = { version = "0.4" }
 derive-into-owned = "0.2"
 memchr = "2"
-serde = { version = "1.0", default-features = false, features = [
+serde = { workspace = true, default-features = false, features = [
   "derive"
 ], optional = true }
 thiserror = { workspace = true }

--- a/src/rust/uid-allocator/Cargo.toml
+++ b/src/rust/uid-allocator/Cargo.toml
@@ -16,7 +16,7 @@ opentelemetry = { workspace = true }
 opentelemetry-jaeger = { workspace = true }
 rand = "0.8.5"
 rust-proto = { path = "../rust-proto" }
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { workspace = true }
 sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://github.com/grapl-security/issue-tracker/issues/1063
https://app.zenhub.com/workspaces/grapl-6036cbd36bacff000ef314f2/issues/grapl-security/issue-tracker/1063
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
The current GetPluginHealth implementation is bad and wrong. It only checks "is the Nomad job running?" and not "is the Consul service healthy?" This is a stab at doing that. It seems to work.

Also added a test utility for checking eventual health (seems to happen in 20-30s after deploying a plugin)

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Integrated this RPC into tests. Itactually helped me catch a bug in grapl-web-ui!

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
