### PR TITLE
Internal 1059 throttling controller

### DIFF
--- a/pulumi/infra/log_levels.py
+++ b/pulumi/infra/log_levels.py
@@ -7,6 +7,7 @@ RUST_LOG_LEVELS = ",".join(
         "DEBUG",
         "h2=WARN",
         "hyper=WARN",
+        "moka=ERROR",
         "rusoto_core=WARN",
         "rustls=WARN",
         # By default, sqlx outputs an INFO for every query executed.

--- a/src/proto/graplinc/grapl/api/throttling_controller/v1beta1/throttling_controller.proto
+++ b/src/proto/graplinc/grapl/api/throttling_controller/v1beta1/throttling_controller.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package graplinc.grapl.api.throttling_controller.v1beta1;
+
+import "graplinc/common/v1beta1/types.proto";
+
+// Request for the current throttling rate for the given event source
+message ThrottlingRateForEventSourceRequest {
+  graplinc.common.v1beta1.Uuid event_source_id = 1;
+}
+
+// Response containing the current throttling rate
+message ThrottlingRateForEventSourceResponse {
+  uint32 events_per_second = 1;
+}
+
+service ThrottlingControllerService {
+  // Returns the current throttling rate for the given event source
+  rpc ThrottlingRateForEventSource(ThrottlingRateForEventSourceRequest) returns (ThrottlingRateForEventSourceResponse);
+}

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2836,6 +2836,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "futures-util",
+ "log",
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.1",
@@ -5110,6 +5111,26 @@ dependencies = [
  "log",
  "ordered-float",
  "threadpool",
+]
+
+[[package]]
+name = "throttling-controller"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "eyre",
+ "figment",
+ "grapl-config",
+ "grapl-tracing",
+ "moka",
+ "rust-proto",
+ "serde",
+ "sqlx",
+ "test-context",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -38,6 +38,7 @@ members = [
   "./rust-proto",
   "./scylla-provisioner",
   "./sysmon-parser",
+  "./throttling-controller",
   "./uid-allocator",
 ]
 
@@ -51,6 +52,7 @@ clap = { version = "3.0", default_features = false, features = [
 ] }
 eyre = "0.6"
 figment = { version = "0.10", features = ["env", "json"] }
+moka = { version = "0.9", features = ["future", "logging"] }
 opentelemetry = { version = "0.18", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "0.17", features = [
   "collector_client",

--- a/src/rust/async-cache/Cargo.toml
+++ b/src/rust/async-cache/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 futures = "0.3"
-moka = { version = "0.9", features = ["future"] }
+moka = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/src/rust/async-cache/src/lib.rs
+++ b/src/rust/async-cache/src/lib.rs
@@ -94,8 +94,8 @@ where
         let (updater_tx, updater_rx) = futures::channel::mpsc::channel(updater_queue_depth);
 
         // The updater task is responsible for handling messages on the update
-        // queue and querying the plugin-registry for updates corresponding to
-        // each message.
+        // queue and querying the underlying data source for updates
+        // corresponding to each message.
         tokio::task::spawn(async move {
             updater_rx
                 .for_each_concurrent(updater_pool_size, move |key: K| {

--- a/src/rust/bin/generate_sqlx_data.sh
+++ b/src/rust/bin/generate_sqlx_data.sh
@@ -60,6 +60,7 @@ sqlx_prepare "${REPOSITORY_ROOT}/src/rust/graph-schema-manager"
 sqlx_prepare "${REPOSITORY_ROOT}/src/rust/event-source"
 sqlx_prepare "${REPOSITORY_ROOT}/src/rust/plugin-work-queue"
 sqlx_prepare "${REPOSITORY_ROOT}/src/rust/plugin-registry"
+sqlx_prepare "${REPOSITORY_ROOT}/src/rust/throttling-controller"
 sqlx_prepare "${REPOSITORY_ROOT}/src/rust/uid-allocator"
 
 # Undo the above trap

--- a/src/rust/rust-proto/src/graplinc/grapl/api/throttling_controller/v1beta1.rs
+++ b/src/rust/rust-proto/src/graplinc/grapl/api/throttling_controller/v1beta1.rs
@@ -1,0 +1,318 @@
+use crate::{
+    graplinc::common::v1beta1::Uuid,
+    protobufs::graplinc::grapl::api::throttling_controller::v1beta1::{
+        ThrottlingRateForEventSourceRequest as ThrottlingRateForEventSourceRequestProto,
+        ThrottlingRateForEventSourceResponse as ThrottlingRateForEventSourceResponseProto,
+    },
+    serde_impl,
+    type_url,
+    SerDeError,
+};
+
+//
+// ThrottlingRateForEventSourceRequest
+//
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThrottlingRateForEventSourceRequest {
+    event_source_id: Uuid,
+}
+
+impl ThrottlingRateForEventSourceRequest {
+    pub fn new(event_source_id: Uuid) -> Self {
+        Self { event_source_id }
+    }
+
+    pub fn event_source_id(&self) -> Uuid {
+        self.event_source_id
+    }
+}
+
+impl TryFrom<ThrottlingRateForEventSourceRequestProto> for ThrottlingRateForEventSourceRequest {
+    type Error = SerDeError;
+
+    fn try_from(
+        request_proto: ThrottlingRateForEventSourceRequestProto,
+    ) -> Result<Self, Self::Error> {
+        let event_source_id = request_proto
+            .event_source_id
+            .ok_or(SerDeError::MissingField("event_source_id"))?
+            .into();
+
+        Ok(Self::new(event_source_id))
+    }
+}
+
+impl From<ThrottlingRateForEventSourceRequest> for ThrottlingRateForEventSourceRequestProto {
+    fn from(request: ThrottlingRateForEventSourceRequest) -> Self {
+        Self {
+            event_source_id: Some(request.event_source_id().into()),
+        }
+    }
+}
+
+impl type_url::TypeUrl for ThrottlingRateForEventSourceRequest {
+    const TYPE_URL: &'static str =
+        "graplsecurity.com/graplinc.grapl.api.throttling_controller.v1beta1.ThrottlingRateForEventSourceRequest";
+}
+
+impl serde_impl::ProtobufSerializable for ThrottlingRateForEventSourceRequest {
+    type ProtobufMessage = ThrottlingRateForEventSourceRequestProto;
+}
+
+//
+// ThrottlingRateForEventSourceResponse
+//
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThrottlingRateForEventSourceResponse {
+    events_per_second: u32,
+}
+
+impl ThrottlingRateForEventSourceResponse {
+    pub fn new(events_per_second: u32) -> Self {
+        Self { events_per_second }
+    }
+
+    pub fn events_per_second(&self) -> u32 {
+        self.events_per_second
+    }
+}
+
+impl From<ThrottlingRateForEventSourceResponseProto> for ThrottlingRateForEventSourceResponse {
+    fn from(response_proto: ThrottlingRateForEventSourceResponseProto) -> Self {
+        Self::new(response_proto.events_per_second)
+    }
+}
+
+impl From<ThrottlingRateForEventSourceResponse> for ThrottlingRateForEventSourceResponseProto {
+    fn from(response: ThrottlingRateForEventSourceResponse) -> Self {
+        Self {
+            events_per_second: response.events_per_second(),
+        }
+    }
+}
+
+impl type_url::TypeUrl for ThrottlingRateForEventSourceResponse {
+    const TYPE_URL: &'static str =
+        "graplsecurity.com/graplinc.grapl.api.throttling_controller.v1beta1.ThrottlingRateForEventSourceResponse";
+}
+
+impl serde_impl::ProtobufSerializable for ThrottlingRateForEventSourceResponse {
+    type ProtobufMessage = ThrottlingRateForEventSourceResponseProto;
+}
+
+//
+// Client
+//
+
+pub mod client {
+    use tonic::transport::Endpoint;
+
+    use crate::{
+        graplinc::grapl::api::{
+            client::{
+                Client,
+                ClientError,
+                Connectable,
+                WithClient,
+            },
+            throttling_controller::v1beta1 as native,
+        },
+        protobufs::graplinc::grapl::api::throttling_controller::v1beta1::throttling_controller_service_client::ThrottlingControllerServiceClient,
+    };
+
+    #[async_trait::async_trait]
+    impl Connectable for ThrottlingControllerServiceClient<tonic::transport::Channel> {
+        async fn connect(endpoint: Endpoint) -> Result<Self, ClientError> {
+            Ok(Self::connect(endpoint).await?)
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct ThrottlingControllerClient {
+        client: Client<ThrottlingControllerServiceClient<tonic::transport::Channel>>,
+    }
+
+    impl WithClient<ThrottlingControllerServiceClient<tonic::transport::Channel>>
+        for ThrottlingControllerClient
+    {
+        fn with_client(
+            client: Client<ThrottlingControllerServiceClient<tonic::transport::Channel>>,
+        ) -> Self {
+            Self { client }
+        }
+    }
+
+    impl ThrottlingControllerClient {
+        pub async fn throttling_rate_for_event_source(
+            &mut self,
+            request: native::ThrottlingRateForEventSourceRequest,
+        ) -> Result<native::ThrottlingRateForEventSourceResponse, ClientError> {
+            self.client
+                .execute(
+                    request,
+                    |status| status.code() == tonic::Code::Unavailable,
+                    10,
+                    |mut client, request| async move {
+                        client.throttling_rate_for_event_source(request).await
+                    },
+                )
+                .await
+        }
+    }
+}
+
+//
+// Server
+//
+
+pub mod server {
+    use std::time::Duration;
+
+    use futures::{
+        channel::oneshot::{
+            self,
+            Receiver,
+            Sender,
+        },
+        Future,
+        FutureExt,
+    };
+    use tokio::net::TcpListener;
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::transport::{
+        NamedService,
+        Server,
+    };
+
+    use crate::{
+        execute_rpc,
+        graplinc::grapl::api::{
+            protocol::{
+                error::ServeError,
+                healthcheck::{
+                    server::init_health_service,
+                    HealthcheckError,
+                    HealthcheckStatus,
+                },
+                status::Status,
+            },
+            server::GrpcApi,
+            throttling_controller::v1beta1::{
+                ThrottlingRateForEventSourceRequest,
+                ThrottlingRateForEventSourceResponse,
+            },
+        },
+        protobufs::graplinc::grapl::api::throttling_controller::v1beta1::{
+            throttling_controller_service_server::{
+                ThrottlingControllerService as ThrottlingControllerServiceProto,
+                ThrottlingControllerServiceServer as ThrottlingControllerServiceServerProto,
+            },
+            ThrottlingRateForEventSourceRequest as ThrottlingRateForEventSourceRequestProto,
+            ThrottlingRateForEventSourceResponse as ThrottlingRateForEventSourceResponseProto,
+        },
+    };
+
+    //
+    // protocol buffer stuff
+    //
+
+    #[tonic::async_trait]
+    impl<T> ThrottlingControllerServiceProto for GrpcApi<T>
+    where
+        T: ThrottlingControllerApi + Send + Sync + 'static,
+    {
+        async fn throttling_rate_for_event_source(
+            &self,
+            request: tonic::Request<ThrottlingRateForEventSourceRequestProto>,
+        ) -> Result<tonic::Response<ThrottlingRateForEventSourceResponseProto>, tonic::Status>
+        {
+            execute_rpc!(self, request, throttling_rate_for_event_source)
+        }
+    }
+
+    //
+    // public API
+    //
+
+    #[tonic::async_trait]
+    pub trait ThrottlingControllerApi {
+        type Error: Into<Status>;
+
+        async fn throttling_rate_for_event_source(
+            &self,
+            request: ThrottlingRateForEventSourceRequest,
+        ) -> Result<ThrottlingRateForEventSourceResponse, Self::Error>;
+    }
+
+    pub struct ThrottlingControllerServer<T, H, F>
+    where
+        T: ThrottlingControllerApi + Send + Sync + 'static,
+        H: Fn() -> F + Send + Sync + 'static,
+        F: Future<Output = Result<HealthcheckStatus, HealthcheckError>> + Send + Sync + 'static,
+    {
+        api_server: T,
+        healthcheck: H,
+        healthcheck_polling_interval: Duration,
+        tcp_listener: TcpListener,
+        shutdown_rx: Receiver<()>,
+        service_name: &'static str,
+    }
+
+    impl<T, H, F> ThrottlingControllerServer<T, H, F>
+    where
+        T: ThrottlingControllerApi + Send + Sync + 'static,
+        H: Fn() -> F + Send + Sync + 'static,
+        F: Future<Output = Result<HealthcheckStatus, HealthcheckError>> + Send + Sync + 'static,
+    {
+        pub fn new(
+            api_server: T,
+            tcp_listener: TcpListener,
+            healthcheck: H,
+            healthcheck_polling_interval: Duration,
+        ) -> (Self, Sender<()>) {
+            let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+            (
+                ThrottlingControllerServer {
+                    api_server,
+                    healthcheck,
+                    healthcheck_polling_interval,
+                    tcp_listener,
+                    shutdown_rx,
+                    service_name: ThrottlingControllerServiceServerProto::<GrpcApi<T>>::NAME,
+                },
+                shutdown_tx,
+            )
+        }
+
+        pub fn service_name(&self) -> &'static str {
+            self.service_name
+        }
+
+        pub async fn serve(self) -> Result<(), ServeError> {
+            let (healthcheck_handle, health_service) =
+                init_health_service::<ThrottlingControllerServiceServerProto<GrpcApi<T>>, _, _>(
+                    self.healthcheck,
+                    self.healthcheck_polling_interval,
+                )
+                .await;
+
+            Ok(Server::builder()
+                .trace_fn(|_request| tracing::info_span!("throttling-controller"))
+                .add_service(health_service)
+                .add_service(ThrottlingControllerServiceServerProto::new(GrpcApi::new(
+                    self.api_server,
+                )))
+                .serve_with_incoming_shutdown(
+                    TcpListenerStream::new(self.tcp_listener),
+                    self.shutdown_rx.map(|_| ()),
+                )
+                .then(|result| async move {
+                    healthcheck_handle.abort();
+                    result
+                })
+                .await?)
+        }
+    }
+}

--- a/src/rust/rust-proto/src/lib.rs
+++ b/src/rust/rust-proto/src/lib.rs
@@ -160,6 +160,15 @@ pub(crate) mod protobufs {
                     }
                 }
 
+                pub(crate) mod throttling_controller {
+                    pub(crate) mod v1beta1 {
+                        include!(concat!(
+                            env!("OUT_DIR"),
+                            "/graplinc.grapl.api.throttling_controller.v1beta1.rs"
+                        ));
+                    }
+                }
+
                 pub(crate) mod uid_allocator {
                     pub(crate) mod v1beta1 {
                         include!(concat!(
@@ -274,6 +283,10 @@ pub mod graplinc {
             }
 
             pub mod scylla_provisioner {
+                pub mod v1beta1;
+            }
+
+            pub mod throttling_controller {
                 pub mod v1beta1;
             }
 

--- a/src/rust/rust-proto/tests/proto_serde_tests.rs
+++ b/src/rust/rust-proto/tests/proto_serde_tests.rs
@@ -529,6 +529,28 @@ mod graph_schema_manager {
     }
 }
 
+mod throttling_controller {
+    use strategies::throttling_controller as st;
+
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn test_throttling_rate_for_event_source_request_encode_decode(
+            request in st::throttling_rate_for_event_source_requests()
+        ) {
+            check_encode_decode_invariant(request)
+        }
+
+        #[test]
+        fn test_throttling_rate_for_event_source_response_encode_decode(
+            response in st::throttling_rate_for_event_source_responses()
+        ) {
+            check_encode_decode_invariant(response)
+        }
+    }
+}
+
 mod analyzer_sdk {
 
     use strategies::analyzer_sdk as as_strats;

--- a/src/rust/rust-proto/tests/test_utils/strategies.rs
+++ b/src/rust/rust-proto/tests/test_utils/strategies.rs
@@ -1172,6 +1172,31 @@ pub mod graph_schema_manager {
     }
 }
 
+pub mod throttling_controller {
+    use rust_proto::graplinc::grapl::api::throttling_controller::v1beta1::{
+        ThrottlingRateForEventSourceRequest,
+        ThrottlingRateForEventSourceResponse,
+    };
+
+    use super::*;
+
+    prop_compose! {
+        pub fn throttling_rate_for_event_source_requests()(
+            event_source_id in uuids()
+        ) -> ThrottlingRateForEventSourceRequest {
+            ThrottlingRateForEventSourceRequest::new(event_source_id)
+        }
+    }
+
+    prop_compose! {
+        pub fn throttling_rate_for_event_source_responses()(
+            events_per_second in any::<u32>()
+        ) -> ThrottlingRateForEventSourceResponse {
+            ThrottlingRateForEventSourceResponse::new(events_per_second)
+        }
+    }
+}
+
 pub mod analyzer_sdk {
     use rust_proto::graplinc::grapl::api::plugin_sdk::analyzers::v1beta1::messages::{
         self as native,

--- a/src/rust/throttling-controller/.#Cargo.toml
+++ b/src/rust/throttling-controller/.#Cargo.toml
@@ -1,0 +1,1 @@
+jgrillo@penguin.2106:1669557902

--- a/src/rust/throttling-controller/.#Cargo.toml
+++ b/src/rust/throttling-controller/.#Cargo.toml
@@ -1,1 +1,0 @@
-jgrillo@penguin.2106:1669557902

--- a/src/rust/throttling-controller/Cargo.toml
+++ b/src/rust/throttling-controller/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "throttling-controller"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+async-trait = "0.1"
+eyre = { workspace = true }
+figment = { workspace = true }
+grapl-config = { path = "../grapl-config" }
+grapl-tracing = { path = "../grapl-tracing" }
+moka = { version = "0.9", features = ["future", "logging"] }
+rust-proto = { path = "../rust-proto", version = "*" }
+serde = { workspace = true }
+sqlx = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+test-context = { workspace = true }
+
+[features]
+integration_tests = []

--- a/src/rust/throttling-controller/Cargo.toml
+++ b/src/rust/throttling-controller/Cargo.toml
@@ -9,7 +9,7 @@ eyre = { workspace = true }
 figment = { workspace = true }
 grapl-config = { path = "../grapl-config" }
 grapl-tracing = { path = "../grapl-tracing" }
-moka = { version = "0.9", features = ["future", "logging"] }
+moka = { workspace = true }
 rust-proto = { path = "../rust-proto", version = "*" }
 serde = { workspace = true }
 sqlx = { workspace = true }

--- a/src/rust/throttling-controller/migrations/20221128195636_create_controllers_table.sql
+++ b/src/rust/throttling-controller/migrations/20221128195636_create_controllers_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS controllers
+(
+    event_source_id     uuid                    NOT NULL,
+    plugin_id           uuid                    NOT NULL,
+    is_generator        bool                    NOT NULL,
+    K                   double precision        NOT NULL,
+    T_i                 double precision        NOT NULL,
+    T_d                 double precision        NOT NULL,
+    T_t                 double precision        NOT NULL,
+    N                   double precision        NOT NULL,
+    b                   double precision        NOT NULL,
+    P_k1                double precision        NOT NULL,
+    I_k1                double precision        NOT NULL,
+    D_k1                double precision        NOT NULL,
+    r_k1                double precision        NOT NULL,
+    y_k1                double precision        NOT NULL,
+    y_k2                double precision        NOT NULL,
+    t_k1                timestamptz             NOT NULL,
+    PRIMARY KEY (event_source_id, plugin_id)
+);

--- a/src/rust/throttling-controller/src/controller.rs
+++ b/src/rust/throttling-controller/src/controller.rs
@@ -1,0 +1,334 @@
+use std::time::{
+    SystemTime,
+    Duration,
+};
+
+use figment::{
+    Figment,
+    providers::Env,
+};
+use grapl_config::PostgresClient;
+use moka::future::Cache;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::db::{
+    ControllerDb,
+    self,
+    ControllerDbError,
+};
+
+/// This implementation of a PID controller comes from
+///
+/// ```text
+/// Åström, K. J., & Hägglund, T. (1988).
+/// Automatic Tuning of PID Controllers.
+/// Instrument Society of America (ISA).
+/// ISBN 1-55617-081-5
+/// ```
+///
+/// While I've used English natural language names for the public API, I've kept
+/// the mathematical symbols (at least within reason) faithful to their typeset
+/// representation. This code is meant to be read alongside a copy of the book!
+/// I found that keeping these variable names closely matched to the mathematics
+/// aids understanding by reducing the amount of mental indirection, making
+/// implementation errors easier to spot.
+///
+/// If you have any questions about this code feel free to reach out:
+///
+/// ```text
+/// Jesse C. Grillo
+/// jgrillo@protonmail.com
+/// ```
+#[allow(non_snake_case)]
+#[derive(Clone, Debug)]
+struct PidController {
+    K: f64,
+    T_i: f64,
+    T_d: f64,
+    T_t: f64,
+    N: f64,
+    b: f64,
+    P_k1: f64,
+    I_k1: f64,
+    D_k1: f64,
+    r_k1: f64,
+    y_k1: f64,
+    y_k2: f64,
+    t_k1: SystemTime,
+}
+
+#[allow(non_snake_case)]
+impl PidController {
+
+    /// Construct a new PidController.
+    /// \
+    /// # Arguments:
+    /// \
+    /// - `proportional_gain` -- The output the controller is multiplied by this
+    ///   factor
+    /// \
+    /// - `integral_time_constant` -- The time required for the integral term to
+    ///   "catch up to" the proportional term in the face of an instantaneous
+    ///   jump in controller error
+    /// \
+    /// - `derivative_time_constant` -- The time required for the proportional
+    ///   term to "catch up to" the derivative term if the error starts at zero
+    ///   and increases at a fixed rate
+    /// \
+    /// - `tracking_time_constant` -- The time required for the integral term to
+    ///   "reset". This is necessary to prevent integral wind-up.
+    /// \
+    /// - `derivative_gain_limit` -- This term mitigates the effects of high
+    ///   frequency noise in the derivative term by limiting the gain, which in
+    ///   turn limits the high frequency noise amplification factor.
+    /// \
+    /// - `set_point_coefficient` -- This term determines how the controller
+    ///   reacts to a change in the setpoint.
+    pub fn new(
+        proportional_gain: f64,
+        integral_time_constant: f64,
+        derivative_time_constant: f64,
+        tracking_time_constant: f64,
+        derivative_gain_limit: f64,
+        set_point_coefficient: f64,
+    ) -> Self {
+        Self {
+            K: proportional_gain,
+            T_i: integral_time_constant,
+            T_d: derivative_time_constant,
+            T_t: tracking_time_constant,
+            N: derivative_gain_limit,
+            b: set_point_coefficient,
+            P_k1: 0.0,
+            I_k1: 0.0,
+            D_k1: 0.0,
+            r_k1: 0.0,
+            y_k1: 0.0,
+            y_k2: 0.0,
+            t_k1: SystemTime::now(),
+        }
+    }
+
+    // TODO: numerical stability
+    fn calculate_P(&self, r_k: f64, y_k: f64) -> f64 {
+        self.P_k1 + self.K * (self.b * r_k - y_k - self.b * self.r_k1 + self.y_k1)
+    }
+
+    // TODO: numerical stability
+    fn calculate_I(&self, h: f64, r_k: f64, y_k: f64, u: f64, v: f64) -> f64 {
+        self.I_k1 + (self.K * h / self.T_i) * (r_k - y_k) + (h / self.T_t) * (u - v)
+    }
+
+    // TODO: numerical stability
+    fn calculate_D(&self, h: f64, y_k: f64) -> f64 {
+        let (a_i, b_i) = if self.T_d < (self.N * h) / 2.0 {
+            // use backward difference
+            let a_i = self.T_d / (self.T_d + self.N * h);
+            let b_i = -1.0 * self.K * self.T_d * self.N / (self.T_d + h * self.N);
+
+            (a_i, b_i)
+        } else {
+            // use Tustin's approximation
+            let a_i = (2.0 * self.T_d - h * self.N) / (2.0 * self.T_d + h * self.N);
+            let b_i = -2.0 * self.K * self.N * self.T_d / (2.0 * self.T_d + h * self.N);
+
+            (a_i, b_i)
+        };
+
+        self.D_k1 + (b_i / (1.0 - a_i)) * (y_k - 2.0 * self.y_k1 + self.y_k2)
+    }
+
+    fn update_state(
+        &mut self,
+        h: f64,
+        r_k: f64,
+        y_k: f64,
+        u_low: f64,
+        u_high: f64
+    ) -> f64 {
+        self.P_k1 = self.calculate_P(r_k, y_k);
+        self.D_k1 = self.calculate_D(h, y_k);
+
+        let v = self.control_output();
+        let u = sat(v, u_low, u_high);
+
+        self.I_k1 = self.calculate_I(h, r_k, y_k, u, v);
+
+        self.r_k1 = r_k;
+        self.y_k2 = self.y_k1;
+        self.y_k1 = y_k;
+
+        self.control_output()
+    }
+
+    /// Updates this controller's state according to the given
+    /// parameters. Returns the updated control output.
+    /// \
+    /// # Arguments:
+    /// \
+    /// - `set_point` -- the desired value for the process variable
+    /// \
+    /// - `process_measurement` -- the measured process variable value
+    /// \
+    /// - `measurement_time` -- the time when the `process_measurement` was made
+    /// \
+    /// - `lower_saturation_limit` -- the minimum value the controller can take
+    /// \
+    /// - `upper_saturation_limit` -- the maximum value the controller can take
+    pub fn update(
+        &mut self,
+        set_point: f64,
+        process_measurement: f64,
+        measurement_time: SystemTime,
+        lower_saturation_limit: f64,
+        upper_saturation_limit: f64
+    ) -> f64 {
+        let h = match measurement_time.duration_since(self.last_update_time()) {
+            Ok(duration) => duration.as_secs_f64(),
+            Err(e) => Duration::from_nanos(1).as_secs_f64(), // FIXME?
+        };
+
+        self.update_state(
+            h,
+            set_point,
+            process_measurement,
+            lower_saturation_limit,
+            upper_saturation_limit
+        )
+    }
+
+    /// Returns the most recently computed control output
+    pub fn control_output(&self) -> f64 {
+        self.P_k1 + self.I_k1 + self.D_k1
+    }
+
+    /// Returns the last time this controller was updated
+    pub fn last_update_time(&self) -> SystemTime {
+        self.t_k1
+    }
+}
+
+impl From<db::Controller> for PidController {
+    fn from(controller: db::Controller) -> Self {
+        Self {
+            K: controller.K(),
+            T_i: controller.T_i(),
+            T_d: controller.T_d(),
+            T_t: controller.T_t(),
+            N: controller.N(),
+            b: controller.b(),
+            P_k1: controller.P_k1(),
+            I_k1: controller.I_k1(),
+            D_k1: controller.D_k1(),
+            r_k1: controller.r_k1(),
+            y_k1: controller.y_k1(),
+            y_k2: controller.y_k2(),
+            t_k1: controller.t_k1(),
+        }
+    }
+}
+
+/// The saturation function restricts the input `v` to the interval
+/// `[u_low, u_high]`.
+fn sat(v: f64, u_low: f64, u_high: f64) -> f64 {
+    if v < u_low {
+        u_low
+    } else if v > u_high {
+        u_high
+    } else {
+        v
+    }
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ControllerError {
+    #[error("database error {0}")]
+    Database(#[from] ControllerDbError),
+
+    #[error("error extracting figment config {0}")]
+    Figment(#[from] figment::Error),
+
+    #[error("found no controller")]
+    NotFound,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct Key {
+    event_source_id: Uuid,
+    plugin_id: Uuid,
+}
+
+impl Key {
+    fn new(event_source_id: Uuid, plugin_id: Uuid) -> Self {
+        Self { event_source_id, plugin_id }
+    }
+
+    fn event_source_id(&self) -> Uuid {
+        self.event_source_id
+    }
+
+    fn plugin_id(&self) -> Uuid {
+        self.plugin_id
+    }
+}
+
+pub struct Controller {
+    cache: Cache<Key, PidController>,
+    db: ControllerDb,
+}
+
+impl Controller {
+    pub async fn new(
+        cache_capacity: u64,
+        cache_ttl: Duration,
+    ) -> Result<Self, ControllerError> {
+        let listener = move |k, v, cause| {
+            todo!()
+        };
+
+        let cache = Cache::builder()
+            .max_capacity(cache_capacity)
+            .time_to_live(cache_ttl)
+            .eviction_listener_with_queued_delivery_mode(listener)
+            .build();
+
+        let db = ControllerDb::init_with_config(
+            Figment::new()
+                .merge(Env::prefixed("CONTROLLER_DB_"))
+                .extract()?
+        ).await?;
+
+        Ok(Self { cache, db })
+    }
+
+    pub async fn throttling_quota_for_event_source(
+        &self,
+        event_source_id: Uuid,
+        plugin_id: Uuid,
+    ) -> Result<f64, ControllerError> {
+        match self.cache.get(&Key::new(event_source_id, plugin_id)) {
+            Some(controller) => Ok(controller.control_output()),
+            None => {
+                // cache miss so we'll retrieve the controller from db
+                if let Some(controller) = self.db.get_controller(
+                    event_source_id,
+                    plugin_id
+                ).await? {
+                    let pid_controller = PidController::from(controller);
+                    let retval = pid_controller.control_output();
+
+                    self.cache.insert(
+                        Key::new(event_source_id, plugin_id),
+                        pid_controller
+                    ).await;
+
+                    Ok(retval)
+                } else {
+                    Err(ControllerError::NotFound)
+                }
+            }
+        }
+    }
+}

--- a/src/rust/throttling-controller/src/db.rs
+++ b/src/rust/throttling-controller/src/db.rs
@@ -1,0 +1,240 @@
+use std::time::SystemTime;
+
+use figment::{
+    Provider,
+    Figment,
+};
+use grapl_config::PostgresClient;
+use serde::Deserialize;
+use thiserror::Error;
+use uuid::Uuid;
+
+#[derive(Clone, Debug)]
+#[allow(non_snake_case)]
+pub(crate) struct Controller {
+    event_source_id: Uuid,
+    plugin_id: Uuid,
+    is_generator: bool,
+    K: f64,
+    T_i: f64,
+    T_d: f64,
+    T_t: f64,
+    N: f64,
+    b: f64,
+    P_k1: f64,
+    I_k1: f64,
+    D_k1: f64,
+    r_k1: f64,
+    y_k1: f64,
+    y_k2: f64,
+    t_k1: SystemTime,
+}
+
+#[allow(non_snake_case)]
+impl Controller {
+    pub fn new(
+        event_source_id: Uuid,
+        plugin_id: Uuid,
+        is_generator: bool,
+        K: f64,
+        T_i: f64,
+        T_d: f64,
+        T_t: f64,
+        N: f64,
+        b: f64,
+        P_k1: f64,
+        I_k1: f64,
+        D_k1: f64,
+        r_k1: f64,
+        y_k1: f64,
+        y_k2: f64,
+        t_k1: SystemTime,
+    ) -> Self {
+        Self {
+            event_source_id,
+            plugin_id,
+            is_generator,
+            K,
+            T_i,
+            T_d,
+            T_t,
+            N,
+            b,
+            P_k1,
+            I_k1,
+            D_k1,
+            r_k1,
+            y_k1,
+            y_k2,
+            t_k1,
+        }
+    }
+
+    pub fn event_source_id(&self) -> Uuid {
+        self.event_source_id
+    }
+
+    pub fn plugin_id(&self) -> Uuid {
+        self.plugin_id
+    }
+
+    pub fn is_generator(&self) -> bool {
+        self.is_generator
+    }
+
+    pub fn K(&self) -> f64 {
+        self.K
+    }
+
+    pub fn T_i(&self) -> f64 {
+        self.T_i
+    }
+
+    pub fn T_d(&self) -> f64 {
+        self.T_d
+    }
+
+    pub fn T_t(&self) -> f64 {
+        self.T_t
+    }
+
+    pub fn N(&self) -> f64 {
+        self.N
+    }
+
+    pub fn b(&self) -> f64 {
+        self.b
+    }
+
+    pub fn P_k1(&self) -> f64 {
+        self.P_k1
+    }
+
+    pub fn I_k1(&self) -> f64 {
+        self.I_k1
+    }
+
+    pub fn D_k1(&self) -> f64 {
+        self.D_k1
+    }
+
+    pub fn r_k1(&self) -> f64 {
+        self.r_k1
+    }
+
+    pub fn y_k1(&self) -> f64 {
+        self.y_k1
+    }
+
+    pub fn y_k2(&self) -> f64 {
+        self.y_k2
+    }
+
+    pub fn t_k1(&self) -> SystemTime {
+        self.t_k1
+    }
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ConfigurationError {
+    #[error("error extracting figment config {0}")]
+    Figment(#[from] figment::Error),
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct ControllerDbConfiguration {
+    address: String,
+    username: String,
+    password: grapl_config::SecretString,
+}
+
+impl ControllerDbConfiguration {
+    pub fn new(
+        address: String,
+        username: String,
+        password: grapl_config::SecretString,
+    ) -> Self {
+        Self { address, username, password }
+    }
+
+    pub fn from<T>(provider: T) -> Result<Self, ConfigurationError>
+    where
+        T: Provider
+    {
+        Ok(Figment::from(provider).extract()?)
+    }
+
+    pub(crate) fn address(&self) -> &str {
+        &self.address
+    }
+
+    pub(crate) fn username(&self) -> &str {
+        &self.username
+    }
+
+    pub(crate) fn password(&self) -> grapl_config::SecretString {
+        self.password.clone()
+    }
+}
+
+impl grapl_config::ToPostgresUrl for ControllerDbConfiguration {
+    fn to_postgres_url(self) -> grapl_config::PostgresUrl {
+        grapl_config::PostgresUrl {
+            address: self.address().to_owned(),
+            username: self.username().to_owned(),
+            password: self.password(),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub(crate) enum ControllerDbError {
+    #[error("sqlx migration error {0}")]
+    Migration(#[from] sqlx::migrate::MigrateError),
+
+    #[error("initialization error {0}")]
+    Initialization(#[from] grapl_config::PostgresDbInitError),
+}
+
+#[derive(Clone)]
+pub(crate) struct ControllerDb {
+    pool: sqlx::PgPool
+}
+
+#[async_trait::async_trait]
+impl PostgresClient for ControllerDb {
+    type Config = ControllerDbConfiguration;
+    type Error = ControllerDbError;
+
+    fn new(pool: sqlx::Pool<sqlx::Postgres>) -> Self {
+        Self { pool }
+    }
+
+    #[tracing::instrument]
+    async fn migrate(pool: &sqlx::Pool<sqlx::Postgres>) -> Result<(), sqlx::migrate::MigrateError> {
+        tracing::info!(message = "Performing database migration");
+
+        sqlx::migrate!().run(pool).await
+    }
+}
+
+impl ControllerDb {
+    #[tracing::instrument(skip(self), err)]
+    pub async fn create_or_update_controller(
+        &self,
+        controller: Controller,
+    ) -> Result<(), ControllerDbError> {
+        todo!()
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    pub async fn get_controller(
+        &self,
+        event_source_id: Uuid,
+        plugin_id: Uuid,
+    ) -> Result<Option<Controller>, ControllerDbError> {
+        todo!()
+    }
+}

--- a/src/rust/throttling-controller/src/main.rs
+++ b/src/rust/throttling-controller/src/main.rs
@@ -1,0 +1,67 @@
+use controller::ControllerError;
+use rust_proto::graplinc::grapl::api::{
+    throttling_controller::v1beta1::{
+        server::{
+            ThrottlingControllerApi,
+            ThrottlingControllerServer,
+        },
+        ThrottlingRateForEventSourceRequest,
+        ThrottlingRateForEventSourceResponse,
+    },
+    protocol::{
+        error::ServeError,
+        healthcheck::HealthcheckStatus,
+        status::Status,
+    },
+};
+use thiserror::Error;
+use uuid::Uuid;
+
+mod controller;
+mod db;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+enum ControllerApiError {
+    #[error("controller error {0}")]
+    Controller(#[from] ControllerError),
+}
+
+impl From<ControllerApiError> for Status {
+    fn from(error: ControllerApiError) -> Self {
+        match error {
+            ControllerApiError::Controller(e) => match e {
+                ControllerError::Database(db_err) => Status::unavailable(
+                    format!("database error {0}", db_err)
+                ),
+                ControllerError::Figment(fig_err) => Status::unavailable(
+                    format!("configuration error {0}", fig_err)
+                ),
+                ControllerError::NotFound => Status::not_found("controller not found"),
+            },
+        }
+    }
+}
+
+struct ControllerApi {
+    controller: controller::Controller,
+}
+
+#[async_trait::async_trait]
+impl ThrottlingControllerApi for ControllerApi {
+    type Error = ControllerApiError;
+
+    async fn throttling_rate_for_event_source(
+        &self,
+        request: ThrottlingRateForEventSourceRequest
+    ) -> Result<ThrottlingRateForEventSourceResponse, ControllerApiError> {
+        todo!()
+    }
+}
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    println!("Hello, world!");
+
+    Ok(())
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to Grapl! Please take some time
to fill out this short template to help us review and understand your
PR. -->

### Which issue does this PR correspond to?
https://app.zenhub.com/workspaces/grapl-6036cbd36bacff000ef314f2/issues/grapl-security/issue-tracker/1059
<!-- Please provide a link to the GitHub Issue this pull request is
meant to address. -->

### What changes does this PR make to Grapl? Why?

<!-- Please describe the functional impact of these changes and the
rationale behind them. This will help us understand your approach to
solving the problem. -->

This PR adds the throttling-controller service which is responsible for maintaining a PID controller for every `(plugin_id, event_source_id)` pair.

The idea here is to optimally throttle event sources s.t. they don't overwhelm the plugins. We do this by choosing a throttling rate per event source which is continuously optimized to maintain the corresponding plugin work queue(s')'s depths at a configured set-point.

Generator queues are "simple" in the sense that each one only has a single corresponding event source. Analyzer queues are a little more "interesting" because they may have _many_ event sources which contribute to them.  

### How were these changes tested?

Tests.

<!-- Please describe how these changes were tested. There should be
sufficient detail that reviewers can replicate your testing
procedure. If the procedure is a manual one that's OK, your
description will help us work with you to get it automated. -->
