### PR TITLE
Universal server tracing function

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -4238,6 +4238,7 @@ dependencies = [
  "client-executor",
  "figment",
  "futures",
+ "http",
  "humantime-serde",
  "proptest",
  "prost",

--- a/src/rust/rust-proto/Cargo.toml
+++ b/src/rust/rust-proto/Cargo.toml
@@ -12,6 +12,7 @@ bytes = { workspace = true }
 client-executor = { path = "../client-executor" }
 figment = { workspace = true }
 futures = "0.3"
+http = "0.2"
 humantime-serde = "1.0"
 prost = "0.11"
 rand = "0.8.5"

--- a/src/rust/rust-proto/src/graplinc/grapl/api/event_source/v1beta1/server.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/event_source/v1beta1/server.rs
@@ -167,15 +167,7 @@ where
             .await;
 
         // TODO: add tower tracing, concurrency limits
-        let mut server_builder = Server::builder().trace_fn(|request| {
-            tracing::info_span!(
-                "exec_service",
-                headers = ?request.headers(),
-                method = ?request.method(),
-                uri = %request.uri(),
-                extensions = ?request.extensions(),
-            )
-        });
+        let mut server_builder = Server::builder().trace_fn(crate::server_tracing::server_trace_fn);
 
         Ok(server_builder
             .add_service(health_service)

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_query/v1beta1/server.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_query/v1beta1/server.rs
@@ -163,21 +163,7 @@ where
             .await;
 
         // TODO: add tower tracing, concurrency limits
-        let mut server_builder = Server::builder().trace_fn(|request| {
-            let mut headers = request.headers().clone();
-            // Redacting mostly because it clogs up the logs with useless info
-            headers.insert(
-                "x-forwarded-client-cert",
-                "redacted-client-cert".parse().unwrap(),
-            );
-            tracing::info_span!(
-                "exec_service",
-                headers = ?headers,
-                method = ?request.method(),
-                uri = %request.uri(),
-                extensions = ?request.extensions(),
-            )
-        });
+        let mut server_builder = Server::builder().trace_fn(crate::server_tracing::server_trace_fn);
 
         Ok(server_builder
             .add_service(health_service)

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_proxy/v1beta1/server.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_query_proxy/v1beta1/server.rs
@@ -152,15 +152,7 @@ where
             .await;
 
         // TODO: add tower tracing, concurrency limits
-        let mut server_builder = Server::builder().trace_fn(|request| {
-            tracing::info_span!(
-                "exec_service",
-                headers = ?request.headers(),
-                method = ?request.method(),
-                uri = %request.uri(),
-                extensions = ?request.extensions(),
-            )
-        });
+        let mut server_builder = Server::builder().trace_fn(crate::server_tracing::server_trace_fn);
 
         Ok(server_builder
             .add_service(health_service)

--- a/src/rust/rust-proto/src/graplinc/grapl/api/graph_schema_manager/v1beta1/server.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/graph_schema_manager/v1beta1/server.rs
@@ -158,14 +158,7 @@ where
             .await;
 
         // TODO: add tower tracing, concurrency limits
-        let mut server_builder = Server::builder().trace_fn(|request| {
-            tracing::info_span!(
-                "exec_service",
-                method = ?request.method(),
-                uri = %request.uri(),
-                extensions = ?request.extensions(),
-            )
-        });
+        let mut server_builder = Server::builder().trace_fn(crate::server_tracing::server_trace_fn);
 
         Ok(server_builder
             .add_service(health_service)

--- a/src/rust/rust-proto/src/graplinc/grapl/api/pipeline_ingress/v1beta1/server.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/pipeline_ingress/v1beta1/server.rs
@@ -140,7 +140,7 @@ where
             )
             .await;
         Ok(Server::builder()
-            .trace_fn(|_request| tracing::info_span!("pipeline-ingress"))
+            .trace_fn(crate::server_tracing::server_trace_fn)
             .add_service(health_service)
             .add_service(PipelineIngressServiceServerProto::new(GrpcApi::new(
                 self.api_server,

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_server.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_registry/v1beta1_server.rs
@@ -285,15 +285,7 @@ where
 
         // TODO: add tower tracing, tls_config, concurrency limits
         Ok(Server::builder()
-            .trace_fn(|request| {
-                tracing::info_span!(
-                    "Plugin Registry",
-                    request_id = ?request.headers().get("x-request-id"),
-                    method = ?request.method(),
-                    uri = %request.uri(),
-                    extensions = ?request.extensions(),
-                )
-            })
+            .trace_fn(crate::server_tracing::server_trace_fn)
             .add_service(health_service)
             .add_service(PluginRegistryServiceProto::new(GrpcApi::new(
                 self.api_server,

--- a/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/generators/v1beta1/server.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/plugin_sdk/generators/v1beta1/server.rs
@@ -143,15 +143,7 @@ where
             .await;
 
         // TODO: add tower tracing, concurrency limits
-        let mut server_builder = Server::builder().trace_fn(|request| {
-            tracing::info_span!(
-                "exec_service",
-                headers = ?request.headers(),
-                method = ?request.method(),
-                uri = %request.uri(),
-                extensions = ?request.extensions(),
-            )
-        });
+        let mut server_builder = Server::builder().trace_fn(crate::server_tracing::server_trace_fn);
 
         Ok(server_builder
             .add_service(health_service)

--- a/src/rust/rust-proto/src/graplinc/grapl/api/scylla_provisioner/v1beta1/server.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/scylla_provisioner/v1beta1/server.rs
@@ -135,15 +135,7 @@ where
 
         // TODO: add tower tracing, tls_config, concurrency limits
         Ok(Server::builder()
-            .trace_fn(|request| {
-                tracing::info_span!(
-                    "ScyllaProvisioner",
-                    request_id = ?request.headers().get("x-request-id"),
-                    method = ?request.method(),
-                    uri = %request.uri(),
-                    extensions = ?request.extensions(),
-                )
-            })
+            .trace_fn(crate::server_tracing::server_trace_fn)
             .add_service(health_service)
             .add_service(ScyllaProvisionerServiceProto::new(GrpcApi::new(
                 self.api_server,

--- a/src/rust/rust-proto/src/lib.rs
+++ b/src/rust/rust-proto/src/lib.rs
@@ -425,3 +425,5 @@ pub(crate) mod serde_impl {
         }
     }
 }
+
+pub mod server_tracing;

--- a/src/rust/rust-proto/src/server_tracing.rs
+++ b/src/rust/rust-proto/src/server_tracing.rs
@@ -1,0 +1,10 @@
+pub fn server_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
+    let headers = request.headers();
+    tracing::info_span!(
+        "server_trace_fn",
+        request_id = ?headers.get("x-request-id"),
+        trace_id = ?headers.get("x-trace-id"),
+        method = ?request.method(),
+        extensions = ?request.extensions(),
+    )
+}


### PR DESCRIPTION
Previously we had the same trace logic repeated over and over again - and worse, it usually included the full `headers` which contains all sorts of useless fields that clog up logging. (also `uri` is mostly useless when `method` is included).

So now I just do request id and trace id.

Don't worry - services can, in the future, specify addl trace fns if they really want to!