### PR TITLE
Change a test-utils panic into a Result; add a wait-for-healthy-generator to analyzer_dispatcher_integration_tests to harden it

### DIFF
--- a/src/rust/e2e-tests/tests/sysmon_log_e2e_test.rs
+++ b/src/rust/e2e-tests/tests/sysmon_log_e2e_test.rs
@@ -223,12 +223,11 @@ async fn test_sysmon_log_e2e(ctx: &mut E2eTestContext) -> eyre::Result<()> {
         ">> Test: `generator-dispatcher` consumes the raw-log and enqueues it in Plugin Work Queue"
     );
     {
-        let msg = scan_for_generator_plugin_message_in_pwq(
+        scan_for_generator_plugin_message_in_pwq(
             ctx.plugin_work_queue_psql_client.clone(),
             generator_plugin_id,
         )
-        .await;
-        assert!(msg.is_some());
+        .await?;
     }
 
     // Then, the generator-execution-sidecar will pull this PWQ message and
@@ -288,13 +287,12 @@ async fn test_sysmon_log_e2e(ctx: &mut E2eTestContext) -> eyre::Result<()> {
         ">> Test: `analyzer-dispatcher` consumes the Update and enqueues it in Plugin Work Queue"
     );
     {
-        let msg = scan_analyzer_messages(
+        scan_analyzer_messages(
             ctx.plugin_work_queue_psql_client.clone(),
             Duration::from_secs(10), // should be basically instantaneous?
             analyzer_plugin_id,
         )
-        .await;
-        assert!(msg.is_some());
+        .await?;
     }
 
     tracing::info!(">> Test: `analyzer` emits ExecutionHits to `analyzer-executions` topic");

--- a/src/rust/generator-dispatcher/tests/generator_dispatcher_integration_tests.rs
+++ b/src/rust/generator-dispatcher/tests/generator_dispatcher_integration_tests.rs
@@ -88,11 +88,10 @@ async fn test_dispatcher_inserts_job_into_plugin_work_queue(
         ))
         .await?;
 
-    let matching_job = scan_for_generator_plugin_message_in_pwq(
+    scan_for_generator_plugin_message_in_pwq(
         ctx.plugin_work_queue_psql_client.clone(),
         generator_plugin_id,
     )
-    .await;
-    assert!(matching_job.is_some());
+    .await?;
     Ok(())
 }

--- a/src/rust/plugin-work-queue/Cargo.toml
+++ b/src/rust/plugin-work-queue/Cargo.toml
@@ -17,6 +17,7 @@ bytes = { workspace = true }
 chrono = "0.4"
 clap = { workspace = true }
 figment = { workspace = true }
+eyre = { workspace = true }
 futures = "0.3"
 grapl-config = { path = "../grapl-config" }
 grapl-tracing = { path = "../grapl-tracing" }
@@ -30,7 +31,6 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-eyre = { workspace = true }
 test-context = { workspace = true }
 test-log = { workspace = true }
 tracing-subscriber = { version = "0.3", default-features = false, features = [


### PR DESCRIPTION
1. We had this ugly panic in our check-PWQ utils that I've replaced with an eyre::Result.
2. analyzer_dispatcher_integration_tests fails sometimes doe to the generator not being ready in time. I fortunately already wrote `assert_eventual_health` for this :) 