### PR TITLE
Save some Nomad memory credits for plugin consul connect envoy proxy tasks

### DIFF
--- a/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_analyzer.nomad
@@ -45,6 +45,13 @@ variable "rust_log" {
   description = "Controls the logging behavior of Rust-based services."
 }
 
+locals {
+  # default values are cpu = 100 / mem = 300
+  # per https://developer.hashicorp.com/nomad/docs/job-specification/resources
+  consul_connect_proxy_cpu    = 50
+  consul_connect_proxy_mem_mb = 50
+}
+
 job "grapl-plugin" {
   datacenters = ["dc1"]
   namespace   = "plugin-${var.plugin_id}"
@@ -86,7 +93,8 @@ job "grapl-plugin" {
       connect {
         sidecar_task {
           resources {
-            cpu = 50
+            cpu = local.consul_connect_proxy_cpu
+            memory = local.consul_connect_proxy_mem_mb
           }
         }
 
@@ -120,7 +128,8 @@ job "grapl-plugin" {
       connect {
         sidecar_task {
           resources {
-            cpu = 50
+            cpu = local.consul_connect_proxy_cpu
+            memory = local.consul_connect_proxy_mem_mb
           }
         }
 
@@ -234,7 +243,8 @@ job "grapl-plugin" {
       connect {
         sidecar_task {
           resources {
-            cpu = 50
+            cpu = local.consul_connect_proxy_cpu
+            memory = local.consul_connect_proxy_mem_mb
           }
         }
 

--- a/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
+++ b/src/rust/plugin-registry/src/static_files/hax_docker_generator.nomad
@@ -39,6 +39,13 @@ variable "rust_log" {
   description = "Controls the logging behavior of Rust-based services."
 }
 
+locals {
+  # default values are cpu = 100 / mem = 300
+  # per https://developer.hashicorp.com/nomad/docs/job-specification/resources
+  consul_connect_proxy_cpu    = 50
+  consul_connect_proxy_mem_mb = 50
+}
+
 job "grapl-plugin" {
   datacenters = ["dc1"]
   namespace   = "plugin-${var.plugin_id}"
@@ -79,7 +86,8 @@ job "grapl-plugin" {
       connect {
         sidecar_task {
           resources {
-            cpu = 50
+            cpu = local.consul_connect_proxy_cpu
+            memory = local.consul_connect_proxy_mem_mb
           }
         }
 
@@ -167,7 +175,8 @@ job "grapl-plugin" {
       connect {
         sidecar_task {
           resources {
-            cpu = 50
+            cpu = local.consul_connect_proxy_cpu
+            memory = local.consul_connect_proxy_mem_mb
           }
         }
 


### PR DESCRIPTION


<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
Currently, by default, every `sidecar_service` gets 300MB of Nomad memory credits. That's so much?! We don't use that! 

Here's what current usage actually looks like for the plugin tasks I see right now.
![image](https://user-images.githubusercontent.com/69007229/199619713-880a733b-279e-48b2-b2d6-9eb1c5a24e47.png)


It may turn out we need to tune these numbers a bit, but in the meantime I'm just running it against CI and seeing how it turns out.


<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
CI here and now

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
