### PR TITLE
Rust-proto supports sending grpc metadata

### DIFF
--- a/src/python/grapl-plugin-sdk/grapl_plugin_sdk/analyzer/service_impl.py
+++ b/src/python/grapl-plugin-sdk/grapl_plugin_sdk/analyzer/service_impl.py
@@ -77,8 +77,6 @@ class AnalyzerServiceImpl:
         context: grpc_aio.ServicerContext,
     ) -> analyzer_messages.RunAnalyzerResponse:
 
-        meta = context.invocation_metadata()
-        LOGGER.debug("META", meta=str(meta))
         # TODO: Extract a Request ID from context.invocation_metadata()
         request_id = uuid4()
         logger = LOGGER.bind(

--- a/src/python/grapl-plugin-sdk/grapl_plugin_sdk/analyzer/service_impl.py
+++ b/src/python/grapl-plugin-sdk/grapl_plugin_sdk/analyzer/service_impl.py
@@ -77,6 +77,8 @@ class AnalyzerServiceImpl:
         context: grpc_aio.ServicerContext,
     ) -> analyzer_messages.RunAnalyzerResponse:
 
+        meta = context.invocation_metadata()
+        LOGGER.debug("META", meta=str(meta))
         # TODO: Extract a Request ID from context.invocation_metadata()
         request_id = uuid4()
         logger = LOGGER.bind(

--- a/src/rust/plugin-execution-sidecar/src/work/analyzer_work_processor.rs
+++ b/src/rust/plugin-execution-sidecar/src/work/analyzer_work_processor.rs
@@ -150,7 +150,7 @@ impl PluginWorkProcessor for AnalyzerWorkProcessor {
         job: ExecutionJob,
     ) -> Result<Self::ProducedMessage, PluginWorkProcessorError> {
         let request_metadata =
-            RequestMetadata::new(vec![("x-grapl-trace-id".to_string(), job.trace_id().to_string())]);
+            RequestMetadata::new(vec![("x-trace-id".to_string(), job.trace_id().to_string())]);
         let run_analyzer_response = self
             .analyzer_client
             .run_analyzer(

--- a/src/rust/plugin-execution-sidecar/src/work/analyzer_work_processor.rs
+++ b/src/rust/plugin-execution-sidecar/src/work/analyzer_work_processor.rs
@@ -150,7 +150,7 @@ impl PluginWorkProcessor for AnalyzerWorkProcessor {
         job: ExecutionJob,
     ) -> Result<Self::ProducedMessage, PluginWorkProcessorError> {
         let request_metadata =
-            RequestMetadata::new(vec![("x-trace-id".to_string(), job.trace_id().to_string())]);
+            RequestMetadata::new(vec![("x-trace-id".to_string(), job.trace_id().to_string())])?;
         let run_analyzer_response = self
             .analyzer_client
             .run_analyzer(

--- a/src/rust/plugin-execution-sidecar/src/work/analyzer_work_processor.rs
+++ b/src/rust/plugin-execution-sidecar/src/work/analyzer_work_processor.rs
@@ -27,6 +27,7 @@ use rust_proto::{
             GetExecuteAnalyzerResponse,
             PluginWorkQueueClient,
         },
+        request_metadata::RequestMetadata,
     },
     SerDe,
 };
@@ -148,9 +149,14 @@ impl PluginWorkProcessor for AnalyzerWorkProcessor {
         _plugin_id: Uuid,
         job: ExecutionJob,
     ) -> Result<Self::ProducedMessage, PluginWorkProcessorError> {
+        let request_metadata =
+            RequestMetadata::new(vec![("x-grapl-trace-id".to_string(), job.trace_id().to_string())]);
         let run_analyzer_response = self
             .analyzer_client
-            .run_analyzer(RunAnalyzerRequest::new(Update::deserialize(job.data())?))
+            .run_analyzer(
+                RunAnalyzerRequest::new(Update::deserialize(job.data())?),
+                Some(request_metadata),
+            )
             .await?;
 
         Ok(run_analyzer_response.execution_result)

--- a/src/rust/rust-proto/src/graplinc/grapl/api/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/client.rs
@@ -90,15 +90,20 @@ use serde::{
     Serialize,
 };
 use thiserror::Error;
-use tonic::{transport::Endpoint,};
+use tonic::transport::Endpoint;
 use tracing::Instrument;
 
-use super::{protocol::status::Status, request_metadata::{InvalidRequestMetadataError, RequestMetadata}};
+use super::{
+    protocol::status::Status,
+    request_metadata::{
+        InvalidRequestMetadataError,
+        RequestMetadata,
+    },
+};
 use crate::{
     serde_impl::ProtobufSerializable,
     SerDeError,
 };
-
 
 #[non_exhaustive]
 #[derive(Debug, Error)]

--- a/src/rust/rust-proto/src/graplinc/grapl/api/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/client.rs
@@ -456,7 +456,6 @@ where
         let request_timeout = self.configuration.request_timeout;
         let client_executor = self.client_executor.clone();
         let backoff_strategy = self.configuration.backoff_strategy().take(max_retries);
-        let request_metadata = request_metadata.map(|m| m.validate()).transpose()?;
 
         let result = client_executor
             .spawn_conditional(

--- a/src/rust/rust-proto/src/graplinc/grapl/api/event_source/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/event_source/v1beta1/client.rs
@@ -40,6 +40,7 @@ impl EventSourceClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.create_event_source(request).await },
@@ -55,6 +56,7 @@ impl EventSourceClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.update_event_source(request).await },
@@ -70,6 +72,7 @@ impl EventSourceClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.get_event_source(request).await },

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_mutation/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_mutation/v1beta1/client.rs
@@ -49,6 +49,7 @@ impl GraphMutationClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.create_node(request).await },
@@ -63,6 +64,7 @@ impl GraphMutationClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.set_node_property(request).await },
@@ -77,6 +79,7 @@ impl GraphMutationClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.create_edge(request).await },

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_query/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_query/v1beta1/client.rs
@@ -39,6 +39,7 @@ impl GraphQueryClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.query_graph_with_uid(request).await },
@@ -53,6 +54,7 @@ impl GraphQueryClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.query_graph_from_uid(request).await },

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_proxy/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_proxy/v1beta1/client.rs
@@ -41,6 +41,7 @@ impl GraphQueryProxyClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.query_graph_with_uid(request).await },
@@ -55,6 +56,7 @@ impl GraphQueryProxyClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.query_graph_from_uid(request).await },

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_schema_manager/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_schema_manager/v1beta1/client.rs
@@ -43,6 +43,7 @@ impl GraphSchemaManagerClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.deploy_schema(request).await },
@@ -57,6 +58,7 @@ impl GraphSchemaManagerClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.get_edge_schema(request).await },

--- a/src/rust/rust-proto/src/graplinc/grapl/api/organization_management/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/organization_management/v1beta1.rs
@@ -237,6 +237,7 @@ pub mod client {
             self.client
                 .execute(
                     request,
+                    None,
                     |status| status.code() == tonic::Code::Unavailable,
                     10,
                     |mut client, request| async move { client.create_organization(request).await },
@@ -252,6 +253,7 @@ pub mod client {
             self.client
                 .execute(
                     request,
+                    None,
                     |status| status.code() == tonic::Code::Unavailable,
                     10,
                     |mut client, request| async move { client.create_user(request).await },

--- a/src/rust/rust-proto/src/graplinc/grapl/api/pipeline_ingress/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/pipeline_ingress/v1beta1/client.rs
@@ -41,6 +41,7 @@ impl PipelineIngressClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.publish_raw_log(request).await },

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_bootstrap/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_bootstrap/v1beta1.rs
@@ -207,6 +207,7 @@ pub mod client {
             self.client
                 .execute(
                     request,
+                    None,
                     |status| status.code() == tonic::Code::Unavailable,
                     10,
                     |mut client, request| async move { client.get_bootstrap(request).await },

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_client.rs
@@ -76,6 +76,7 @@ impl PluginRegistryClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.get_plugin(request).await },
@@ -91,6 +92,7 @@ impl PluginRegistryClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.list_plugins(request).await },
@@ -106,6 +108,7 @@ impl PluginRegistryClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.get_plugin_deployment(request).await },
@@ -122,6 +125,7 @@ impl PluginRegistryClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.deploy_plugin(request).await },
@@ -138,6 +142,7 @@ impl PluginRegistryClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.tear_down_plugin(request).await },
@@ -153,6 +158,7 @@ impl PluginRegistryClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.get_plugin_health(request).await },
@@ -169,6 +175,7 @@ impl PluginRegistryClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move {
@@ -187,6 +194,7 @@ impl PluginRegistryClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.get_analyzers_for_tenant(request).await },

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/analyzers/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/analyzers/v1beta1/client.rs
@@ -10,6 +10,7 @@ use crate::{
             WithClient,
         },
         plugin_sdk::analyzers::v1beta1::messages as native,
+        request_metadata::RequestMetadata,
     },
     protobufs::graplinc::grapl::api::plugin_sdk::analyzers::v1beta1::analyzer_service_client::AnalyzerServiceClient,
 };
@@ -34,15 +35,16 @@ impl WithClient<AnalyzerServiceClient<tonic::transport::Channel>> for AnalyzerCl
 
 impl AnalyzerClient {
     /// retrieve the plugin corresponding to the given plugin_id
-    #[instrument(skip(self, request), err)]
+    #[instrument(skip(self, request, request_metadata), err)]
     pub async fn run_analyzer(
         &mut self,
         request: native::RunAnalyzerRequest,
+        request_metadata: Option<RequestMetadata>,
     ) -> Result<native::RunAnalyzerResponse, ClientError> {
         self.client
             .execute(
                 request,
-                None,
+                request_metadata,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.run_analyzer(request).await },

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/analyzers/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/analyzers/v1beta1/client.rs
@@ -42,6 +42,7 @@ impl AnalyzerClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.run_analyzer(request).await },

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/generators/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/generators/v1beta1/client.rs
@@ -40,6 +40,7 @@ impl GeneratorClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.run_generator(request).await },

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1_client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_work_queue/v1beta1_client.rs
@@ -43,6 +43,7 @@ impl PluginWorkQueueClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.push_execute_generator(request).await },
@@ -59,6 +60,7 @@ impl PluginWorkQueueClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.push_execute_analyzer(request).await },
@@ -75,6 +77,7 @@ impl PluginWorkQueueClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.get_execute_generator(request).await },
@@ -91,6 +94,7 @@ impl PluginWorkQueueClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.get_execute_analyzer(request).await },
@@ -107,6 +111,7 @@ impl PluginWorkQueueClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.acknowledge_generator(request).await },
@@ -123,6 +128,7 @@ impl PluginWorkQueueClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.acknowledge_analyzer(request).await },
@@ -139,6 +145,7 @@ impl PluginWorkQueueClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.queue_depth_for_generator(request).await },
@@ -155,6 +162,7 @@ impl PluginWorkQueueClient {
         self.client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.queue_depth_for_analyzer(request).await },

--- a/src/rust/rust-proto/src/graplinc/grapl/api/request_metadata.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/request_metadata.rs
@@ -18,7 +18,12 @@ type UnvalidatedKV = (String, String);
 type ValidatedKV = (AsciiMetadataKey, AsciiMetadataValue);
 
 pub struct RequestMetadata(Vec<UnvalidatedKV>);
+
 impl RequestMetadata {
+    pub fn new(input: Vec<UnvalidatedKV>) -> Self {
+        Self(input)
+    }
+
     /// First, validate the user input at `execute()` time, and return an
     /// Err if it's invalid metadata.
     pub fn validate(self) -> Result<ValidatedRequestMetadata, InvalidRequestMetadataError> {

--- a/src/rust/rust-proto/src/graplinc/grapl/api/request_metadata.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/request_metadata.rs
@@ -1,0 +1,35 @@
+use std::str::FromStr;
+
+use tonic::metadata::MetadataMap;
+
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidRequestMetadataError {
+    #[error(transparent)]
+    InvalidMetadataKey(#[from] tonic::metadata::errors::InvalidMetadataKey),
+    #[error(transparent)]
+    InvalidMetadataValue(#[from] tonic::metadata::errors::InvalidMetadataValue),
+}
+
+pub struct RequestMetadata(std::collections::HashMap<String, String>);
+impl RequestMetadata {
+    pub fn validate(self) -> Result<ValidatedRequestMetadata, InvalidRequestMetadataError>{
+        let validated_metadata = tonic::metadata::MetadataMap::new();
+
+        for (key, value) in self.0.into_iter() {
+            let key = tonic::metadata::AsciiMetadataKey::from_str(&key)?;
+            let value: tonic::metadata::AsciiMetadataValue = value.try_into()?;
+            validated_metadata.insert(key, value);
+        }
+        Ok(ValidatedRequestMetadata(validated_metadata))
+    }
+}
+
+#[derive(Clone)]
+pub struct ValidatedRequestMetadata(MetadataMap);
+impl ValidatedRequestMetadata {
+    pub fn merge_into(self, other: &mut MetadataMap) {
+        for (key, value) in self.0.into_iter() {
+            other.insert(key, value);
+        }
+    }
+}

--- a/src/rust/rust-proto/src/graplinc/grapl/api/scylla_provisioner/v1beta1/client.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/scylla_provisioner/v1beta1/client.rs
@@ -43,6 +43,7 @@ impl ScyllaProvisionerClient {
             .client
             .execute(
                 request,
+                None,
                 |status| status.code() == tonic::Code::Unavailable,
                 10,
                 |mut client, request| async move { client.provision_graph_for_tenant(request).await },

--- a/src/rust/rust-proto/src/graplinc/grapl/api/uid_allocator/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/uid_allocator/v1beta1.rs
@@ -230,6 +230,7 @@ pub mod client {
             self.client
                 .execute(
                     request,
+                    None,
                     |status| status.code() == tonic::Code::Unavailable,
                     10,
                     |mut client, request| async move { client.allocate_ids(request).await },
@@ -245,6 +246,7 @@ pub mod client {
                 .client
                 .execute(
                     request,
+                    None,
                     |status| status.code() == tonic::Code::Unavailable,
                     10,
                     |mut client, request| async move { client.create_tenant_keyspace(request).await },

--- a/src/rust/rust-proto/src/lib.rs
+++ b/src/rust/rust-proto/src/lib.rs
@@ -211,6 +211,8 @@ pub mod graplinc {
 
             pub mod protocol;
 
+            pub mod request_metadata;
+
             pub mod event_source {
                 pub mod v1beta1;
             }


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
None.

<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?
This is the "right" home for headers like x-trace-id, etc.
This will help me trace stuff across requests, like Analyzer Execution Sidecar -> Analyzer -> Graph Query Proxy -> Graph Query

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

### How were these changes tested?
I threw a log line into an analyzer to make sure it gets the trace id (previous x-grpal-trace-id now x-trace-id):

![image](https://user-images.githubusercontent.com/69007229/202011456-636ec42c-b475-4231-bf8d-eca80bb3eae1.png)

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
