### PR TITLE
Internal 1057 pwq backpressure

### DIFF
--- a/src/proto/graplinc/grapl/api/plugin_work_queue/v1beta1/plugin_work_queue.proto
+++ b/src/proto/graplinc/grapl/api/plugin_work_queue/v1beta1/plugin_work_queue.proto
@@ -122,6 +122,38 @@ message AcknowledgeAnalyzerRequest {
 // A response to an AcknowledgeAnalyzerRequest
 message AcknowledgeAnalyzerResponse {}
 
+// A request for the current queue depth for a given analyzer (useful for
+// backpressure)
+message QueueDepthForAnalyzerRequest {
+  // The analyzer's plugin ID
+  graplinc.common.v1beta1.Uuid analyzer_id = 1;
+}
+
+// A response containing the current queue depth for the given analyzer and the
+// current "dominant event source ID" present in the queue
+message QueueDepthForAnalyzerResponse {
+  // How many messages are currently in the given analyzer's queue
+  uint32 queue_depth = 1;
+
+  // The event source ID which contributes most to this analyzer's queue
+  graplinc.common.v1beta1.Uuid dominant_event_source_id = 2;
+}
+
+// A request for the current queue depth for a given generator (useful for
+// backpressure)
+message QueueDepthForGeneratorRequest {
+  // The generator's plugin ID
+  graplinc.common.v1beta1.Uuid generator_id = 1;
+}
+
+message QueueDepthForGeneratorResponse {
+  // How many messages are currently in the given generator's queue
+  uint32 queue_depth = 1;
+
+  // The event source corresponding to this generator
+  graplinc.common.v1beta1.Uuid event_source_id = 2;
+}
+
 // The PluginWorkQueueService manages ExecutionJobs for Generator and Analyzer plugins
 service PluginWorkQueueService {
   // Adds a new execution job for a generator
@@ -136,4 +168,8 @@ service PluginWorkQueueService {
   rpc AcknowledgeGenerator(AcknowledgeGeneratorRequest) returns (AcknowledgeGeneratorResponse);
   // Acknowledges the completion of an analyzer job
   rpc AcknowledgeAnalyzer(AcknowledgeAnalyzerRequest) returns (AcknowledgeAnalyzerResponse);
+  // Retrieves the current queue depth for a given generator
+  rpc QueueDepthForGenerator(QueueDepthForGeneratorRequest) returns (QueueDepthForGeneratorResponse);
+  // Retrieves the current queue depth for a given analyzer
+  rpc QueueDepthForAnalyzer(QueueDepthForAnalyzerRequest) returns (QueueDepthForAnalyzerResponse);
 }

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -3602,6 +3602,8 @@ dependencies = [
  "kafka",
  "rust-proto",
  "sqlx",
+ "test-context",
+ "test-log",
  "thiserror",
  "tokio",
  "tracing",

--- a/src/rust/plugin-work-queue/Cargo.toml
+++ b/src/rust/plugin-work-queue/Cargo.toml
@@ -31,7 +31,12 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 eyre = { workspace = true }
-tracing-subscriber = "0.3"
+test-context = { workspace = true }
+test-log = { workspace = true }
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+  "env-filter",
+  "fmt"
+] }
 
 [features]
 test-utils = []

--- a/src/rust/plugin-work-queue/sqlx-data.json
+++ b/src/rust/plugin-work-queue/sqlx-data.json
@@ -50,32 +50,6 @@
     },
     "query": "\n            UPDATE plugin_work_queue.generator_plugin_executions\n            SET\n                try_count  = try_count + 1,\n                last_updated = CURRENT_TIMESTAMP,\n                visible_after  = CURRENT_TIMESTAMP + INTERVAL '10 seconds'\n            FROM (\n                 SELECT\n                     execution_key,\n                     plugin_id,\n                     pipeline_message,\n                     tenant_id,\n                     trace_id,\n                     event_source_id,\n                     current_status,\n                     creation_time,\n                     visible_after\n                 FROM plugin_work_queue.generator_plugin_executions\n                 WHERE plugin_id = $1\n                   AND current_status = 'enqueued'\n                   AND visible_after <= CURRENT_TIMESTAMP\n                 ORDER BY creation_time ASC\n                 FOR UPDATE SKIP LOCKED\n                 LIMIT 1\n             ) AS next_execution\n             WHERE plugin_work_queue.generator_plugin_executions.execution_key = next_execution.execution_key\n             RETURNING\n                 next_execution.execution_key AS \"execution_key!: ExecutionId\",\n                 next_execution.plugin_id,\n                 next_execution.pipeline_message,\n                 next_execution.tenant_id,\n                 next_execution.trace_id,\n                 next_execution.event_source_id\n        "
   },
-  "2319ef9ce3a2cd2ec3fad42469dab219191c987d6c68ae02c35a2fa398e3796a": {
-    "describe": {
-      "columns": [
-        {
-          "name": "queue_depth",
-          "ordinal": 0,
-          "type_info": "Int8"
-        },
-        {
-          "name": "dominant_event_source_id",
-          "ordinal": 1,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        null,
-        null
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      }
-    },
-    "query": "\n                SELECT\n                    COUNT(*) AS queue_depth,\n                    mode() WITHIN GROUP (ORDER BY event_source_id) AS dominant_event_source_id\n                FROM plugin_work_queue.analyzer_plugin_executions\n                WHERE plugin_id = $1 AND current_status = 'enqueued'\n            "
-  },
   "34822afa8bef4e4faf115130b855398f9e7396d74bd4a0ed476c6dd5c9128f9b": {
     "describe": {
       "columns": [],
@@ -275,6 +249,32 @@
       }
     },
     "query": "\n                SELECT\n                    COUNT(plugin_id) AS queue_depth,\n                    event_source_id\n                FROM plugin_work_queue.generator_plugin_executions\n                WHERE plugin_id = $1 AND current_status = 'enqueued'\n                GROUP BY plugin_id, event_source_id\n            "
+  },
+  "bf6e38ddd689d6cb29abffb4f1e08bde993bc309824652f832fc2ce46d43fc58": {
+    "describe": {
+      "columns": [
+        {
+          "name": "queue_depth",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "dominant_event_source_id",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        null,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                SELECT\n                    COUNT(plugin_id) AS queue_depth,\n                    mode() WITHIN GROUP (ORDER BY event_source_id) AS dominant_event_source_id\n                FROM plugin_work_queue.analyzer_plugin_executions\n                WHERE plugin_id = $1 AND current_status = 'enqueued'\n            "
   },
   "c11895f595c9ba8344179cc5fd5b883b92e2bde70763e3330a62bbade15863a3": {
     "describe": {

--- a/src/rust/plugin-work-queue/sqlx-data.json
+++ b/src/rust/plugin-work-queue/sqlx-data.json
@@ -50,6 +50,32 @@
     },
     "query": "\n            UPDATE plugin_work_queue.generator_plugin_executions\n            SET\n                try_count  = try_count + 1,\n                last_updated = CURRENT_TIMESTAMP,\n                visible_after  = CURRENT_TIMESTAMP + INTERVAL '10 seconds'\n            FROM (\n                 SELECT\n                     execution_key,\n                     plugin_id,\n                     pipeline_message,\n                     tenant_id,\n                     trace_id,\n                     event_source_id,\n                     current_status,\n                     creation_time,\n                     visible_after\n                 FROM plugin_work_queue.generator_plugin_executions\n                 WHERE plugin_id = $1\n                   AND current_status = 'enqueued'\n                   AND visible_after <= CURRENT_TIMESTAMP\n                 ORDER BY creation_time ASC\n                 FOR UPDATE SKIP LOCKED\n                 LIMIT 1\n             ) AS next_execution\n             WHERE plugin_work_queue.generator_plugin_executions.execution_key = next_execution.execution_key\n             RETURNING\n                 next_execution.execution_key AS \"execution_key!: ExecutionId\",\n                 next_execution.plugin_id,\n                 next_execution.pipeline_message,\n                 next_execution.tenant_id,\n                 next_execution.trace_id,\n                 next_execution.event_source_id\n        "
   },
+  "2319ef9ce3a2cd2ec3fad42469dab219191c987d6c68ae02c35a2fa398e3796a": {
+    "describe": {
+      "columns": [
+        {
+          "name": "queue_depth",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "dominant_event_source_id",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        null,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                SELECT\n                    COUNT(*) AS queue_depth,\n                    mode() WITHIN GROUP (ORDER BY event_source_id) AS dominant_event_source_id\n                FROM plugin_work_queue.analyzer_plugin_executions\n                WHERE plugin_id = $1 AND current_status = 'enqueued'\n            "
+  },
   "34822afa8bef4e4faf115130b855398f9e7396d74bd4a0ed476c6dd5c9128f9b": {
     "describe": {
       "columns": [],
@@ -223,6 +249,32 @@
       }
     },
     "query": "\n            SELECT\n                 execution_key AS \"execution_key!: ExecutionId\",\n                 plugin_id,\n                 pipeline_message,\n                 tenant_id,\n                 trace_id,\n                 event_source_id\n            FROM plugin_work_queue.analyzer_plugin_executions\n            WHERE plugin_id = $1\n            "
+  },
+  "b5e09d9b8c267880b4fd67114a3dc4da1f0f5900327ed21f7f8a4bb806e2a805": {
+    "describe": {
+      "columns": [
+        {
+          "name": "queue_depth",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "event_source_id",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        null,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                SELECT\n                    COUNT(plugin_id) AS queue_depth,\n                    event_source_id\n                FROM plugin_work_queue.generator_plugin_executions\n                WHERE plugin_id = $1 AND current_status = 'enqueued'\n                GROUP BY plugin_id, event_source_id\n            "
   },
   "c11895f595c9ba8344179cc5fd5b883b92e2bde70763e3330a62bbade15863a3": {
     "describe": {

--- a/src/rust/plugin-work-queue/sqlx-data.json
+++ b/src/rust/plugin-work-queue/sqlx-data.json
@@ -1,5 +1,55 @@
 {
   "db": "PostgreSQL",
+  "0f6f92cb2075c0800c5d612989ab2262f6d41d8c81e432283787b61328864adc": {
+    "describe": {
+      "columns": [
+        {
+          "name": "execution_key!: ExecutionId",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "plugin_id",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "pipeline_message",
+          "ordinal": 2,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "tenant_id",
+          "ordinal": 3,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "trace_id",
+          "ordinal": 4,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "event_source_id",
+          "ordinal": 5,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n            UPDATE plugin_work_queue.generator_plugin_executions\n            SET\n                try_count  = try_count + 1,\n                last_updated = CURRENT_TIMESTAMP,\n                visible_after  = CURRENT_TIMESTAMP + INTERVAL '10 seconds'\n            FROM (\n                 SELECT\n                     execution_key,\n                     plugin_id,\n                     pipeline_message,\n                     tenant_id,\n                     trace_id,\n                     event_source_id,\n                     current_status,\n                     creation_time,\n                     visible_after\n                 FROM plugin_work_queue.generator_plugin_executions\n                 WHERE plugin_id = $1\n                   AND current_status = 'enqueued'\n                   AND visible_after <= CURRENT_TIMESTAMP\n                 ORDER BY creation_time ASC\n                 FOR UPDATE SKIP LOCKED\n                 LIMIT 1\n             ) AS next_execution\n             WHERE plugin_work_queue.generator_plugin_executions.execution_key = next_execution.execution_key\n             RETURNING\n                 next_execution.execution_key AS \"execution_key!: ExecutionId\",\n                 next_execution.plugin_id,\n                 next_execution.pipeline_message,\n                 next_execution.tenant_id,\n                 next_execution.trace_id,\n                 next_execution.event_source_id\n        "
+  },
   "34822afa8bef4e4faf115130b855398f9e7396d74bd4a0ed476c6dd5c9128f9b": {
     "describe": {
       "columns": [],
@@ -23,6 +73,56 @@
       }
     },
     "query": "\n                UPDATE plugin_work_queue.generator_plugin_executions\n                SET current_status = $2,\n                    last_updated = CASE\n                        WHEN current_status != 'processed'\n                            THEN CURRENT_TIMESTAMP\n                            ELSE last_updated\n                        END\n                WHERE execution_key = $1\n            "
+  },
+  "3dfcf9f8cd97e8bb41d00ee6440f1a624cec2ddc7d1a7adc256ed383c78148c7": {
+    "describe": {
+      "columns": [
+        {
+          "name": "execution_key!: ExecutionId",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "plugin_id",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "pipeline_message",
+          "ordinal": 2,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "tenant_id",
+          "ordinal": 3,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "trace_id",
+          "ordinal": 4,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "event_source_id",
+          "ordinal": 5,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n            UPDATE plugin_work_queue.analyzer_plugin_executions\n            SET\n                try_count  = plugin_work_queue.analyzer_plugin_executions.try_count + 1,\n                last_updated = CURRENT_TIMESTAMP,\n                visible_after  = CURRENT_TIMESTAMP + INTERVAL '10 seconds'\n            FROM (\n                 SELECT\n                     execution_key,\n                     plugin_id,\n                     pipeline_message,\n                     tenant_id,\n                     trace_id,\n                     event_source_id,\n                     current_status,\n                     creation_time,\n                     visible_after\n                 FROM plugin_work_queue.analyzer_plugin_executions\n                 WHERE plugin_id = $1\n                   AND current_status = 'enqueued'\n                   AND visible_after <= CURRENT_TIMESTAMP\n                 ORDER BY creation_time ASC\n                 FOR UPDATE SKIP LOCKED\n                 LIMIT 1\n             ) AS next_execution\n             WHERE plugin_work_queue.analyzer_plugin_executions.execution_key = next_execution.execution_key\n             RETURNING\n                 next_execution.execution_key AS \"execution_key!: ExecutionId\",\n                 next_execution.plugin_id,\n                 next_execution.pipeline_message,\n                 next_execution.tenant_id,\n                 next_execution.trace_id,\n                 next_execution.event_source_id\n        "
   },
   "4c8f08166bb802f5d99794700fa8af0bfaa33d7c5425f55f09f882b1b2e13862": {
     "describe": {
@@ -124,56 +224,6 @@
     },
     "query": "\n            SELECT\n                 execution_key AS \"execution_key!: ExecutionId\",\n                 plugin_id,\n                 pipeline_message,\n                 tenant_id,\n                 trace_id,\n                 event_source_id\n            FROM plugin_work_queue.analyzer_plugin_executions\n            WHERE plugin_id = $1\n            "
   },
-  "7a3eff0f2833d5c44e592b83e62da1ef1f5e2f3aaa7f155e8223a00115e3fd40": {
-    "describe": {
-      "columns": [
-        {
-          "name": "execution_key!: ExecutionId",
-          "ordinal": 0,
-          "type_info": "Int8"
-        },
-        {
-          "name": "plugin_id",
-          "ordinal": 1,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "pipeline_message",
-          "ordinal": 2,
-          "type_info": "Bytea"
-        },
-        {
-          "name": "tenant_id",
-          "ordinal": 3,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "trace_id",
-          "ordinal": 4,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "event_source_id",
-          "ordinal": 5,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      }
-    },
-    "query": "\n            UPDATE plugin_work_queue.analyzer_plugin_executions\n            SET\n                try_count  = plugin_work_queue.analyzer_plugin_executions.try_count + 1,\n                last_updated = CURRENT_TIMESTAMP,\n                visible_after  = CURRENT_TIMESTAMP + INTERVAL '10 seconds'\n            FROM (\n                 SELECT\n                     execution_key,\n                     plugin_id,\n                     pipeline_message,\n                     tenant_id,\n                     trace_id,\n                     event_source_id,\n                     current_status,\n                     creation_time,\n                     visible_after\n                 FROM plugin_work_queue.analyzer_plugin_executions\n                 WHERE plugin_id = $1\n                   AND current_status = 'enqueued'\n                   AND creation_time >= (CURRENT_TIMESTAMP - INTERVAL '1 day')\n                   AND visible_after <= CURRENT_TIMESTAMP\n                 ORDER BY creation_time ASC\n                 FOR UPDATE SKIP LOCKED\n                 LIMIT 1\n             ) AS next_execution\n             WHERE plugin_work_queue.analyzer_plugin_executions.execution_key = next_execution.execution_key\n             RETURNING\n                 next_execution.execution_key AS \"execution_key!: ExecutionId\",\n                 next_execution.plugin_id,\n                 next_execution.pipeline_message,\n                 next_execution.tenant_id,\n                 next_execution.trace_id,\n                 next_execution.event_source_id\n        "
-  },
   "c11895f595c9ba8344179cc5fd5b883b92e2bde70763e3330a62bbade15863a3": {
     "describe": {
       "columns": [],
@@ -205,56 +255,6 @@
       }
     },
     "query": "\n            INSERT INTO plugin_work_queue.analyzer_plugin_executions (\n                plugin_id,\n                pipeline_message,\n                tenant_id,\n                trace_id,\n                event_source_id,\n                current_status,\n                try_count\n            )\n            VALUES( $1::UUID, $2, $3::UUID, $4::UUID, $5::UUID, 'enqueued', -1 )\n        "
-  },
-  "ddd9fb538d1d30d1d330eff378a7755afda7bf5422b1829adc765f7b637a4033": {
-    "describe": {
-      "columns": [
-        {
-          "name": "execution_key!: ExecutionId",
-          "ordinal": 0,
-          "type_info": "Int8"
-        },
-        {
-          "name": "plugin_id",
-          "ordinal": 1,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "pipeline_message",
-          "ordinal": 2,
-          "type_info": "Bytea"
-        },
-        {
-          "name": "tenant_id",
-          "ordinal": 3,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "trace_id",
-          "ordinal": 4,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "event_source_id",
-          "ordinal": 5,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      }
-    },
-    "query": "\n            UPDATE plugin_work_queue.generator_plugin_executions\n            SET\n                try_count  = try_count + 1,\n                last_updated = CURRENT_TIMESTAMP,\n                visible_after  = CURRENT_TIMESTAMP + INTERVAL '10 seconds'\n            FROM (\n                 SELECT\n                     execution_key,\n                     plugin_id,\n                     pipeline_message,\n                     tenant_id,\n                     trace_id,\n                     event_source_id,\n                     current_status,\n                     creation_time,\n                     visible_after\n                 FROM plugin_work_queue.generator_plugin_executions\n                 WHERE plugin_id = $1\n                   AND current_status = 'enqueued'\n                   AND creation_time >= (CURRENT_TIMESTAMP - INTERVAL '1 day')\n                   AND visible_after <= CURRENT_TIMESTAMP\n                 ORDER BY creation_time ASC\n                 FOR UPDATE SKIP LOCKED\n                 LIMIT 1\n             ) AS next_execution\n             WHERE plugin_work_queue.generator_plugin_executions.execution_key = next_execution.execution_key\n             RETURNING\n                 next_execution.execution_key AS \"execution_key!: ExecutionId\",\n                 next_execution.plugin_id,\n                 next_execution.pipeline_message,\n                 next_execution.tenant_id,\n                 next_execution.trace_id,\n                 next_execution.event_source_id\n        "
   },
   "f71b00154ecb7c5ac2d507c4dcae96e35bcc7a3a246af12cf02d077211ee155d": {
     "describe": {

--- a/src/rust/plugin-work-queue/src/psql_queue.rs
+++ b/src/rust/plugin-work-queue/src/psql_queue.rs
@@ -87,9 +87,8 @@ impl AnalyzerQueueDepth {
             .expect("queue_depth could not be converted to u32")
     }
 
-    pub fn dominant_event_source_id(&self) -> Uuid {
+    pub fn dominant_event_source_id(&self) -> Option<Uuid> {
         self.dominant_event_source_id
-            .expect("dominant_event_source_id was null")
     }
 }
 
@@ -392,7 +391,7 @@ impl PsqlQueue {
             AnalyzerQueueDepth,
             r#"
                 SELECT
-                    COUNT(*) AS queue_depth,
+                    COUNT(plugin_id) AS queue_depth,
                     mode() WITHIN GROUP (ORDER BY event_source_id) AS dominant_event_source_id
                 FROM plugin_work_queue.analyzer_plugin_executions
                 WHERE plugin_id = $1 AND current_status = 'enqueued'

--- a/src/rust/plugin-work-queue/src/psql_queue.rs
+++ b/src/rust/plugin-work-queue/src/psql_queue.rs
@@ -150,7 +150,6 @@ impl PsqlQueue {
     ) -> Result<Option<Message>, PsqlQueueError> {
         // This function does a few things
         // 1. It attempts to get a message from the queue
-        //      -> Where that message isn't over a day old
         //      -> Where that message is "visible"
         //      -> Where that message isn't currently being evaluated by another transaction
         //      -> Where that message is in the 'enqueued' state
@@ -161,11 +160,9 @@ impl PsqlQueue {
         // * messages are invisible for 10 seconds *after* each select
         //      * The 10 second timeout is arbitrary but reasonable.
         // * messages are immediately visible after their insert
-        // * messages 'expire' after one day
         // * messages currently do not have a maximum retry limit
-        // * The one day expiration matches our 1 day partitioning strategy
 
-        // In the future we can leverage a maximum retry limit as well as a batch version of this query
+        // In the future we can leverage a batch version of this query
         // A more dynamic visibility strategy would also be reasonable
         let request: Option<NextExecutionRequest> = sqlx::query_as!(
             NextExecutionRequest,
@@ -189,7 +186,6 @@ impl PsqlQueue {
                  FROM plugin_work_queue.generator_plugin_executions
                  WHERE plugin_id = $1
                    AND current_status = 'enqueued'
-                   AND creation_time >= (CURRENT_TIMESTAMP - INTERVAL '1 day')
                    AND visible_after <= CURRENT_TIMESTAMP
                  ORDER BY creation_time ASC
                  FOR UPDATE SKIP LOCKED
@@ -219,7 +215,6 @@ impl PsqlQueue {
     ) -> Result<Option<Message>, PsqlQueueError> {
         // `get_message` does a few things
         // 1. It attempts to get a message from the queue
-        //      -> Where that message isn't over a day old
         //      -> Where that message is "visible"
         //      -> Where that message isn't currently being evaluated by another transaction
         //      -> Where that message is in the 'enqueued' state
@@ -230,11 +225,9 @@ impl PsqlQueue {
         // * messages are invisible for 10 seconds *after* each select
         //      * The 10 second timeout is arbitrary but reasonable.
         // * messages are immediately visible after their insert
-        // * messages 'expire' after one day
         // * messages currently do not have a maximum retry limit
-        // * The one day expiration matches our 1 day partitioning strategy
 
-        // In the future we can leverage a maximum retry limit as well as a batch version of this query
+        // In the future we can leverage a batch version of this query
         // A more dynamic visibility strategy would also be reasonable
         let request: Option<NextExecutionRequest> = sqlx::query_as!(
             NextExecutionRequest,
@@ -258,7 +251,6 @@ impl PsqlQueue {
                  FROM plugin_work_queue.analyzer_plugin_executions
                  WHERE plugin_id = $1
                    AND current_status = 'enqueued'
-                   AND creation_time >= (CURRENT_TIMESTAMP - INTERVAL '1 day')
                    AND visible_after <= CURRENT_TIMESTAMP
                  ORDER BY creation_time ASC
                  FOR UPDATE SKIP LOCKED

--- a/src/rust/plugin-work-queue/src/server.rs
+++ b/src/rust/plugin-work-queue/src/server.rs
@@ -301,6 +301,22 @@ impl PluginWorkQueueApi for PluginWorkQueue {
             .await?;
         Ok(v1beta1::AcknowledgeAnalyzerResponse {})
     }
+
+    #[tracing::instrument(skip(self, _request), err)]
+    async fn queue_depth_for_generator(
+        &self,
+        _request: v1beta1::QueueDepthForGeneratorRequest,
+    ) -> Result<v1beta1::QueueDepthForGeneratorResponse, PluginWorkQueueError> {
+        todo!()
+    }
+
+    #[tracing::instrument(skip(self, _request), err)]
+    async fn queue_depth_for_analyzer(
+        &self,
+        _request: v1beta1::QueueDepthForAnalyzerRequest,
+    ) -> Result<v1beta1::QueueDepthForAnalyzerResponse, PluginWorkQueueError> {
+        todo!()
+    }
 }
 
 pub async fn exec_service(configs: ConfigUnion) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/rust/plugin-work-queue/src/server.rs
+++ b/src/rust/plugin-work-queue/src/server.rs
@@ -38,12 +38,14 @@ use crate::{
 
 #[derive(Debug, thiserror::Error)]
 pub enum PluginWorkQueueError {
-    #[error("PsqlQueueError {0}")]
+    #[error("Database error: {0}")]
     PsqlQueueError(#[from] PsqlQueueError),
-    #[error("PluginWorkQueueDeserializationError {0}")]
+    #[error("Deserialization error: {0}")]
     DeserializationError(#[from] SerDeError),
-    #[error("KafkaProducerError {0}")]
+    #[error("Kafka producer error: {0}")]
     KafkaProducerError(#[from] ProducerError),
+    #[error("Not found: {0}")]
+    NotFound(String),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -62,6 +64,7 @@ impl From<PluginWorkQueueError> for Status {
             PluginWorkQueueError::DeserializationError(_) => {
                 Status::invalid_argument("Invalid argument")
             }
+            PluginWorkQueueError::NotFound(msg) => Status::not_found(msg),
         }
     }
 }
@@ -306,16 +309,19 @@ impl PluginWorkQueueApi for PluginWorkQueue {
     async fn queue_depth_for_generator(
         &self,
         request: v1beta1::QueueDepthForGeneratorRequest,
-    ) -> Result<Option<v1beta1::QueueDepthForGeneratorResponse>, PluginWorkQueueError> {
+    ) -> Result<v1beta1::QueueDepthForGeneratorResponse, PluginWorkQueueError> {
         let generator_id = request.generator_id();
 
         if let Some(result) = self.queue.queue_depth_for_generator(generator_id).await? {
-            Ok(Some(v1beta1::QueueDepthForGeneratorResponse::new(
+            Ok(v1beta1::QueueDepthForGeneratorResponse::new(
                 result.queue_depth(),
                 result.event_source_id(),
-            )))
+            ))
         } else {
-            Ok(None)
+            Err(PluginWorkQueueError::NotFound(format!(
+                "no messages currently enqueued for generator {}",
+                generator_id
+            )))
         }
     }
 
@@ -323,20 +329,26 @@ impl PluginWorkQueueApi for PluginWorkQueue {
     async fn queue_depth_for_analyzer(
         &self,
         request: v1beta1::QueueDepthForAnalyzerRequest,
-    ) -> Result<Option<v1beta1::QueueDepthForAnalyzerResponse>, PluginWorkQueueError> {
+    ) -> Result<v1beta1::QueueDepthForAnalyzerResponse, PluginWorkQueueError> {
         let analyzer_id = request.analyzer_id();
 
         if let Some(result) = self.queue.queue_depth_for_analyzer(analyzer_id).await? {
             if let Some(dominant_event_source_id) = result.dominant_event_source_id() {
-                Ok(Some(v1beta1::QueueDepthForAnalyzerResponse::new(
+                Ok(v1beta1::QueueDepthForAnalyzerResponse::new(
                     result.queue_depth(),
                     dominant_event_source_id,
-                )))
+                ))
             } else {
-                Ok(None)
+                Err(PluginWorkQueueError::NotFound(format!(
+                    "no messages currently enqueued for analyzer {}",
+                    analyzer_id
+                )))
             }
         } else {
-            Ok(None)
+            Err(PluginWorkQueueError::NotFound(format!(
+                "no messages currently enqueued for analyzer {}",
+                analyzer_id
+            )))
         }
     }
 }

--- a/src/rust/plugin-work-queue/src/server.rs
+++ b/src/rust/plugin-work-queue/src/server.rs
@@ -302,20 +302,39 @@ impl PluginWorkQueueApi for PluginWorkQueue {
         Ok(v1beta1::AcknowledgeAnalyzerResponse {})
     }
 
-    #[tracing::instrument(skip(self, _request), err)]
+    #[tracing::instrument(skip(self, request), err)]
     async fn queue_depth_for_generator(
         &self,
-        _request: v1beta1::QueueDepthForGeneratorRequest,
-    ) -> Result<v1beta1::QueueDepthForGeneratorResponse, PluginWorkQueueError> {
-        todo!()
+        request: v1beta1::QueueDepthForGeneratorRequest,
+    ) -> Result<Option<v1beta1::QueueDepthForGeneratorResponse>, PluginWorkQueueError> {
+        let generator_id = request.generator_id();
+
+        if let Some(result) = self.queue.queue_depth_for_generator(generator_id).await? {
+            Ok(Some(v1beta1::QueueDepthForGeneratorResponse::new(
+                result.queue_depth(),
+                result.event_source_id(),
+            )))
+        } else {
+            Ok(None)
+        }
     }
 
-    #[tracing::instrument(skip(self, _request), err)]
+    #[tracing::instrument(skip(self, request), err)]
     async fn queue_depth_for_analyzer(
         &self,
-        _request: v1beta1::QueueDepthForAnalyzerRequest,
-    ) -> Result<v1beta1::QueueDepthForAnalyzerResponse, PluginWorkQueueError> {
-        todo!()
+        request: v1beta1::QueueDepthForAnalyzerRequest,
+    ) -> Result<Option<v1beta1::QueueDepthForAnalyzerResponse>, PluginWorkQueueError> {
+        let analyzer_id = request.analyzer_id();
+
+        if let Some(result) = self.queue.queue_depth_for_analyzer(analyzer_id).await? {
+            let dominant_event_source_id = result.dominant_event_source_id();
+            Ok(Some(v1beta1::QueueDepthForAnalyzerResponse::new(
+                result.queue_depth(),
+                dominant_event_source_id,
+            )))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/src/rust/plugin-work-queue/src/server.rs
+++ b/src/rust/plugin-work-queue/src/server.rs
@@ -327,11 +327,14 @@ impl PluginWorkQueueApi for PluginWorkQueue {
         let analyzer_id = request.analyzer_id();
 
         if let Some(result) = self.queue.queue_depth_for_analyzer(analyzer_id).await? {
-            let dominant_event_source_id = result.dominant_event_source_id();
-            Ok(Some(v1beta1::QueueDepthForAnalyzerResponse::new(
-                result.queue_depth(),
-                dominant_event_source_id,
-            )))
+            if let Some(dominant_event_source_id) = result.dominant_event_source_id() {
+                Ok(Some(v1beta1::QueueDepthForAnalyzerResponse::new(
+                    result.queue_depth(),
+                    dominant_event_source_id,
+                )))
+            } else {
+                Ok(None)
+            }
         } else {
             Ok(None)
         }

--- a/src/rust/plugin-work-queue/tests/pwq_integration_test.rs
+++ b/src/rust/plugin-work-queue/tests/pwq_integration_test.rs
@@ -1,6 +1,9 @@
 #![cfg(feature = "integration_tests")]
 
-use std::time::Duration;
+use std::{
+    assert_eq,
+    time::Duration,
+};
 
 use figment::{
     providers::Env,
@@ -12,7 +15,10 @@ use rust_proto::graplinc::grapl::api::{
         ExecutionJob,
         GetExecuteGeneratorRequest,
         PluginWorkQueueClient,
+        PushExecuteAnalyzerRequest,
         PushExecuteGeneratorRequest,
+        QueueDepthForAnalyzerRequest,
+        QueueDepthForGeneratorRequest,
     },
 };
 
@@ -164,6 +170,142 @@ async fn test_message_available_after_failure() -> eyre::Result<()> {
         retrieved_job,
         job
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_queue_depth_for_generator() -> eyre::Result<()> {
+    let client_config = Figment::new()
+        .merge(Env::prefixed("PLUGIN_WORK_QUEUE_CLIENT_"))
+        .extract()?;
+    let mut pwq_client = PluginWorkQueueClient::connect(client_config).await?;
+
+    // Send 2 jobs to Plugin Work Queue
+    let tenant_id = uuid::Uuid::new_v4();
+    let (event_source_id_1, event_source_id_2) = (uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+    let (generator_id_1, generator_id_2) = (uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+
+    let job_1 = PushExecuteGeneratorRequest::new(
+        ExecutionJob::new(
+            "for generator 1".into(),
+            tenant_id,
+            uuid::Uuid::new_v4(),
+            event_source_id_1,
+        ),
+        generator_id_1,
+    );
+
+    let job_2 = PushExecuteGeneratorRequest::new(
+        ExecutionJob::new(
+            "for generator 2".into(),
+            tenant_id,
+            uuid::Uuid::new_v4(),
+            event_source_id_2,
+        ),
+        generator_id_2,
+    );
+
+    let job_3 = PushExecuteGeneratorRequest::new(
+        ExecutionJob::new(
+            "also for generator 2".into(),
+            tenant_id,
+            uuid::Uuid::new_v4(),
+            event_source_id_2,
+        ),
+        generator_id_2,
+    );
+
+    for request in [&job_1, &job_2, &job_3] {
+        pwq_client.push_execute_generator(request.clone()).await?;
+    }
+
+    let response_1 = pwq_client
+        .queue_depth_for_generator(QueueDepthForGeneratorRequest::new(generator_id_1))
+        .await?;
+
+    assert_eq!(response_1.queue_depth(), 1);
+    assert_eq!(response_1.event_source_id(), event_source_id_1);
+
+    let response_2 = pwq_client
+        .queue_depth_for_generator(QueueDepthForGeneratorRequest::new(generator_id_2))
+        .await?;
+
+    assert_eq!(response_2.queue_depth(), 2);
+    assert_eq!(response_2.event_source_id(), event_source_id_2);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_queue_depth_for_analyzer() -> eyre::Result<()> {
+    let client_config = Figment::new()
+        .merge(Env::prefixed("PLUGIN_WORK_QUEUE_CLIENT_"))
+        .extract()?;
+    let mut pwq_client = PluginWorkQueueClient::connect(client_config).await?;
+
+    // Send 2 jobs to Plugin Work Queue
+    let tenant_id = uuid::Uuid::new_v4();
+    let (event_source_id_1, event_source_id_2) = (uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+    let (analyzer_id_1, analyzer_id_2) = (uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+
+    let job_1 = PushExecuteAnalyzerRequest::new(
+        ExecutionJob::new(
+            "for analyzer 1".into(),
+            tenant_id,
+            uuid::Uuid::new_v4(),
+            event_source_id_1,
+        ),
+        analyzer_id_1,
+    );
+
+    let job_2 = PushExecuteAnalyzerRequest::new(
+        ExecutionJob::new(
+            "for analyzer 2".into(),
+            tenant_id,
+            uuid::Uuid::new_v4(),
+            event_source_id_1,
+        ),
+        analyzer_id_2,
+    );
+
+    let job_3 = PushExecuteAnalyzerRequest::new(
+        ExecutionJob::new(
+            "also for analyzer 2".into(),
+            tenant_id,
+            uuid::Uuid::new_v4(),
+            event_source_id_2,
+        ),
+        analyzer_id_2,
+    );
+
+    let job_4 = PushExecuteAnalyzerRequest::new(
+        ExecutionJob::new(
+            "again for analyzer 2".into(),
+            tenant_id,
+            uuid::Uuid::new_v4(),
+            event_source_id_1,
+        ),
+        analyzer_id_2,
+    );
+
+    for request in [&job_1, &job_2, &job_3, &job_4] {
+        pwq_client.push_execute_analyzer(request.clone()).await?;
+    }
+
+    let response_1 = pwq_client
+        .queue_depth_for_analyzer(QueueDepthForAnalyzerRequest::new(analyzer_id_1))
+        .await?;
+
+    assert_eq!(response_1.queue_depth(), 1);
+    assert_eq!(response_1.dominant_event_source_id(), event_source_id_1);
+
+    let response_2 = pwq_client
+        .queue_depth_for_analyzer(QueueDepthForAnalyzerRequest::new(analyzer_id_2))
+        .await?;
+
+    assert_eq!(response_2.queue_depth(), 3);
+    assert_eq!(response_2.dominant_event_source_id(), event_source_id_1);
 
     Ok(())
 }

--- a/src/rust/plugin-work-queue/tests/pwq_integration_test.rs
+++ b/src/rust/plugin-work-queue/tests/pwq_integration_test.rs
@@ -1,4 +1,4 @@
-//#![cfg(feature = "integration_tests")]
+#![cfg(feature = "integration_tests")]
 
 use std::{
     assert_eq,

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1.rs
@@ -809,3 +809,207 @@ impl TryFrom<get_execute_generator_response::MaybeJob> for Option<ExecutionJob> 
         Ok(maybe_job)
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueueDepthForAnalyzerRequest {
+    analyzer_id: Uuid,
+}
+
+impl QueueDepthForAnalyzerRequest {
+    pub fn new(analyzer_id: Uuid) -> Self {
+        Self { analyzer_id }
+    }
+
+    pub fn analyzer_id(&self) -> Uuid {
+        self.analyzer_id
+    }
+}
+
+impl TryFrom<proto::QueueDepthForAnalyzerRequest> for QueueDepthForAnalyzerRequest {
+    type Error = SerDeError;
+
+    fn try_from(request: proto::QueueDepthForAnalyzerRequest) -> Result<Self, Self::Error> {
+        let analyzer_id = request
+            .analyzer_id
+            .ok_or(SerDeError::MissingField("analyzer_id"))?
+            .into();
+
+        Ok(Self { analyzer_id })
+    }
+}
+
+impl From<QueueDepthForAnalyzerRequest> for proto::QueueDepthForAnalyzerRequest {
+    fn from(request: QueueDepthForAnalyzerRequest) -> Self {
+        Self {
+            analyzer_id: Some(request.analyzer_id().into()),
+        }
+    }
+}
+
+impl ProtobufSerializable for QueueDepthForAnalyzerRequest {
+    type ProtobufMessage = proto::QueueDepthForAnalyzerRequest;
+}
+
+impl type_url::TypeUrl for QueueDepthForAnalyzerRequest {
+    const TYPE_URL: &'static str =
+        "graplsecurity.com/graplinc.grapl.api.plugin_work_queue.v1beta1.QueueDepthForAnalyzerRequest";
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueueDepthForAnalyzerResponse {
+    queue_depth: u32,
+    dominant_event_source_id: Uuid,
+}
+
+impl QueueDepthForAnalyzerResponse {
+    pub fn new(queue_depth: u32, dominant_event_source_id: Uuid) -> Self {
+        Self {
+            queue_depth,
+            dominant_event_source_id,
+        }
+    }
+
+    pub fn queue_depth(&self) -> u32 {
+        self.queue_depth
+    }
+
+    pub fn dominant_event_source_id(&self) -> Uuid {
+        self.dominant_event_source_id
+    }
+}
+
+impl TryFrom<proto::QueueDepthForAnalyzerResponse> for QueueDepthForAnalyzerResponse {
+    type Error = SerDeError;
+
+    fn try_from(response: proto::QueueDepthForAnalyzerResponse) -> Result<Self, Self::Error> {
+        let dominant_event_source_id = response
+            .dominant_event_source_id
+            .ok_or(SerDeError::MissingField("dominant_event_source_id"))?
+            .into();
+
+        Ok(Self {
+            queue_depth: response.queue_depth,
+            dominant_event_source_id,
+        })
+    }
+}
+
+impl From<QueueDepthForAnalyzerResponse> for proto::QueueDepthForAnalyzerResponse {
+    fn from(response: QueueDepthForAnalyzerResponse) -> Self {
+        Self {
+            queue_depth: response.queue_depth(),
+            dominant_event_source_id: Some(response.dominant_event_source_id().into()),
+        }
+    }
+}
+
+impl ProtobufSerializable for QueueDepthForAnalyzerResponse {
+    type ProtobufMessage = proto::QueueDepthForAnalyzerResponse;
+}
+
+impl type_url::TypeUrl for QueueDepthForAnalyzerResponse {
+    const TYPE_URL: &'static str =
+        "graplsecurity.com/graplinc.grapl.api.plugin_work_queue.v1beta1.QueueDepthForAnalyzerResponse";
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueueDepthForGeneratorRequest {
+    generator_id: Uuid,
+}
+
+impl QueueDepthForGeneratorRequest {
+    pub fn new(generator_id: Uuid) -> Self {
+        Self { generator_id }
+    }
+
+    pub fn generator_id(&self) -> Uuid {
+        self.generator_id
+    }
+}
+
+impl TryFrom<proto::QueueDepthForGeneratorRequest> for QueueDepthForGeneratorRequest {
+    type Error = SerDeError;
+
+    fn try_from(request: proto::QueueDepthForGeneratorRequest) -> Result<Self, Self::Error> {
+        let generator_id = request
+            .generator_id
+            .ok_or(SerDeError::MissingField("generator_id"))?
+            .into();
+
+        Ok(Self { generator_id })
+    }
+}
+
+impl From<QueueDepthForGeneratorRequest> for proto::QueueDepthForGeneratorRequest {
+    fn from(request: QueueDepthForGeneratorRequest) -> Self {
+        Self {
+            generator_id: Some(request.generator_id().into()),
+        }
+    }
+}
+
+impl ProtobufSerializable for QueueDepthForGeneratorRequest {
+    type ProtobufMessage = proto::QueueDepthForGeneratorRequest;
+}
+
+impl type_url::TypeUrl for QueueDepthForGeneratorRequest {
+    const TYPE_URL: &'static str =
+        "graplsecurity.com/graplinc.grapl.api.plugin_work_queue.v1beta1.QueueDepthForGeneratorRequest";
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueueDepthForGeneratorResponse {
+    queue_depth: u32,
+    event_source_id: Uuid,
+}
+
+impl QueueDepthForGeneratorResponse {
+    pub fn new(queue_depth: u32, event_source_id: Uuid) -> Self {
+        Self {
+            queue_depth,
+            event_source_id,
+        }
+    }
+
+    pub fn queue_depth(&self) -> u32 {
+        self.queue_depth
+    }
+
+    pub fn event_source_id(&self) -> Uuid {
+        self.event_source_id
+    }
+}
+
+impl TryFrom<proto::QueueDepthForGeneratorResponse> for QueueDepthForGeneratorResponse {
+    type Error = SerDeError;
+
+    fn try_from(response: proto::QueueDepthForGeneratorResponse) -> Result<Self, Self::Error> {
+        let event_source_id = response
+            .event_source_id
+            .ok_or(SerDeError::MissingField("event_source_id"))?
+            .into();
+
+        Ok(Self {
+            queue_depth: response.queue_depth,
+            event_source_id,
+        })
+    }
+}
+
+impl From<QueueDepthForGeneratorResponse> for proto::QueueDepthForGeneratorResponse {
+    fn from(response: QueueDepthForGeneratorResponse) -> Self {
+        Self {
+            queue_depth: response.queue_depth,
+            event_source_id: Some(response.event_source_id().into()),
+        }
+    }
+}
+
+impl ProtobufSerializable for QueueDepthForGeneratorResponse {
+    type ProtobufMessage = proto::QueueDepthForGeneratorResponse;
+}
+
+impl type_url::TypeUrl for QueueDepthForGeneratorResponse {
+    const TYPE_URL: &'static str =
+        "graplsecurity.com/graplinc.grapl.api.plugin_work_queue.v1beta1.QueueDepthForGeneratorResponse";
+}

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1_client.rs
@@ -129,4 +129,36 @@ impl PluginWorkQueueClient {
             )
             .await
     }
+
+    /// Retrieve the current queue depth for the given generator
+    #[tracing::instrument(skip(self, request), err)]
+    pub async fn queue_depth_for_generator(
+        &mut self,
+        request: native::QueueDepthForGeneratorRequest,
+    ) -> Result<native::QueueDepthForGeneratorResponse, ClientError> {
+        self.client
+            .execute(
+                request,
+                |status| status.code() == tonic::Code::Unavailable,
+                10,
+                |mut client, request| async move { client.queue_depth_for_generator(request).await },
+            )
+            .await
+    }
+
+    /// Retrieve the current queue depth for the given analyzer
+    #[tracing::instrument(skip(self, request), err)]
+    pub async fn queue_depth_for_analyzer(
+        &mut self,
+        request: native::QueueDepthForAnalyzerRequest,
+    ) -> Result<native::QueueDepthForAnalyzerResponse, ClientError> {
+        self.client
+            .execute(
+                request,
+                |status| status.code() == tonic::Code::Unavailable,
+                10,
+                |mut client, request| async move { client.queue_depth_for_analyzer(request).await },
+            )
+            .await
+    }
 }

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1_server.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1_server.rs
@@ -71,6 +71,16 @@ pub trait PluginWorkQueueApi {
         &self,
         request: native::AcknowledgeAnalyzerRequest,
     ) -> Result<native::AcknowledgeAnalyzerResponse, Self::Error>;
+
+    async fn queue_depth_for_generator(
+        &self,
+        request: native::QueueDepthForGeneratorRequest,
+    ) -> Result<native::QueueDepthForGeneratorResponse, Self::Error>;
+
+    async fn queue_depth_for_analyzer(
+        &self,
+        request: native::QueueDepthForAnalyzerRequest,
+    ) -> Result<native::QueueDepthForAnalyzerResponse, Self::Error>;
 }
 
 #[tonic::async_trait]
@@ -118,6 +128,20 @@ where
         request: tonic::Request<proto::AcknowledgeAnalyzerRequest>,
     ) -> Result<tonic::Response<proto::AcknowledgeAnalyzerResponse>, tonic::Status> {
         execute_rpc!(self, request, acknowledge_analyzer)
+    }
+
+    async fn queue_depth_for_generator(
+        &self,
+        request: tonic::Request<proto::QueueDepthForGeneratorRequest>,
+    ) -> Result<tonic::Response<proto::QueueDepthForGeneratorResponse>, tonic::Status> {
+        execute_rpc!(self, request, queue_depth_for_generator)
+    }
+
+    async fn queue_depth_for_analyzer(
+        &self,
+        request: tonic::Request<proto::QueueDepthForAnalyzerRequest>,
+    ) -> Result<tonic::Response<proto::QueueDepthForAnalyzerResponse>, tonic::Status> {
+        execute_rpc!(self, request, queue_depth_for_analyzer)
     }
 }
 

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1_server.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1_server.rs
@@ -75,12 +75,12 @@ pub trait PluginWorkQueueApi {
     async fn queue_depth_for_generator(
         &self,
         request: native::QueueDepthForGeneratorRequest,
-    ) -> Result<Option<native::QueueDepthForGeneratorResponse>, Self::Error>;
+    ) -> Result<native::QueueDepthForGeneratorResponse, Self::Error>;
 
     async fn queue_depth_for_analyzer(
         &self,
         request: native::QueueDepthForAnalyzerRequest,
-    ) -> Result<Option<native::QueueDepthForAnalyzerResponse>, Self::Error>;
+    ) -> Result<native::QueueDepthForAnalyzerResponse, Self::Error>;
 }
 
 #[tonic::async_trait]
@@ -134,54 +134,14 @@ where
         &self,
         request: tonic::Request<proto::QueueDepthForGeneratorRequest>,
     ) -> Result<tonic::Response<proto::QueueDepthForGeneratorResponse>, tonic::Status> {
-        let proto_request = request.into_inner();
-        let native_request: native::QueueDepthForGeneratorRequest = proto_request.try_into()?;
-        let generator_id = native_request.generator_id();
-
-        if let Some(native_response) = self
-            .api_server
-            .queue_depth_for_generator(native_request)
-            .await
-            .map_err(Into::into)?
-        {
-            let proto_response = native_response
-                .try_into()
-                .map_err(crate::SerDeError::from)?;
-
-            Ok(tonic::Response::new(proto_response))
-        } else {
-            Err(tonic::Status::not_found(format!(
-                "no messages currently enqueued for generator {}",
-                generator_id
-            )))
-        }
+        execute_rpc!(self, request, queue_depth_for_generator)
     }
 
     async fn queue_depth_for_analyzer(
         &self,
         request: tonic::Request<proto::QueueDepthForAnalyzerRequest>,
     ) -> Result<tonic::Response<proto::QueueDepthForAnalyzerResponse>, tonic::Status> {
-        let proto_request = request.into_inner();
-        let native_request: native::QueueDepthForAnalyzerRequest = proto_request.try_into()?;
-        let analyzer_id = native_request.analyzer_id();
-
-        if let Some(native_response) = self
-            .api_server
-            .queue_depth_for_analyzer(native_request)
-            .await
-            .map_err(Into::into)?
-        {
-            let proto_response = native_response
-                .try_into()
-                .map_err(crate::SerDeError::from)?;
-
-            Ok(tonic::Response::new(proto_response))
-        } else {
-            Err(tonic::Status::not_found(format!(
-                "no messages currently enqueued for analyzer {}",
-                analyzer_id
-            )))
-        }
+        execute_rpc!(self, request, queue_depth_for_analyzer)
     }
 }
 

--- a/src/rust/rust-proto/tests/proto_serde_tests.rs
+++ b/src/rust/rust-proto/tests/proto_serde_tests.rs
@@ -488,6 +488,26 @@ mod plugin_work_queue {
         fn test_push_execute_generator_responses(value in pwq_strats::push_execute_generator_responses()) {
             check_encode_decode_invariant(value)
         }
+
+        #[test]
+        fn test_queue_depth_for_generator_requests(value in pwq_strats::queue_depth_for_generator_requests()) {
+            check_encode_decode_invariant(value)
+        }
+
+        #[test]
+        fn test_queue_depth_for_generator_responses(value in pwq_strats::queue_depth_for_generator_responses()) {
+            check_encode_decode_invariant(value)
+        }
+
+        #[test]
+        fn test_queue_depth_for_analyzer_requests(value in pwq_strats::queue_depth_for_analyzer_requests()) {
+            check_encode_decode_invariant(value)
+        }
+
+        #[test]
+        fn test_queue_depth_for_analyzer_responses(value in pwq_strats::queue_depth_for_analyzer_responses()) {
+            check_encode_decode_invariant(value)
+        }
     }
 }
 

--- a/src/rust/rust-proto/tests/test_utils/strategies.rs
+++ b/src/rust/rust-proto/tests/test_utils/strategies.rs
@@ -1071,6 +1071,50 @@ pub mod plugin_work_queue {
     ) -> impl Strategy<Value = native::PushExecuteGeneratorResponse> {
         Just(native::PushExecuteGeneratorResponse {})
     }
+
+    prop_compose! {
+        pub fn queue_depth_for_generator_requests()(
+            generator_id in uuids(),
+        ) -> native::QueueDepthForGeneratorRequest {
+            native::QueueDepthForGeneratorRequest::new(
+                generator_id,
+            )
+        }
+    }
+
+    prop_compose! {
+        pub fn queue_depth_for_generator_responses()(
+            queue_depth in any::<u32>(),
+            event_source_id in uuids(),
+        ) -> native::QueueDepthForGeneratorResponse {
+            native::QueueDepthForGeneratorResponse::new(
+                queue_depth,
+                event_source_id,
+            )
+        }
+    }
+
+    prop_compose! {
+        pub fn queue_depth_for_analyzer_requests()(
+            analyzer_id in uuids(),
+        ) -> native::QueueDepthForAnalyzerRequest {
+            native::QueueDepthForAnalyzerRequest::new(
+                analyzer_id,
+            )
+        }
+    }
+
+    prop_compose! {
+        pub fn queue_depth_for_analyzer_responses()(
+            queue_depth in any::<u32>(),
+            dominant_event_source_id in uuids(),
+        ) -> native::QueueDepthForAnalyzerResponse {
+            native::QueueDepthForAnalyzerResponse::new(
+                queue_depth,
+                dominant_event_source_id,
+            )
+        }
+    }
 }
 
 pub mod graph_schema_manager {


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://app.zenhub.com/workspaces/grapl-6036cbd36bacff000ef314f2/issues/grapl-security/issue-tracker/1057
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
This PR adds two gRPC endpoints which expose backpressure metrics from the plugin-work-queue:
- `queue_depth_for_generator` -- returns the number of messages currently enqueued for the given generator plugin, along with the corresponding `event_source_id`.
- `queue_depth_for_analyzer` -- returns the number of messages currently enqueued for the given analyzer plugin, along with the `dominant_event_source_id` (the most frequently occurring one among the enqueued messages).

Also, this PR removes a feature whereby p-w-q would "age out" messages after 1 day. This could lead to data loss, so it's gone now.

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
Automated tests.
<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
