### PR TITLE
Customize which integ tests build/run with an environment variable

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -92,6 +92,14 @@ variable "DIST_DIR" {
 variable "PROTOC_VERSION" {
 }
 
+# Override this variable to limit the integration tests run by 
+# rust-integration-tests to a subset.
+# Specify this as a comma-separated value, i.e.
+# RUST_INTEGRATION_TEST_FEATURES_OVERRIDE="e2e-tests/integration_tests,uid-allocator/integration_tests"
+variable "RUST_INTEGRATION_TEST_FEATURES_OVERRIDE" {
+  default = ""
+}
+
 # When performing a release build, we will tag our images with our
 # "raw" Cloudsmith repository Docker registry address. We have a
 # series of repositories that we promote containers through as they
@@ -298,6 +306,8 @@ target "_rust-base" {
     RUST_BUILD     = "${RUST_BUILD}"
     RUST_VERSION   = "${RUST_VERSION}"
     PROTOC_VERSION = "${PROTOC_VERSION}"
+
+    INTEGRATION_TEST_FEATURES_OVERRIDE = "${RUST_INTEGRATION_TEST_FEATURES_OVERRIDE}"
   }
 }
 

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -146,6 +146,10 @@ RUN --mount=type=cache,target="${REGISTRY_CACHE_TARGET}",sharing=locked \
 ################################################################################
 FROM base AS build-test-integration
 
+# You can override which integration tests are run by
+# specifying this ARG as a comma-separated value. See docker-bake.hcl for more info.
+ARG INTEGRATION_TEST_FEATURES_OVERRIDE
+
 # For running integration tests we're going to copy the test binaries to a new
 # container base and run the directly, as opposed to running them via `cargo
 # test`. Cargo will recompile tests if it thinks the test binaries in target/
@@ -180,7 +184,14 @@ uid-allocator/integration_tests
 
 # cargo --features expects a comma-separated feature1,feature2,feature3
 function join_by { local IFS="$1"; shift; echo "$*"; }
-join_by , "${INTEGRATION_TEST_FEATURES[@]}" > integration_test_features.csv
+
+if [ -n "${INTEGRATION_TEST_FEATURES_OVERRIDE}" ]; then
+  # Override list of features with INTEGRATION_TEST_FEATURES_OVERRIDE if it is set
+  echo "${INTEGRATION_TEST_FEATURES_OVERRIDE}" > integration_test_features.csv
+else
+  join_by , "${INTEGRATION_TEST_FEATURES[@]}" > integration_test_features.csv
+fi
+
 EOF
 
 ENV TEST_DIR=/grapl/tests

--- a/src/rust/Dockerfile
+++ b/src/rust/Dockerfile
@@ -178,10 +178,6 @@ sysmon-generator/integration_tests
 uid-allocator/integration_tests
 )
 
-INTEGRATION_TEST_FEATURES=(
-e2e-tests/integration_tests
-)
-
 # cargo --features expects a comma-separated feature1,feature2,feature3
 function join_by { local IFS="$1"; shift; echo "$*"; }
 join_by , "${INTEGRATION_TEST_FEATURES[@]}" > integration_test_features.csv


### PR DESCRIPTION
TLDR: This enables
```
RUST_INTEGRATION_TEST_FEATURES_OVERRIDE="e2e-tests/integration_tests,uid-allocator/integration_tests" \
  make test-integration-rust
```

It enables the behavior I initially wanted (and accidentally committed) that led to https://github.com/grapl-security/grapl/pull/2098

---

I tested it locally without specifying it and with specifying it.