### PR TITLE
Make validate codecov step of CI soft_fail=true

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -21,6 +21,8 @@ steps:
 
       - label: ":codecov: Validate codecov.yml"
         command: curl --proto "=https" --tlsv1.2 --fail-with-body --verbose --data-binary @codecov.yml https://codecov.io/validate
+        # codecov.io/validate went down on Nov 15 2022, so, temporarily allowing failures
+        soft_fail: true
 
       - label: ":python: Ensure regenerated constraints.txt"
         command:


### PR DESCRIPTION
This endpoint has been failing for a day blocking PRs from landing. Seeing as we really rarely modify the codecov config, I'm "temporarily" (that is to say: i will likely forget to ever turn this off) changing this to soft_fail: true. 
